### PR TITLE
Allow the non-execute prefix to be terminated by non-Unix line endings

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -110,7 +110,7 @@ public final class Gson {
   static final boolean DEFAULT_SPECIALIZE_FLOAT_VALUES = false;
 
   private static final TypeToken<?> NULL_KEY_SURROGATE = TypeToken.get(Object.class);
-  private static final String JSON_NON_EXECUTABLE_PREFIX = ")]}'\n";
+  private static final String JSON_NON_EXECUTE_PREFIX = new String(JsonReader.NON_EXECUTE_PREFIX) + "\n";
 
   /**
    * This thread local guards against reentrant calls to getAdapter(). In
@@ -711,7 +711,7 @@ public final class Gson {
    */
   public JsonWriter newJsonWriter(Writer writer) throws IOException {
     if (generateNonExecutableJson) {
-      writer.write(JSON_NON_EXECUTABLE_PREFIX);
+      writer.write(JSON_NON_EXECUTE_PREFIX);
     }
     JsonWriter jsonWriter = new JsonWriter(writer);
     if (prettyPrinting) {

--- a/gson/src/test/java/com/google/gson/functional/SecurityTest.java
+++ b/gson/src/test/java/com/google/gson/functional/SecurityTest.java
@@ -20,6 +20,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.common.TestTypes.BagOfPrimitives;
 
+import com.google.gson.stream.JsonReader;
 import junit.framework.TestCase;
 
 /**
@@ -28,10 +29,7 @@ import junit.framework.TestCase;
  * @author Inderjeet Singh
  */
 public class SecurityTest extends TestCase {
-  /**
-   * Keep this in sync with Gson.JSON_NON_EXECUTABLE_PREFIX
-   */
-  private static final String JSON_NON_EXECUTABLE_PREFIX = ")]}'\n";
+  private static final String JSON_NON_EXECUTE_PREFIX = new String(JsonReader.NON_EXECUTE_PREFIX) + '\n';
 
   private GsonBuilder gsonBuilder;
 
@@ -44,11 +42,11 @@ public class SecurityTest extends TestCase {
   public void testNonExecutableJsonSerialization() {
     Gson gson = gsonBuilder.generateNonExecutableJson().create();
     String json = gson.toJson(new BagOfPrimitives());
-    assertTrue(json.startsWith(JSON_NON_EXECUTABLE_PREFIX));
+    assertTrue(json.startsWith(JSON_NON_EXECUTE_PREFIX));
   }
   
   public void testNonExecutableJsonDeserialization() {
-    String json = JSON_NON_EXECUTABLE_PREFIX + "{longValue:1}";
+    String json = JSON_NON_EXECUTE_PREFIX + "{longValue:1}";
     Gson gson = gsonBuilder.create();
     BagOfPrimitives target = gson.fromJson(json, BagOfPrimitives.class);
     assertEquals(1, target.longValue);
@@ -56,7 +54,7 @@ public class SecurityTest extends TestCase {
   
   public void testJsonWithNonExectuableTokenSerialization() {
     Gson gson = gsonBuilder.generateNonExecutableJson().create();
-    String json = gson.toJson(JSON_NON_EXECUTABLE_PREFIX);
+    String json = gson.toJson(JSON_NON_EXECUTE_PREFIX);
     assertTrue(json.contains(")]}'\n"));
   }
   
@@ -66,7 +64,7 @@ public class SecurityTest extends TestCase {
    */
   public void testJsonWithNonExectuableTokenWithRegularGsonDeserialization() {
     Gson gson = gsonBuilder.create();
-    String json = JSON_NON_EXECUTABLE_PREFIX + "{stringValue:')]}\\u0027\\n'}";
+    String json = JSON_NON_EXECUTE_PREFIX + "{stringValue:')]}\\u0027\\n'}";
     BagOfPrimitives target = gson.fromJson(json, BagOfPrimitives.class);
     assertEquals(")]}'\n", target.stringValue);
   }  
@@ -78,7 +76,7 @@ public class SecurityTest extends TestCase {
   public void testJsonWithNonExectuableTokenWithConfiguredGsonDeserialization() {
     // Gson should be able to deserialize a stream with non-exectuable token even if it is created 
     Gson gson = gsonBuilder.generateNonExecutableJson().create();
-    String json = JSON_NON_EXECUTABLE_PREFIX + "{intValue:2,stringValue:')]}\\u0027\\n'}";
+    String json = JSON_NON_EXECUTE_PREFIX + "{intValue:2,stringValue:')]}\\u0027\\n'}";
     BagOfPrimitives target = gson.fromJson(json, BagOfPrimitives.class);
     assertEquals(")]}'\n", target.stringValue);
     assertEquals(2, target.intValue);

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -1305,6 +1305,14 @@ public final class JsonReaderTest extends TestCase {
     assertEquals(JsonToken.END_DOCUMENT, reader.peek());
   }
 
+  public void testLenientNonExecutePrefixWithWindowsLineEndings() throws IOException {
+    JsonReader reader = new JsonReader(reader(")]}'\r\n []"));
+    reader.setLenient(true);
+    reader.beginArray();
+    reader.endArray();
+    assertEquals(JsonToken.END_DOCUMENT, reader.peek());
+  }
+
   public void testLenientNonExecutePrefixWithLeadingWhitespace() throws IOException {
     JsonReader reader = new JsonReader(reader("\r\n \t)]}'\n []"));
     reader.setLenient(true);


### PR DESCRIPTION
Allowing non-Unix line endings for the non-execute prefix is particularly useful when running unit tests against committed JSON files that may have platform-specific line endings in the working tree.
