### PR TITLE
Fixed code style to remove explicit casting op.

### DIFF
--- a/examples/android-proguard-example/src/com/google/gson/examples/android/model/LineItem.java
+++ b/examples/android-proguard-example/src/com/google/gson/examples/android/model/LineItem.java
@@ -52,6 +52,6 @@ public class LineItem {
   @Override
   public String toString() {
     return String.format("(item: %s, qty: %s, price: %.2f %s)",
-        name, quantity, priceInMicros/(double)1000000, currencyCode);
+        name, quantity, priceInMicros / 1000000d, currencyCode);
   }
 }


### PR DESCRIPTION
· Separated binary operator

This is a very, very, **very** small change, but that unnecessary explicit `(double)` casting with joined expressions on binary operator was affecting my OCD.