### PR TITLE
Gson.fromJson methods now respect the lenient flag

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -869,8 +869,6 @@ public final class Gson {
   @SuppressWarnings("unchecked")
   public <T> T fromJson(JsonReader reader, Type typeOfT) throws JsonIOException, JsonSyntaxException {
     boolean isEmpty = true;
-    boolean oldLenient = reader.isLenient();
-    reader.setLenient(true);
     try {
       reader.peek();
       isEmpty = false;
@@ -892,8 +890,6 @@ public final class Gson {
     } catch (IOException e) {
       // TODO(inder): Figure out whether it is indeed right to rethrow this as JsonSyntaxException
       throw new JsonSyntaxException(e);
-    } finally {
-      reader.setLenient(oldLenient);
     }
   }
 

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -888,7 +888,7 @@ public class JsonReader implements Closeable {
    *
    * @throws IllegalStateException if the next token is not a literal value.
    * @throws NumberFormatException if the next literal value cannot be parsed
-   *     as a double, or is non-finite.
+   *     as a double
    */
   public double nextDouble() throws IOException {
     int p = peeked;
@@ -916,10 +916,6 @@ public class JsonReader implements Closeable {
 
     peeked = PEEKED_BUFFERED;
     double result = Double.parseDouble(peekedString); // don't catch this NumberFormatException.
-    if (!lenient && (Double.isNaN(result) || Double.isInfinite(result))) {
-      throw new MalformedJsonException("JSON forbids NaN and infinities: " + result
-          + " at line " + getLineNumber() + " column " + getColumnNumber() + " path " + getPath());
-    }
     peekedString = null;
     peeked = PEEKED_NONE;
     pathIndices[stackSize - 1]++;

--- a/gson/src/test/java/com/google/gson/CommentsTest.java
+++ b/gson/src/test/java/com/google/gson/CommentsTest.java
@@ -39,7 +39,8 @@ public final class CommentsTest extends TestCase {
         + "  \"c\"\n"
         + "]";
 
-    List<String> abc = new Gson().fromJson(json, new TypeToken<List<String>>() {}.getType());
+    Gson gson = new GsonBuilder().setLenient().create();
+    List<String> abc = gson.fromJson(json, new TypeToken<List<String>>() {}.getType());
     assertEquals(Arrays.asList("a", "b", "c"), abc);
   }
 }

--- a/gson/src/test/java/com/google/gson/functional/ArrayTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ArrayTest.java
@@ -186,7 +186,7 @@ public class ArrayTest extends TestCase {
   }
 
   public void testArrayOfPrimitivesAsObjectsDeserialization() throws Exception {
-    String json = "[1,'abc',0.3,1.1,5]";
+    String json = "[1,\"abc\",0.3,1.1,5]";
     Object[] objs = gson.fromJson(json, Object[].class);
     assertEquals(1, ((Number)objs[0]).intValue());
     assertEquals("abc", objs[1]);
@@ -249,8 +249,8 @@ public class ArrayTest extends TestCase {
    * Regression tests for Issue 272
    */
   public void testMultidimenstionalArraysDeserialization() {
-    String json = "[['3m Co','71.72','0.02','0.03','4/2 12:00am','Manufacturing'],"
-      + "['Alcoa Inc','29.01','0.42','1.47','4/1 12:00am','Manufacturing']]";
+    String json = "[[\"3m Co\",\"71.72\",\"0.02\",\"0.03\",\"4/2 12:00am\",\"Manufacturing\"],"
+      + "[\"Alcoa Inc\",\"29.01\",\"0.42\",\"1.47\",\"4/1 12:00am\",\"Manufacturing\"]]";
     String[][] items = gson.fromJson(json, String[][].class);
     assertEquals("3m Co", items[0][0]);
     assertEquals("Manufacturing", items[1][5]);

--- a/gson/src/test/java/com/google/gson/functional/CollectionTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CollectionTest.java
@@ -101,7 +101,7 @@ public class CollectionTest extends TestCase {
   }
 
   public void testLinkedListDeserialization() {
-    String json = "['a1','a2']";
+    String json = "[\"a1\",\"a2\"]";
     Type linkedListType = new TypeToken<LinkedList<String>>() {}.getType();
     List<String> list = gson.fromJson(json, linkedListType);
     assertEquals("a1", list.get(0));
@@ -119,7 +119,7 @@ public class CollectionTest extends TestCase {
   }
 
   public void testQueueDeserialization() {
-    String json = "['a1','a2']";
+    String json = "[\"a1\",\"a2\"]";
     Type queueType = new TypeToken<Queue<String>>() {}.getType();
     Queue<String> queue = gson.fromJson(json, queueType);
     assertEquals("a1", queue.element());
@@ -385,7 +385,7 @@ public class CollectionTest extends TestCase {
     assertTrue(json.contains("2"));
   }
   public void testSetDeserialization() {
-    String json = "[{value:1},{value:2}]";
+    String json = "[{\"value\":1},{\"value\":2}]";
     Type type = new TypeToken<Set<Entry>>() {}.getType();
     Set<Entry> set = gson.fromJson(json, type);
     assertEquals(2, set.size());

--- a/gson/src/test/java/com/google/gson/functional/ConcurrencyTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ConcurrencyTest.java
@@ -56,7 +56,7 @@ public class ConcurrencyTest extends TestCase {
    */
   public void testSingleThreadDeserialization() { 
     for (int i = 0; i < 10; i++) { 
-      gson.fromJson("{'a':'hello','b':'world','i':1}", MyObject.class); 
+      gson.fromJson("{\"a\":\"hello\",\"b\":\"world\",\"i\":1}", MyObject.class); 
     } 
   } 
 
@@ -106,7 +106,7 @@ public class ConcurrencyTest extends TestCase {
           try {
             startLatch.await();
             for (int i = 0; i < 10; i++) {
-              gson.fromJson("{'a':'hello','b':'world','i':1}", MyObject.class); 
+              gson.fromJson("{\"a\":\"hello\",\"b\":\"world\",\"i\":1}", MyObject.class); 
             }
           } catch (Throwable t) {
             failed.set(true);

--- a/gson/src/test/java/com/google/gson/functional/CustomDeserializerTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CustomDeserializerTest.java
@@ -111,7 +111,7 @@ public class CustomDeserializerTest extends TestCase {
   }
 
   public void testJsonTypeFieldBasedDeserialization() {
-    String json = "{field1:'abc',field2:'def',__type__:'SUB_TYPE1'}";
+    String json = "{\"field1\":\"abc\",\"field2\":\"def\",\"__type__\":\"SUB_TYPE1\"}";
     Gson gson = new GsonBuilder().registerTypeAdapter(MyBase.class, new JsonDeserializer<MyBase>() {
       @Override public MyBase deserialize(JsonElement json, Type pojoType,
           JsonDeserializationContext context) throws JsonParseException {
@@ -157,7 +157,7 @@ public class CustomDeserializerTest extends TestCase {
           return null;
         }
       }).create();
-    String json = "{baseName:'Base',subName:'SubRevised'}";
+    String json = "{\"baseName\":\"Base\",\"subName\":\"SubRevised\"}";
     Base target = gson.fromJson(json, Base.class);
     assertNull(target);
   }
@@ -171,7 +171,7 @@ public class CustomDeserializerTest extends TestCase {
           return null;
         }
       }).create();
-    String json = "{base:{baseName:'Base',subName:'SubRevised'}}";
+    String json = "{\"base\":{\"baseName\":\"Base\",\"subName\":\"SubRevised\"}}";
     ClassWithBaseField target = gson.fromJson(json, ClassWithBaseField.class);
     assertNull(target.base);
   }
@@ -185,7 +185,7 @@ public class CustomDeserializerTest extends TestCase {
           return null;
         }
       }).create();
-    String json = "[{baseName:'Base'},{baseName:'Base'}]";
+    String json = "[{\"baseName\":\"Base\"},{\"baseName\":\"Base\"}]";
     Base[] target = gson.fromJson(json, Base[].class);
     assertNull(target[0]);
     assertNull(target[1]);
@@ -200,7 +200,7 @@ public class CustomDeserializerTest extends TestCase {
           return null;
         }
       }).create();
-    String json = "{bases:[{baseName:'Base'},{baseName:'Base'}]}";
+    String json = "{\"bases\":[{\"baseName\":\"Base\"},{\"baseName\":\"Base\"}]}";
     ClassWithBaseArray target = gson.fromJson(json, ClassWithBaseArray.class);
     assertNull(target.bases[0]);
     assertNull(target.bases[1]);

--- a/gson/src/test/java/com/google/gson/functional/CustomTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CustomTypeAdaptersTest.java
@@ -263,7 +263,7 @@ public class CustomTypeAdaptersTest extends TestCase {
         return data;
       }
     });
-    Gson gson = gsonBuilder.create();
+    Gson gson = gsonBuilder.setLenient().create();
     String json = "'0123456789'";
     byte[] actual = gson.fromJson(json, byte[].class);
     byte[] expected = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -336,6 +336,7 @@ public class CustomTypeAdaptersTest extends TestCase {
   public void testCustomAdapterInvokedForCollectionElementDeserialization() {
     Gson gson = new GsonBuilder()
       .registerTypeAdapter(StringHolder.class, new StringHolderTypeAdapter())
+      .setLenient()
       .create();
     Type setType = new TypeToken<Set<StringHolder>>() {}.getType();
     Set<StringHolder> setOfHolders = gson.fromJson("['Jacob:Tomaw']", setType);
@@ -376,7 +377,7 @@ public class CustomTypeAdaptersTest extends TestCase {
       .registerTypeAdapter(StringHolder.class, new StringHolderTypeAdapter())
       .create();
     Type mapType = new TypeToken<Map<String, StringHolder>>() {}.getType();
-    Map<String, StringHolder> mapOfFoo = gson.fromJson("{'foo':'Jacob:Tomaw'}", mapType);
+    Map<String, StringHolder> mapOfFoo = gson.fromJson("{\"foo\":\"Jacob:Tomaw\"}", mapType);
     assertEquals(1, mapOfFoo.size());
     StringHolder foo = mapOfFoo.get("foo");
     assertEquals("Jacob", foo.part1);
@@ -396,7 +397,7 @@ public class CustomTypeAdaptersTest extends TestCase {
     Gson gson = new GsonBuilder()
         .registerTypeAdapter(DataHolder.class, new DataHolderDeserializer())
         .create();
-    String json = "{wrappedData:null}";
+    String json = "{\"wrappedData\":null}";
     DataHolderWrapper actual = gson.fromJson(json, DataHolderWrapper.class);
     assertNull(actual.wrappedData);
   }

--- a/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
@@ -94,11 +94,11 @@ public class DefaultTypeAdaptersTest extends TestCase {
 
   public void testClassDeserialization() {
     try {
-      gson.fromJson("String.class", String.class.getClass());  
+      gson.fromJson("\"String.class\"", String.class.getClass());  
     } catch (UnsupportedOperationException expected) {}
     // Override with a custom type adapter for class.
     gson = new GsonBuilder().registerTypeAdapter(Class.class, new MyClassTypeAdapter()).create();
-    assertEquals(String.class, gson.fromJson("java.lang.String", Class.class));  
+    assertEquals(String.class, gson.fromJson("\"java.lang.String\"", Class.class));  
   }
 
   public void testUrlSerialization() throws Exception {
@@ -109,7 +109,7 @@ public class DefaultTypeAdaptersTest extends TestCase {
 
   public void testUrlDeserialization() {
     String urlValue = "http://google.com/";
-    String json = "'http:\\/\\/google.com\\/'";
+    String json = "\"http:\\/\\/google.com\\/\"";
     URL target = gson.fromJson(json, URL.class);
     assertEquals(urlValue, target.toExternalForm());
 
@@ -332,7 +332,7 @@ public class DefaultTypeAdaptersTest extends TestCase {
   }
 
   public void testDefaultDateDeserialization() {
-    String json = "'Dec 13, 2009 07:18:02 AM'";
+    String json = "\"Dec 13, 2009 07:18:02 AM\"";
     Date extracted = gson.fromJson(json, Date.class);
     assertEqualsDate(extracted, 2009, 11, 13);
     assertEqualsTime(extracted, 7, 18, 2);
@@ -361,7 +361,7 @@ public class DefaultTypeAdaptersTest extends TestCase {
   }
 
   public void testDefaultJavaSqlDateDeserialization() {
-    String json = "'Dec 3, 2009'";
+    String json = "\"Dec 3, 2009\"";
     java.sql.Date extracted = gson.fromJson(json, java.sql.Date.class);
     assertEqualsDate(extracted, 2009, 11, 3);
   }
@@ -373,7 +373,7 @@ public class DefaultTypeAdaptersTest extends TestCase {
   }
 
   public void testDefaultJavaSqlTimestampDeserialization() {
-    String json = "'Dec 3, 2009 1:18:02 PM'";
+    String json = "\"Dec 3, 2009 1:18:02 PM\"";
     Timestamp extracted = gson.fromJson(json, Timestamp.class);
     assertEqualsDate(extracted, 2009, 11, 3);
     assertEqualsTime(extracted, 13, 18, 2);
@@ -386,7 +386,7 @@ public class DefaultTypeAdaptersTest extends TestCase {
   }
 
   public void testDefaultJavaSqlTimeDeserialization() {
-    String json = "'1:18:02 PM'";
+    String json = "\"1:18:02 PM\"";
     Time extracted = gson.fromJson(json, Time.class);
     assertEqualsTime(extracted, 13, 18, 2);
   }
@@ -419,7 +419,7 @@ public class DefaultTypeAdaptersTest extends TestCase {
 
   public void testDefaultCalendarDeserialization() throws Exception {
     Gson gson = new GsonBuilder().create();
-    String json = "{year:2009,month:2,dayOfMonth:11,hourOfDay:14,minute:29,second:23}";
+    String json = "{\"year\":2009,\"month\":2,\"dayOfMonth\":11,\"hourOfDay\":14,\"minute\":29,\"second\":23}";
     Calendar cal = gson.fromJson(json, Calendar.class);
     assertEquals(2009, cal.get(Calendar.YEAR));
     assertEquals(2, cal.get(Calendar.MONTH));
@@ -443,7 +443,7 @@ public class DefaultTypeAdaptersTest extends TestCase {
 
   public void testDefaultGregorianCalendarDeserialization() throws Exception {
     Gson gson = new GsonBuilder().create();
-    String json = "{year:2009,month:2,dayOfMonth:11,hourOfDay:14,minute:29,second:23}";
+    String json = "{\"year\":2009,\"month\":2,\"dayOfMonth\":11,\"hourOfDay\":14,\"minute\":29,\"second\":23}";
     GregorianCalendar cal = gson.fromJson(json, GregorianCalendar.class);
     assertEquals(2009, cal.get(Calendar.YEAR));
     assertEquals(2, cal.get(Calendar.MONTH));
@@ -657,7 +657,7 @@ public class DefaultTypeAdaptersTest extends TestCase {
   }
 
   public void testPropertiesDeserialization() {
-    String json = "{foo:'bar'}";
+    String json = "{\"foo\":\"bar\"}";
     Properties props = gson.fromJson(json, Properties.class);
     assertEquals("bar", props.getProperty("foo"));
   }
@@ -670,7 +670,7 @@ public class DefaultTypeAdaptersTest extends TestCase {
   }
 
   public void testTreeSetDeserialization() {
-    String json = "['Value1']";
+    String json = "[\"Value1\"]";
     Type type = new TypeToken<TreeSet<String>>() {}.getType();
     TreeSet<String> treeSet = gson.fromJson(json, type);
     assertTrue(treeSet.contains("Value1"));
@@ -683,7 +683,7 @@ public class DefaultTypeAdaptersTest extends TestCase {
   }
 
   public void testStringBuilderDeserialization() {
-    StringBuilder sb = gson.fromJson("'abc'", StringBuilder.class);
+    StringBuilder sb = gson.fromJson("\"abc\"", StringBuilder.class);
     assertEquals("abc", sb.toString());
   }
 
@@ -694,7 +694,7 @@ public class DefaultTypeAdaptersTest extends TestCase {
   }
 
   public void testStringBufferDeserialization() {
-    StringBuffer sb = gson.fromJson("'abc'", StringBuffer.class);
+    StringBuffer sb = gson.fromJson("\"abc\"", StringBuffer.class);
     assertEquals("abc", sb.toString());
   }
 

--- a/gson/src/test/java/com/google/gson/functional/EnumTest.java
+++ b/gson/src/test/java/com/google/gson/functional/EnumTest.java
@@ -89,7 +89,7 @@ public class EnumTest extends TestCase {
   }
 
   public void testClassWithEnumFieldDeserialization() throws Exception {
-    String json = "{value1:'VALUE1',value2:'VALUE2'}";
+    String json = "{\"value1\":\"VALUE1\",\"value2\":\"VALUE2\"}";
     ClassWithEnumFields target = gson.fromJson(json, ClassWithEnumFields.class);
     assertEquals(MyEnum.VALUE1,target.value1);
     assertEquals(MyEnum.VALUE2,target.value2);

--- a/gson/src/test/java/com/google/gson/functional/ExposeFieldsTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ExposeFieldsTest.java
@@ -72,7 +72,7 @@ public class ExposeFieldsTest extends TestCase {
   }
 
   public void testExposeAnnotationDeserialization() throws Exception {
-    String json = "{a:3,b:4,d:20.0}";
+    String json = "{\"a\":3,\"b\":4,\"d\":20.0}";
     ClassWithExposedFields target = gson.fromJson(json, ClassWithExposedFields.class);
 
     assertEquals(3, (int) target.a);
@@ -88,7 +88,7 @@ public class ExposeFieldsTest extends TestCase {
   }
 
   public void testNoExposedFieldDeserialization() throws Exception {
-    String json = "{a:4,b:5}";
+    String json = "{\"a\":4,\"b\":5}";
     ClassWithNoExposedFields obj = gson.fromJson(json, ClassWithNoExposedFields.class);
 
     assertEquals(0, obj.a);

--- a/gson/src/test/java/com/google/gson/functional/InstanceCreatorTest.java
+++ b/gson/src/test/java/com/google/gson/functional/InstanceCreatorTest.java
@@ -48,7 +48,7 @@ public class InstanceCreatorTest extends TestCase {
        }
       })
       .create();
-    String json = "{baseName:'BaseRevised',subName:'Sub'}";
+    String json = "{\"baseName\":\"BaseRevised\",\"subName\":\"Sub\"}";
     Base base = gson.fromJson(json, Base.class);
     assertEquals("BaseRevised", base.baseName);
   }
@@ -62,7 +62,7 @@ public class InstanceCreatorTest extends TestCase {
     })
     .create();
 
-    String json = "{baseName:'Base',subName:'SubRevised'}";
+    String json = "{\"baseName\":\"Base\",\"subName\":\"SubRevised\"}";
     Base base = gson.fromJson(json, Base.class);
     assertTrue(base instanceof Sub);
 
@@ -79,7 +79,7 @@ public class InstanceCreatorTest extends TestCase {
       }
     })
     .create();
-    String json = "{base:{baseName:'Base',subName:'SubRevised'}}";
+    String json = "{\"base\":{\"baseName\":\"Base\",\"subName\":\"SubRevised\"}}";
     ClassWithBaseField target = gson.fromJson(json, ClassWithBaseField.class);
     assertTrue(target.base instanceof Sub);
     assertEquals(Sub.SUB_NAME, ((Sub)target.base).subName);

--- a/gson/src/test/java/com/google/gson/functional/InternationalizationTest.java
+++ b/gson/src/test/java/com/google/gson/functional/InternationalizationTest.java
@@ -65,7 +65,7 @@ public class InternationalizationTest extends TestCase {
   }
 
   public void testStringsWithUnicodeChineseCharactersEscapedDeserialization() throws Exception {
-    String actual = gson.fromJson("'\\u597d\\u597d\\u597d'", String.class);
+    String actual = gson.fromJson("\"\\u597d\\u597d\\u597d\"", String.class);
     assertEquals("\u597d\u597d\u597d", actual);
   }
 }

--- a/gson/src/test/java/com/google/gson/functional/JavaUtilConcurrentAtomicTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JavaUtilConcurrentAtomicTest.java
@@ -65,7 +65,7 @@ public class JavaUtilConcurrentAtomicTest extends TestCase {
     Gson gson = new GsonBuilder()
         .setLongSerializationPolicy(LongSerializationPolicy.STRING)
         .create();
-    AtomicLongHolder target = gson.fromJson("{'value':'10'}", AtomicLongHolder.class);
+    AtomicLongHolder target = gson.fromJson("{\"value\":\"10\"}", AtomicLongHolder.class);
     assertEquals(10, target.value.get());
     String json = gson.toJson(target);
     assertEquals("{\"value\":\"10\"}", json);
@@ -95,7 +95,7 @@ public class JavaUtilConcurrentAtomicTest extends TestCase {
     Gson gson = new GsonBuilder()
         .setLongSerializationPolicy(LongSerializationPolicy.STRING)
         .create();
-    AtomicLongArray target = gson.fromJson("['10', '13', '14']", AtomicLongArray.class);
+    AtomicLongArray target = gson.fromJson("[\"10\", \"13\", \"14\"]", AtomicLongArray.class);
     assertEquals(3, target.length());
     assertEquals(10, target.get(0));
     assertEquals(13, target.get(1));

--- a/gson/src/test/java/com/google/gson/functional/JavaUtilTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JavaUtilTest.java
@@ -36,13 +36,13 @@ public class JavaUtilTest extends TestCase {
   }
 
   public void testCurrency() throws Exception {
-    CurrencyHolder target = gson.fromJson("{'value':'USD'}", CurrencyHolder.class);
+    CurrencyHolder target = gson.fromJson("{\"value\":\"USD\"}", CurrencyHolder.class);
     assertEquals("USD", target.value.getCurrencyCode());
     String json = gson.toJson(target);
     assertEquals("{\"value\":\"USD\"}", json);
 
     // null handling
-    target = gson.fromJson("{'value':null}", CurrencyHolder.class);
+    target = gson.fromJson("{\"value\":null}", CurrencyHolder.class);
     assertNull(target.value);
     assertEquals("{}", gson.toJson(target));
   }
@@ -52,7 +52,7 @@ public class JavaUtilTest extends TestCase {
   }
 
   public void testProperties() {
-    Properties props = gson.fromJson("{'a':'v1','b':'v2'}", Properties.class);
+    Properties props = gson.fromJson("{\"a\":\"v1\",\"b\":\"v2\"}", Properties.class);
     assertEquals("v1", props.getProperty("a"));
     assertEquals("v2", props.getProperty("b"));
     String json = gson.toJson(props);

--- a/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java
@@ -49,7 +49,7 @@ public final class JsonAdapterAnnotationOnClassesTest extends TestCase {
    // Also invoke the JsonAdapter javadoc sample
     json = gson.toJson(new User("Inderjeet", "Singh"));
     assertEquals("{\"name\":\"Inderjeet Singh\"}", json);
-    User user = gson.fromJson("{'name':'Joel Leitch'}", User.class);
+    User user = gson.fromJson("{\"name\":\"Joel Leitch\"}", User.class);
     assertEquals("Joel", user.firstName);
     assertEquals("Leitch", user.lastName);
 
@@ -95,6 +95,7 @@ public final class JsonAdapterAnnotationOnClassesTest extends TestCase {
     };
     Gson gson = new GsonBuilder()
       .registerTypeAdapter(A.class, serializer)
+      .setLenient()
       .create();
     String json = gson.toJson(new A("abcd"));
     assertEquals("\"registeredSerializer\"", json);
@@ -114,6 +115,7 @@ public final class JsonAdapterAnnotationOnClassesTest extends TestCase {
     };
     Gson gson = new GsonBuilder()
       .registerTypeAdapter(A.class, deserializer)
+      .setLenient()
       .create();
     String json = gson.toJson(new A("abcd"));
     assertEquals("\"jsonAdapter\"", json);

--- a/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnFieldsTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnFieldsTest.java
@@ -35,7 +35,7 @@ public final class JsonAdapterAnnotationOnFieldsTest extends TestCase {
     Gson gson = new Gson();
     String json = gson.toJson(new Computer(new User("Inderjeet Singh")));
     assertEquals("{\"user\":\"UserClassAnnotationAdapter\"}", json);
-    Computer computer = gson.fromJson("{'user':'Inderjeet Singh'}", Computer.class);
+    Computer computer = gson.fromJson("{\"user\":\"Inderjeet Singh\"}", Computer.class);
     assertEquals("UserClassAnnotationAdapter", computer.user.name);
   }
 
@@ -43,7 +43,7 @@ public final class JsonAdapterAnnotationOnFieldsTest extends TestCase {
     Gson gson = new Gson();
     String json = gson.toJson(new Gizmo(new Part("Part")));
     assertEquals("{\"part\":\"GizmoPartTypeAdapterFactory\"}", json);
-    Gizmo computer = gson.fromJson("{'part':'Part'}", Gizmo.class);
+    Gizmo computer = gson.fromJson("{\"part\":\"Part\"}", Gizmo.class);
     assertEquals("GizmoPartTypeAdapterFactory", computer.part.name);
   }
 
@@ -53,7 +53,7 @@ public final class JsonAdapterAnnotationOnFieldsTest extends TestCase {
         .create();
     String json = gson.toJson(new Computer(new User("Inderjeet Singh")));
     assertEquals("{\"user\":\"RegisteredUserAdapter\"}", json);
-    Computer computer = gson.fromJson("{'user':'Inderjeet Singh'}", Computer.class);
+    Computer computer = gson.fromJson("{\"user\":\"Inderjeet Singh\"}", Computer.class);
     assertEquals("RegisteredUserAdapter", computer.user.name);
   }
 
@@ -70,7 +70,7 @@ public final class JsonAdapterAnnotationOnFieldsTest extends TestCase {
       }).create();
     String json = gson.toJson(new Gadget(new Part("screen")));
     assertEquals("{\"part\":\"PartJsonFieldAnnotationAdapter\"}", json);
-    Gadget gadget = gson.fromJson("{'part':'screen'}", Gadget.class);
+    Gadget gadget = gson.fromJson("{\"part\":\"screen\"}", Gadget.class);
     assertEquals("PartJsonFieldAnnotationAdapter", gadget.part.name);
   }
 
@@ -78,7 +78,7 @@ public final class JsonAdapterAnnotationOnFieldsTest extends TestCase {
     Gson gson = new Gson();
     String json = gson.toJson(new Computer2(new User("Inderjeet Singh")));
     assertEquals("{\"user\":\"UserFieldAnnotationAdapter\"}", json);
-    Computer2 target = gson.fromJson("{'user':'Interjeet Singh'}", Computer2.class);
+    Computer2 target = gson.fromJson("{\"user\":\"Interjeet Singh\"}", Computer2.class);
     assertEquals("UserFieldAnnotationAdapter", target.user.name);
   }
 
@@ -186,7 +186,7 @@ public final class JsonAdapterAnnotationOnFieldsTest extends TestCase {
 
   public void testJsonAdapterInvokedOnlyForAnnotatedFields() {
     Gson gson = new Gson();
-    String json = "{'part1':'name','part2':{'name':'name2'}}";
+    String json = "{\"part1\":\"name\",\"part2\":{\"name\":\"name2\"}}";
     GadgetWithTwoParts gadget = gson.fromJson(json, GadgetWithTwoParts.class);
     assertEquals("PartJsonFieldAnnotationAdapter", gadget.part1.name);
     assertEquals("name2", gadget.part2.name);
@@ -203,7 +203,7 @@ public final class JsonAdapterAnnotationOnFieldsTest extends TestCase {
 
   public void testJsonAdapterWrappedInNullSafeAsRequested() {
     Gson gson = new Gson();
-    String fromJson = "{'part':null}";
+    String fromJson = "{\"part\":null}";
 
     GadgetWithOptionalPart gadget = gson.fromJson(fromJson, GadgetWithOptionalPart.class);
     assertNull(gadget.part);

--- a/gson/src/test/java/com/google/gson/functional/JsonParserTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonParserTest.java
@@ -17,6 +17,7 @@
 package com.google.gson.functional;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
@@ -122,6 +123,7 @@ public class JsonParserTest extends TestCase {
   }
 
   public void testExtraCommasInArrays() {
+    Gson gson = new GsonBuilder().setLenient().create();
     Type type = new TypeToken<List<String>>() {}.getType();
     assertEquals(list("a", null, "b", null, null), gson.fromJson("[a,,b,,]", type));
     assertEquals(list(null, null), gson.fromJson("[,]", type));

--- a/gson/src/test/java/com/google/gson/functional/MapAsArrayTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MapAsArrayTypeAdapterTest.java
@@ -106,7 +106,7 @@ public class MapAsArrayTypeAdapterTest extends TestCase {
   }
 
   public void testMapWithTypeVariableDeserialization() {
-    Gson gson = new GsonBuilder().enableComplexMapKeySerialization().create();
+    Gson gson = new GsonBuilder().setLenient().enableComplexMapKeySerialization().create();
     String json = "{map:[[{x:2,y:3},{x:4,y:5}]]}";
     Type type = new TypeToken<PointWithProperty<Point>>(){}.getType();
     PointWithProperty<Point> map = gson.fromJson(json, type);

--- a/gson/src/test/java/com/google/gson/functional/MapTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MapTest.java
@@ -144,7 +144,7 @@ public class MapTest extends TestCase {
     assertEquals(123, map.get("null").intValue());
     assertNull(map.get(null));
 
-    map = gson.fromJson("{null:123}", typeOfMap);
+    map = gson.fromJson("{\"null\":123}", typeOfMap);
     assertEquals(1, map.size());
     assertEquals(123, map.get("null").intValue());
     assertNull(map.get(null));
@@ -247,7 +247,7 @@ public class MapTest extends TestCase {
   }
 
   public void testMapStandardSubclassDeserialization() {
-    String json = "{a:'1',b:'2'}";
+    String json = "{\"a\":\"1\",\"b\":\"2\"}";
     Type type = new TypeToken<LinkedHashMap<String, String>>() {}.getType();
     LinkedHashMap<String, Integer> map = gson.fromJson(json, type);
     assertEquals("1", map.get("a"));
@@ -366,7 +366,7 @@ public class MapTest extends TestCase {
    * From bug report http://code.google.com/p/google-gson/issues/detail?id=95
    */
   public void testMapOfMapDeserialization() {
-    String json = "{nestedMap:{'2':'2','1':'1'}}";
+    String json = "{\"nestedMap\":{\"2\":\"2\",\"1\":\"1\"}}";
     Type type = new TypeToken<Map<String, Map<String, String>>>(){}.getType();
     Map<String, Map<String, String>> map = gson.fromJson(json, type);
     Map<String, String> nested = map.get("nestedMap");
@@ -520,7 +520,7 @@ public class MapTest extends TestCase {
   }
 
   public void testStringKeyDeserialization() {
-    String json = "{'2,3':'a','5,7':'b'}";
+    String json = "{\"2,3\":\"a\",\"5,7\":\"b\"}";
     Map<String, String> map = new LinkedHashMap<String, String>();
     map.put("2,3", "a");
     map.put("5,7", "b");
@@ -528,7 +528,7 @@ public class MapTest extends TestCase {
   }
 
   public void testNumberKeyDeserialization() {
-    String json = "{'2.3':'a','5.7':'b'}";
+    String json = "{\"2.3\":\"a\",\"5.7\":\"b\"}";
     Map<Double, String> map = new LinkedHashMap<Double, String>();
     map.put(2.3, "a");
     map.put(5.7, "b");
@@ -536,7 +536,7 @@ public class MapTest extends TestCase {
   }
 
   public void testBooleanKeyDeserialization() {
-    String json = "{'true':'a','false':'b'}";
+    String json = "{\"true\":\"a\",\"false\":\"b\"}";
     Map<Boolean, String> map = new LinkedHashMap<Boolean, String>();
     map.put(true, "a");
     map.put(false, "b");
@@ -565,7 +565,7 @@ public class MapTest extends TestCase {
     Map<String, Map<String, String>> map = newMap(
         "a", newMap("ka1", "va1", "ka2", "va2"),
         "b", newMap("kb1", "vb1", "kb2", "vb2"));
-    String json = "{'a':{'ka1':'va1','ka2':'va2'},'b':{'kb1':'vb1','kb2':'vb2'}}";
+    String json = "{\"a\":{\"ka1\":\"va1\",\"ka2\":\"va2\"},\"b\":{\"kb1\":\"vb1\",\"kb2\":\"vb2\"}}";
     assertEquals(map, gson.fromJson(json, type));
   }
 

--- a/gson/src/test/java/com/google/gson/functional/NullObjectAndFieldTest.java
+++ b/gson/src/test/java/com/google/gson/functional/NullObjectAndFieldTest.java
@@ -99,7 +99,7 @@ public class NullObjectAndFieldTest extends TestCase {
    */
   public void testNullWrappedPrimitiveMemberDeserialization() {
     Gson gson = gsonBuilder.create();
-    String json = "{'value':null}";
+    String json = "{\"value\":null}";
     ClassWithNullWrappedPrimitive target = gson.fromJson(json, ClassWithNullWrappedPrimitive.class);
     assertNull(target.value);
   }
@@ -153,7 +153,7 @@ public class NullObjectAndFieldTest extends TestCase {
   public void testAbsentJsonElementsAreSetToNull() {
     Gson gson = new Gson();
     ClassWithInitializedMembers target =
-        gson.fromJson("{array:[1,2,3]}", ClassWithInitializedMembers.class);
+        gson.fromJson("{\"array\":[1,2,3]}", ClassWithInitializedMembers.class);
     assertTrue(target.array.length == 3 && target.array[1] == 2);
     assertEquals(ClassWithInitializedMembers.MY_STRING_DEFAULT, target.str1);
     assertNull(target.str2);
@@ -202,7 +202,7 @@ public class NullObjectAndFieldTest extends TestCase {
 
   public void testExplicitNullSetsFieldToNullDuringDeserialization() {
     Gson gson = new Gson();
-    String json = "{value:null}";
+    String json = "{\"value\":null}";
     ObjectWithField obj = gson.fromJson(json, ObjectWithField.class);
     assertNull(obj.value);    
   }
@@ -229,7 +229,7 @@ public class NullObjectAndFieldTest extends TestCase {
             return context.deserialize(null, type);
           }
         }).create();
-    String json = "{value:'value1'}";
+    String json = "{\"value\":\"value1\"}";
     ObjectWithField target = gson.fromJson(json, ObjectWithField.class);
     assertNull(target);
   }

--- a/gson/src/test/java/com/google/gson/functional/ObjectTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ObjectTest.java
@@ -34,6 +34,9 @@ import com.google.gson.common.TestTypes.ClassWithTransientFields;
 import com.google.gson.common.TestTypes.Nested;
 import com.google.gson.common.TestTypes.PrimitiveArray;
 import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+
+import java.io.StringReader;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -71,15 +74,19 @@ public class ObjectTest extends TestCase {
   }
   public void testJsonInSingleQuotesDeserialization() {
     String json = "{'stringValue':'no message','intValue':10,'longValue':20}";
-    BagOfPrimitives target = gson.fromJson(json, BagOfPrimitives.class);
+    JsonReader lenientReader = new JsonReader(new StringReader(json));
+    lenientReader.setLenient(true);
+    BagOfPrimitives target = gson.fromJson(lenientReader, BagOfPrimitives.class);
     assertEquals("no message", target.stringValue);
     assertEquals(10, target.intValue);
     assertEquals(20, target.longValue);
   }
 
   public void testJsonInMixedQuotesDeserialization() {
-    String json = "{\"stringValue\":'no message','intValue':10,'longValue':20}";
-    BagOfPrimitives target = gson.fromJson(json, BagOfPrimitives.class);
+	String json = "{\"stringValue\":'no message','intValue':10,'longValue':20}";
+	JsonReader lenientReader = gson.newJsonReader(new StringReader(json));
+	lenientReader.setLenient(true);
+    BagOfPrimitives target = gson.fromJson(lenientReader, BagOfPrimitives.class);
     assertEquals("no message", target.stringValue);
     assertEquals(10, target.intValue);
     assertEquals(20, target.longValue);
@@ -339,7 +346,7 @@ public class ObjectTest extends TestCase {
         return p.new Child();
       }
     }).create();
-    String json = "{'value2':3}";
+    String json = "{\"value2\":3}";
     Parent.Child c = gson.fromJson(json, Parent.Child.class);
     assertEquals(3, c.value2);
   }
@@ -401,7 +408,9 @@ public class ObjectTest extends TestCase {
    */
   public void testObjectFieldNamesWithoutQuotesDeserialization() {
     String json = "{longValue:1,'booleanValue':true,\"stringValue\":'bar'}";
-    BagOfPrimitives bag = gson.fromJson(json, BagOfPrimitives.class);
+    JsonReader lenientReader = gson.newJsonReader(new StringReader(json));
+    lenientReader.setLenient(true);
+    BagOfPrimitives bag = gson.fromJson(lenientReader, BagOfPrimitives.class);
     assertEquals(1, bag.longValue);
     assertTrue(bag.booleanValue);
     assertEquals("bar", bag.stringValue);
@@ -437,7 +446,7 @@ public class ObjectTest extends TestCase {
    * Created to reproduce issue 140
    */
   public void testStringFieldWithEmptyValueDeserialization() {
-    String json = "{a:\"5794749\",b:\"\",c:\"\"}";
+    String json = "{\"a\":\"5794749\",\"b\":\"\",\"c\":\"\"}";
     ClassWithEmptyStringFields target = gson.fromJson(json, ClassWithEmptyStringFields.class);
     assertEquals("5794749", target.a);
     assertEquals("", target.b);

--- a/gson/src/test/java/com/google/gson/functional/ParameterizedTypesTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ParameterizedTypesTest.java
@@ -494,7 +494,7 @@ public class ParameterizedTypesTest extends TestCase {
   }
   
   public void testDeepParameterizedTypeDeserialization() {
-    String json = "{value:30}";
+    String json = "{\"value\":30}";
     Type type = new TypeToken<Amount<MyQuantity>>() {}.getType();    
     Amount<MyQuantity> amount = gson.fromJson(json, type);
     assertEquals(30, amount.value);

--- a/gson/src/test/java/com/google/gson/functional/PrimitiveCharacterTest.java
+++ b/gson/src/test/java/com/google/gson/functional/PrimitiveCharacterTest.java
@@ -18,7 +18,10 @@ package com.google.gson.functional;
 
 import junit.framework.TestCase;
 
+import java.io.StringReader;
+
 import com.google.gson.Gson;
+import com.google.gson.stream.JsonReader;
 
 /**
  * Functional tests for Java Character values.
@@ -43,13 +46,15 @@ public class PrimitiveCharacterTest extends TestCase {
 
   public void testPrimitiveCharacterAutoboxedDeserialization() {
     char expected = 'a';
-    char actual = gson.fromJson("a", char.class);
+    JsonReader lenientReader = new JsonReader(new StringReader("a"));
+    lenientReader.setLenient(true);
+    char actual = gson.fromJson(lenientReader, char.class);
     assertEquals(expected, actual);
 
     actual = gson.fromJson("\"a\"", char.class);
     assertEquals(expected, actual);
 
-    actual = gson.fromJson("a", Character.class);
+    actual = gson.fromJson("\"a\"", Character.class);
     assertEquals(expected, actual);
   }
 }

--- a/gson/src/test/java/com/google/gson/functional/PrimitiveTest.java
+++ b/gson/src/test/java/com/google/gson/functional/PrimitiveTest.java
@@ -363,8 +363,8 @@ public class PrimitiveTest extends TestCase {
   }
 
   public void testDoubleNaNDeserialization() {
-    assertTrue(Double.isNaN(gson.fromJson("NaN", Double.class)));
-    assertTrue(Double.isNaN(gson.fromJson("NaN", double.class)));
+    assertTrue(Double.isNaN(gson.fromJson("\"NaN\"", Double.class)));
+    assertTrue(Double.isNaN(gson.fromJson("\"NaN\"", double.class)));
   }
 
   public void testFloatNaNSerializationNotSupportedByDefault() {
@@ -389,8 +389,8 @@ public class PrimitiveTest extends TestCase {
   }
 
   public void testFloatNaNDeserialization() {
-    assertTrue(Float.isNaN(gson.fromJson("NaN", Float.class)));
-    assertTrue(Float.isNaN(gson.fromJson("NaN", float.class)));
+    assertTrue(Float.isNaN(gson.fromJson("\"NaN\"", Float.class)));
+    assertTrue(Float.isNaN(gson.fromJson("\"NaN\"", float.class)));
   }
 
   public void testBigDecimalNaNDeserializationNotSupported() {
@@ -423,8 +423,8 @@ public class PrimitiveTest extends TestCase {
   }
 
   public void testDoubleInfinityDeserialization() {
-    assertTrue(Double.isInfinite(gson.fromJson("Infinity", Double.class)));
-    assertTrue(Double.isInfinite(gson.fromJson("Infinity", double.class)));
+    assertTrue(Double.isInfinite(gson.fromJson("\"Infinity\"", Double.class)));
+    assertTrue(Double.isInfinite(gson.fromJson("\"Infinity\"", double.class)));
   }
 
   public void testFloatInfinitySerializationNotSupportedByDefault() {
@@ -449,8 +449,8 @@ public class PrimitiveTest extends TestCase {
   }
 
   public void testFloatInfinityDeserialization() {
-    assertTrue(Float.isInfinite(gson.fromJson("Infinity", Float.class)));
-    assertTrue(Float.isInfinite(gson.fromJson("Infinity", float.class)));
+    assertTrue(Float.isInfinite(gson.fromJson("\"Infinity\"", Float.class)));
+    assertTrue(Float.isInfinite(gson.fromJson("\"Infinity\"", float.class)));
   }
 
   public void testBigDecimalInfinityDeserializationNotSupported() {
@@ -483,8 +483,8 @@ public class PrimitiveTest extends TestCase {
   }
 
   public void testNegativeInfinityDeserialization() {
-    assertTrue(Double.isInfinite(gson.fromJson("-Infinity", double.class)));
-    assertTrue(Double.isInfinite(gson.fromJson("-Infinity", Double.class)));
+    assertEquals(Double.NEGATIVE_INFINITY, gson.fromJson("\"-Infinity\"", double.class));
+    assertEquals(Double.NEGATIVE_INFINITY, gson.fromJson("\"-Infinity\"", Double.class));
   }
 
   public void testNegativeInfinityFloatSerializationNotSupportedByDefault() {
@@ -509,8 +509,8 @@ public class PrimitiveTest extends TestCase {
   }
 
   public void testNegativeInfinityFloatDeserialization() {
-    assertTrue(Float.isInfinite(gson.fromJson("-Infinity", float.class)));
-    assertTrue(Float.isInfinite(gson.fromJson("-Infinity", Float.class)));
+    assertTrue(Float.isInfinite(gson.fromJson("\"-Infinity\"", float.class)));
+    assertTrue(Float.isInfinite(gson.fromJson("\"-Infinity\"", Float.class)));
   }
 
   public void testBigDecimalNegativeInfinityDeserializationNotSupported() {
@@ -550,7 +550,10 @@ public class PrimitiveTest extends TestCase {
   }
 
   public void testUnquotedStringDeserializationFails() throws Exception {
-    assertEquals("UnquotedSingleWord", gson.fromJson("UnquotedSingleWord", String.class));
+    try {
+    	gson.fromJson("UnquotedSingleWord", String.class);
+    	fail();
+    } catch (JsonSyntaxException expected) { }
 
     String value = "String Blah Blah Blah...1, 2, 3";
     try {
@@ -570,7 +573,7 @@ public class PrimitiveTest extends TestCase {
   }
 
   public void testDeserializePrimitiveWrapperAsObjectField() {
-    String json = "{i:10}";
+    String json = "{\"i\":10}";
     ClassWithIntegerField target = gson.fromJson(json, ClassWithIntegerField.class);
     assertEquals(10, target.i.intValue());
   }
@@ -814,7 +817,7 @@ public class PrimitiveTest extends TestCase {
   }
 
   public void testStringsAsBooleans() {
-    String json = "['true', 'false', 'TRUE', 'yes', '1']";
+    String json = "[\"true\", \"false\", \"TRUE\", \"yes\", \"1\"]";
     assertEquals(Arrays.asList(true, false, true, false, false),
         gson.<List<Boolean>>fromJson(json, new TypeToken<List<Boolean>>() {}.getType()));
   }

--- a/gson/src/test/java/com/google/gson/functional/SecurityTest.java
+++ b/gson/src/test/java/com/google/gson/functional/SecurityTest.java
@@ -48,8 +48,8 @@ public class SecurityTest extends TestCase {
   }
   
   public void testNonExecutableJsonDeserialization() {
-    String json = JSON_NON_EXECUTABLE_PREFIX + "{longValue:1}";
-    Gson gson = gsonBuilder.create();
+    String json = JSON_NON_EXECUTABLE_PREFIX + "{\"longValue\":1}";
+    Gson gson = new GsonBuilder().setLenient().create();
     BagOfPrimitives target = gson.fromJson(json, BagOfPrimitives.class);
     assertEquals(1, target.longValue);
   }
@@ -65,7 +65,7 @@ public class SecurityTest extends TestCase {
    *  without {@link GsonBuilder#generateNonExecutableJson()}.
    */
   public void testJsonWithNonExectuableTokenWithRegularGsonDeserialization() {
-    Gson gson = gsonBuilder.create();
+    Gson gson = gsonBuilder.setLenient().create();
     String json = JSON_NON_EXECUTABLE_PREFIX + "{stringValue:')]}\\u0027\\n'}";
     BagOfPrimitives target = gson.fromJson(json, BagOfPrimitives.class);
     assertEquals(")]}'\n", target.stringValue);
@@ -77,8 +77,8 @@ public class SecurityTest extends TestCase {
    */
   public void testJsonWithNonExectuableTokenWithConfiguredGsonDeserialization() {
     // Gson should be able to deserialize a stream with non-exectuable token even if it is created 
-    Gson gson = gsonBuilder.generateNonExecutableJson().create();
-    String json = JSON_NON_EXECUTABLE_PREFIX + "{intValue:2,stringValue:')]}\\u0027\\n'}";
+    Gson gson = gsonBuilder.generateNonExecutableJson().setLenient().create();
+    String json = JSON_NON_EXECUTABLE_PREFIX + "{\"intValue\":2,\"stringValue\":\")]}\\u0027\\n\"}";
     BagOfPrimitives target = gson.fromJson(json, BagOfPrimitives.class);
     assertEquals(")]}'\n", target.stringValue);
     assertEquals(2, target.intValue);

--- a/gson/src/test/java/com/google/gson/functional/SerializedNameTest.java
+++ b/gson/src/test/java/com/google/gson/functional/SerializedNameTest.java
@@ -30,17 +30,17 @@ public final class SerializedNameTest extends TestCase {
   }
 
   public void testMultipleNamesDeserializedCorrectly() {
-    assertEquals("v1", gson.fromJson("{'name':'v1'}", MyClass.class).a);
+    assertEquals("v1", gson.fromJson("{\"name\":\"v1\"}", MyClass.class).a);
 
     // Both name1 and name2 gets deserialized to b
-    assertEquals("v11", gson.fromJson("{'name1':'v11'}", MyClass.class).b);
-    assertEquals("v2", gson.fromJson("{'name2':'v2'}", MyClass.class).b);
-    assertEquals("v3", gson.fromJson("{'name3':'v3'}", MyClass.class).b);
+    assertEquals("v11", gson.fromJson("{\"name1\":\"v11\"}", MyClass.class).b);
+    assertEquals("v2", gson.fromJson("{\"name2\":\"v2\"}", MyClass.class).b);
+    assertEquals("v3", gson.fromJson("{\"name3\":\"v3\"}", MyClass.class).b);
   }
 
   public void testMultipleNamesInTheSameString() {
     // The last value takes precedence
-    assertEquals("v3", gson.fromJson("{'name1':'v1','name2':'v2','name3':'v3'}", MyClass.class).b);
+    assertEquals("v3", gson.fromJson("{\"name1\":\"v1\",\"name2\":\"v2\",\"name3\":\"v3\"}", MyClass.class).b);
   }
 
   private static final class MyClass {

--- a/gson/src/test/java/com/google/gson/functional/StreamingTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/StreamingTypeAdaptersTest.java
@@ -172,7 +172,7 @@ public final class StreamingTypeAdaptersTest extends TestCase {
       gson.toJson(truck, Truck.class);
       fail();
     } catch (NullPointerException expected) {}
-    String json = "{horsePower:1.0,passengers:[null,'jesse,30']}";
+    String json = "{\"horsePower\":1.0,\"passengers\":[null,\"jesse,30\"]}";
     try {
       gson.fromJson(json, Truck.class);
       fail();

--- a/gson/src/test/java/com/google/gson/functional/StringTest.java
+++ b/gson/src/test/java/com/google/gson/functional/StringTest.java
@@ -43,7 +43,7 @@ public class StringTest extends TestCase {
   }
 
   public void testEscapedCtrlNInStringDeserialization() throws Exception {
-    String json = "'a\\nb'";
+    String json = "\"a\\nb\"";
     String actual = gson.fromJson(json, String.class);
     assertEquals("a\nb", actual);
   }
@@ -55,7 +55,7 @@ public class StringTest extends TestCase {
   }
 
   public void testEscapedCtrlRInStringDeserialization() throws Exception {
-    String json = "'a\\rb'";
+    String json = "\"a\\rb\"";
     String actual = gson.fromJson(json, String.class);
     assertEquals("a\rb", actual);
   }
@@ -67,7 +67,7 @@ public class StringTest extends TestCase {
   }
 
   public void testEscapedBackslashInStringDeserialization() throws Exception {
-    String actual = gson.fromJson("'a\\\\b'", String.class);
+    String actual = gson.fromJson("\"a\\\\b\"", String.class);
     assertEquals("a\\b", actual);
   }
 
@@ -99,7 +99,7 @@ public class StringTest extends TestCase {
 
   public void testStringWithEscapedSlashDeserialization() {
     String value = "/";
-    String json = "'\\/'";
+    String json = "\"\\/\"";
     String actual = gson.fromJson(json, String.class);
     assertEquals(value, actual);
   }
@@ -121,7 +121,7 @@ public class StringTest extends TestCase {
     String value = gson.fromJson(json, String.class);
     assertEquals("abc=", value);
 
-    json = "'abc\u003d'";
+    json = "\"abc\u003d\"";
     value = gson.fromJson(json, String.class);
     assertEquals("abc=", value);
   }
@@ -133,7 +133,7 @@ public class StringTest extends TestCase {
   }
 
   public void testJavascriptKeywordsInStringDeserialization() {
-    String json = "'null true false function'";
+    String json = "\"null true false function\"";
     String value = gson.fromJson(json, String.class);
     assertEquals(json.substring(1, json.length() - 1), value);
   }

--- a/gson/src/test/java/com/google/gson/functional/ThrowableFunctionalTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ThrowableFunctionalTest.java
@@ -17,7 +17,7 @@ public final class ThrowableFunctionalTest extends TestCase {
     String json = gson.toJson(e);
     assertTrue(json.contains("hello"));
 
-    e = gson.fromJson("{'detailMessage':'hello'}", RuntimeException.class);
+    e = gson.fromJson("{\"detailMessage\":\"hello\"}", RuntimeException.class);
     assertEquals("hello", e.getMessage());
   }
 
@@ -26,7 +26,7 @@ public final class ThrowableFunctionalTest extends TestCase {
     String json = gson.toJson(e);
     assertTrue(json.contains("{\"detailMessage\":\"top level\",\"cause\":{\"detailMessage\":\"io error\""));
 
-    e = gson.fromJson("{'detailMessage':'top level','cause':{'detailMessage':'io error'}}", Exception.class);
+    e = gson.fromJson("{\"detailMessage\":\"top level\",\"cause\":{\"detailMessage\":\"io error\"}}", Exception.class);
     assertEquals("top level", e.getMessage());
     assertTrue(e.getCause() instanceof Throwable); // cause is not parameterized so type info is lost
     assertEquals("io error", e.getCause().getMessage());
@@ -43,7 +43,7 @@ public final class ThrowableFunctionalTest extends TestCase {
     String json = gson.toJson(e);
     assertTrue(json.contains("hello"));
 
-    e = gson.fromJson("{'detailMessage':'hello'}", OutOfMemoryError.class);
+    e = gson.fromJson("{\"detailMessage\":\"hello\"}", OutOfMemoryError.class);
     assertEquals("hello", e.getMessage());
   }
 
@@ -53,7 +53,7 @@ public final class ThrowableFunctionalTest extends TestCase {
     assertTrue(json.contains("top level"));
     assertTrue(json.contains("io error"));
 
-    e = gson.fromJson("{'detailMessage':'top level','cause':{'detailMessage':'io error'}}", Error.class);
+    e = gson.fromJson("{\"detailMessage\":\"top level\",\"cause\":{\"detailMessage\":\"io error\"}}", Error.class);
     assertEquals("top level", e.getMessage());
     assertTrue(e.getCause() instanceof Throwable); // cause is not parameterized so type info is lost
     assertEquals("io error", e.getCause().getMessage());

--- a/gson/src/test/java/com/google/gson/functional/TreeTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/TreeTypeAdaptersTest.java
@@ -68,8 +68,8 @@ public class TreeTypeAdaptersTest extends TestCase {
   }
 
   public void testDeserializeId() {
-    String json = "{courseId:1,students:[{id:1,name:'first'},{id:6,name:'second'}],"
-      + "numAssignments:4,assignment:{}}";
+    String json = "{\"courseId\":1,\"students\":[{\"id\":1,\"name\":\"first\"},{\"id\":6,\"name\":\"second\"}],"
+      + "\"numAssignments\":4,\"assignment\":{}}";
     Course<HistoryCourse> target = gson.fromJson(json, TYPE_COURSE_HISTORY);
     assertEquals("1", target.getStudents().get(0).id.getValue());
     assertEquals("6", target.getStudents().get(1).id.getValue());

--- a/gson/src/test/java/com/google/gson/functional/TypeAdapterPrecedenceTest.java
+++ b/gson/src/test/java/com/google/gson/functional/TypeAdapterPrecedenceTest.java
@@ -40,7 +40,7 @@ public final class TypeAdapterPrecedenceTest extends TestCase {
         .registerTypeAdapter(Foo.class, newDeserializer("deserializer 2"))
         .create();
     assertEquals("\"foo via serializer 2\"", gson.toJson(new Foo("foo")));
-    assertEquals("foo via deserializer 2", gson.fromJson("foo", Foo.class).name);
+    assertEquals("foo via deserializer 2", gson.fromJson("\"foo\"", Foo.class).name);
   }
 
   public void testStreamingFollowedByStreaming() {
@@ -49,7 +49,7 @@ public final class TypeAdapterPrecedenceTest extends TestCase {
         .registerTypeAdapter(Foo.class, newTypeAdapter("type adapter 2"))
         .create();
     assertEquals("\"foo via type adapter 2\"", gson.toJson(new Foo("foo")));
-    assertEquals("foo via type adapter 2", gson.fromJson("foo", Foo.class).name);
+    assertEquals("foo via type adapter 2", gson.fromJson("\"foo\"", Foo.class).name);
   }
 
   public void testSerializeNonstreamingTypeAdapterFollowedByStreamingTypeAdapter() {
@@ -59,7 +59,7 @@ public final class TypeAdapterPrecedenceTest extends TestCase {
         .registerTypeAdapter(Foo.class, newTypeAdapter("type adapter"))
         .create();
     assertEquals("\"foo via type adapter\"", gson.toJson(new Foo("foo")));
-    assertEquals("foo via type adapter", gson.fromJson("foo", Foo.class).name);
+    assertEquals("foo via type adapter", gson.fromJson("\"foo\"", Foo.class).name);
   }
 
   public void testStreamingFollowedByNonstreaming() {
@@ -69,7 +69,7 @@ public final class TypeAdapterPrecedenceTest extends TestCase {
         .registerTypeAdapter(Foo.class, newDeserializer("deserializer"))
         .create();
     assertEquals("\"foo via serializer\"", gson.toJson(new Foo("foo")));
-    assertEquals("foo via deserializer", gson.fromJson("foo", Foo.class).name);
+    assertEquals("foo via deserializer", gson.fromJson("\"foo\"", Foo.class).name);
   }
 
   public void testStreamingHierarchicalFollowedByNonstreaming() {
@@ -79,7 +79,7 @@ public final class TypeAdapterPrecedenceTest extends TestCase {
         .registerTypeAdapter(Foo.class, newDeserializer("deserializer"))
         .create();
     assertEquals("\"foo via serializer\"", gson.toJson(new Foo("foo")));
-    assertEquals("foo via deserializer", gson.fromJson("foo", Foo.class).name);
+    assertEquals("foo via deserializer", gson.fromJson("\"foo\"", Foo.class).name);
   }
 
   public void testStreamingFollowedByNonstreamingHierarchical() {
@@ -89,7 +89,7 @@ public final class TypeAdapterPrecedenceTest extends TestCase {
         .registerTypeHierarchyAdapter(Foo.class, newDeserializer("deserializer"))
         .create();
     assertEquals("\"foo via type adapter\"", gson.toJson(new Foo("foo")));
-    assertEquals("foo via type adapter", gson.fromJson("foo", Foo.class).name);
+    assertEquals("foo via type adapter", gson.fromJson("\"foo\"", Foo.class).name);
   }
 
   public void testStreamingHierarchicalFollowedByNonstreamingHierarchical() {
@@ -99,7 +99,7 @@ public final class TypeAdapterPrecedenceTest extends TestCase {
         .registerTypeHierarchyAdapter(Foo.class, newTypeAdapter("type adapter"))
         .create();
     assertEquals("\"foo via type adapter\"", gson.toJson(new Foo("foo")));
-    assertEquals("foo via type adapter", gson.fromJson("foo", Foo.class).name);
+    assertEquals("foo via type adapter", gson.fromJson("\"foo\"", Foo.class).name);
   }
 
   public void testNonstreamingHierarchicalFollowedByNonstreaming() {
@@ -110,7 +110,7 @@ public final class TypeAdapterPrecedenceTest extends TestCase {
         .registerTypeAdapter(Foo.class, newDeserializer("non hierarchical"))
         .create();
     assertEquals("\"foo via non hierarchical\"", gson.toJson(new Foo("foo")));
-    assertEquals("foo via non hierarchical", gson.fromJson("foo", Foo.class).name);
+    assertEquals("foo via non hierarchical", gson.fromJson("\"foo\"", Foo.class).name);
   }
 
   private static class Foo {

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -21,6 +21,9 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.Arrays;
+
+import com.google.gson.GsonBuilder;
+
 import junit.framework.TestCase;
 
 import static com.google.gson.stream.JsonToken.BEGIN_ARRAY;
@@ -318,15 +321,16 @@ public final class JsonReaderTest extends TestCase {
     }
   }
 
+  /**
+   * javadoc for {@link GsonBuilder#serializeSpecialFloatingPointValues()}
+   * specifies "Gson always accepts these special values during deserialization"
+   * @throws IOException
+   */
   public void testStrictQuotedNonFiniteDoubles() throws IOException {
     String json = "[\"NaN\"]";
     JsonReader reader = new JsonReader(reader(json));
     reader.beginArray();
-    try {
-      reader.nextDouble();
-      fail();
-    } catch (MalformedJsonException expected) {
-    }
+    assertEquals(Double.NaN, reader.nextDouble());
   }
 
   public void testLenientNonFiniteDoubles() throws IOException {


### PR DESCRIPTION
Gson.fromJson(JsonReader, Type) would previously override the lenient flag in the JsonReader to always be true while being used from here.  This would cause all instances of Gson to act as though the lenient flag is set to true regardless of the actual state in the Gson object.  I have corrected this to respect the lenient flag.

also updated JsonReader.nextDouble() method to deserialize infinite values, following the comments
in GsonBuilder.serializeSpecialFloatingPointValues() method which claims:
"Gson always accepts these special values during deserialization"

These fixes should also address issue #372