### PR TITLE
Getters and setters

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -123,8 +123,8 @@ public final class Gson {
   private final boolean prettyPrinting;
 
   final JsonDeserializationContext deserializationContext = new JsonDeserializationContext() {
-    @SuppressWarnings("unchecked")
-	public <T> T deserialize(JsonElement json, Type typeOfT) throws JsonParseException {
+  @SuppressWarnings("unchecked")
+  public <T> T deserialize(JsonElement json, Type typeOfT) throws JsonParseException {
       return (T) fromJson(json, typeOfT);
     }
   };
@@ -173,13 +173,13 @@ public final class Gson {
    * </ul>
    */
   public Gson() {
-    this(Excluder.DEFAULT, FieldNamingPolicy.IDENTITY,
+    this(Excluder.DEFAULT, MethodAndFieldNamingPolicy.DEFAULT,
         Collections.<Type, InstanceCreator<?>>emptyMap(), false, false, DEFAULT_JSON_NON_EXECUTABLE,
         true, false, false, LongSerializationPolicy.DEFAULT,
         Collections.<TypeAdapterFactory>emptyList());
   }
-
-  Gson(final Excluder excluder, final FieldNamingStrategy fieldNamingPolicy,
+  
+  Gson(final Excluder excluder, final FieldNamingStrategy namingPolicy,
       final Map<Type, InstanceCreator<?>> instanceCreators, boolean serializeNulls,
       boolean complexMapKeySerialization, boolean generateNonExecutableGson, boolean htmlSafe,
       boolean prettyPrinting, boolean serializeSpecialFloatingPointValues,
@@ -241,7 +241,7 @@ public final class Gson {
     factories.add(new JsonAdapterAnnotationTypeAdapterFactory(constructorConstructor));
     factories.add(TypeAdapters.ENUM_FACTORY);
     factories.add(new ReflectiveTypeAdapterFactory(
-        constructorConstructor, fieldNamingPolicy, excluder));
+        constructorConstructor, namingPolicy, excluder));
 
     this.factories = Collections.unmodifiableList(factories);
   }

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -68,7 +68,7 @@ import com.google.gson.reflect.TypeToken;
 public final class GsonBuilder {
   private Excluder excluder = Excluder.DEFAULT;
   private LongSerializationPolicy longSerializationPolicy = LongSerializationPolicy.DEFAULT;
-  private FieldNamingStrategy fieldNamingPolicy = FieldNamingPolicy.IDENTITY;
+  private FieldNamingStrategy fieldNamingPolicy = MethodAndFieldNamingPolicy.DEFAULT;
   private final Map<Type, InstanceCreator<?>> instanceCreators
       = new HashMap<Type, InstanceCreator<?>>();
   private final List<TypeAdapterFactory> factories = new ArrayList<TypeAdapterFactory>();
@@ -337,6 +337,11 @@ public final class GsonBuilder {
    */
   public GsonBuilder addDeserializationExclusionStrategy(ExclusionStrategy strategy) {
     excluder = excluder.withExclusionStrategy(strategy, false, true);
+    return this;
+  }
+  
+  public GsonBuilder allowGetterAndSetterMethods() {
+    excluder = excluder.allowGettersAndSetterMethods();
     return this;
   }
 

--- a/gson/src/main/java/com/google/gson/MethodAndFieldNamingPolicy.java
+++ b/gson/src/main/java/com/google/gson/MethodAndFieldNamingPolicy.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2008 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import com.google.gson.annotations.GsonGetter;
+import com.google.gson.annotations.GsonSetter;
+
+public enum MethodAndFieldNamingPolicy implements MethodAndFieldNamingStrategy {
+
+  
+  DEFAULT() {
+    public String translateName(Field f) {
+      return f.getName();
+    }
+
+    @Override
+    public String translateName(Method m) {
+      return cleanMethodName(m, /*lowerCaseFirstLetter*/true);
+    }
+  },
+  
+  IDENTITY() {
+    public String translateName(Field f) {
+      return f.getName();
+    }
+
+    @Override
+    public String translateName(Method m) {
+      return cleanMethodName(m, /*lowerCaseFirstLetter*/false);
+    }
+  },
+
+  UPPER_CAMEL_CASE() {
+    public String translateName(Field f) {
+      return upperCaseFirstLetter(f.getName());
+    }
+
+    @Override
+    public String translateName(Method m) {
+      String cleanedMethodName = cleanMethodName(m, /*lowerCaseFirstLetter*/false);
+      return upperCaseFirstLetter(cleanedMethodName);
+    }
+  },
+
+  UPPER_CAMEL_CASE_WITH_SPACES() {
+    public String translateName(Field f) {
+      return upperCaseFirstLetter(separateCamelCase(f.getName(), " "));
+    }
+
+    @Override
+    public String translateName(Method m) {
+      String cleanedMethodName = cleanMethodName(m, /*lowerCaseFirstLetter*/false);
+      return upperCaseFirstLetter(separateCamelCase(cleanedMethodName, " "));
+    }
+  },
+
+  LOWER_CASE_WITH_UNDERSCORES() {
+    public String translateName(Field f) {
+      return separateCamelCase(f.getName(), "_").toLowerCase();
+    }
+
+    @Override
+    public String translateName(Method m) {
+      String cleanedMethodName = cleanMethodName(m, /*lowerCaseFirstLetter*/true);
+      return separateCamelCase(cleanedMethodName, "_").toLowerCase();
+    }
+  },
+
+  LOWER_CASE_WITH_DASHES() {
+    public String translateName(Field f) {
+      return separateCamelCase(f.getName(), "-").toLowerCase();
+    }
+
+    @Override
+    public String translateName(Method m) {
+      String cleanedMethodName = cleanMethodName(m, /*lowerCaseFirstLetter*/true);
+      return separateCamelCase(cleanedMethodName, "-").toLowerCase();
+    }
+  };
+
+  private static String separateCamelCase(String name, String separator) {
+    StringBuilder translation = new StringBuilder();
+    for (int i = 0; i < name.length(); i++) {
+      char character = name.charAt(i);
+      if (Character.isUpperCase(character) && translation.length() != 0) {
+        translation.append(separator);
+      }
+      translation.append(character);
+    }
+    return translation.toString();
+  }
+
+  private static String upperCaseFirstLetter(String name) {
+    StringBuilder fieldNameBuilder = new StringBuilder();
+    int index = 0;
+    char firstCharacter = name.charAt(index);
+
+    while (index < name.length() - 1) {
+      if (Character.isLetter(firstCharacter)) {
+        break;
+      }
+
+      fieldNameBuilder.append(firstCharacter);
+      firstCharacter = name.charAt(++index);
+    }
+
+    if (index == name.length()) {
+      return fieldNameBuilder.toString();
+    }
+
+    if (!Character.isUpperCase(firstCharacter)) {
+      String modifiedTarget = modifyString(Character.toUpperCase(firstCharacter), name, ++index);
+      return fieldNameBuilder.append(modifiedTarget).toString();
+    } else {
+      return name;
+    }
+  }
+  
+  private static String lowerCaseFirstLetter(String name) {
+    StringBuilder fieldNameBuilder = new StringBuilder();
+    int index = 0;
+    char firstCharacter = name.charAt(index);
+
+    while (index < name.length() - 1) {
+      if (Character.isLetter(firstCharacter)) {
+        break;
+      }
+
+      fieldNameBuilder.append(firstCharacter);
+      firstCharacter = name.charAt(++index);
+    }
+
+    if (index == name.length()) {
+      return fieldNameBuilder.toString();
+    }
+
+    if (!Character.isLowerCase(firstCharacter)) {
+      String modifiedTarget = modifyString(Character.toLowerCase(firstCharacter), name, ++index);
+      return fieldNameBuilder.append(modifiedTarget).toString();
+    } else {
+      return name;
+    }
+  }
+
+  private static String modifyString(char firstCharacter, String srcString, int indexOfSubstring) {
+    return (indexOfSubstring < srcString.length())
+        ? firstCharacter + srcString.substring(indexOfSubstring)
+        : String.valueOf(firstCharacter);
+  }
+  
+  private static String cleanMethodName(Method method, boolean lowercaseFirstLetter) {
+   GsonGetter g = method.getAnnotation(GsonGetter.class); 
+   GsonSetter s = method.getAnnotation(GsonSetter.class);
+   String methodName = method.getName();
+   String methodPrefix = methodName.substring(0, 3);
+   String methodWithoutPrefix = method.getName().substring(3);
+   if (g != null && !methodPrefix.equals("get")) {
+     throwTranslatingMethodException(method, /*isGetter*/true); 
+   } else if (s != null && !methodPrefix.equals("set")) {
+     throwTranslatingMethodException(method, /*isGetter*/false); 
+   } else if (methodWithoutPrefix.length() == 0) {
+     throwTranslatingMethodException(method, g != null);
+   } else if (g == null && s == null){
+     throw new RuntimeException("Should never get here");
+   }
+   if (lowercaseFirstLetter) {
+     return lowerCaseFirstLetter(methodWithoutPrefix);
+   }
+   return methodWithoutPrefix;
+  }
+ 
+  private static IllegalArgumentException throwTranslatingMethodException(Method m, boolean isGetter) {
+     //TODO: getFoo/setFoo and getfoo/setfoo are too specific.  This error should point users to 
+     //documentation about valid naming for GsonGetters and GsonSetters.
+    String message = isGetter 
+      ? "Gson failed to translate your GsonGetter method name to a JSON property name. " +
+        "The MethodAndFieldNamingStrategy you're using assumes your GsonGetters are of the form " +
+        "getFoo() or getfoo() where Foo/foo is the name of your property.  Please rename " +
+        "your getter method, use a different MethodAndFieldNamingStrategy, " +
+        "or specify this GsonGetter's JSON property explicitly with @SerializedName."
+        
+      : "Gson failed to translate your GsonSetter method name to a JSON property name. " +
+        "The MethodAndFieldNamingStrategy you're using assumes your GsonSetters are of the form " +
+        "setFoo() or setfoo() where Foo/foo is the name of your property.  Please rename " +
+        "your setter method, use a different MethodAndFieldNamingStrategy, " +
+        "or specify this GsonSetter's JSON property explicitly with @SerializedName.";
+    String fullMessage = "Error parsing " + m.getName() + " on " + m.getDeclaringClass() + ": " + message;
+    throw new IllegalArgumentException(fullMessage);
+  }
+}

--- a/gson/src/main/java/com/google/gson/MethodAndFieldNamingStrategy.java
+++ b/gson/src/main/java/com/google/gson/MethodAndFieldNamingStrategy.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2008 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson;
+
+import java.lang.reflect.Method;
+
+public interface MethodAndFieldNamingStrategy extends FieldNamingStrategy {
+
+  public String translateName(Method m);
+
+}

--- a/gson/src/main/java/com/google/gson/annotations/GsonGetter.java
+++ b/gson/src/main/java/com/google/gson/annotations/GsonGetter.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2008 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface GsonGetter {
+  public boolean exposed() default true;
+}

--- a/gson/src/main/java/com/google/gson/annotations/GsonSetter.java
+++ b/gson/src/main/java/com/google/gson/annotations/GsonSetter.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2008 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface GsonSetter {
+  public boolean exposed() default true;
+}

--- a/gson/src/main/java/com/google/gson/internal/Excluder.java
+++ b/gson/src/main/java/com/google/gson/internal/Excluder.java
@@ -55,6 +55,7 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
   private int modifiers = Modifier.TRANSIENT | Modifier.STATIC;
   private boolean serializeInnerClasses = true;
   private boolean requireExpose;
+  private boolean allowGettersAndSetterMethods;
   private List<ExclusionStrategy> serializationStrategies = Collections.emptyList();
   private List<ExclusionStrategy> deserializationStrategies = Collections.emptyList();
 
@@ -106,6 +107,12 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
       result.deserializationStrategies.add(exclusionStrategy);
     }
     return result;
+  }
+  
+  public Excluder allowGettersAndSetterMethods() {
+	  Excluder result = clone();
+	  result.allowGettersAndSetterMethods = true;
+	  return result;
   }
 
   public <T> TypeAdapter<T> create(final Gson gson, final TypeToken<T> type) {
@@ -212,6 +219,10 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
     return false;
   }
 
+  public boolean doesAllowGettersAndSetters() {
+  	return this.allowGettersAndSetterMethods;
+  }
+  
   private boolean isAnonymousOrLocal(Class<?> clazz) {
     return !Enum.class.isAssignableFrom(clazz)
         && (clazz.isAnonymousClass() || clazz.isLocalClass());

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -19,8 +19,12 @@ package com.google.gson.internal.bind;
 import com.google.gson.FieldNamingStrategy;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
+import com.google.gson.MethodAndFieldNamingPolicy;
+import com.google.gson.MethodAndFieldNamingStrategy;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.GsonGetter;
+import com.google.gson.annotations.GsonSetter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.internal.$Gson$Types;
@@ -32,9 +36,14 @@ import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
+
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -46,19 +55,23 @@ import static com.google.gson.internal.bind.JsonAdapterAnnotationTypeAdapterFact
 public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
   private final ConstructorConstructor constructorConstructor;
   private final FieldNamingStrategy fieldNamingPolicy;
+  private final MethodAndFieldNamingStrategy methodAndFieldNamingPolicy;
   private final Excluder excluder;
 
   public ReflectiveTypeAdapterFactory(ConstructorConstructor constructorConstructor,
-      FieldNamingStrategy fieldNamingPolicy, Excluder excluder) {
+      FieldNamingStrategy namingPolicy, Excluder excluder) {
     this.constructorConstructor = constructorConstructor;
-    this.fieldNamingPolicy = fieldNamingPolicy;
+    this.methodAndFieldNamingPolicy = namingPolicy instanceof MethodAndFieldNamingPolicy
+        ? (MethodAndFieldNamingPolicy)namingPolicy
+        : null;
+    this.fieldNamingPolicy = namingPolicy;
     this.excluder = excluder;
   }
 
   public boolean excludeField(Field f, boolean serialize) {
     return excludeField(f, serialize, excluder);
   }
-
+  
   static boolean excludeField(Field f, boolean serialize, Excluder excluder) {
     return !excluder.excludeClass(f.getType(), serialize) && !excluder.excludeField(f, serialize);
   }
@@ -66,12 +79,32 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
   private String getFieldName(Field f) {
     return getFieldName(fieldNamingPolicy, f);
   }
+  
+  private String getMethodName(Method m) {
+    if (methodAndFieldNamingPolicy == null) {
+      throwParsingMethodException(m, 
+        "You are trying to translate a method (e.g. GsonGetter/GsonSetter) " +
+        "to a json property name with a FieldNamingStrategy.  To use " +
+        "GsonGetter/GsonSetter you must use a MethodAndFieldNamingStrategy.");
+    }
+    return getMethodName(methodAndFieldNamingPolicy, m);
+  }
 
   static String getFieldName(FieldNamingStrategy fieldNamingPolicy, Field f) {
     SerializedName serializedName = f.getAnnotation(SerializedName.class);
     return serializedName == null ? fieldNamingPolicy.translateName(f) : serializedName.value();
   }
+  
+  static String getMethodName(MethodAndFieldNamingStrategy methodAndFieldNamingPolicy, Method m) {
+    SerializedName serializedName = m.getAnnotation(SerializedName.class);
+    return serializedName == null ? methodAndFieldNamingPolicy.translateName(m) : serializedName.value();
+  }
 
+  static IllegalArgumentException throwParsingMethodException(Method m, String message) {
+    String fullMessage = "Error parsing " + m.getName() + " on " + m.getDeclaringClass() + ". " + message;
+    throw new IllegalArgumentException(fullMessage);
+  }
+  
   public <T> TypeAdapter<T> create(Gson gson, final TypeToken<T> type) {
     Class<? super T> raw = type.getRawType();
 
@@ -80,7 +113,12 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
     }
 
     ObjectConstructor<T> constructor = constructorConstructor.get(type);
-    return new Adapter<T>(constructor, getBoundFields(gson, type, raw));
+    Map<String, BoundField> boundFields = getBoundFields(gson, type, raw);
+    BoundMethods boundMethods = excluder.doesAllowGettersAndSetters() 
+      ? getBoundMethods(gson, type, raw)
+      : BoundMethods.EMPTY;
+    BoundProperties boundProperties = new BoundProperties(boundFields, boundMethods);
+    return new Adapter<T>(constructor, boundProperties);
   }
 
   private ReflectiveTypeAdapterFactory.BoundField createBoundField(
@@ -112,6 +150,53 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
       }
     };
   }
+  
+  private ReflectiveTypeAdapterFactory.BoundMethod createBoundMethod(
+     final Gson context, final Method method, final String name,
+     final TypeToken<?> propertyType, boolean serialize) {
+     // special casing primitives here saves ~5% on Android...
+     return new ReflectiveTypeAdapterFactory.BoundMethod(name, serialize) {
+       final TypeAdapter<?> typeAdapter = getMethodAdapter(context, method, propertyType);
+       
+       @SuppressWarnings({"unchecked", "rawtypes"}) // the type adapter and field type always agree
+       @Override 
+       void write(JsonWriter writer, Object value) throws IOException, IllegalAccessException {
+         Object returnValue = this.invokeGetter(value, method);
+         TypeAdapter t =
+           new TypeAdapterRuntimeTypeWrapper(context, this.typeAdapter, propertyType.getType());
+         t.write(writer, returnValue);
+       }
+       
+       @Override 
+       void read(JsonReader reader, Object value) throws IOException, IllegalAccessException {
+         Object inputValue = typeAdapter.read(reader);
+         this.invokeSetter(value, method, inputValue);
+       }
+        
+      private Object invokeGetter(Object self, Method method) {
+        Object returnValue;
+        try {
+          returnValue = method.invoke(self);
+        } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+          throw new RuntimeException(
+            "Error deserializing GsonGetter " + method.getName() + " on " + method.getDeclaringClass(), 
+            e);
+        }
+        return returnValue;
+      }
+        
+      private void invokeSetter(Object self, Method method, Object value) {
+        try {
+          method.invoke(self, value);
+        } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+          throw new RuntimeException(
+            "Error invoking GsonSetter " + method.getName() + " with value " + value + 
+            " on " + method.getDeclaringClass(), 
+            e);
+        }
+      }
+    };
+  }
 
   private TypeAdapter<?> getFieldAdapter(Gson gson, Field field, TypeToken<?> fieldType) {
     JsonAdapter annotation = field.getAnnotation(JsonAdapter.class);
@@ -122,6 +207,15 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
     return gson.getAdapter(fieldType);
   }
 
+  private TypeAdapter<?> getMethodAdapter(Gson gson, Method method, TypeToken<?> propertyType) {
+    JsonAdapter annotation = method.getAnnotation(JsonAdapter.class);
+    if (annotation != null) {
+      TypeAdapter<?> adapter = getTypeAdapter(constructorConstructor, gson, propertyType, annotation);
+      if (adapter != null) return adapter;
+    }
+    return gson.getAdapter(propertyType);
+  }
+  
   private Map<String, BoundField> getBoundFields(Gson context, TypeToken<?> type, Class<?> raw) {
     Map<String, BoundField> result = new LinkedHashMap<String, BoundField>();
     if (raw.isInterface()) {
@@ -152,6 +246,93 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
     }
     return result;
   }
+  
+  private BoundMethods getBoundMethods(Gson context, TypeToken<?> type, Class<?> raw) {
+    Map<String, BoundMethod> getters = new LinkedHashMap<String, BoundMethod>();
+    Map<String, BoundMethod> setters = new LinkedHashMap<String, BoundMethod>();
+    if (raw.isInterface()) {
+      return new BoundMethods(getters, setters);
+    }
+    Type declaredType = type.getType();
+    while (raw != Object.class) {
+      Method[] methods = raw.getDeclaredMethods();
+      for (Method method : methods) {
+        Boolean serialize = determineSerializationForMethod(method);
+        if (serialize == null) {
+          continue;
+        }
+        assertGetterSetterHasValidModifiers(method, serialize);
+        method.setAccessible(true);
+        Type[] parameterTypes = method.getGenericParameterTypes();
+        if (serialize) {
+          if (parameterTypes.length != 0) {
+            throwParsingMethodException(method, "GsonGetters must have zero parameters.");
+          }
+          Type propertyType = $Gson$Types.resolve(type.getType(), raw, method.getGenericReturnType());
+          if (propertyType.equals(Void.TYPE)) {
+            throwParsingMethodException(method, "GsonGetters must not return void.");
+          }
+          BoundMethod boundMethod = createBoundMethod(
+            context,
+            method,
+            getMethodName(method),
+            TypeToken.get(propertyType),
+            serialize);
+          BoundMethod previous = getters.put(boundMethod.name, boundMethod);
+          if (previous != null) {
+            throw new IllegalArgumentException(
+              declaredType + " declares multiple gson getters named " + previous.name);
+          }
+        } else {
+          if (parameterTypes.length != 1) {
+            throwParsingMethodException(method, "GsonSetters must have exactly one parameter.");
+          }
+          Type propertyType = $Gson$Types.resolve(type.getType(), raw, parameterTypes[0]);
+          BoundMethod boundMethod = createBoundMethod(
+            context,
+            method,
+            getMethodName(method),
+            TypeToken.get(propertyType),
+            serialize);
+          BoundMethod previous = setters.put(boundMethod.name, boundMethod);
+          if (previous != null) {
+            throw new IllegalArgumentException(
+              declaredType + " declares multiple gson setters named " + previous.name);
+          }
+        }
+      }
+      type = TypeToken.get($Gson$Types.resolve(type.getType(), raw, raw.getGenericSuperclass()));
+      raw = type.getRawType();
+    }
+    return new BoundMethods(getters, setters);
+  }
+  
+  private static void assertGetterSetterHasValidModifiers(Method getterSetter, boolean serialize) {
+    if ((getterSetter.getModifiers() & Modifier.STATIC) != 0) {
+      if (serialize) {
+        throwParsingMethodException(getterSetter, "GsonGetters cannot be static.");
+      }
+      if (!serialize) {
+        throwParsingMethodException(getterSetter, "GsonSetters cannot be static.");
+      }
+    }
+  }
+  
+  private static Boolean determineSerializationForMethod(Method method) {
+    Boolean retVal = null;
+    GsonGetter getterAnnotation = method.getAnnotation(GsonGetter.class);
+    GsonSetter setterAnnotation = method.getAnnotation(GsonSetter.class);
+    if (getterAnnotation != null && setterAnnotation != null) {
+      throwParsingMethodException(
+        method,
+        "Methods cannot be both a GsonGetter and a GsonSetter.");
+    } else if (getterAnnotation != null && getterAnnotation.exposed()) {
+      retVal = true;
+    } else if (setterAnnotation != null && setterAnnotation.exposed()) {
+      retVal = false;
+    }
+    return retVal;
+  }
 
   static abstract class BoundField {
     final String name;
@@ -167,14 +348,77 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
     abstract void write(JsonWriter writer, Object value) throws IOException, IllegalAccessException;
     abstract void read(JsonReader reader, Object value) throws IOException, IllegalAccessException;
   }
+  
+  static abstract class BoundMethod {
+    final String name;
+    final boolean serialized;
+    final boolean deserialized;
+
+    protected BoundMethod(String name, boolean serialized) {
+      this.name = name;
+      this.serialized = serialized;
+      this.deserialized = !serialized;
+    }
+    abstract void write(JsonWriter writer, Object value) throws IOException, IllegalAccessException;
+    abstract void read(JsonReader reader, Object value) throws IOException, IllegalAccessException;
+  }
+  
+  private static class BoundMethods {
+    private final Map<String, BoundMethod> getters;
+    private final Map<String, BoundMethod> setters;
+    
+    private BoundMethods(Map<String, BoundMethod> getters, Map<String, BoundMethod> setters) {
+      this.getters = getters;
+      this.setters = setters;
+    }
+    
+    private Collection<BoundMethod> getGetters() {
+      return this.getters.values();
+    }
+    
+    private BoundMethod getSetter(String name) {
+      return this.setters.get(name);
+    }
+    
+    private static final BoundMethods EMPTY = new BoundMethods(new LinkedHashMap<String, BoundMethod>(), new LinkedHashMap<String, BoundMethod>());
+  }
+  
+  private static class BoundProperties {
+    private final BoundMethods boundMethods;
+    private final Map<String, BoundField> boundFields;
+    
+    private BoundProperties(Map<String, BoundField> boundFields, BoundMethods boundMethods) {
+      this.boundFields = boundFields;
+      this.boundMethods = boundMethods;
+      for (String getter : this.boundMethods.getters.keySet()) {
+        this.boundFields.remove(getter);
+      }
+    }
+    
+    private BoundField getField(String name) {
+      return this.boundFields.get(name);
+    }
+    
+    private BoundMethod getSetter(String name) {
+      return this.boundMethods.getSetter(name);
+    }
+    
+    private Collection<BoundMethod> getGetters() {
+      return this.boundMethods.getGetters();
+    }
+    
+    private Collection<BoundField> getFields() {
+      return this.boundFields.values();
+    }
+  }
 
   public static final class Adapter<T> extends TypeAdapter<T> {
     private final ObjectConstructor<T> constructor;
-    private final Map<String, BoundField> boundFields;
+    private final BoundProperties boundProperties;
 
-    private Adapter(ObjectConstructor<T> constructor, Map<String, BoundField> boundFields) {
+    private Adapter(ObjectConstructor<T> constructor, BoundProperties boundProperties) {
       this.constructor = constructor;
-      this.boundFields = boundFields;
+      this.boundProperties = boundProperties;
     }
 
     @Override public T read(JsonReader in) throws IOException {
@@ -189,11 +433,14 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
         in.beginObject();
         while (in.hasNext()) {
           String name = in.nextName();
-          BoundField field = boundFields.get(name);
-          if (field == null || !field.deserialized) {
-            in.skipValue();
+          BoundField field = boundProperties.getField(name);
+          BoundMethod method = boundProperties.getSetter(name);
+          if (field != null && field.deserialized) {
+            field.read(in,  instance);
+          } else if (method != null && method.deserialized) {
+            method.read(in, instance);
           } else {
-            field.read(in, instance);
+            in.skipValue();
           }
         }
       } catch (IllegalStateException e) {
@@ -213,11 +460,15 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
 
       out.beginObject();
       try {
-        for (BoundField boundField : boundFields.values()) {
+        for (BoundField boundField : boundProperties.getFields()) {
           if (boundField.writeField(value)) {
             out.name(boundField.name);
             boundField.write(out, value);
           }
+        }
+        for (BoundMethod boundMethod : boundProperties.getGetters()) {
+          out.name(boundMethod.name);
+          boundMethod.write(out, value);
         }
       } catch (IllegalAccessException e) {
         throw new AssertionError();

--- a/gson/src/test/java/com/google/gson/functional/MethodNamingTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MethodNamingTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2008 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson.functional;
+
+import junit.framework.TestCase;
+
+public class MethodNamingTest extends TestCase {
+	//TODO Tests for method naming
+}

--- a/gson/src/test/java/com/google/gson/functional/MethodTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MethodTest.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright (C) 2008 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson.functional;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.GsonGetter;
+import com.google.gson.annotations.GsonSetter;
+
+import junit.framework.TestCase;
+
+public class MethodTest extends TestCase {
+  private static final String OBJ_JSON = "{\"foo\":\"bar\"}";
+  private static final String OBJ_FOO_NOT_SERIALIZED_JSON = "{\"mFoo\":\"bar\"}";
+  private static final String OBJ_EMPTY_JSON = "{}";
+
+  private Gson gson;
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    gson = new GsonBuilder().allowGetterAndSetterMethods().create();
+  }
+
+  public void testSimpleDeserialization() throws Exception {
+    Simple obj = gson.fromJson(OBJ_JSON, Simple.class);
+    assertEquals(obj.getFoo(), "bar");
+  }
+  
+  
+  public void testSimpleSerialization() throws Exception {
+    Simple obj = new Simple("bar");
+    String result = gson.toJson(obj);
+    assertEquals(OBJ_JSON, result);
+  }
+  
+  public void testImplDeserialization() {
+    Impl obj = gson.fromJson(OBJ_JSON, Impl.class);
+    assertEquals(obj.getFoo(), "bar");
+  }
+  
+  public void testImplSerialization() {
+    Impl obj = new Impl("bar");
+    String result = gson.toJson(obj);
+    assertEquals(OBJ_JSON, result);
+  }
+  
+  public void testImplWithExposedOverridesDeserialization() {
+    ImplWithExposedOverrides obj = gson.fromJson(OBJ_JSON, ImplWithExposedOverrides.class);
+    assertEquals(obj.getFoo(), "bar");
+  }
+  
+  public void testImplWithExposedOverridesSerialization() {
+    ImplWithExposedOverrides obj = new ImplWithExposedOverrides("bar");
+    String result = gson.toJson(obj);
+    assertEquals(OBJ_JSON, result);
+  }
+
+  public void testImplWithUnExposedOverridesDeserialization() {
+    ImplWithUnExposedOverrides obj = gson.fromJson(OBJ_JSON, ImplWithUnExposedOverrides.class);
+    assertNull(obj.getFoo());
+  }
+  
+  public void testImplWithUnExposedOverridesSerialization() {
+    ImplWithUnExposedOverrides obj = new ImplWithUnExposedOverrides("bar");
+    String result = gson.toJson(obj);
+    assertEquals(OBJ_FOO_NOT_SERIALIZED_JSON, result);
+  }
+ 
+  public void testPoorlyNamedGetter() {
+    PoorlyNamedGetter obj = new PoorlyNamedGetter();
+    try {
+      gson.toJson(obj);
+    } catch (IllegalArgumentException e) {
+      return;
+    }
+    fail();
+  }
+  
+  public void testPoorlyNamedSetter() {
+    PoorlyNamedSetter obj = new PoorlyNamedSetter();
+    try {
+      gson.toJson(obj);
+    } catch (IllegalArgumentException e) {
+      return;
+    }
+    fail();
+  }
+  
+  public void testGetterThatReturnsVoid() {
+    GetterThatReturnsVoid obj = new GetterThatReturnsVoid();
+    try {
+      gson.toJson(obj);
+    } catch (IllegalArgumentException e) {
+      return;
+    }
+    fail();
+  }
+  
+  public void testGetterWithParameters() {
+    GetterWithParameters obj = new GetterWithParameters();
+    try {
+      gson.toJson(obj);
+    } catch (IllegalArgumentException e) {
+      return;
+    }
+    fail();
+  }
+  
+  public void testSetterWithNotExactlyOneParameter() {
+    SetterWithNotExactlyOneParameter obj = new SetterWithNotExactlyOneParameter();
+    try {
+      gson.toJson(obj);
+    } catch (IllegalArgumentException e) {
+      return;
+    }
+    fail();
+  }
+  
+  public void testMethodWithGsonGetterAndGsonSetter() {
+    MethodWithGsonGetterAndGsonSetter obj = new MethodWithGsonGetterAndGsonSetter();
+    try {
+      gson.toJson(obj);
+    } catch (IllegalArgumentException e) {
+      return;
+    }
+    fail();
+
+  }
+  
+  public void testGetterThatThrowsAnException() {
+    GetterThatThrowsException  obj = new GetterThatThrowsException();
+    try {
+      gson.toJson(obj);
+    } catch (RuntimeException e) {
+      return;
+    }
+    fail();
+  }
+  
+  public void testSetterThatThrowsAnException() {
+    try {
+      gson.fromJson(OBJ_JSON, SetterThatThrowsException.class);
+    } catch (RuntimeException e) {
+      return;
+    }
+    fail();  
+  }
+  
+  public void testInheritedMethodsDeserialization() throws Exception {
+    InheritedMethods obj = gson.fromJson(OBJ_JSON, InheritedMethods.class);
+    assertEquals(obj.getFoo(), "bar");
+  }
+  
+  
+  public void testInheritedMethodsSerialization() throws Exception {
+    InheritedMethods obj = new InheritedMethods("bar");
+    String result = gson.toJson(obj);
+    assertEquals(OBJ_JSON, result);
+  }
+  
+  public void testSkipMethodsDeserialization() {
+    Gson gsonNoMethods = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
+    Simple obj = gsonNoMethods.fromJson(OBJ_JSON, Simple.class);
+    assertNull(obj.getFoo());
+  }
+  
+  
+  public void testSkipMethodsSerialization() {
+    Gson gsonNoMethods = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
+    Simple obj = new Simple("bar");
+    String result = gsonNoMethods.toJson(obj);
+    assertEquals(OBJ_EMPTY_JSON, result);
+  }
+  
+  public void testStaticGetter() {
+    try {
+      gson.fromJson(OBJ_JSON, StaticGetter.class);
+    } catch (IllegalArgumentException e) {
+      return;
+    }
+    fail();
+  }
+  
+  public void testStaticSetter() {
+    try {
+      gson.fromJson(OBJ_JSON, StaticSetter.class);
+    } catch (IllegalArgumentException e) {
+      return;
+    }
+    fail();
+
+  }
+  
+  static class Simple {
+    private String foo;
+    
+    private Simple(String value) {
+      this.foo = value;
+    }
+    
+    @GsonGetter
+    public String getFoo() {
+      return this.foo;
+    }
+    
+    @GsonSetter 
+    public void setFoo(String value) {
+      this.foo = value;
+    }
+  }
+  
+  public static interface IGetterSetter {
+    @GsonSetter
+    void setFoo(String value);
+    @GsonGetter
+    String getFoo();
+  }
+  
+  static class Impl implements IGetterSetter {
+    private String foo;
+    
+    private Impl(String value) {
+      this.foo = value;
+    }
+    
+    public String getFoo() {
+      return this.foo;
+    }
+    
+    public void setFoo(String value) {
+      this.foo = value;
+    }
+  }
+  
+  static class ImplWithExposedOverrides implements IGetterSetter {
+    private String foo;
+    
+    private ImplWithExposedOverrides(String value) {
+      this.foo = value;
+    }
+    
+    @GsonGetter
+    public String getFoo() {
+      return this.foo;
+    }
+    
+    @GsonSetter
+    public void setFoo(String value) {
+      this.foo = value;
+    }
+  }
+  
+  static class ImplWithUnExposedOverrides implements IGetterSetter {
+    private String mFoo;
+    
+    private ImplWithUnExposedOverrides(String value) {
+      this.mFoo = value;
+    }
+    
+    @GsonGetter(exposed=false)
+    public String getFoo() {
+      return this.mFoo;
+    }
+    
+    @GsonSetter(exposed=false)
+    public void setFoo(String value) {
+      this.mFoo = value;
+    }
+  }
+  
+  static class InheritedMethods extends Simple {
+
+    private InheritedMethods(String value) {
+      super(value);
+    }
+
+  }
+  
+  static class PoorlyNamedGetter {
+
+    @GsonGetter
+    public String gestFoo() {
+      return "bar";
+    }
+
+  }
+  
+  static class PoorlyNamedSetter {
+    
+    @GsonSetter
+    public void sestFoo(String value) { }
+
+  }
+  
+  static class GetterThatReturnsVoid {
+    
+    @GsonGetter
+    public void getFoo() { }
+    
+  }
+  
+  static class SetterWithNotExactlyOneParameter {
+    
+    @GsonSetter
+    public void setFoo(Object bar, Object baz) { }
+    
+  }
+  
+  static class GetterWithParameters {
+    
+    @GsonGetter
+    public String getFoo(Object bar) {
+      return "bar";
+    }
+    
+  }
+  
+  static class MethodWithGsonGetterAndGsonSetter {
+  
+    @GsonGetter
+    @GsonSetter
+    public String getFoo() { 
+      return "bar";
+    }
+    
+  }
+  
+  static class GetterThatThrowsException {
+
+    @GsonGetter
+    public String getFoo() {
+      throw new RuntimeException("bar");
+    }
+
+  }
+ 
+  static class SetterThatThrowsException {
+    
+    @GsonSetter
+    public void setFoo(String value) {
+      throw new RuntimeException("bar");
+    }
+
+  }
+  
+  static class StaticGetter {
+
+    @GsonGetter
+    public static String getFoo() {
+      return "bar";
+    }
+
+  }
+  
+  static class StaticSetter {
+    
+    @GsonSetter
+    public static void setFoo() { }
+    
+  }
+
+}


### PR DESCRIPTION
Hi Gson team,

My company ([Hurdlr](hurdlr.com)) uses gson extensively.  We really enjoy the library and appreciate all your work!

This pull request includes an attempt to implement support for getters and setters.  I realize you probably have deliberately chosen to not implement this feature.  However, the other day I stumbled across a problem where I really wanted to serialize a computed property.  So along the way I implemented support for getters and setters for my company.  (A full explanation of my use case is explained below.)

After implementing this feature for my own purposes, I figured creating a pull request couldn't hurt.  And after seeing [others with similar requests](http://stackoverflow.com/questions/6203487/why-does-gson-use-fields-and-not-getters-setters) I hope this pull request will make it into the codebase or inspire ideas for getter/setter support.

Before I invest more effort into this feature, I'm curious to hear initial thoughts and reactions.  If you want to proceed with this feature, I'd be interested to learn what I can do for a next step.

**Basic usage**
```
class Foo {
  private String bar;

  @GsonGetter
  public String getBar() {
    return this.bar;
  }

  @GsonSetter
  public String setBar(String value) {
    this.bar = value;
  }
}

//JSON
{ "bar": "baz" }  //using getter and setter, not the private field

Gson gson = new GsonBuilder().allowGetterAndSetterMethods().create();
```

*More examples can be found in MethodTest.java*

**API additions**
* @GsonGetter
* @GsonSetter
* GsonBuilder.allowGettersAndSetterMethods
* Excluder.allowGettersAndSetterMethods
* MethodAndFieldNamingStrategy (new interface)
* MethodAndFieldNamingPolicy (new enum)

**Expected common use cases**
* Computed properties via getters
* Lazily evaluated properties via getters
* Safer way to expose only public API
  * Often private fields can mistakenly be serialized because we often overlook them when thinking about our exposed API
* Data formatting via getters and/or setters
* Data validation via getters and/or setters
```
public void setFoo(String value) {
  if (value < 0) { throw new IllegalArgumentException(); }
  this.foo = value;
}
```

**Positives**
* Simple and readable annotations
* Fully backwards compatible
* Opt-in
  * allowGetterAndSetterMethods is necessary on GsonBuilder
  * @GsonGetter and @GsonSetter are required for gson to consider a method
* Intuitive default naming 
  * e.g. getBar => "bar", setBar => "bar"
* Handles collisions
  * e.g. getBar/setBar take precedence over bar

**Negatives**
* Extra annotations added...more bloated API
* Extra MethodAndFieldNamingStrategy interface and MethodAndFieldNamingPolicy policy make the API more bloated and confusing.

**Implementation / Testing gaps**
* No tests for naming
* No performance testing
* No Java support testing.  I'm pretty sure it works for Java 1.6+


**Context for the use case that prompted me to implement @GsonGetter and @GsonSetter:**

We factored out functionality in class ```Foo``` into a separate helper class.  But we wanted to preserve the JSON API in order to not break backwards compatibility.

There are a few way so solve this problem.  Three include
* Shadow fooHelper.bar in NewFoo
* Create a custom serializer/deserializer
* Use a GsonGetter for a computed property.  IMO this solution is the simplest and most elegant :)

```
class Foo {
  private String bar;
}
//JSON
{  "bar": "baz" }
```

```
class NewFoo {
   private FooHelper fooHelper;
}
//Current JSON
{  "fooHelper": { "bar": "baz" } }
//Desired JSON
{ "bar": "baz" }
```
*Solution 3: Computed getter*
```
class NewFoo {
  private FooHelper fooHelper;

  @ GsonGetter
  public getBar() {
    return this.fooHelper.bar;
  }
}
```