### PR TITLE
respect the lenient flag in Gson.fromJson

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -102,7 +102,7 @@ import com.google.gson.stream.MalformedJsonException;
  */
 public final class Gson {
   static final boolean DEFAULT_JSON_NON_EXECUTABLE = false;
-  static final boolean DEFAULT_LENIENT = false;
+  static final boolean DEFAULT_LENIENT = true;
   static final boolean DEFAULT_PRETTY_PRINT = false;
   static final boolean DEFAULT_ESCAPE_HTML = true;
   static final boolean DEFAULT_SERIALIZE_NULLS = false;
@@ -870,15 +870,15 @@ public final class Gson {
    * Reads the next JSON value from {@code reader} and convert it to an object
    * of type {@code typeOfT}. Returns {@code null}, if the {@code reader} is at EOF.
    * Since Type is not parameterized by T, this method is type unsafe and should be used carefully
-   *
+   * <p>
+   * The leniency of the reader passed in is respected. See {@linkplain JsonReader#setLenient(boolean)}
+   * </p>
    * @throws JsonIOException if there was a problem writing to the Reader
    * @throws JsonSyntaxException if json is not a valid representation for an object of type
    */
   @SuppressWarnings("unchecked")
   public <T> T fromJson(JsonReader reader, Type typeOfT) throws JsonIOException, JsonSyntaxException {
     boolean isEmpty = true;
-    boolean oldLenient = reader.isLenient();
-    reader.setLenient(true);
     try {
       reader.peek();
       isEmpty = false;
@@ -900,8 +900,6 @@ public final class Gson {
     } catch (IOException e) {
       // TODO(inder): Figure out whether it is indeed right to rethrow this as JsonSyntaxException
       throw new JsonSyntaxException(e);
-    } finally {
-      reader.setLenient(oldLenient);
     }
   }
 

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -363,12 +363,22 @@ public final class GsonBuilder {
   }
 
   /**
-   * By default, Gson is strict and only accepts JSON as specified by
-   * <a href="http://www.ietf.org/rfc/rfc4627.txt">RFC 4627</a>. This option makes the parser
-   * liberal in what it accepts.
+   * By default, Gson is liberal in what it accepts. Setting lenient to false causes Gson to
+   * only accept JSON as specified by 
+   * <a href="http://www.ietf.org/rfc/rfc4627.txt">RFC 4627</a>.
    *
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
    * @see JsonReader#setLenient(boolean)
+   */
+  public GsonBuilder setLenient(boolean lenient) {
+    this.lenient = lenient;
+    return this;
+  }
+
+  /**
+   * Gson is lenient by default. Use {@link #setLenient(boolean)} if
+   *             you wish to change the leniency
+   * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
    */
   public GsonBuilder setLenient() {
     lenient = true;

--- a/gson/src/test/java/com/google/gson/functional/PrimitiveTest.java
+++ b/gson/src/test/java/com/google/gson/functional/PrimitiveTest.java
@@ -18,6 +18,7 @@ package com.google.gson.functional;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonIOException;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.LongSerializationPolicy;
@@ -556,7 +557,7 @@ public class PrimitiveTest extends TestCase {
     try {
       gson.fromJson(value, String.class);
       fail();
-    } catch (JsonSyntaxException expected) { }
+    } catch (JsonIOException expected) { }
   }
 
   public void testHtmlCharacterSerialization() throws Exception {


### PR DESCRIPTION
This fix causes Gson to respect the lenient flag without affecting the default behavior.  Gson will continue to be lenient by default, but now the lenient flag will be respected if it is set to false in the GsonBuilder.  The lenient flag will also be respected from a JsonReader.  It is unfortunate that the default behavior of Gson and the default behavior of JsonReader are different with respect to the lenient flag; however, this seems to be the only solution that will respect the settings used without drastically changing the expected behavior.

The following is an explanation of some of the issues with the behavior prior to my changes.  I think Gson.lenient flag probably does more harm than good in the previous state.  The comments on the GsonBuilder.setLenient() method say 

> By default, Gson is strict and only accepts JSON as specified by <a href="http://www.ietf.org/rfc/rfc4627.txt">RFC 4627</a>.

The comments on Gson.setLenient() also references the <a href="https://google-gson.googlecode.com/svn/trunk/gson/docs/javadocs/com/google/gson/stream/JsonReader.html#setLenient%28boolean%29">JsonReader.setLenient(boolean)</a> method which has a great explanation of what should and shouldn't be considered when using the lenient flag.

The unfortunate fact here is that due to the Gson.fromJson(JsonReader, Type) method always setting the lenient flag to true when parsing, almost none of what is commented in GsonBuilder about the default behavior of Gson is true.  The only affect that setting the lenient flag on Gson will do is to allow comments to be at the end of your json buffer when calling Gson.fromJson(Reader, Type) since the assertFullConsumption(Object, JsonReader) method will be called from here and only checks for data at the end of the buffer having not been consumed (e.g. comments at the end).

Consider, for example, the test in com.google.gson.functional.LeniencyTest

```
    @Override
   protected void setUp() throws Exception {
     super.setUp();
     gson = new GsonBuilder().setLenient().create();
   }

   public void testLenientFromJson() {
     List<String> json = gson.fromJson(""
         + "[ # One!\n"
         + "  'Hi' #Element!\n"
         + "] # Array!", new TypeToken<List<String>>() {}.getType());
     assertEquals(singletonList("Hi"), json);
   }
```

If you were to remove the comment at the end of the String ("# Array!"), then it would not make any difference at all whether or not the lenient flag had been set.  The following would also pass:

```
     List<String> json = new GsonBuilder().create().fromJson(""
         + "[ # One!\n"
         + "  'Hi' #Element!\n"
         + "]", new TypeToken<List<String>>() {}.getType());
     assertEquals(singletonList("Hi"), json);
```

It seems counterintuitive that with the lenient flag unset, comments in the middle of the JSON data would be ignored but comments at the end would cause a failure when the Gson parser is supposed to be "strict".
