### PR TITLE
Convenience methods in JsonObject

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonArray.java
+++ b/gson/src/main/java/com/google/gson/JsonArray.java
@@ -325,6 +325,22 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
     throw new IllegalStateException();
   }
 
+  /**
+   * convenience method to get this array as a {@link Boolean} if it contains a single element.
+   *
+   * @return get this element as a {@link Boolean} if it is single element array.
+   * @throws ClassCastException if the element in the array is of not a {@link JsonPrimitive} and
+   * is not a valid {@link Boolean}.
+   * @throws IllegalStateException if the array has more than one element.
+   */
+  @Override
+  public Boolean getAsBooleanWrapper() {
+    if (elements.size() == 1) {
+      return elements.get(0).getAsBooleanWrapper();
+    }
+    throw new IllegalStateException();
+  }
+
   @Override
   public boolean equals(Object o) {
     return (o == this) || (o instanceof JsonArray && ((JsonArray) o).elements.equals(elements));

--- a/gson/src/main/java/com/google/gson/JsonObject.java
+++ b/gson/src/main/java/com/google/gson/JsonObject.java
@@ -18,6 +18,8 @@ package com.google.gson;
 
 import com.google.gson.internal.LinkedTreeMap;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Map;
 import java.util.Set;
 
@@ -153,13 +155,40 @@ public final class JsonObject extends JsonElement {
   }
 
   /**
+   * Returns the member with the specified name if it exists, otherwise the supplied default value
+   * is returned.
+   *
+   * @param memberName name of the member that is being requested.
+   * @param defaultValue the value to be returned if the member does not exist.
+   * @return the member matching the name. <code>defaultValue</code> if no such member exists.
+   */
+  public JsonElement get(String memberName, JsonElement defaultValue) {
+    JsonElement result = get(memberName);
+    return result != null ? result : defaultValue;
+  }
+
+  /**
    * Convenience method to get the specified member as a JsonPrimitive element.
    *
    * @param memberName name of the member being requested.
    * @return the JsonPrimitive corresponding to the specified member.
    */
   public JsonPrimitive getAsJsonPrimitive(String memberName) {
-    return (JsonPrimitive) members.get(memberName);
+    return (JsonPrimitive) get(memberName);
+  }
+
+  /**
+   * Convenience method to get the specified member as a JsonPrimitive element if it exists,
+   * otherwise the supplied default value is returned.
+   *
+   * @param memberName name of the member being requested.
+   * @param defaultValue the value to be returned if the member does not exist.
+   * @return the JsonPrimitive corresponding to the specified member. <code>defaultValue</code>
+   * if no such member exists.
+   */
+  public JsonPrimitive getAsJsonPrimitive(String memberName, JsonPrimitive defaultValue) {
+    JsonPrimitive result = getAsJsonPrimitive(memberName);
+    return result != null ? result : defaultValue;
   }
 
   /**
@@ -169,7 +198,21 @@ public final class JsonObject extends JsonElement {
    * @return the JsonArray corresponding to the specified member.
    */
   public JsonArray getAsJsonArray(String memberName) {
-    return (JsonArray) members.get(memberName);
+    return (JsonArray) get(memberName);
+  }
+
+  /**
+   * Convenience method to get the specified member as a JsonArray if it exists, otherwise the
+   * supplied default value is returned.
+   *
+   * @param memberName name of the member being requested.
+   * @param defaultValue the value to be returned if the member does not exist.
+   * @return the JsonArray corresponding to the specified member. <code>defaultValue</code> if no
+   * such member exists.
+   */
+  public JsonArray getAsJsonArray(String memberName, JsonArray defaultValue) {
+    JsonArray result = getAsJsonArray(memberName);
+    return result != null ? result : defaultValue;
   }
 
   /**
@@ -179,7 +222,541 @@ public final class JsonObject extends JsonElement {
    * @return the JsonObject corresponding to the specified member.
    */
   public JsonObject getAsJsonObject(String memberName) {
-    return (JsonObject) members.get(memberName);
+    return (JsonObject) get(memberName);
+  }
+
+  /**
+   * Convenience method to get the specified member as a JsonObject if it exists, otherwise the
+   * supplied default value is returned.
+   *
+   * @param memberName name of the member being requested.
+   * @param defaultValue the value to be returned if the member does not exist.
+   * @return the JsonObject corresponding to the specified member. <code>defaultValue</code> if no
+   * such member exists.
+   */
+  public JsonObject getAsJsonObject(String memberName, JsonObject defaultValue) {
+    JsonObject result = getAsJsonObject(memberName);
+    return result != null ? result : defaultValue;
+  }
+
+  /**
+   * Convenience method to get the specified member as a boolean value.
+   *
+   * @param memberName name of the member being requested.
+   * @return the boolean corresponding to the specified member.
+   * @throws ClassCastException if the member is not a {@link JsonPrimitive} and is not a valid
+   * boolean value.
+   * @throws IllegalStateException if the member is a {@link JsonArray} but contains
+   * more than a single element.
+   * @throws NullPointerException if the member does not exist.
+   */
+  public boolean getAsBoolean(String memberName) {
+    try {
+      return get(memberName).getAsBoolean();
+    } catch (UnsupportedOperationException e) {
+      throw new ClassCastException("Member is not a value type");
+    }
+  }
+
+  /**
+   * Convenience method to get the specified member as a boolean value if it exists, otherwise the
+   * supplied default value is returned.
+   *
+   * @param memberName name of the member being requested.
+   * @param defaultValue the value to be returned if the member does not exist.
+   * @return the boolean corresponding to the specified member. <code>defaultValue</code> if no
+   * such member exists.
+   * @throws ClassCastException if the member is not a {@link JsonPrimitive} and is not a valid
+   * boolean value.
+   * @throws IllegalStateException if the member is a {@link JsonArray} but contains
+   * more than a single element.
+   */
+  public boolean getAsBoolean(String memberName, boolean defaultValue) {
+    try {
+      return getAsBoolean(memberName);
+    } catch (NullPointerException e) {
+      return defaultValue;
+    }
+  }
+
+  /**
+   * Convenience method to get the specified member as a {@link Boolean} value.
+   *
+   * @param memberName name of the member being requested.
+   * @return the {@link Boolean} corresponding to the specified member.
+   * @throws ClassCastException if the member is not a {@link JsonPrimitive} and is not a valid
+   * {@link Boolean} value.
+   * @throws IllegalStateException if the member is a {@link JsonArray} but contains
+   * more than a single element.
+   * @throws NullPointerException if the member does not exist.
+   */
+  Boolean getAsBooleanWrapper(String memberName) {
+    try {
+      return get(memberName).getAsBooleanWrapper();
+    } catch (UnsupportedOperationException e) {
+      throw new ClassCastException("Member is not a value type");
+    }
+  }
+
+  /**
+   * Convenience method to get the specified member as a {@link Boolean} value if it exists,
+   * otherwise the supplied default value is returned.
+   *
+   * @param memberName name of the member being requested.
+   * @param defaultValue the value to be returned if the member does not exist.
+   * @return the {@link Boolean} corresponding to the specified member. <code>defaultValue</code>
+   * if no such member exists.
+   * @throws ClassCastException if the member is not a {@link JsonPrimitive} and is not a valid
+   * {@link Boolean} value.
+   * @throws IllegalStateException if the member is a {@link JsonArray} but contains
+   * more than a single element.
+   */
+  public Boolean getAsBooleanWrapper(String memberName, Boolean defaultValue) {
+    try {
+      return getAsBooleanWrapper(memberName);
+    } catch (NullPointerException e) {
+      return defaultValue;
+    }
+  }
+
+  /**
+   * Convenience method to get the specified member as a {@link Number}.
+   *
+   * @param memberName name of the member being requested.
+   * @return the {@link Number} corresponding to the specified member.
+   * @throws ClassCastException if the member is not a {@link JsonPrimitive} and is not a valid
+   * {@link Number} value.
+   * @throws IllegalStateException if the member is a {@link JsonArray} but contains
+   * more than a single element.
+   * @throws NullPointerException if the member does not exist.
+   */
+  public Number getAsNumber(String memberName) {
+    try {
+      return get(memberName).getAsNumber();
+    } catch (UnsupportedOperationException e) {
+      throw new ClassCastException("Member is not a value type");
+    }
+  }
+
+  /**
+   * Convenience method to get the specified member as a {@link Number} value if it exists,
+   * otherwise the supplied default value is returned.
+   *
+   * @param memberName name of the member being requested.
+   * @param defaultValue the value to be returned if the member does not exist.
+   * @return the {@link Number} corresponding to the specified member. <code>defaultValue</code>
+   * if no such member exists.
+   * @throws ClassCastException if the member is not a {@link JsonPrimitive} and is not a valid
+   * {@link Number} value.
+   * @throws IllegalStateException if the member is a {@link JsonArray} but contains
+   * more than a single element.
+   */
+  public Number getAsNumber(String memberName, Number defaultValue) {
+    try {
+      return getAsNumber(memberName);
+    } catch (NullPointerException e) {
+      return defaultValue;
+    }
+  }
+
+  /**
+   * Convenience method to get the specified member as a {@link String} value.
+   *
+   * @param memberName name of the member being requested.
+   * @return the {@link String} corresponding to the specified member.
+   * @throws ClassCastException if the member is not a {@link JsonPrimitive} and is not a valid
+   * {@link String} value.
+   * @throws IllegalStateException if the member is a {@link JsonArray} but contains
+   * more than a single element.
+   * @throws NullPointerException if the member does not exist.
+   */
+  public String getAsString(String memberName) {
+    try {
+      return get(memberName).getAsString();
+    } catch (UnsupportedOperationException e) {
+      throw new ClassCastException("Member is not a value type");
+    }
+  }
+
+  /**
+   * Convenience method to get the specified member as a {@link String} value if it exists,
+   * otherwise the supplied default value is returned.
+   *
+   * @param memberName name of the member being requested.
+   * @param defaultValue the value to be returned if the member does not exist.
+   * @return the {@link String} corresponding to the specified member. <code>defaultValue</code>
+   * if no such member exists.
+   * @throws ClassCastException if the member is not a {@link JsonPrimitive} and is not a valid
+   * {@link String} value.
+   * @throws IllegalStateException if the member is a {@link JsonArray} but contains
+   * more than a single element.
+   */
+  public String getAsString(String memberName, String defaultValue) {
+    try {
+      return getAsString(memberName);
+    } catch (NullPointerException e) {
+      return defaultValue;
+    }
+  }
+
+  /**
+   * Convenience method to get the specified member as a double value.
+   *
+   * @param memberName name of the member being requested.
+   * @return the double corresponding to the specified member.
+   * @throws ClassCastException if the member is not a {@link JsonPrimitive} and is not a valid
+   * double value.
+   * @throws IllegalStateException if the member is a {@link JsonArray} but contains
+   * more than a single element.
+   * @throws NullPointerException if the member does not exist.
+   */
+  public double getAsDouble(String memberName) {
+    try {
+      return get(memberName).getAsDouble();
+    } catch (UnsupportedOperationException e) {
+      throw new ClassCastException("Member is not a value type");
+    }
+  }
+
+  /**
+   * Convenience method to get the specified member as a double value if it exists, otherwise the
+   * supplied default value is returned.
+   *
+   * @param memberName name of the member being requested.
+   * @param defaultValue the value to be returned if the member does not exist.
+   * @return the double corresponding to the specified member. <code>defaultValue</code> if no
+   * such member exists.
+   * @throws ClassCastException if the member is not a {@link JsonPrimitive} and is not a valid
+   * double value.
+   * @throws IllegalStateException if the member is a {@link JsonArray} but contains
+   * more than a single element.
+   */
+  public double getAsDouble(String memberName, double defaultValue) {
+    try {
+      return getAsDouble(memberName);
+    } catch (NullPointerException e) {
+      return defaultValue;
+    }
+  }
+
+  /**
+   * Convenience method to get the specified member as a float value.
+   *
+   * @param memberName name of the member being requested.
+   * @return the float corresponding to the specified member.
+   * @throws ClassCastException if the member is not a {@link JsonPrimitive} and is not a valid
+   * float value.
+   * @throws IllegalStateException if the member is a {@link JsonArray} but contains
+   * more than a single element.
+   * @throws NullPointerException if the member does not exist.
+   */
+  public float getAsFloat(String memberName) {
+    try {
+      return get(memberName).getAsFloat();
+    } catch (UnsupportedOperationException e) {
+      throw new ClassCastException("Member is not a value type");
+    }
+  }
+
+  /**
+   * Convenience method to get the specified member as a float value if it exists, otherwise the
+   * supplied default value is returned.
+   *
+   * @param memberName name of the member being requested.
+   * @param defaultValue the value to be returned if the member does not exist.
+   * @return the float corresponding to the specified member. <code>defaultValue</code> if no
+   * such member exists.
+   * @throws ClassCastException if the member is not a {@link JsonPrimitive} and is not a valid
+   * float value.
+   * @throws IllegalStateException if the member is a {@link JsonArray} but contains
+   * more than a single element.
+   */
+  public float getAsFloat(String memberName, float defaultValue) {
+    try {
+      return getAsFloat(memberName);
+    } catch (NullPointerException e) {
+      return defaultValue;
+    }
+  }
+
+  /**
+   * Convenience method to get the specified member as a long value.
+   *
+   * @param memberName name of the member being requested.
+   * @return the long corresponding to the specified member.
+   * @throws ClassCastException if the member is not a {@link JsonPrimitive} and is not a valid
+   * long value.
+   * @throws IllegalStateException if the member is a {@link JsonArray} but contains
+   * more than a single element.
+   * @throws NullPointerException if the member does not exist.
+   */
+  public long getAsLong(String memberName) {
+    try {
+      return get(memberName).getAsLong();
+    } catch (UnsupportedOperationException e) {
+      throw new ClassCastException("Member is not a value type");
+    }
+  }
+
+  /**
+   * Convenience method to get the specified member as a long value if it exists, otherwise the
+   * supplied default value is returned.
+   *
+   * @param memberName name of the member being requested.
+   * @param defaultValue the value to be returned if the member does not exist.
+   * @return the long corresponding to the specified member. <code>defaultValue</code> if no
+   * such member exists.
+   * @throws ClassCastException if the member is not a {@link JsonPrimitive} and is not a valid
+   * long value.
+   * @throws IllegalStateException if the member is a {@link JsonArray} but contains
+   * more than a single element.
+   */
+  public long getAsLong(String memberName, long defaultValue) {
+    try {
+      return getAsLong(memberName);
+    } catch (NullPointerException e) {
+      return defaultValue;
+    }
+  }
+
+  /**
+   * Convenience method to get the specified member as a integer value.
+   *
+   * @param memberName name of the member being requested.
+   * @return the int corresponding to the specified member.
+   * @throws ClassCastException if the member is not a {@link JsonPrimitive} and is not a valid
+   * int value.
+   * @throws IllegalStateException if the member is a {@link JsonArray} but contains
+   * more than a single element.
+   * @throws NullPointerException if the member does not exist.
+   */
+  public int getAsInt(String memberName) {
+    try {
+      return get(memberName).getAsInt();
+    } catch (UnsupportedOperationException e) {
+      throw new ClassCastException("Member is not a value type");
+    }
+  }
+
+  /**
+   * Convenience method to get the specified member as a int value if it exists, otherwise the
+   * supplied default value is returned.
+   *
+   * @param memberName name of the member being requested.
+   * @param defaultValue the value to be returned if the member does not exist.
+   * @return the int corresponding to the specified member. <code>defaultValue</code> if no
+   * such member exists.
+   * @throws ClassCastException if the member is not a {@link JsonPrimitive} and is not a valid
+   * int value.
+   * @throws IllegalStateException if the member is a {@link JsonArray} but contains
+   * more than a single element.
+   */
+  public int getAsInt(String memberName, int defaultValue) {
+    try {
+      return getAsInt(memberName);
+    } catch (NullPointerException e) {
+      return defaultValue;
+    }
+  }
+
+  /**
+   * Convenience method to get the specified member as a short value.
+   *
+   * @param memberName name of the member being requested.
+   * @return the short corresponding to the specified member.
+   * @throws ClassCastException if the member is not a {@link JsonPrimitive} and is not a valid
+   * short value.
+   * @throws IllegalStateException if the member is a {@link JsonArray} but contains
+   * more than a single element.
+   * @throws NullPointerException if the member does not exist.
+   */
+  public short getAsShort(String memberName) {
+    try {
+      return get(memberName).getAsShort();
+    } catch (UnsupportedOperationException e) {
+      throw new ClassCastException("Member is not a value type");
+    }
+  }
+
+  /**
+   * Convenience method to get the specified member as a short value if it exists, otherwise the
+   * supplied default value is returned.
+   *
+   * @param memberName name of the member being requested.
+   * @param defaultValue the value to be returned if the member does not exist.
+   * @return the short corresponding to the specified member. <code>defaultValue</code> if no
+   * such member exists.
+   * @throws ClassCastException if the member is not a {@link JsonPrimitive} and is not a valid
+   * short value.
+   * @throws IllegalStateException if the member is a {@link JsonArray} but contains
+   * more than a single element.
+   */
+  public short getAsShort(String memberName, short defaultValue) {
+    try {
+      return getAsShort(memberName);
+    } catch (NullPointerException e) {
+      return defaultValue;
+    }
+  }
+
+  /**
+   * Convenience method to get the specified member as a byte value.
+   *
+   * @param memberName name of the member being requested.
+   * @return the byte corresponding to the specified member.
+   * @throws ClassCastException if the member is not a {@link JsonPrimitive} and is not a valid
+   * byte value.
+   * @throws IllegalStateException if the member is a {@link JsonArray} but contains
+   * more than a single element.
+   * @throws NullPointerException if the member does not exist.
+   */
+  public byte getAsByte(String memberName) {
+    try {
+      return get(memberName).getAsByte();
+    } catch (UnsupportedOperationException e) {
+      throw new ClassCastException("Member is not a value type");
+    }
+  }
+
+  /**
+   * Convenience method to get the specified member as a byte value if it exists, otherwise the
+   * supplied default value is returned.
+   *
+   * @param memberName name of the member being requested.
+   * @param defaultValue the value to be returned if the member does not exist.
+   * @return the byte corresponding to the specified member. <code>defaultValue</code> if no
+   * such member exists.
+   * @throws ClassCastException if the member is not a {@link JsonPrimitive} and is not a valid
+   * byte value.
+   * @throws IllegalStateException if the member is a {@link JsonArray} but contains
+   * more than a single element.
+   */
+  public byte getAsByte(String memberName, byte defaultValue) {
+    try {
+      return getAsByte(memberName);
+    } catch (NullPointerException e) {
+      return defaultValue;
+    }
+  }
+
+  /**
+   * Convenience method to get the specified member as a character value.
+   *
+   * @param memberName name of the member being requested.
+   * @return the char corresponding to the specified member.
+   * @throws ClassCastException if the member is not a {@link JsonPrimitive} and is not a valid
+   * char value.
+   * @throws IllegalStateException if the member is a {@link JsonArray} but contains
+   * more than a single element.
+   * @throws NullPointerException if the member does not exist.
+   */
+  public char getAsCharacter(String memberName) {
+    try {
+      return get(memberName).getAsCharacter();
+    } catch (UnsupportedOperationException e) {
+      throw new ClassCastException("Member is not a value type");
+    }
+  }
+
+  /**
+   * Convenience method to get the specified member as a char value if it exists, otherwise the
+   * supplied default value is returned.
+   *
+   * @param memberName name of the member being requested.
+   * @param defaultValue the value to be returned if the member does not exist.
+   * @return the char corresponding to the specified member. <code>defaultValue</code> if no
+   * such member exists.
+   * @throws ClassCastException if the member is not a {@link JsonPrimitive} and is not a valid
+   * char value.
+   * @throws IllegalStateException if the member is a {@link JsonArray} but contains
+   * more than a single element.
+   */
+  public char getAsCharacter(String memberName, char defaultValue) {
+    try {
+      return getAsCharacter(memberName);
+    } catch (NullPointerException e) {
+      return defaultValue;
+    }
+  }
+
+  /**
+   * Convenience method to get the specified member as a {@link BigDecimal}.
+   *
+   * @param memberName name of the member being requested.
+   * @return the {@link BigDecimal} corresponding to the specified member.
+   * @throws ClassCastException if the member is not a {@link JsonPrimitive} and is not a valid
+   * {@link BigDecimal} value.
+   * @throws IllegalStateException if the member is a {@link JsonArray} but contains
+   * more than a single element.
+   * @throws NullPointerException if the member does not exist.
+   */
+  public BigDecimal getAsBigDecimal(String memberName) {
+    try {
+      return get(memberName).getAsBigDecimal();
+    } catch (UnsupportedOperationException e) {
+      throw new ClassCastException("Member is not a value type");
+    }
+  }
+
+  /**
+   * Convenience method to get the specified member as a {@link BigDecimal} value if it exists,
+   * otherwise the supplied default value is returned.
+   *
+   * @param memberName name of the member being requested.
+   * @param defaultValue the value to be returned if the member does not exist.
+   * @return the {@link BigDecimal} corresponding to the specified member. <code>defaultValue</code>
+   * if no such member exists.
+   * @throws ClassCastException if the member is not a {@link JsonPrimitive} and is not a valid
+   * {@link BigDecimal} value.
+   * @throws IllegalStateException if the member is a {@link JsonArray} but contains
+   * more than a single element.
+   */
+  public BigDecimal getAsBigDecimal(String memberName, BigDecimal defaultValue) {
+    try {
+      return getAsBigDecimal(memberName);
+    } catch (NullPointerException e) {
+      return defaultValue;
+    }
+  }
+
+  /**
+   * Convenience method to get the specified member as a {@link BigInteger}.
+   *
+   * @param memberName name of the member being requested.
+   * @return the {@link BigInteger} corresponding to the specified member.
+   * @throws ClassCastException if the member is not a {@link JsonPrimitive} and is not a valid
+   * {@link BigInteger} value.
+   * @throws IllegalStateException if the member is a {@link JsonArray} but contains
+   * more than a single element.
+   * @throws NullPointerException if the member does not exist.
+   */
+  public BigInteger getAsBigInteger(String memberName) {
+    try {
+      return get(memberName).getAsBigInteger();
+    } catch (UnsupportedOperationException e) {
+      throw new ClassCastException("Member is not a value type");
+    }
+  }
+
+  /**
+   * Convenience method to get the specified member as a {@link BigInteger} value if it exists,
+   * otherwise the supplied default value is returned.
+   *
+   * @param memberName name of the member being requested.
+   * @param defaultValue the value to be returned if the member does not exist.
+   * @return the {@link BigInteger} corresponding to the specified member. <code>defaultValue</code>
+   * if no such member exists.
+   * @throws ClassCastException if the member is not a {@link JsonPrimitive} and is not a valid
+   * {@link BigInteger} value.
+   * @throws IllegalStateException if the member is a {@link JsonArray} but contains
+   * more than a single element.
+   */
+  public BigInteger getAsBigInteger(String memberName, BigInteger defaultValue) {
+    try {
+      return getAsBigInteger(memberName);
+    } catch (NullPointerException e) {
+      return defaultValue;
+    }
   }
 
   @Override

--- a/gson/src/test/java/com/google/gson/JsonObjectTest.java
+++ b/gson/src/test/java/com/google/gson/JsonObjectTest.java
@@ -20,6 +20,9 @@ import com.google.gson.common.MoreAsserts;
 
 import junit.framework.TestCase;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
 /**
  * Unit test for the {@link JsonObject} class.
  *
@@ -156,6 +159,381 @@ public class JsonObjectTest extends TestCase {
     b.add("bar", JsonNull.INSTANCE);
     assertFalse(a.equals(b));
     assertFalse(b.equals(a));
+  }
+
+  public void testConvenienceMethods() {
+    JsonObject jsonObject = new JsonObject();
+
+    // primitive
+    JsonPrimitive jsonPrimitive = new JsonPrimitive(42);
+    JsonPrimitive jsonPrimitiveTwo = new JsonPrimitive(43);
+    jsonObject.add("primitive", jsonPrimitive);
+    assertEquals(jsonPrimitive, jsonObject.getAsJsonPrimitive("primitive", jsonPrimitive));
+    assertEquals(jsonPrimitive, jsonObject.getAsJsonPrimitive("primitive", jsonPrimitiveTwo));
+    assertEquals(jsonPrimitive, jsonObject.getAsJsonPrimitive("nonexisting", jsonPrimitive));
+    assertNotSame(jsonPrimitive, jsonObject.getAsJsonPrimitive("nonexisting", jsonPrimitiveTwo));
+
+    // array
+    JsonArray jsonArray = new JsonArray();
+    jsonObject.add("empty_array", jsonArray);
+    JsonArray jsonArrayTwo = new JsonArray();
+    jsonArrayTwo.add(jsonPrimitive);
+    jsonArrayTwo.add(jsonPrimitiveTwo);
+    jsonObject.add("array_with_two_elements", jsonArrayTwo);
+    assertEquals(jsonArray, jsonObject.getAsJsonArray("empty_array", jsonArray));
+    assertEquals(jsonArray, jsonObject.getAsJsonArray("empty_array", jsonArrayTwo));
+    assertEquals(jsonArray, jsonObject.getAsJsonArray("nonexisting", jsonArray));
+    assertNotSame(jsonArray, jsonObject.getAsJsonArray("nonexisting", jsonArrayTwo));
+
+    // object
+    JsonObject jsonObjectTwo = new JsonObject();
+    JsonObject jsonObjectThree = new JsonObject();
+    jsonObject.add("empty_object", jsonObjectTwo);
+    assertEquals(jsonObjectTwo, jsonObject.getAsJsonObject("empty_object", jsonObjectTwo));
+    assertEquals(jsonObjectTwo, jsonObject.getAsJsonObject("empty_object", jsonObjectThree));
+    assertEquals(jsonObjectTwo, jsonObject.getAsJsonObject("nonexisting", jsonObjectTwo));
+    assertNotSame(jsonObjectTwo, jsonObject.getAsJsonObject("nonexisting", jsonObjectThree));
+
+    // get with default
+    assertEquals(jsonPrimitive, jsonObject.get("primitive", jsonPrimitiveTwo));
+    assertEquals(jsonPrimitive, jsonObject.get("nonexisting", jsonPrimitive));
+    assertNotSame(jsonPrimitive, jsonObject.get("nonexisting", jsonPrimitiveTwo));
+
+    // boolean, Boolean
+    jsonObject.addProperty("true_boolean", true);
+    jsonObject.addProperty("false_boolean", false);
+    JsonArray arrayWithOneBoolean = new JsonArray();
+    arrayWithOneBoolean.add(new JsonPrimitive(true));
+    jsonObject.add("array_with_one_boolean", arrayWithOneBoolean);
+    assertTrue(jsonObject.getAsBoolean("true_boolean", true));
+    assertTrue(jsonObject.getAsBoolean("true_boolean", false));
+    assertFalse(jsonObject.getAsBoolean("false_boolean", true));
+    assertFalse(jsonObject.getAsBoolean("false_boolean", false));
+    assertTrue(jsonObject.getAsBoolean("nonexisting", true));
+    assertFalse(jsonObject.getAsBoolean("nonexisting", false));
+    try {
+      jsonObject.getAsBoolean("empty_object", true);
+      fail("Expected ClassCastException when attempting to parse JsonObject as a boolean");
+    } catch (ClassCastException e) {
+      // expected
+    }
+    try {
+      jsonObject.getAsBoolean("empty_array", true);
+      fail("Expected IllegalStateException when attempting to parse empty JsonArray as a boolean");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+    assertTrue(jsonObject.getAsBoolean("array_with_one_boolean", false));
+    try {
+      jsonObject.getAsBoolean("array_with_two_elements", true);
+      fail("Expected IllegalStateException when attempting to parse JsonArray with two elements as a boolean");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+    jsonObject.addProperty("true_boolean_wrapper", Boolean.TRUE);
+    jsonObject.addProperty("false_boolean_wrapper", Boolean.FALSE);
+    assertTrue(jsonObject.getAsBooleanWrapper("true_boolean_wrapper", Boolean.TRUE));
+    assertTrue(jsonObject.getAsBooleanWrapper("true_boolean_wrapper", Boolean.FALSE));
+    assertFalse(jsonObject.getAsBooleanWrapper("false_boolean_wrapper", Boolean.TRUE));
+    assertFalse(jsonObject.getAsBooleanWrapper("false_boolean_wrapper", Boolean.FALSE));
+    assertTrue(jsonObject.getAsBooleanWrapper("nonexisting", Boolean.TRUE));
+    assertFalse(jsonObject.getAsBooleanWrapper("nonexisting", Boolean.FALSE));
+    try {
+      jsonObject.getAsBooleanWrapper("empty_object", Boolean.TRUE);
+      fail("Expected exception when attempting to parse JsonObject as a Boolean");
+    } catch (ClassCastException e) {
+      // expected
+    }
+    try {
+      jsonObject.getAsBooleanWrapper("empty_array", Boolean.TRUE);
+      fail("Expected exception when attempting to parse empty JsonArray as a Boolean");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+    assertTrue(jsonObject.getAsBooleanWrapper("array_with_one_boolean", Boolean.FALSE));
+    try {
+      jsonObject.getAsBooleanWrapper("array_with_two_elements", Boolean.TRUE);
+      fail("Expected IllegalStateException when attempting to parse JsonArray with two elements as a Boolean");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+
+    // character
+    jsonObject.addProperty("character", 'c');
+    JsonArray arrayWithOneChar = new JsonArray();
+    arrayWithOneChar.add(new JsonPrimitive('c'));
+    jsonObject.add("array_with_one_char", arrayWithOneChar);
+    assertEquals('c', jsonObject.getAsCharacter("character", 'c'));
+    assertEquals('c', jsonObject.getAsCharacter("character", 'd'));
+    assertEquals('c', jsonObject.getAsCharacter("nonexisting", 'c'));
+    assertNotSame('c', jsonObject.getAsCharacter("nonexisting", 'd'));
+    try {
+      jsonObject.getAsCharacter("empty_object", 'c');
+      fail("Expected exception when attempting to parse JsonObject as a char");
+    } catch (ClassCastException e) {
+      // expected
+    }
+    try {
+      jsonObject.getAsCharacter("empty_array", 'c');
+      fail("Expected exception when attempting to parse empty JsonArray as a char");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+    assertEquals('c', jsonObject.getAsCharacter("array_with_one_char", 'd'));
+    try {
+      jsonObject.getAsCharacter("array_with_two_elements", 'c');
+      fail("Expected IllegalStateException when attempting to parse JsonArray with two elements as a char");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+
+    // long, int, short, byte, Number, BigInteger
+    jsonObject.addProperty("integer", 42);
+    JsonArray arrayWithOneNumber = new JsonArray();
+    arrayWithOneNumber.add(new JsonPrimitive(42));
+    jsonObject.add("array_with_one_number", arrayWithOneNumber);
+    assertEquals((long) 42, jsonObject.getAsLong("integer", (long) 42));
+    assertEquals((long) 42, jsonObject.getAsLong("integer", (long) 43));
+    assertEquals((long) 42, jsonObject.getAsLong("nonexisting", (long) 42));
+    assertNotSame((long) 42, jsonObject.getAsLong("nonexisting", (long) 43));
+    try {
+      jsonObject.getAsLong("empty_object", (long) 42);
+      fail("Expected exception when attempting to parse JsonObject as a long");
+    } catch (ClassCastException e) {
+      // expected
+    }
+    try {
+      jsonObject.getAsLong("empty_array", (long) 42);
+      fail("Expected exception when attempting to parse empty JsonArray as a long");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+    assertEquals((long) 42, jsonObject.getAsLong("array_with_one_number", (long) 43));
+    try {
+      jsonObject.getAsLong("array_with_two_elements", (long) 42);
+      fail("Expected IllegalStateException when attempting to parse JsonArray with two elements as a long");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+    assertEquals(42, jsonObject.getAsInt("integer", 42));
+    assertEquals(42, jsonObject.getAsInt("integer", 43));
+    assertEquals(42, jsonObject.getAsInt("nonexisting", 42));
+    assertNotSame(42, jsonObject.getAsInt("nonexisting", 43));
+    try {
+      jsonObject.getAsInt("empty_object", 42);
+      fail("Expected exception when attempting to parse JsonObject as an integer");
+    } catch (ClassCastException e) {
+      // expected
+    }
+    try {
+      jsonObject.getAsInt("empty_array", 42);
+      fail("Expected exception when attempting to parse empty JsonArray as an integer");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+    assertEquals(42, jsonObject.getAsInt("array_with_one_number", 43));
+    try {
+      jsonObject.getAsInt("array_with_two_elements", 42);
+      fail("Expected IllegalStateException when attempting to parse JsonArray with two elements as an integer");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+    assertEquals((short) 42, jsonObject.getAsShort("integer", (short) 42));
+    assertEquals((short) 42, jsonObject.getAsShort("integer", (short) 43));
+    assertEquals((short) 42, jsonObject.getAsShort("nonexisting", (short) 42));
+    assertNotSame((short) 42, jsonObject.getAsShort("nonexisting", (short) 43));
+    try {
+      jsonObject.getAsShort("empty_object", (short) 42);
+      fail("Expected exception when attempting to parse JsonObject as a short");
+    } catch (ClassCastException e) {
+      // expected
+    }
+    try {
+      jsonObject.getAsShort("empty_array", (short) 42);
+      fail("Expected exception when attempting to parse empty JsonArray as a short");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+    assertEquals((short) 42, jsonObject.getAsShort("array_with_one_number", (short) 43));
+    try {
+      jsonObject.getAsShort("array_with_two_elements", (short) 42);
+      fail("Expected IllegalStateException when attempting to parse JsonArray with two elements as a short");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+    assertEquals((byte) 42, jsonObject.getAsByte("integer", (byte) 42));
+    assertEquals((byte) 42, jsonObject.getAsByte("integer", (byte) 43));
+    assertEquals((byte) 42, jsonObject.getAsByte("nonexisting", (byte) 42));
+    assertNotSame((byte) 42, jsonObject.getAsByte("nonexisting", (byte) 43));
+    try {
+      jsonObject.getAsByte("empty_object", (byte) 42);
+      fail("Expected exception when attempting to parse JsonObject as a byte");
+    } catch (ClassCastException e) {
+      // expected
+    }
+    try {
+      jsonObject.getAsByte("empty_array", (byte) 42);
+      fail("Expected exception when attempting to parse empty JsonArray as a byte");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+    assertEquals((byte) 42, jsonObject.getAsByte("array_with_one_number", (byte) 43));
+    try {
+      jsonObject.getAsByte("array_with_two_elements", (byte) 42);
+      fail("Expected IllegalStateException when attempting to parse JsonArray with two elements as a byte");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+    assertEquals((Number) 42, jsonObject.getAsNumber("integer", 42));
+    assertEquals((Number) 42, jsonObject.getAsNumber("integer", 43));
+    assertEquals((Number) 42, jsonObject.getAsNumber("nonexisting", 42));
+    assertNotSame((Number) 42, jsonObject.getAsNumber("nonexisting", 43));
+    try {
+      jsonObject.getAsNumber("empty_object", 42);
+      fail("Expected exception when attempting to parse JsonObject as a Number");
+    } catch (ClassCastException e) {
+      // expected
+    }
+    try {
+      jsonObject.getAsNumber("empty_array", 42);
+      fail("Expected exception when attempting to parse empty JsonArray as a Number");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+    assertEquals((Number) 42, jsonObject.getAsNumber("array_with_one_number", 43));
+    try {
+      jsonObject.getAsNumber("array_with_two_elements", 42);
+      fail("Expected IllegalStateException when attempting to parse JsonArray with two elements as a Number");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+    assertEquals(BigInteger.valueOf(42), jsonObject.getAsBigInteger("integer", BigInteger.valueOf(42)));
+    assertEquals(BigInteger.valueOf(42), jsonObject.getAsBigInteger("integer", BigInteger.valueOf(43)));
+    assertEquals(BigInteger.valueOf(42), jsonObject.getAsBigInteger("nonexisting", BigInteger.valueOf(42)));
+    assertNotSame(BigInteger.valueOf(42), jsonObject.getAsBigInteger("nonexisting", BigInteger.valueOf(43)));
+    try {
+      jsonObject.getAsBigInteger("empty_object", BigInteger.valueOf(42));
+      fail("Expected exception when attempting to parse JsonObject as a BigInteger");
+    } catch (ClassCastException e) {
+      // expected
+    }
+    try {
+      jsonObject.getAsBigInteger("empty_array", BigInteger.valueOf(42));
+      fail("Expected exception when attempting to parse empty JsonArray as a BigInteger");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+    assertEquals(BigInteger.valueOf(42), jsonObject.getAsBigInteger("array_with_one_number", BigInteger.valueOf(43)));
+    try {
+      jsonObject.getAsBigInteger("array_with_two_elements", BigInteger.valueOf(42));
+      fail("Expected IllegalStateException when attempting to parse JsonArray with two elements as a BigInteger");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+
+    // double, float, BigDecimal
+    jsonObject.addProperty("real", 3.1415);
+    JsonArray arrayWithOneReal = new JsonArray();
+    arrayWithOneReal.add(new JsonPrimitive(3.1415));
+    jsonObject.add("array_with_one_real", arrayWithOneReal);
+    assertEquals(3.1415, jsonObject.getAsDouble("real", 3.1415));
+    assertEquals(3.1415, jsonObject.getAsDouble("real", 2.7183));
+    assertEquals(3.1415, jsonObject.getAsDouble("nonexisting", 3.1415));
+    assertNotSame(3.1415, jsonObject.getAsDouble("nonexisting", 2.7183));
+    try {
+      jsonObject.getAsDouble("empty_object", 3.1415);
+      fail("Expected exception when attempting to parse JsonObject as a double");
+    } catch (ClassCastException e) {
+      // expected
+    }
+    try {
+      jsonObject.getAsDouble("empty_array", 3.1415);
+      fail("Expected exception when attempting to parse empty JsonArray as a double");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+    assertEquals(3.1415, jsonObject.getAsDouble("array_with_one_real", 2.7183));
+    try {
+      jsonObject.getAsDouble("array_with_two_elements", 3.1415);
+      fail("Expected IllegalStateException when attempting to parse JsonArray with two elements as a double");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+    assertEquals((float) 3.1415, jsonObject.getAsFloat("real", (float) 3.1415));
+    assertEquals((float) 3.1415, jsonObject.getAsFloat("real", (float) 2.7183));
+    assertEquals((float) 3.1415, jsonObject.getAsFloat("nonexisting", (float) 3.1415));
+    assertNotSame((float) 3.1415, jsonObject.getAsFloat("nonexisting", (float) 2.7183));
+    try {
+      jsonObject.getAsFloat("empty_object", (float) 3.1415);
+      fail("Expected exception when attempting to parse JsonObject as a float");
+    } catch (ClassCastException e) {
+      // expected
+    }
+    try {
+      jsonObject.getAsFloat("empty_array", (float) 3.1415);
+      fail("Expected exception when attempting to parse empty JsonArray as a float");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+    assertEquals((float) 3.1415, jsonObject.getAsFloat("array_with_one_real", (float) 2.7183));
+    try {
+      jsonObject.getAsFloat("array_with_two_elements", (float) 3.1415);
+      fail("Expected IllegalStateException when attempting to parse JsonArray with two elements as a float");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+    assertEquals(BigDecimal.valueOf(3.1415), jsonObject.getAsBigDecimal("real", BigDecimal.valueOf(3.1415)));
+    assertEquals(BigDecimal.valueOf(3.1415), jsonObject.getAsBigDecimal("real", BigDecimal.valueOf(2.7183)));
+    assertEquals(BigDecimal.valueOf(3.1415), jsonObject.getAsBigDecimal("nonexisting", BigDecimal.valueOf(3.1415)));
+    assertNotSame(BigDecimal.valueOf(3.1415), jsonObject.getAsBigDecimal("nonexisting", BigDecimal.valueOf(2.7183)));
+    try {
+      jsonObject.getAsBigDecimal("empty_object", BigDecimal.valueOf(3.1415));
+      fail("Expected exception when attempting to parse JsonObject as a BigDecimal");
+    } catch (ClassCastException e) {
+      // expected
+    }
+    try {
+      jsonObject.getAsBigDecimal("empty_array", BigDecimal.valueOf(3.1415));
+      fail("Expected exception when attempting to parse empty JsonArray as a BigDecimal");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+    assertEquals(BigDecimal.valueOf(3.1415), jsonObject.getAsBigDecimal("array_with_one_real", BigDecimal.valueOf(2.7183)));
+    try {
+      jsonObject.getAsBigDecimal("array_with_two_elements", BigDecimal.valueOf(3.1415));
+      fail("Expected IllegalStateException when attempting to parse JsonArray with two elements as a BigDecimal");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+
+    // string
+    jsonObject.addProperty("string", "gson");
+    JsonArray arrayWithOneString = new JsonArray();
+    arrayWithOneString.add(new JsonPrimitive("gson"));
+    jsonObject.add("array_with_one_string", arrayWithOneString);
+    assertEquals("gson", jsonObject.getAsString("string", "gson"));
+    assertEquals("gson", jsonObject.getAsString("string", "nosg"));
+    assertEquals("gson", jsonObject.getAsString("nonexisting", "gson"));
+    assertNotSame("gson", jsonObject.getAsString("nonexisting", "nosg"));
+    try {
+      jsonObject.getAsString("empty_object", "gson");
+      fail("Expected exception when attempting to parse JsonObject as a String");
+    } catch (ClassCastException e) {
+      // expected
+    }
+    try {
+      jsonObject.getAsString("empty_array", "gson");
+      fail("Expected exception when attempting to parse empty JsonArray as a String");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+    assertEquals("gson", jsonObject.getAsString("array_with_one_string", "nosg"));
+    try {
+      jsonObject.getAsString("array_with_two_elements", "gson");
+      fail("Expected IllegalStateException when attempting to parse JsonArray with two elements as a String");
+    } catch (IllegalStateException e) {
+      // expected
+    }
   }
 
   public void testDeepCopy() {


### PR DESCRIPTION
I've added several convenience methods to JsonObject. I find that whenever I use Gson for directly parsing JSON I end up creating similar convenience methods in my own project.
See second commit message for a simple example of the change.