### PR TITLE
Expose serializeNulls with an accessor.

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -246,6 +246,11 @@ public final class Gson {
     this.factories = Collections.unmodifiableList(factories);
   }
 
+  /** Returns true if this Gson instance writes fields with null values. */
+  public boolean serializeNulls() {
+    return serializeNulls;
+  }
+
   private TypeAdapter<Number> doubleAdapter(boolean serializeSpecialFloatingPointValues) {
     if (serializeSpecialFloatingPointValues) {
       return TypeAdapters.DOUBLE;


### PR DESCRIPTION
Useful for frameworks that build on Gson.