### PR TITLE
Build Gson for Java 1.6.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>1.7</java.version>
+    <java.version>1.6</java.version>
   </properties>
 
   <scm>


### PR DESCRIPTION
The upgrade to Java 1.7 was a clumsy bug.