### PR TITLE
reduce precision of millisecond to fit ISO8601

### DIFF
--- a/gson/src/main/java/com/google/gson/DefaultDateTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/DefaultDateTypeAdapter.java
@@ -101,11 +101,15 @@ final class DefaultDateTypeAdapter implements JsonSerializer<Date>, JsonDeserial
         return enUsFormat.parse(json.getAsString());
       } catch (ParseException ignored) {
       }
-      try {
-        return iso8601Format.parse(json.getAsString());
-      } catch (ParseException e) {
-        throw new JsonSyntaxException(json.getAsString(), e);
-      }
+	    try {
+		    return iso8601Format.parse(json.getAsString());
+	    } catch (ParseException ignored) {
+	    }
+	    try {
+		    return iso8601Format.parse(json.getAsString().replaceFirst("\\.\\d\\d\\d", ""));
+	    } catch (ParseException e) {
+		    throw new JsonSyntaxException(json.getAsString(), e);
+	    }
     }
   }
 

--- a/gson/src/main/java/com/google/gson/internal/bind/DateTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/DateTypeAdapter.java
@@ -77,6 +77,10 @@ public final class DateTypeAdapter extends TypeAdapter<Date> {
     }
     try {
       return iso8601Format.parse(json);
+    } catch (ParseException ignored) {
+    }
+    try {
+      return iso8601Format.parse(json.replaceFirst("\\.\\d\\d\\d", ""));
     } catch (ParseException e) {
       throw new JsonSyntaxException(json, e);
     }

--- a/gson/src/test/java/com/google/gson/DefaultDateTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/DefaultDateTypeAdapterTest.java
@@ -16,12 +16,13 @@
 
 package com.google.gson;
 
+import junit.framework.TestCase;
+
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
-import junit.framework.TestCase;
 
 /**
  * A simple unit test for the {@link DefaultDateTypeAdapter} class.
@@ -159,5 +160,7 @@ public class DefaultDateTypeAdapterTest extends TestCase {
     assertEquals(date, new Date(0), adapter.deserialize(new JsonPrimitive(date), Date.class, null));
     assertEquals("ISO 8601", new Date(0), adapter.deserialize(
         new JsonPrimitive("1970-01-01T00:00:00Z"), Date.class, null));
+    assertEquals("ISO 8601", new Date(0), adapter.deserialize(
+        new JsonPrimitive("1970-01-01T00:00:00.000Z"), Date.class, null));
   }
 }


### PR DESCRIPTION
make format yyyy-MM-dd'T'HH:mm:ss.SSS'Z' fit yyyy-MM-dd'T'HH:mm:ss'Z'.

Some api provide millisecond precision, but it'll throw exception. This change cut millisecond part to fit ISO8601 format.