### PR TITLE
Fix issues if runing in an environment with a Turkish locale

### DIFF
--- a/gson/src/main/java/com/google/gson/FieldNamingPolicy.java
+++ b/gson/src/main/java/com/google/gson/FieldNamingPolicy.java
@@ -17,6 +17,7 @@
 package com.google.gson;
 
 import java.lang.reflect.Field;
+import java.util.Locale;
 
 /**
  * An enumeration that defines a few standard naming conventions for JSON field names.
@@ -88,7 +89,7 @@ public enum FieldNamingPolicy implements FieldNamingStrategy {
    */
   LOWER_CASE_WITH_UNDERSCORES() {
     public String translateName(Field f) {
-      return separateCamelCase(f.getName(), "_").toLowerCase();
+      return separateCamelCase(f.getName(), "_").toLowerCase(Locale.ENGLISH);
     }
   },
 
@@ -111,7 +112,7 @@ public enum FieldNamingPolicy implements FieldNamingStrategy {
    */
   LOWER_CASE_WITH_DASHES() {
     public String translateName(Field f) {
-      return separateCamelCase(f.getName(), "-").toLowerCase();
+      return separateCamelCase(f.getName(), "-").toLowerCase(Locale.ENGLISH);
     }
   };
 

--- a/gson/src/test/java/com/google/gson/functional/FieldNamingTest.java
+++ b/gson/src/test/java/com/google/gson/functional/FieldNamingTest.java
@@ -21,6 +21,8 @@ import static com.google.gson.FieldNamingPolicy.LOWER_CASE_WITH_DASHES;
 import static com.google.gson.FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES;
 import static com.google.gson.FieldNamingPolicy.UPPER_CAMEL_CASE;
 import static com.google.gson.FieldNamingPolicy.UPPER_CAMEL_CASE_WITH_SPACES;
+
+import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.SerializedName;
@@ -28,43 +30,49 @@ import junit.framework.TestCase;
 
 public final class FieldNamingTest extends TestCase {
   public void testIdentity() {
-    Gson gson = new GsonBuilder().setFieldNamingPolicy(IDENTITY).create();
+    Gson gson = getGsonWithNamingPolicy(IDENTITY);
     assertEquals("{'lowerCamel':1,'UpperCamel':2,'_lowerCamelLeadingUnderscore':3," +
         "'_UpperCamelLeadingUnderscore':4,'lower_words':5,'UPPER_WORDS':6," +
-        "'annotatedName':7}",
+        "'annotatedName':7,'lowerId':8}",
         gson.toJson(new TestNames()).replace('\"', '\''));
   }
 
   public void testUpperCamelCase() {
-    Gson gson = new GsonBuilder().setFieldNamingPolicy(UPPER_CAMEL_CASE).create();
+    Gson gson = getGsonWithNamingPolicy(UPPER_CAMEL_CASE);
     assertEquals("{'LowerCamel':1,'UpperCamel':2,'_LowerCamelLeadingUnderscore':3," +
         "'_UpperCamelLeadingUnderscore':4,'Lower_words':5,'UPPER_WORDS':6," +
-        "'annotatedName':7}",
+        "'annotatedName':7,'LowerId':8}",
         gson.toJson(new TestNames()).replace('\"', '\''));
   }
 
   public void testUpperCamelCaseWithSpaces() {
-    Gson gson = new GsonBuilder().setFieldNamingPolicy(UPPER_CAMEL_CASE_WITH_SPACES).create();
+    Gson gson = getGsonWithNamingPolicy(UPPER_CAMEL_CASE_WITH_SPACES);
     assertEquals("{'Lower Camel':1,'Upper Camel':2,'_Lower Camel Leading Underscore':3," +
         "'_ Upper Camel Leading Underscore':4,'Lower_words':5,'U P P E R_ W O R D S':6," +
-        "'annotatedName':7}",
+        "'annotatedName':7,'Lower Id':8}",
         gson.toJson(new TestNames()).replace('\"', '\''));
   }
 
   public void testLowerCaseWithUnderscores() {
-    Gson gson = new GsonBuilder().setFieldNamingPolicy(LOWER_CASE_WITH_UNDERSCORES).create();
+    Gson gson = getGsonWithNamingPolicy(LOWER_CASE_WITH_UNDERSCORES);
     assertEquals("{'lower_camel':1,'upper_camel':2,'_lower_camel_leading_underscore':3," +
         "'__upper_camel_leading_underscore':4,'lower_words':5,'u_p_p_e_r__w_o_r_d_s':6," +
-        "'annotatedName':7}",
+        "'annotatedName':7,'lower_id':8}",
         gson.toJson(new TestNames()).replace('\"', '\''));
   }
 
   public void testLowerCaseWithDashes() {
-    Gson gson = new GsonBuilder().setFieldNamingPolicy(LOWER_CASE_WITH_DASHES).create();
+    Gson gson = getGsonWithNamingPolicy(LOWER_CASE_WITH_DASHES);
     assertEquals("{'lower-camel':1,'upper-camel':2,'_lower-camel-leading-underscore':3," +
         "'_-upper-camel-leading-underscore':4,'lower_words':5,'u-p-p-e-r_-w-o-r-d-s':6," +
-        "'annotatedName':7}",
+        "'annotatedName':7,'lower-id':8}",
         gson.toJson(new TestNames()).replace('\"', '\''));
+  }
+
+  private Gson getGsonWithNamingPolicy(FieldNamingPolicy fieldNamingPolicy){
+    return new GsonBuilder()
+      .setFieldNamingPolicy(fieldNamingPolicy)
+        .create();
   }
 
   @SuppressWarnings("unused") // fields are used reflectively
@@ -76,5 +84,6 @@ public final class FieldNamingTest extends TestCase {
     int lower_words = 5;
     int UPPER_WORDS = 6;
     @SerializedName("annotatedName") int annotated = 7;
+    int lowerId = 8;
   }
 }


### PR DESCRIPTION
### Description 
When using `LOWER_CASE_WITH_DASHES` or `LOWER_CASE_WITH_UNDERSCORES` as FieldNamingPolicy it could happen that certain fields won't get serialized/deserialized. 
I've seen that behavior on devices with a turkish (`tr-TR`) locale. `toLowerCase()` uses the device's locale and converts an `I` into an `ı`. ([JavaDoc](http://docs.oracle.com/javase/7/docs/api/java/lang/String.html#toLowerCase()))

### Example
A field with the name: 
```
...
int lowerId = 8;
....
```
will turn into:
```
{ ... 'lower-ıd':8 ... }
```

### Recreation steps
Check out the first commit (299ee89) and run the test with the following JVM flags:  `-Duser.language=tr -Duser.region=TR`
 
### References
https://code.google.com/p/google-gson/issues/detail?id=541
http://docs.oracle.com/javase/7/docs/api/java/lang/String.html#toLowerCase()
