### PR TITLE
getDelegateAdapter is order dependant and skips more than one typeAdapterFactory.

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -410,6 +410,10 @@ public final class Gson {
    *  System.out.println("Num JSON reads" + stats.numReads);
    *  System.out.println("Num JSON writes" + stats.numWrites);
    *  }</pre>
+   *  Note that this call will skip all factories registered before {@code skipPast}. In case of
+   *  multiple TypeAdapterFactories registered it is up to the caller of this function to insure
+   *  that the order of registration does not prevent this method from reaching a factory they 
+   *  would expect to reply from this call.
    *  Note that since you can not override type adapter factories for String and Java primitive
    *  types, our stats factory will not count the number of String or primitives that will be
    *  read or written.


### PR DESCRIPTION
### Problem: 
` getDelegateAdapter` is not only skipping the passed in TypeAdapterFactory but all the previous one in the registered list. It seems unlikely that this is expected behaviour as this is not documented and makes this feature dependant on the order of the registration of the given factories.

#### Example:
``` java
TypeAdapterFactoryA factoryA = new TypeAdapterFactoryA()
new GsonBuilder()
                .registerTypeAdapterFactory(factoryA)
                .registerTypeAdapterFactory(new TypeAdapterFactoryB(factoryA))
                .create()
```

If TypeAdapterFactoryB calls ` getDelegateAdapter(factoryA, ...)` and TypeAdapterFactoryA calls `getDelegateAdapter(this, ...) then TypeAdapterFactoryB is not invoked back.

Inverting order in creation makes the resolution work as expected.

``` java
TypeAdapterFactoryA factoryA = new TypeAdapterFactoryA()
TypeAdapterFactoryB factoryB = new TypeAdapterFactoryB(factoryA)
new GsonBuilder()
                .registerTypeAdapterFactory(factoryB)
                .registerTypeAdapterFactory(factoryA)
                .create()
```


### Proposed solution (not working):
Only skipping the factory passed in parameter.