### PR TITLE
added a strategy to manage unknown fields during deserialization

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -170,16 +170,21 @@ public final class Gson {
    *   <li>By default, Gson excludes <code>transient</code> or <code>static</code> fields from
    *   consideration for serialization and deserialization. You can change this behavior through
    *   {@link GsonBuilder#excludeFieldsWithModifiers(int...)}.</li>
+   *   <li>By default, during deserialization Gson silently ignores fields that are present in the
+   *   incoming Json but not in the Java classes. You can change this policy through
+   *   {@link GsonBuilder#setUnknownFieldHandlingStrategy(UnknownFieldHandlingStrategy)}.</li>
    * </ul>
    */
   public Gson() {
     this(Excluder.DEFAULT, FieldNamingPolicy.IDENTITY,
+        UnknownFieldHandlingPolicy.IGNORE,
         Collections.<Type, InstanceCreator<?>>emptyMap(), false, false, DEFAULT_JSON_NON_EXECUTABLE,
         true, false, false, LongSerializationPolicy.DEFAULT,
         Collections.<TypeAdapterFactory>emptyList());
   }
 
   Gson(final Excluder excluder, final FieldNamingStrategy fieldNamingPolicy,
+      UnknownFieldHandlingStrategy unknownFieldHandlingPolicy,
       final Map<Type, InstanceCreator<?>> instanceCreators, boolean serializeNulls,
       boolean complexMapKeySerialization, boolean generateNonExecutableGson, boolean htmlSafe,
       boolean prettyPrinting, boolean serializeSpecialFloatingPointValues,
@@ -241,7 +246,7 @@ public final class Gson {
     factories.add(new JsonAdapterAnnotationTypeAdapterFactory(constructorConstructor));
     factories.add(TypeAdapters.ENUM_FACTORY);
     factories.add(new ReflectiveTypeAdapterFactory(
-        constructorConstructor, fieldNamingPolicy, excluder));
+        constructorConstructor, fieldNamingPolicy, unknownFieldHandlingPolicy, excluder));
 
     this.factories = Collections.unmodifiableList(factories);
   }

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -47,6 +47,7 @@ import com.google.gson.reflect.TypeToken;
  *     .serializeNulls()
  *     .setDateFormat(DateFormat.LONG)
  *     .setFieldNamingPolicy(FieldNamingPolicy.UPPER_CAMEL_CASE)
+ *     .setUnknownFieldHandlingStrategy(UnknownFieldHandlingPolicy.THROW_EXCEPTION)
  *     .setPrettyPrinting()
  *     .setVersion(1.0)
  *     .create();
@@ -69,6 +70,7 @@ public final class GsonBuilder {
   private Excluder excluder = Excluder.DEFAULT;
   private LongSerializationPolicy longSerializationPolicy = LongSerializationPolicy.DEFAULT;
   private FieldNamingStrategy fieldNamingPolicy = FieldNamingPolicy.IDENTITY;
+  private UnknownFieldHandlingStrategy unknownFieldHandlingPolicy = UnknownFieldHandlingPolicy.IGNORE;
   private final Map<Type, InstanceCreator<?>> instanceCreators
       = new HashMap<Type, InstanceCreator<?>>();
   private final List<TypeAdapterFactory> factories = new ArrayList<TypeAdapterFactory>();
@@ -286,6 +288,18 @@ public final class GsonBuilder {
    */
   public GsonBuilder setFieldNamingStrategy(FieldNamingStrategy fieldNamingStrategy) {
     this.fieldNamingPolicy = fieldNamingStrategy;
+    return this;
+  }
+
+  /**
+   * Configures Gson to apply a specific unknown field strategy during deserialization.
+   *
+   * @param unknownFieldHandlingStrategy the actual naming strategy to apply to the fields
+   * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
+   * @since 2.3.2
+   */
+  public GsonBuilder setUnknownFieldHandlingStrategy(UnknownFieldHandlingStrategy unknownFieldHandlingStrategy) {
+    this.unknownFieldHandlingPolicy = unknownFieldHandlingStrategy;
     return this;
   }
 
@@ -542,8 +556,8 @@ public final class GsonBuilder {
     factories.addAll(this.hierarchyFactories);
     addTypeAdaptersForDate(datePattern, dateStyle, timeStyle, factories);
 
-    return new Gson(excluder, fieldNamingPolicy, instanceCreators,
-        serializeNulls, complexMapKeySerialization,
+    return new Gson(excluder, fieldNamingPolicy, unknownFieldHandlingPolicy,
+        instanceCreators, serializeNulls, complexMapKeySerialization,
         generateNonExecutableJson, escapeHtmlChars, prettyPrinting,
         serializeSpecialFloatingPointValues, longSerializationPolicy, factories);
   }

--- a/gson/src/main/java/com/google/gson/UnknownFieldHandlingPolicy.java
+++ b/gson/src/main/java/com/google/gson/UnknownFieldHandlingPolicy.java
@@ -21,18 +21,18 @@ import java.io.IOException;
 import com.google.gson.stream.JsonReader;
 
 /**
- * An enumeration that defines a few standard naming conventions for JSON field names.
+ * An enumeration that defines a few standard handling strategies for fields
+ * present in the incoming Json but not in the Java classes.
  * This enumeration should be used in conjunction with {@link com.google.gson.GsonBuilder}
- * to configure a {@link com.google.gson.Gson} instance to properly translate Java field
- * names into the desired JSON field names.
+ * to configure a {@link com.google.gson.Gson} instance
  *
  * @author Matteo Cerina
+ * @since 2.3.2
  */
 public enum UnknownFieldHandlingPolicy implements UnknownFieldHandlingStrategy {
 
   /**
-   * Using this naming policy with Gson will ensure that the field name is
-   * unchanged.
+   * Using this handling policy with Gson will silently ignore an unknown field.
    */
   IGNORE() {
     public void handleUnknownField(JsonReader in, Object instance, String name) throws IOException {
@@ -41,14 +41,8 @@ public enum UnknownFieldHandlingPolicy implements UnknownFieldHandlingStrategy {
   },
 
   /**
-   * Using this naming policy with Gson will ensure that the first "letter" of the Java
-   * field name is capitalized when serialized to its JSON form.
-   *
-   * <p>Here's a few examples of the form "Java Field Name" ---> "JSON Field Name":</p>
-   * <ul>
-   *   <li>someFieldName ---> SomeFieldName</li>
-   *   <li>_someFieldName ---> _SomeFieldName</li>
-   * </ul>
+   * Using this handling policy with Gson will throw an exception when an unknown field
+   * is present.
    */
   THROW_EXCEPTION() {
     public void handleUnknownField(JsonReader in, Object instance, String name) throws IOException {

--- a/gson/src/main/java/com/google/gson/UnknownFieldHandlingPolicy.java
+++ b/gson/src/main/java/com/google/gson/UnknownFieldHandlingPolicy.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson;
+
+import java.io.IOException;
+
+import com.google.gson.stream.JsonReader;
+
+/**
+ * An enumeration that defines a few standard naming conventions for JSON field names.
+ * This enumeration should be used in conjunction with {@link com.google.gson.GsonBuilder}
+ * to configure a {@link com.google.gson.Gson} instance to properly translate Java field
+ * names into the desired JSON field names.
+ *
+ * @author Matteo Cerina
+ */
+public enum UnknownFieldHandlingPolicy implements UnknownFieldHandlingStrategy {
+
+  /**
+   * Using this naming policy with Gson will ensure that the field name is
+   * unchanged.
+   */
+  IGNORE() {
+    public void handleUnknownField(JsonReader in, Object instance, String name) throws IOException {
+        in.skipValue();
+    }
+  },
+
+  /**
+   * Using this naming policy with Gson will ensure that the first "letter" of the Java
+   * field name is capitalized when serialized to its JSON form.
+   *
+   * <p>Here's a few examples of the form "Java Field Name" ---> "JSON Field Name":</p>
+   * <ul>
+   *   <li>someFieldName ---> SomeFieldName</li>
+   *   <li>_someFieldName ---> _SomeFieldName</li>
+   * </ul>
+   */
+  THROW_EXCEPTION() {
+    public void handleUnknownField(JsonReader in, Object instance, String name) throws IOException {
+        String msg = String.format("Unrecognized field \"%s\" (Class %s)", name, instance.getClass().getName());
+        throw new JsonParseException(msg);
+    }
+  }
+}

--- a/gson/src/main/java/com/google/gson/UnknownFieldHandlingStrategy.java
+++ b/gson/src/main/java/com/google/gson/UnknownFieldHandlingStrategy.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson;
+
+import java.io.IOException;
+
+import com.google.gson.stream.JsonReader;
+
+/**
+ * A mechanism for providing custom unknown property handling in Gson during deserialization.
+ * This allows to provide custom behavior to handle fields present in the incoming Json which
+ * are not present in the Java classes, such as ignore them or throw an exception.
+ *
+ * @author Matteo Cerina
+ * @since 2.3.2
+ */
+public interface UnknownFieldHandlingStrategy {
+
+  /**
+   * Handles a field present in the incoming Json but not in the Java class
+   *
+   * @param in the {@link JsonReader} reading the incoming Json
+   * @param instance the instance of the Java class we are trying to deserialize to
+   * @param name the name of the field in the incoming Json
+   */
+  public void handleUnknownField(JsonReader in, Object instance, String name) throws IOException;
+}

--- a/gson/src/test/java/com/google/gson/functional/UnknownFieldHandlingTest.java
+++ b/gson/src/test/java/com/google/gson/functional/UnknownFieldHandlingTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2011 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson.functional;
+
+import static com.google.gson.UnknownFieldHandlingPolicy.IGNORE;
+import static com.google.gson.UnknownFieldHandlingPolicy.THROW_EXCEPTION;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
+
+import junit.framework.Assert;
+import junit.framework.TestCase;
+
+public final class UnknownFieldHandlingTest extends TestCase {
+
+  private static final String JSON = "{'one':1,'two':'A','three':null}".replace('\'', '\"');
+
+  @SuppressWarnings("unused") // fields are used reflectively
+  private static class ClassWithTwoFields {
+    int one;
+    String two;
+  }
+
+  public void testIgnore() {
+    Gson gson = new GsonBuilder().setUnknownFieldHandlingStrategy(IGNORE).create();
+    gson.fromJson(JSON, ClassWithTwoFields.class);
+  }
+
+  public void testThrowException() {
+    Gson gson = new GsonBuilder().setUnknownFieldHandlingStrategy(THROW_EXCEPTION).create();
+    try {
+      gson.fromJson(JSON, ClassWithTwoFields.class);
+      Assert.fail("A JsonParseException was expected");
+    } catch (JsonParseException e) {
+      String msg = "Unrecognized field \"three\" (Class com.google.gson.functional.UnknownFieldHandlingTest$ClassWithTwoFields)";
+      assertEquals(msg, e.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
See issue https://github.com/google/gson/issues/188
While I understand the design choice of ignoring unknown fields during deserialization by default, I definitely think that there are use cases in which throwing an exception, or at least being able to log something is preferred.