### PR TITLE
Collapse bullets into a paragraph

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -223,11 +223,8 @@ Unfortunately, there is no way to get around this in Java.
 
 #### <a name="TOC-Collections-Limitations"></a>Collections Limitations
 
-* Can serialize collection of arbitrary objects but can not deserialize from it
-* Because there is no way for the user to indicate the type of the resulting object
-* While deserializing, Collection must be of a specific generic type
-
-All of this makes sense, and is rarely a problem when following good Java coding practices.
+Gson can serialize collection of arbitrary objects but can not deserialize from it, because there is no way for the user to indicate the type of the resulting object. Instead, while deserializing, the Collection must be of a specific, generic type.
+This makes sense, and is rarely a problem when following good Java coding practices.
 
 ### <a name="TOC-Serializing-and-Deserializing-Generic-Types"></a>Serializing and Deserializing Generic Types
 


### PR DESCRIPTION
The section entitled "Collections Limitations" contains 3 bullets, but one semantic point, which is confusing.

Make this point in a paragraph instead of a bullet list.