### PR TITLE
Improving InterceptorFactory to allow usage without Intercept annotation.

### DIFF
--- a/extras/src/main/java/com/google/gson/interceptors/InterceptorFactory.java
+++ b/extras/src/main/java/com/google/gson/interceptors/InterceptorFactory.java
@@ -7,19 +7,86 @@ import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
- * A type adapter factory that implements {@code @Intercept}.
- */
+ * A type adapter factory that allows to do post deserialization processing of newly created object instances. This
+ * class realises two strategies:
+ * <ul>
+ *   <li>For situation in which adding annotation for classes it's not acceptable: Uses pre configured map of type to
+ *   post-deserialiser binding. For such cases use {@link #registerInterception(Class, Class)}</li>
+ *   <li>If adding annotation is desired approach, classes which should be postprocessed should be marked with
+ *   {@link Intercept} annotation. </li>
+ * </ul>
+ *
+ * For usage with annotation please refer to documentation of {@link Intercept}, for usage of pre configured strategy:
+ * <p><pre>
+ * public class User {
+ *   String name;
+ *   String password;
+ *   String emailAddress;
+ * }
+ *
+ * public class UserValidator implements JsonPostDeserializer&lt;User&gt; {
+ *   public void postDeserialize(User user) {
+ *     // Do some checks on user
+ *     if (user.name == null || user.password == null) {
+ *       throw new JsonParseException("name and password are required fields.");
+ *     }
+ *     if (user.emailAddress == null) {
+ *       emailAddress = "unknown"; // assign a default value.
+ *     }
+ *   }
+ * }
+ *
+ * InterceptorFactory factory = new InterceptorFactory();
+ * factory.registerInterception(User.class, UserValidator.class);
+ * </pre></p>
+ *
+ * @author Inderjeet Singh
+ * @author Bartłomiej Żarnowski
+ **/
 public final class InterceptorFactory implements TypeAdapterFactory {
+
+  private Map<Class<?>, Class<? extends JsonPostDeserializer>> interceptors;
+
+  public void registerInterception(Class<?> type, Class<? extends JsonPostDeserializer> interceptor) {
+    if (interceptors == null) {
+      interceptors = new HashMap<Class<?>, Class<? extends JsonPostDeserializer>>();
+    }
+    if (interceptors.containsKey(type)) {
+      throw new IllegalArgumentException("Type " + type + " is already registered for interception.");
+    }
+    interceptors.put(type, interceptor);
+  }
+
   public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
-    Intercept intercept = type.getRawType().getAnnotation(Intercept.class);
-    if (intercept == null) {
-      return null;
+    JsonPostDeserializer<T> postDeserializer = null;
+
+    try {
+      //check pre configured interceptors it any
+      if (interceptors != null) {
+        Class<? extends JsonPostDeserializer> interceptorClass = interceptors.get(type.getRawType());
+        if (interceptorClass != null) {
+          postDeserializer = interceptorClass.newInstance();
+        }
+      }
+
+      //if no pre configured interceptor, try annotation approach
+      if (postDeserializer == null) {
+        Intercept intercept = type.getRawType().getAnnotation(Intercept.class);
+        if (intercept == null) {
+          return null;
+        }
+        postDeserializer = intercept.postDeserialize().newInstance();
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
 
     TypeAdapter<T> delegate = gson.getDelegateAdapter(this, type);
-    return new InterceptorAdapter<T>(delegate, intercept);
+    return new InterceptorAdapter<T>(delegate, postDeserializer);
   }
 
   static class InterceptorAdapter<T> extends TypeAdapter<T> {
@@ -27,13 +94,9 @@ public final class InterceptorFactory implements TypeAdapterFactory {
     private final JsonPostDeserializer<T> postDeserializer;
 
     @SuppressWarnings("unchecked") // ?
-    public InterceptorAdapter(TypeAdapter<T> delegate, Intercept intercept) {
-      try {
-        this.delegate = delegate;
-        this.postDeserializer = intercept.postDeserialize().newInstance();
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
+    public InterceptorAdapter(TypeAdapter<T> delegate, JsonPostDeserializer<T> postDeserializer) {
+      this.delegate = delegate;
+      this.postDeserializer = postDeserializer;
     }
 
     @Override public void write(JsonWriter out, T value) throws IOException {

--- a/extras/src/test/java/com/google/gson/interceptors/PreconfiguredInterceptrorTest.java
+++ b/extras/src/test/java/com/google/gson/interceptors/PreconfiguredInterceptrorTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2012 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gson.interceptors;
+
+import com.google.gson.*;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import junit.framework.TestCase;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link InterceptorFactory} with pre configured interception strategy.
+ *
+ * @author Bartłomiej Żarnowski (based on code from {@link InterceptorTest}
+ */
+public class PreconfiguredInterceptrorTest  extends TestCase  {
+
+  private Gson gson;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+
+    InterceptorFactory interceptorFactory = new InterceptorFactory();
+    interceptorFactory.registerInterception(User.class, UserValidator.class);
+    interceptorFactory.registerInterception(Address.class, AddressValidator.class);
+
+    this.gson = new GsonBuilder()
+        .registerTypeAdapterFactory(interceptorFactory)
+        .enableComplexMapKeySerialization()
+        .create();
+  }
+
+  public void testExceptionsPropagated() {
+    try {
+      gson.fromJson("{}", User.class);
+      fail();
+    } catch (JsonParseException expected) {}
+  }
+
+  public void testTopLevelClass() {
+    User user = gson.fromJson("{name:'bob',password:'pwd'}", User.class);
+    assertEquals(User.DEFAULT_EMAIL, user.email);
+  }
+
+  public void testList() {
+    List<User> list = gson.fromJson("[{name:'bob',password:'pwd'}]", new TypeToken<List<User>>(){}.getType());
+    User user = list.get(0);
+    assertEquals(User.DEFAULT_EMAIL, user.email);
+  }
+
+  public void testCollection() {
+    Collection<User> list = gson.fromJson("[{name:'bob',password:'pwd'}]", new TypeToken<Collection<User>>(){}.getType());
+    User user = list.iterator().next();
+    assertEquals(User.DEFAULT_EMAIL, user.email);
+  }
+
+  public void testMapKeyAndValues() {
+    Type mapType = new TypeToken<Map<User, Address>>(){}.getType();
+    try {
+      gson.fromJson("[[{name:'bob',password:'pwd'},{}]]", mapType);
+      fail();
+    } catch (JsonSyntaxException expected) {}
+    Map<User, Address> map = gson.fromJson("[[{name:'bob',password:'pwd'},{city:'Mountain View',state:'CA',zip:'94043'}]]",
+        mapType);
+    Map.Entry<User, Address> entry = map.entrySet().iterator().next();
+    assertEquals(User.DEFAULT_EMAIL, entry.getKey().email);
+    assertEquals(Address.DEFAULT_FIRST_LINE, entry.getValue().firstLine);
+  }
+
+  public void testField() {
+    UserGroup userGroup = gson.fromJson("{user:{name:'bob',password:'pwd'}}", UserGroup.class);
+    assertEquals(User.DEFAULT_EMAIL, userGroup.user.email);
+  }
+
+  public void testCustomTypeAdapter() {
+    InterceptorFactory interceptorFactory = new InterceptorFactory();
+    interceptorFactory.registerInterception(User.class, UserValidator.class);
+    interceptorFactory.registerInterception(Address.class, AddressValidator.class);
+
+    Gson gson = new GsonBuilder()
+        .registerTypeAdapter(User.class, new TypeAdapter<User>() {
+          @Override public void write(JsonWriter out, User value) throws IOException {
+            throw new UnsupportedOperationException();
+          }
+
+          @Override public User read(JsonReader in) throws IOException {
+            in.beginObject();
+            in.nextName();
+            String name = in.nextString();
+            in.nextName();
+            String password = in.nextString();
+            in.endObject();
+            return new User(name, password);
+          }
+        })
+        .registerTypeAdapterFactory(interceptorFactory)
+        .create();
+    UserGroup userGroup = gson.fromJson("{user:{name:'bob',password:'pwd'}}", UserGroup.class);
+    assertEquals(User.DEFAULT_EMAIL, userGroup.user.email);
+  }
+
+  public void testDirectInvocationOfTypeAdapter() throws Exception {
+    TypeAdapter<UserGroup> adapter = gson.getAdapter(UserGroup.class);
+    UserGroup userGroup = adapter.fromJson("{\"user\":{\"name\":\"bob\",\"password\":\"pwd\"}}");
+    assertEquals(User.DEFAULT_EMAIL, userGroup.user.email);
+  }
+
+  @SuppressWarnings("unused")
+  private static final class UserGroup {
+    User user;
+    String city;
+  }
+
+  @SuppressWarnings("unused")
+  private static final class User {
+    static final String DEFAULT_EMAIL = "invalid@invalid.com";
+    String name;
+    String password;
+    String email;
+    Address address;
+    public User(String name, String password) {
+      this.name = name;
+      this.password = password;
+    }
+  }
+
+  public static final class UserValidator implements JsonPostDeserializer<User> {
+    public void postDeserialize(User user) {
+      if (user.name == null || user.password == null) {
+        throw new JsonSyntaxException("name and password are required fields.");
+      }
+      if (user.email == null) user.email = User.DEFAULT_EMAIL;
+    }
+  }
+
+  @SuppressWarnings("unused")
+  private static final class Address {
+    static final String DEFAULT_FIRST_LINE = "unknown";
+    String firstLine;
+    String secondLine;
+    String city;
+    String state;
+    String zip;
+  }
+
+  public static final class AddressValidator implements JsonPostDeserializer<Address> {
+    public void postDeserialize(Address address) {
+      if (address.city == null || address.state == null || address.zip == null) {
+        throw new JsonSyntaxException("Address city, state and zip are required fields.");
+      }
+      if (address.firstLine == null) address.firstLine = Address.DEFAULT_FIRST_LINE;
+    }
+  }
+
+}


### PR DESCRIPTION
I wan't to use Intercept functionality in my project, however it requires usage of annotation. In fact this is not something which I want to put into my code, this will break my abstraction. So I decided to extend current solution to allow developer "inject" binding without need to annotate classes.