### PR TITLE
Support for adding primitives directly to JsonArray instances

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonArray.java
+++ b/gson/src/main/java/com/google/gson/JsonArray.java
@@ -55,10 +55,7 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
    * @param bool the boolean that needs to be added to the array.
    */
   public void add(Boolean bool) {
-    if (bool == null) {
-      elements.add(JsonNull.INSTANCE);
-    }
-    elements.add(new JsonPrimitive(bool));
+    elements.add(bool == null ? JsonNull.INSTANCE : new JsonPrimitive(bool));
   }
 
   /**
@@ -67,10 +64,7 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
    * @param character the character that needs to be added to the array.
    */
   public void add(Character character) {
-    if (character == null) {
-      elements.add(JsonNull.INSTANCE);
-    }
-    elements.add(new JsonPrimitive(character));
+    elements.add(character == null ? JsonNull.INSTANCE : new JsonPrimitive(character));
   }
 
   /**
@@ -79,10 +73,7 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
    * @param number the number that needs to be added to the array.
    */
   public void add(Number number) {
-    if (number == null) {
-      elements.add(JsonNull.INSTANCE);
-    }
-    elements.add(new JsonPrimitive(number));
+    elements.add(number == null ? JsonNull.INSTANCE : new JsonPrimitive(number));
   }
 
   /**
@@ -91,10 +82,7 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
    * @param string the string that needs to be added to the array.
    */
   public void add(String string) {
-    if (string == null) {
-      elements.add(JsonNull.INSTANCE);
-    }
-    elements.add(new JsonPrimitive(string));
+    elements.add(string == null ? JsonNull.INSTANCE : new JsonPrimitive(string));
   }
 
   /**

--- a/gson/src/main/java/com/google/gson/JsonArray.java
+++ b/gson/src/main/java/com/google/gson/JsonArray.java
@@ -50,6 +50,54 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
   }
 
   /**
+   * Adds the specified boolean to self.
+   *
+   * @param bool the boolean that needs to be added to the array.
+   */
+  public void add(Boolean bool) {
+    if (bool == null) {
+      elements.add(JsonNull.INSTANCE);
+    }
+    elements.add(new JsonPrimitive(bool));
+  }
+
+  /**
+   * Adds the specified character to self.
+   *
+   * @param character the character that needs to be added to the array.
+   */
+  public void add(Character character) {
+    if (character == null) {
+      elements.add(JsonNull.INSTANCE);
+    }
+    elements.add(new JsonPrimitive(character));
+  }
+
+  /**
+   * Adds the specified number to self.
+   *
+   * @param number the number that needs to be added to the array.
+   */
+  public void add(Number number) {
+    if (number == null) {
+      elements.add(JsonNull.INSTANCE);
+    }
+    elements.add(new JsonPrimitive(number));
+  }
+
+  /**
+   * Adds the specified string to self.
+   *
+   * @param string the string that needs to be added to the array.
+   */
+  public void add(String string) {
+    if (string == null) {
+      elements.add(JsonNull.INSTANCE);
+    }
+    elements.add(new JsonPrimitive(string));
+  }
+
+  /**
    * Adds the specified element to self.
    *
    * @param element the element that needs to be added to the array.

--- a/gson/src/test/java/com/google/gson/functional/JsonArrayTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonArrayTest.java
@@ -19,6 +19,8 @@ package com.google.gson.functional;
 import com.google.gson.JsonArray;
 import junit.framework.TestCase;
 
+import java.math.BigInteger;
+
 /**
  * Functional tests for adding primitives to a JsonArray.
  *
@@ -108,6 +110,21 @@ public class JsonArrayTest extends TestCase {
     jsonArray.add("and sometimes Y");
 
     assertEquals("[\"a\",\"e\",\"i\",\"o\",null,\"u\",\"and sometimes Y\"]", jsonArray.toString());
+  }
+
+  public void testMixedPrimitiveAddition() {
+    JsonArray jsonArray = new JsonArray();
+
+    jsonArray.add('a');
+    jsonArray.add("apple");
+    jsonArray.add(12121);
+    jsonArray.add((char) 111);
+    jsonArray.add((Boolean) null);
+    jsonArray.add((Character) null);
+    jsonArray.add(12.232);
+    jsonArray.add(BigInteger.valueOf(2323));
+
+    assertEquals("[\"a\",\"apple\",12121,\"o\",null,null,12.232,2323]", jsonArray.toString());
   }
 
   public void testSameAddition() {

--- a/gson/src/test/java/com/google/gson/functional/JsonArrayTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonArrayTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2008 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson.functional;
+
+import com.google.gson.JsonArray;
+import junit.framework.TestCase;
+
+/**
+ * Functional tests for adding primitives to a JsonArray.
+ *
+ * @author Dillon Dixon
+ */
+public class JsonArrayTest extends TestCase {
+
+  public void testStringPrimitiveAddition() {
+    JsonArray jsonArray = new JsonArray();
+
+    jsonArray.add("Hello");
+    jsonArray.add("Goodbye");
+    jsonArray.add("Thank you");
+    jsonArray.add((String) null);
+    jsonArray.add("Yes");
+
+    assertEquals("[\"Hello\",\"Goodbye\",\"Thank you\",null,\"Yes\"]", jsonArray.toString());
+  }
+
+  public void testIntegerPrimitiveAddition() {
+    JsonArray jsonArray = new JsonArray();
+
+    int x = 1;
+    jsonArray.add(x);
+
+    x = 2;
+    jsonArray.add(x);
+
+    x = -3;
+    jsonArray.add(x);
+
+    jsonArray.add((Integer) null);
+
+    x = 4;
+    jsonArray.add(x);
+
+    x = 0;
+    jsonArray.add(x);
+
+    assertEquals("[1,2,-3,null,4,0]", jsonArray.toString());
+  }
+
+  public void testDoublePrimitiveAddition() {
+    JsonArray jsonArray = new JsonArray();
+
+    double x = 1.0;
+    jsonArray.add(x);
+
+    x = 2.13232;
+    jsonArray.add(x);
+
+    x = 0.121;
+    jsonArray.add(x);
+
+    jsonArray.add((Double) null);
+
+    x = -0.00234;
+    jsonArray.add(x);
+
+    jsonArray.add((Double) null);
+
+    assertEquals("[1.0,2.13232,0.121,null,-0.00234,null]", jsonArray.toString());
+  }
+
+  public void testBooleanPrimitiveAddition() {
+    JsonArray jsonArray = new JsonArray();
+
+    jsonArray.add(true);
+    jsonArray.add(true);
+    jsonArray.add(false);
+    jsonArray.add(false);
+    jsonArray.add((Boolean) null);
+    jsonArray.add(true);
+
+    assertEquals("[true,true,false,false,null,true]", jsonArray.toString());
+  }
+
+  public void testCharPrimitiveAddition() {
+    JsonArray jsonArray = new JsonArray();
+
+    jsonArray.add('a');
+    jsonArray.add('e');
+    jsonArray.add('i');
+    jsonArray.add((char) 111);
+    jsonArray.add((Character) null);
+    jsonArray.add('u');
+    jsonArray.add("and sometimes Y");
+
+    assertEquals("[\"a\",\"e\",\"i\",\"o\",null,\"u\",\"and sometimes Y\"]", jsonArray.toString());
+  }
+
+  public void testSameAddition() {
+    JsonArray jsonArray = new JsonArray();
+
+    jsonArray.add('a');
+    jsonArray.add('a');
+    jsonArray.add(true);
+    jsonArray.add(true);
+    jsonArray.add(1212);
+    jsonArray.add(1212);
+    jsonArray.add(34.34);
+    jsonArray.add(34.34);
+    jsonArray.add((Boolean) null);
+    jsonArray.add((Boolean) null);
+
+    assertEquals("[\"a\",\"a\",true,true,1212,1212,34.34,34.34,null,null]", jsonArray.toString());
+  }
+}

--- a/gson/src/test/java/com/google/gson/functional/JsonArrayTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonArrayTest.java
@@ -127,6 +127,22 @@ public class JsonArrayTest extends TestCase {
     assertEquals("[\"a\",\"apple\",12121,\"o\",null,null,12.232,2323]", jsonArray.toString());
   }
 
+  public void testNullPrimitiveAddition() {
+    JsonArray jsonArray = new JsonArray();
+
+    jsonArray.add((Character) null);
+    jsonArray.add((Boolean) null);
+    jsonArray.add((Integer) null);
+    jsonArray.add((Double) null);
+    jsonArray.add((Float) null);
+    jsonArray.add((BigInteger) null);
+    jsonArray.add((String) null);
+    jsonArray.add((Boolean) null);
+    jsonArray.add((Number) null);
+
+    assertEquals("[null,null,null,null,null,null,null,null,null]", jsonArray.toString());
+  }
+
   public void testSameAddition() {
     JsonArray jsonArray = new JsonArray();
 


### PR DESCRIPTION
Overloaded the "add(...)" method in JsonArray to support directly putting in primitives as arguments.

Now instead of inserting them in the old overly verbose way:
```java
JsonArray array = new JsonArray();
array.add(new JsonPrimitive(true));
array.add(new JsonPrimitive(12));
array.add(new JsonPrimitive("hello"));
array.add(new JsonPrimitive('c'));
```
You can do:
```java
JsonArray array = new JsonArray();
array.add(true);
array.add(12);
array.add("hello");
array.add('c');
```