### PR TITLE
JsonWriter#value supports opaque JSON values.

### DIFF
--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -421,6 +421,23 @@ public class JsonWriter implements Closeable, Flushable {
   }
 
   /**
+   * Writes {@code value} directly to the writer without quoting or
+   * escaping.
+   *
+   * @param value the literal string value, or null to encode a null literal.
+   * @return this writer.
+   */
+  public JsonWriter jsonValue(String value) throws IOException {
+    if (value == null) {
+      return nullValue();
+    }
+    writeDeferredName();
+    beforeValue(false);
+    out.append(value);
+    return this;
+  }
+
+  /**
    * Encodes {@code null}.
    *
    * @return this writer.

--- a/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
@@ -126,6 +126,18 @@ public final class JsonWriterTest extends TestCase {
     assertEquals("{\"a\":null}", stringWriter.toString());
   }
 
+  public void testJsonValue() throws IOException {
+    StringWriter stringWriter = new StringWriter();
+    JsonWriter jsonWriter = new JsonWriter(stringWriter);
+    jsonWriter.beginObject();
+    jsonWriter.name("a");
+    jsonWriter.jsonValue("{\"b\":true}");
+    jsonWriter.name("c");
+    jsonWriter.value(1);
+    jsonWriter.endObject();
+    assertEquals("{\"a\":{\"b\":true},\"c\":1}", stringWriter.toString());
+  }
+
   public void testNonFiniteDoubles() throws IOException {
     StringWriter stringWriter = new StringWriter();
     JsonWriter jsonWriter = new JsonWriter(stringWriter);


### PR DESCRIPTION
Add a polymorphic version of `value(String value)` that takes an additional boolean argument (`encode`) that can be used to write the string directly to the underlying writer without modification, while maintaining the state of the `JsonWriter` so that it can continue to be written to.

The intended use case for this is when building JSON that contains a pre-serialized JSON string as a value in an object or array.

Alternative API ideas/open questions:
*  Should a separate method be used instead of a polymorphic version of `value(String)`? Maybe something like `rawValue(String)`?