### PR TITLE
Support for anonymous class serialization

### DIFF
--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -251,6 +251,17 @@ public final class GsonBuilder {
   }
 
   /**
+   * Configures Gson to include anonymous and/or local classes during serialization.
+   *
+   * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
+   * @since 1.3
+   */
+  public GsonBuilder enableAnonymousClassSerialization() {
+    excluder = excluder.enableAnonymousClassSerialization();
+    return this;
+  }
+
+  /**
    * Configures Gson to apply a specific serialization policy for {@code Long} and {@code long}
    * objects.
    *

--- a/gson/src/main/java/com/google/gson/internal/Excluder.java
+++ b/gson/src/main/java/com/google/gson/internal/Excluder.java
@@ -54,6 +54,7 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
   private double version = IGNORE_VERSIONS;
   private int modifiers = Modifier.TRANSIENT | Modifier.STATIC;
   private boolean serializeInnerClasses = true;
+  private boolean serializeAnonymousClasses = false;
   private boolean requireExpose;
   private List<ExclusionStrategy> serializationStrategies = Collections.emptyList();
   private List<ExclusionStrategy> deserializationStrategies = Collections.emptyList();
@@ -84,6 +85,12 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
   public Excluder disableInnerClassSerialization() {
     Excluder result = clone();
     result.serializeInnerClasses = false;
+    return result;
+  }
+
+  public Excluder enableAnonymousClassSerialization() {
+    Excluder result = clone();
+    result.serializeAnonymousClasses = true;
     return result;
   }
 
@@ -171,7 +178,7 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
       return true;
     }
 
-    if (isAnonymousOrLocal(field.getType())) {
+    if (!serializeAnonymousClasses && isAnonymousOrLocal(field.getType())) {
       return true;
     }
 
@@ -198,7 +205,7 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
       return true;
     }
 
-    if (isAnonymousOrLocal(clazz)) {
+    if (!serializeAnonymousClasses && isAnonymousOrLocal(clazz)) {
       return true;
     }
 

--- a/gson/src/test/java/com/google/gson/functional/FieldExclusionTest.java
+++ b/gson/src/test/java/com/google/gson/functional/FieldExclusionTest.java
@@ -70,6 +70,31 @@ public class FieldExclusionTest extends TestCase {
     assertEquals(target.toJson(), result);
   }
 
+  public void testDefaultAnonymousClassExclusion() throws Exception {
+    Gson gson = new Gson();
+    String result = gson.toJson(new Object(){ String value = VALUE; });
+    assertEquals("null", result);
+
+    result = gson.toJson(new ClassWithAnonymousField());
+    assertEquals("{}", result);
+
+    gson = new GsonBuilder().create();
+    result = gson.toJson(new Object(){ String value = VALUE; });
+    assertEquals("null", result);
+
+    result = gson.toJson(new ClassWithAnonymousField());
+    assertEquals("{}", result);
+  }
+
+  public void testAnonymousClassInclusion() throws Exception {
+    Gson gson = new GsonBuilder().enableAnonymousClassSerialization().create();
+    String result = gson.toJson(new Object(){ String value = VALUE; });
+    assertEquals("{\"value\":\"" + VALUE + "\"}", result);
+
+    result = gson.toJson(new ClassWithAnonymousField());
+    assertEquals("{\"anon\":{\"value\":\"" + VALUE + "\"}}", result);
+  }
+
   private static class Outer {
     private class Inner extends NestedClass {
       public Inner(String value) {
@@ -88,5 +113,11 @@ public class FieldExclusionTest extends TestCase {
     public String toJson() {
       return "{\"value\":\"" + value + "\"}";
     }
+  }
+
+  private static class ClassWithAnonymousField {
+    public Object anon = new Object() {
+      private final String value = VALUE;
+    };
   }
 }


### PR DESCRIPTION
Add a flag to `GsonBuilder` that lets anonymous classes through the serialization pipeline. Among other things, this allows for convenient creation of ad-hoc documents e.g.:
```
gson.toJson(new Object() {
    final int things = 17;
    final String stuff = "fun";
});
```

### Rationale

Currently, anonymous classes are silently dropped or replaced with null, unconditionally. This is needlessly restrictive, and likely to take developers by surprise. The Gson design document already says it best, though on a slightly different subject:

> We could have chosen to restrict the serialization to support only generic collections, but chose not to. This is because often the user of the library are concerned with either serialization or deserialization, but not both. In such cases, there is no need to artificially restrict the serialization capabilities. 