### PR TITLE
Restore OSGi manifest headers

### DIFF
--- a/gson/bnd.bnd
+++ b/gson/bnd.bnd
@@ -1,0 +1,14 @@
+Bundle-SymbolicName: com.google.gson
+Bundle-Name: ${project.name}
+Bundle-Description: ${project.description}
+Bundle-Vendor: Google Gson Project
+Bundle-ContactAddress: ${project.parent.url}
+Bundle-RequiredExecutionEnvironment: J2SE-1.5, JavaSE-1.6, JavaSE-1.7, JavaSE-1.8
+
+-removeheaders: Private-Package
+
+-exportcontents:\
+    com.google.gson,\
+    com.google.gson.annotations,\
+    com.google.gson.reflect,\
+    com.google.gson.stream

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -31,6 +31,18 @@
           </links>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>bnd-process</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,13 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>2.10.3</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <configuration>
+            <useDefaultManifestFile>true</useDefaultManifestFile>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>


### PR DESCRIPTION
Commit 2016e95 removed the necessary MANIFEST.MF headers for Gson to
resolve in an OSGi environment. This patch restores them.

Fixes #796