### PR TITLE
Fix for jdk 8: add Override annotation

### DIFF
--- a/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
@@ -181,7 +181,7 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
     return registerSubtype(type, type.getSimpleName());
   }
 
-  public <R> TypeAdapter<R> create(Gson gson, TypeToken<R> type) {
+  @Override public <R> TypeAdapter<R> create(Gson gson, TypeToken<R> type) {
     if (type.getRawType() != baseType) {
       return null;
     }


### PR DESCRIPTION
Without @Override, create will not be called on latest jdk (probably
since jdk 7)