### PR TITLE
Use the Java 7 language but limit to Java 6 APIs.

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -809,7 +809,7 @@ public final class TypeAdapters {
           constantToName.put(constant, name);
         }
       } catch (NoSuchFieldException e) {
-        throw new AssertionError("Missing field in " + classOfT.getName(), e);
+        throw new AssertionError("Missing field in " + classOfT.getName());
       }
     }
     @Override public T read(JsonReader in) throws IOException {

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,26 @@
           <autoVersionSubmodules>true</autoVersionSubmodules>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+        <version>1.11</version>
+        <executions>
+          <execution>
+            <phase>test</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <signature>
+            <groupId>org.codehaus.mojo.signature</groupId>
+            <artifactId>java16</artifactId>
+            <version>1.1</version>
+          </signature>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
This way we get nice features like ARM blocks and diamonds, but still work
on Android.