### PR TITLE
Add unit tests for constructors from util classes

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/$Gson$Preconditions.java
+++ b/gson/src/main/java/com/google/gson/internal/$Gson$Preconditions.java
@@ -30,6 +30,10 @@ package com.google.gson.internal;
  * @author Joel Leitch
  */
 public final class $Gson$Preconditions {
+  private $Gson$Preconditions() {
+    throw new UnsupportedOperationException();
+  }
+
   public static <T> T checkNotNull(T obj) {
     if (obj == null) {
       throw new NullPointerException();

--- a/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
+++ b/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
@@ -43,7 +43,9 @@ import java.util.Properties;
 public final class $Gson$Types {
   static final Type[] EMPTY_TYPE_ARRAY = new Type[] {};
 
-  private $Gson$Types() {}
+  private $Gson$Types() {
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * Returns a new parameterized type, applying {@code typeArguments} to

--- a/gson/src/main/java/com/google/gson/internal/Primitives.java
+++ b/gson/src/main/java/com/google/gson/internal/Primitives.java
@@ -29,7 +29,9 @@ import java.util.Map;
  * @author Kevin Bourrillion
  */
 public final class Primitives {
-  private Primitives() {}
+  private Primitives() {
+    throw new UnsupportedOperationException();
+  }
 
   /** A map from primitive types to their corresponding wrapper types. */
   private static final Map<Class<?>, Class<?>> PRIMITIVE_TO_WRAPPER_TYPE;

--- a/gson/src/main/java/com/google/gson/internal/Streams.java
+++ b/gson/src/main/java/com/google/gson/internal/Streams.java
@@ -33,6 +33,10 @@ import java.io.Writer;
  * Reads and writes GSON parse trees over streams.
  */
 public final class Streams {
+  private Streams() {
+    throw new UnsupportedOperationException();
+  }
+
   /**
    * Takes a reader in any state and returns the next value as a JsonElement.
    */

--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -55,7 +55,9 @@ import com.google.gson.stream.JsonWriter;
  * Type adapters for basic types.
  */
 public final class TypeAdapters {
-  private TypeAdapters() {}
+  private TypeAdapters() {
+    throw new UnsupportedOperationException();
+  }
 
   @SuppressWarnings("rawtypes")
   public static final TypeAdapter<Class> CLASS = new TypeAdapter<Class>() {

--- a/gson/src/test/java/com/google/gson/common/MoreAsserts.java
+++ b/gson/src/test/java/com/google/gson/common/MoreAsserts.java
@@ -69,4 +69,5 @@ public class MoreAsserts {
     Assert.assertFalse(a.equals(null));
     Assert.assertFalse(a.equals(new Object()));
   }
+
 }


### PR DESCRIPTION
I think that constructors from util classes should pass the following rules (best practices):

1. Each util class should have only the one constructor without parameters.
2. Constructor should be private.
3. Code should not have possibility to instantiate this class even using reflection mechanism (UnsupportedOperationException)