### PR TITLE
Fix typo in JsonArray docs

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonArray.java
+++ b/gson/src/main/java/com/google/gson/JsonArray.java
@@ -162,7 +162,7 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
   }
 
   /**
-   * Returns an iterator to navigate the elemetns of the array. Since the array is an ordered list,
+   * Returns an iterator to navigate the elements of the array. Since the array is an ordered list,
    * the iterator navigates the elements in the order they were inserted.
    *
    * @return an iterator to navigate the elements of the array.


### PR DESCRIPTION
Hey, sorry to bother you guys with such an small pull request, but I saw this typo in the documentation and I couldn't let it go.

:stuck_out_tongue_closed_eyes: 
thankss