### PR TITLE
Add a JSR-305 @ThreadSafe annotation to the Gson class

### DIFF
--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -50,6 +50,12 @@
   </organization>
   <dependencies>
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.0</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>3.8.2</version>

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -31,6 +31,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.concurrent.ThreadSafe;
+
 import com.google.gson.internal.ConstructorConstructor;
 import com.google.gson.internal.Excluder;
 import com.google.gson.internal.Primitives;
@@ -96,6 +98,7 @@ import com.google.gson.stream.MalformedJsonException;
  * @author Joel Leitch
  * @author Jesse Wilson
  */
+@ThreadSafe
 public final class Gson {
   static final boolean DEFAULT_JSON_NON_EXECUTABLE = false;
 


### PR DESCRIPTION
This PR solves Issue #613 that I submitted several months ago on Google Code.

Summary:
- Add an optional dependency to com.google.code.findbugs:jsr305.
  The optional scope is used in order to avoid introducing a new
  transitive dependency to the jsr305 library. This is fine because the 
  @ThreadSafe annotation has only a documentary purpose and it is not
  retained at runtime.
- Annotate the Gson class as @ThreadSafe