### PR TITLE
Replace localhost lookup with static IP to fix test.

### DIFF
--- a/gson/src/test/java/com/google/gson/DefaultInetAddressTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/DefaultInetAddressTypeAdapterTest.java
@@ -35,11 +35,11 @@ public class DefaultInetAddressTypeAdapterTest extends TestCase {
   }
   
   public void testInetAddressSerializationAndDeserialization() throws Exception {
-    InetAddress localhost = InetAddress.getLocalHost();
-    String localInetAddress = gson.toJson(localhost);
-    assertEquals("\"" + localhost.getHostAddress() + "\"", localInetAddress);
+    InetAddress address = InetAddress.getByName("8.8.8.8");
+    String jsonAddress = gson.toJson(address);
+    assertEquals("\"8.8.8.8\"", jsonAddress);
     
-    InetAddress value = gson.fromJson(localInetAddress, InetAddress.class);
-    assertEquals(localhost, value);
+    InetAddress value = gson.fromJson(jsonAddress, InetAddress.class);
+    assertEquals(value, address);
   } 
 }


### PR DESCRIPTION
Calling InetAddress.getLocalHost() will cause a lookup to occur that may
fail with a java.net.UnknownHostException if the system the test is
running on is not configured correctly.

This is often fixed by echoing "127.0.0.1 $HOSTNAME" to /etc/hosts, but
in this case it seems easier to pick a static IP string to avoid the
lookup entirely and prevent false negatives in the test.