### PR TITLE
fixed the error of printing new line for system that dont use '\n'

### DIFF
--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -566,7 +566,7 @@ public class JsonWriter implements Closeable, Flushable {
       return;
     }
 
-    out.write("\n");
+    out.write(System.lineSeparator());
     for (int i = 1, size = stackSize; i < size; i++) {
       out.write(indent);
     }


### PR DESCRIPTION
I have changed it so that it will work on more OS when you are wanting to print a new line 