### PR TITLE
Remove explicit step numbers; use autonumbering.

### DIFF
--- a/ReleaseProcess.md
+++ b/ReleaseProcess.md
@@ -3,22 +3,22 @@
 The following is a step-by-step procedure for releasing a new version of Google-Gson.
 
 1. Go through all open bugs and identify which will be fixed in this release. Mark all others with an appropriate release tag. Identify duplicates, and close the bugs that will never be fixed. Fix all bugs for the release, and mark them fixed.
-2. Edit [`pom.xml`](pom.xml) and update the versions listed for Export-Package to the target version. Also add any new Java packages that have been introduced in Gson.
-3. Ensure all changelists are code-reviewed and have +1
-4. Ensure that your `~/.m2/settings.xml` is configured properly (see steps below)
-5. `cd gson`; ensure there are no open files and all changes are committed.
-6. Run `mvn release:clean`
-7. Do a dry run: `mvn release:prepare -DdryRun=true`
-8. Start the release: `mvn release:prepare`
+1. Edit [`pom.xml`](pom.xml) and update the versions listed for Export-Package to the target version. Also add any new Java packages that have been introduced in Gson.
+1. Ensure all changelists are code-reviewed and have +1
+1. Ensure that your `~/.m2/settings.xml` is configured properly (see steps below)
+1. `cd gson`; ensure there are no open files and all changes are committed.
+1. Run `mvn release:clean`
+1. Do a dry run: `mvn release:prepare -DdryRun=true`
+1. Start the release: `mvn release:prepare`
   * Answer questions: usually the defaults are fine.
   * This will do a full build, change version from `-SNAPSHOT` to the released version, commit and create the tags. It will then change the version to `-SNAPSHOT` for the next release.
-9. Ensure you have defined `sonatype-nexus-staging` in your Maven `settings.xml` and run:
+1. Ensure you have defined `sonatype-nexus-staging` in your Maven `settings.xml` and run:
 
    ```bash
    mvn -s /home/<username>/.m2/settings.xml release:perform
    ```
 
-10. [Log in to Nexus repository manager](https://oss.sonatype.org/index.html#welcome) at Sonatype and close the staging repository for Gson. If you run into an error regarding missing signatures, you need to manually upload the artifacts using `mvn gpg:sign-and-deploy-file` for Gson binary, source and Javadoc jars.
+1. [Log in to Nexus repository manager](https://oss.sonatype.org/index.html#welcome) at Sonatype and close the staging repository for Gson. If you run into an error regarding missing signatures, you need to manually upload the artifacts using `mvn gpg:sign-and-deploy-file` for Gson binary, source and Javadoc jars.
 
   ```bash
   cp -r ~/.m2/repository/com/google/code/gson/gson/1.7.2 /tmp
@@ -45,9 +45,9 @@ The following is a step-by-step procedure for releasing a new version of Google-
       -Dfile=gson-1.7.2.jar
   ```
 
-11. Close the Gson repository. Download and sanity check all downloads. Do not skip this step! Once you release the staging repository, there is no going back. It will get synced with Maven central and you will not be able to update or delete anything. Your only recourse will be to release a new version of Gson and hope that no one uses the old one.
-12. Release the staging repository for Gson. Gson will now get synced to Maven central with-in the next hour. For issues consult [Sonatype Guide](https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide#SonatypeOSSMavenRepositoryUsageGuide-8.ReleaseIt).
-13. Publishing Javadocs
+1. Close the Gson repository. Download and sanity check all downloads. Do not skip this step! Once you release the staging repository, there is no going back. It will get synced with Maven central and you will not be able to update or delete anything. Your only recourse will be to release a new version of Gson and hope that no one uses the old one.
+1. Release the staging repository for Gson. Gson will now get synced to Maven central with-in the next hour. For issues consult [Sonatype Guide](https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide#SonatypeOSSMavenRepositoryUsageGuide-8.ReleaseIt).
+1. Publishing Javadocs
 
   ```bash
   # Switch to the branch `gh-pages`
@@ -63,10 +63,10 @@ The following is a step-by-step procedure for releasing a new version of Google-
   git push
   ```
 
-14. Update the version in the [Using Gson with Maven2 page](https://sites.google.com/site/gson/gson-user-guide/using-gson-with-maven2)
-15. Update [Gson Changelog](https://github.com/google/gson/blob/master/CHANGELOG.md). Also, look at all bugs that were fixed and add a few lines describing what changed in the release.
-16. Create a post on the [Gson Discussion Forum](http://groups.google.com/group/google-gson)
-17. Update the release version in [Wikipedia](http://en.wikipedia.org/wiki/GSON) and update the current "stable" release.
+1. Update the version in the [Using Gson with Maven2 page](https://sites.google.com/site/gson/gson-user-guide/using-gson-with-maven2)
+1. Update [Gson Changelog](https://github.com/google/gson/blob/master/CHANGELOG.md). Also, look at all bugs that were fixed and add a few lines describing what changed in the release.
+1. Create a post on the [Gson Discussion Forum](http://groups.google.com/group/google-gson)
+1. Update the release version in [Wikipedia](http://en.wikipedia.org/wiki/GSON) and update the current "stable" release.
 
 ## Configuring a machine for deployment to Sonatype Repository
 


### PR DESCRIPTION
Markdown supports automatic list numbering; using this approach makes it easier
to add or remove new items without having to update all the following entries.