### PR TITLE
allow unquoted long and integer keys

### DIFF
--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -951,8 +951,12 @@ public class JsonReader implements Closeable {
     if (p == PEEKED_NUMBER) {
       peekedString = new String(buffer, pos, peekedNumberLength);
       pos += peekedNumberLength;
-    } else if (p == PEEKED_SINGLE_QUOTED || p == PEEKED_DOUBLE_QUOTED) {
-      peekedString = nextQuotedValue(p == PEEKED_SINGLE_QUOTED ? '\'' : '"');
+    } else if (p == PEEKED_SINGLE_QUOTED || p == PEEKED_DOUBLE_QUOTED || p == PEEKED_UNQUOTED) {
+      if (p == PEEKED_UNQUOTED) {
+        peekedString = nextUnquotedValue();
+      } else {
+        peekedString = nextQuotedValue(p == PEEKED_SINGLE_QUOTED ? '\'' : '"');
+      }
       try {
         long result = Long.parseLong(peekedString);
         peeked = PEEKED_NONE;
@@ -1179,8 +1183,12 @@ public class JsonReader implements Closeable {
     if (p == PEEKED_NUMBER) {
       peekedString = new String(buffer, pos, peekedNumberLength);
       pos += peekedNumberLength;
-    } else if (p == PEEKED_SINGLE_QUOTED || p == PEEKED_DOUBLE_QUOTED) {
-      peekedString = nextQuotedValue(p == PEEKED_SINGLE_QUOTED ? '\'' : '"');
+    } else if (p == PEEKED_SINGLE_QUOTED || p == PEEKED_DOUBLE_QUOTED || p == PEEKED_UNQUOTED) {
+      if (p == PEEKED_UNQUOTED) {
+        peekedString = nextUnquotedValue();
+      } else {
+        peekedString = nextQuotedValue(p == PEEKED_SINGLE_QUOTED ? '\'' : '"');
+      }
       try {
         result = Integer.parseInt(peekedString);
         peeked = PEEKED_NONE;

--- a/gson/src/test/java/com/google/gson/functional/MapTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MapTest.java
@@ -167,6 +167,34 @@ public class MapTest extends TestCase {
     assertEquals("456", map.get(123));
   }
 
+  public void testMapDeserializationWithUnquotedIntegerKeys() {
+    Type typeOfMap = new TypeToken<Map<Integer, String>>() {}.getType();
+    Map<Integer, String> map = gson.fromJson("{123:\"456\"}", typeOfMap);
+    assertEquals(1, map.size());
+    assertTrue(map.containsKey(123));
+    assertEquals("456", map.get(123));
+  }
+
+  public void testMapDeserializationWithLongKeys() {
+    long longValue = 9876543210L;
+    String json = String.format("{\"%d\":\"456\"}", longValue);
+    Type typeOfMap = new TypeToken<Map<Long, String>>() {}.getType();
+    Map<Long, String> map = gson.fromJson(json, typeOfMap);
+    assertEquals(1, map.size());
+    assertTrue(map.containsKey(longValue));
+    assertEquals("456", map.get(longValue));
+  }
+
+  public void testMapDeserializationWithUnquotedLongKeys() {
+    long longKey = 9876543210L;
+    String json = String.format("{%d:\"456\"}", longKey);
+    Type typeOfMap = new TypeToken<Map<Long, String>>() {}.getType();
+    Map<Long, String> map = gson.fromJson(json, typeOfMap);
+    assertEquals(1, map.size());
+    assertTrue(map.containsKey(longKey));
+    assertEquals("456", map.get(longKey));
+  }
+
   public void testHashMapDeserialization() throws Exception {
     Type typeOfMap = new TypeToken<HashMap<Integer, String>>() {}.getType();
     HashMap<Integer, String> map = gson.fromJson("{\"123\":\"456\"}", typeOfMap);

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -501,7 +501,7 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.nextInt();
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (NumberFormatException expected) {
     }
     assertEquals("12.34e5x", reader.nextString());
   }


### PR DESCRIPTION
Fixes a bug in JsonReader.nextInt() and JsonReader.nextLong() whereby PEEKED_UNQUOTED is not handled.  This bug caused failure to deserialize maps with Long or Integer keys when the key is unquoted.

This fixes issues #604 and #524 