### PR TITLE
Gson synchronized map replaced with concurrent hash map

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -390,10 +390,7 @@ public final class Gson {
    */
   @SuppressWarnings("unchecked")
   public <T> TypeAdapter<T> getAdapter(TypeToken<T> type) {
-    if (type == null) {
-      type = (TypeToken<T>) NULL_KEY_SURROGATE;
-    }
-    TypeAdapter<?> cached = typeTokenCache.get(type);
+    TypeAdapter<?> cached = typeTokenCache.get(type == null ? NULL_KEY_SURROGATE : type);
     if (cached != null) {
       return (TypeAdapter<T>) cached;
     }

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongArray;
 
@@ -108,6 +109,7 @@ public final class Gson {
   static final boolean DEFAULT_COMPLEX_MAP_KEYS = false;
   static final boolean DEFAULT_SPECIALIZE_FLOAT_VALUES = false;
 
+  private static final TypeToken<?> NULL_KEY_SURROGATE = new TypeToken<Object>() {};
   private static final String JSON_NON_EXECUTABLE_PREFIX = ")]}'\n";
 
   /**
@@ -120,8 +122,7 @@ public final class Gson {
   private final ThreadLocal<Map<TypeToken<?>, FutureTypeAdapter<?>>> calls
       = new ThreadLocal<Map<TypeToken<?>, FutureTypeAdapter<?>>>();
 
-  private final Map<TypeToken<?>, TypeAdapter<?>> typeTokenCache
-      = Collections.synchronizedMap(new HashMap<TypeToken<?>, TypeAdapter<?>>());
+  private final Map<TypeToken<?>, TypeAdapter<?>> typeTokenCache = new ConcurrentHashMap<TypeToken<?>, TypeAdapter<?>>();
 
   private final List<TypeAdapterFactory> factories;
   private final ConstructorConstructor constructorConstructor;
@@ -389,6 +390,9 @@ public final class Gson {
    */
   @SuppressWarnings("unchecked")
   public <T> TypeAdapter<T> getAdapter(TypeToken<T> type) {
+    if (type == null) {
+      type = (TypeToken<T>) NULL_KEY_SURROGATE;
+    }
     TypeAdapter<?> cached = typeTokenCache.get(type);
     if (cached != null) {
       return (TypeAdapter<T>) cached;


### PR DESCRIPTION
Internally Gson class uses Collections#synchronizedMap as a thread-safe map for typeTokenCache.
In a highly-contended environment I'm experiencing unpredictable latency spikes, 
while the performance of Gson#toJson degrades significantly even for simple objects. 
It's typical for an application thread to hang on typeTokenCache#get average 3-15 ms in such situations.
See [this](https://gist.github.com/qwwdfsad/a72692ab56a1a946a5fb) benchmark results to observe this problem (results for patch included).

For a more or less generic serialization code it's impossible to use TypeAdapter directly. One of the solutions might be to use thread-local Gson instances, but from programmer's perspective it makes code more obfuscated, requires an additional explanation on why this was done and floods the heap with duplicate objects. Gson is declared as thread-safe, so it seems reasonable to expect fine-grained concurrency level internally.  Moreover, after initial application warmup typeTokenCache becomes a mostly read-only structure (in fact, read-only), so allowing non-blocking reads looks like a perfect fit. 

Provided patch replaces synchronized map with j.u.c.ConcurrentHashMap. The main difference between synchronized map and CHM is null keys prohibition, so implicit code-path for null is added. 
As you can see in benchmark results, even despite of additional code path for null keys, overall throughput increases even in single-threaded case due to absence of explicit synchronization (though JVM optimizes uncontended locks, some overhead is still present), so there is no risks or performance degradation associated with this patch.