### PR TITLE
Remove synthetic accessors from being generated.

### DIFF
--- a/gson/src/main/java/com/google/gson/FieldNamingPolicy.java
+++ b/gson/src/main/java/com/google/gson/FieldNamingPolicy.java
@@ -120,7 +120,7 @@ public enum FieldNamingPolicy implements FieldNamingStrategy {
    * Converts the field name that uses camel-case define word separation into
    * separate words that are separated by the provided {@code separatorString}.
    */
-  private static String separateCamelCase(String name, String separator) {
+  static String separateCamelCase(String name, String separator) {
     StringBuilder translation = new StringBuilder();
     for (int i = 0; i < name.length(); i++) {
       char character = name.charAt(i);
@@ -135,7 +135,7 @@ public enum FieldNamingPolicy implements FieldNamingStrategy {
   /**
    * Ensures the JSON field names begins with an upper case letter.
    */
-  private static String upperCaseFirstLetter(String name) {
+  static String upperCaseFirstLetter(String name) {
     StringBuilder fieldNameBuilder = new StringBuilder();
     int index = 0;
     char firstCharacter = name.charAt(index);

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -303,7 +303,7 @@ public final class Gson {
     };
   }
 
-  private void checkValidFloatingPoint(double value) {
+  static void checkValidFloatingPoint(double value) {
     if (Double.isNaN(value) || Double.isInfinite(value)) {
       throw new IllegalArgumentException(value
           + " is not a valid double value as per JSON specification. To override this"
@@ -459,7 +459,7 @@ public final class Gson {
    *  }</pre>
    *  Note that this call will skip all factories registered before {@code skipPast}. In case of
    *  multiple TypeAdapterFactories registered it is up to the caller of this function to insure
-   *  that the order of registration does not prevent this method from reaching a factory they 
+   *  that the order of registration does not prevent this method from reaching a factory they
    *  would expect to reply from this call.
    *  Note that since you can not override type adapter factories for String and Java primitive
    *  types, our stats factory will not count the number of String or primitives that will be

--- a/gson/src/main/java/com/google/gson/TreeTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/TreeTypeAdapter.java
@@ -38,7 +38,7 @@ final class TreeTypeAdapter<T> extends TypeAdapter<T> {
   /** The delegate is lazily created because it may not be needed, and creating it may fail. */
   private TypeAdapter<T> delegate;
 
-  private TreeTypeAdapter(JsonSerializer<T> serializer, JsonDeserializer<T> deserializer,
+  TreeTypeAdapter(JsonSerializer<T> serializer, JsonDeserializer<T> deserializer,
       Gson gson, TypeToken<T> typeToken, TypeAdapterFactory skipPast) {
     this.serializer = serializer;
     this.deserializer = deserializer;
@@ -112,7 +112,7 @@ final class TreeTypeAdapter<T> extends TypeAdapter<T> {
     private final JsonSerializer<?> serializer;
     private final JsonDeserializer<?> deserializer;
 
-    private SingleTypeFactory(Object typeAdapter, TypeToken<?> exactType, boolean matchRawType,
+    SingleTypeFactory(Object typeAdapter, TypeToken<?> exactType, boolean matchRawType,
         Class<?> hierarchyType) {
       serializer = typeAdapter instanceof JsonSerializer
           ? (JsonSerializer<?>) typeAdapter

--- a/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
+++ b/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
@@ -16,9 +16,6 @@
 
 package com.google.gson.internal;
 
-import static com.google.gson.internal.$Gson$Preconditions.checkArgument;
-import static com.google.gson.internal.$Gson$Preconditions.checkNotNull;
-
 import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.lang.reflect.GenericArrayType;
@@ -33,6 +30,9 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Properties;
+
+import static com.google.gson.internal.$Gson$Preconditions.checkArgument;
+import static com.google.gson.internal.$Gson$Preconditions.checkNotNull;
 
 /**
  * Static methods for working with types.
@@ -212,7 +212,7 @@ public final class $Gson$Types {
     }
   }
 
-  private static int hashCodeOrZero(Object o) {
+  static int hashCodeOrZero(Object o) {
     return o != null ? o.hashCode() : 0;
   }
 
@@ -430,7 +430,7 @@ public final class $Gson$Types {
         : null;
   }
 
-  private static void checkNotPrimitive(Type type) {
+  static void checkNotPrimitive(Type type) {
     checkArgument(!(type instanceof Class<?>) || !((Class<?>) type).isPrimitive());
   }
 

--- a/gson/src/main/java/com/google/gson/internal/LinkedHashTreeMap.java
+++ b/gson/src/main/java/com/google/gson/internal/LinkedHashTreeMap.java
@@ -762,6 +762,9 @@ public final class LinkedHashTreeMap<K, V> extends AbstractMap<K, V> implements 
     Node<K, V> lastReturned = null;
     int expectedModCount = modCount;
 
+    LinkedTreeMapIterator() {
+    }
+
     public final boolean hasNext() {
       return next != header;
     }

--- a/gson/src/main/java/com/google/gson/internal/LinkedTreeMap.java
+++ b/gson/src/main/java/com/google/gson/internal/LinkedTreeMap.java
@@ -528,6 +528,9 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
     Node<K, V> lastReturned = null;
     int expectedModCount = modCount;
 
+    LinkedTreeMapIterator() {
+    }
+
     public final boolean hasNext() {
       return next != header;
     }

--- a/gson/src/main/java/com/google/gson/internal/Streams.java
+++ b/gson/src/main/java/com/google/gson/internal/Streams.java
@@ -85,7 +85,7 @@ public final class Streams {
     private final Appendable appendable;
     private final CurrentWrite currentWrite = new CurrentWrite();
 
-    private AppendableWriter(Appendable appendable) {
+    AppendableWriter(Appendable appendable) {
       this.appendable = appendable;
     }
 

--- a/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
@@ -104,7 +104,7 @@ import java.util.Map;
  */
 public final class MapTypeAdapterFactory implements TypeAdapterFactory {
   private final ConstructorConstructor constructorConstructor;
-  private final boolean complexMapKeySerialization;
+  final boolean complexMapKeySerialization;
 
   public MapTypeAdapterFactory(ConstructorConstructor constructorConstructor,
       boolean complexMapKeySerialization) {

--- a/gson/src/main/java/com/google/gson/internal/bind/ObjectTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ObjectTypeAdapter.java
@@ -47,7 +47,7 @@ public final class ObjectTypeAdapter extends TypeAdapter<Object> {
 
   private final Gson gson;
 
-  private ObjectTypeAdapter(Gson gson) {
+  ObjectTypeAdapter(Gson gson) {
     this.gson = gson;
   }
 

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -16,16 +16,6 @@
 
 package com.google.gson.internal.bind;
 
-import static com.google.gson.internal.bind.JsonAdapterAnnotationTypeAdapterFactory.getTypeAdapter;
-
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.lang.reflect.Type;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-
 import com.google.gson.FieldNamingStrategy;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
@@ -42,6 +32,15 @@ import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.gson.internal.bind.JsonAdapterAnnotationTypeAdapterFactory.getTypeAdapter;
 
 /**
  * Type adapter that reflects over the fields and methods of a class.
@@ -127,7 +126,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
     };
   }
 
-  private TypeAdapter<?> getFieldAdapter(Gson gson, Field field, TypeToken<?> fieldType) {
+  TypeAdapter<?> getFieldAdapter(Gson gson, Field field, TypeToken<?> fieldType) {
     JsonAdapter annotation = field.getAnnotation(JsonAdapter.class);
     if (annotation != null) {
       TypeAdapter<?> adapter = getTypeAdapter(constructorConstructor, gson, fieldType, annotation);
@@ -193,7 +192,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
     private final ObjectConstructor<T> constructor;
     private final Map<String, BoundField> boundFields;
 
-    private Adapter(ObjectConstructor<T> constructor, Map<String, BoundField> boundFields) {
+    Adapter(ObjectConstructor<T> constructor, Map<String, BoundField> boundFields) {
       this.constructor = constructor;
       this.boundFields = boundFields;
     }

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -242,7 +242,7 @@ public class JsonReader implements Closeable {
   private int lineNumber = 0;
   private int lineStart = 0;
 
-  private int peeked = PEEKED_NONE;
+  int peeked = PEEKED_NONE;
 
   /**
    * A peeked value that was composed entirely of digits with an optional
@@ -462,7 +462,7 @@ public class JsonReader implements Closeable {
     }
   }
 
-  private int doPeek() throws IOException {
+  int doPeek() throws IOException {
     int peekStack = stack[stackSize - 1];
     if (peekStack == JsonScope.EMPTY_ARRAY) {
       stack[stackSize - 1] = JsonScope.NONEMPTY_ARRAY;
@@ -1314,11 +1314,11 @@ public class JsonReader implements Closeable {
     return false;
   }
 
-  private int getLineNumber() {
+  int getLineNumber() {
     return lineNumber + 1;
   }
 
-  private int getColumnNumber() {
+  int getColumnNumber() {
     return pos - lineStart + 1;
   }
 


### PR DESCRIPTION
Removes 14 methods being generated for trampolining to private members which brings the total to 1294 from 1308.
```
-rw-r--r--   1 jw  jw   176K Dec 27 01:39 after.dex
-rw-r--r--   1 jw  jw   221K Dec 27 01:38 after.jar
-rw-r--r--   1 jw  jw   177K Dec 27 01:39 before.dex
-rw-r--r--   1 jw  jw   223K Dec 27 01:39 before.jar
```