### PR TITLE
moved the JsonSerializationContext/JsonDeserializationContext fields …

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -133,22 +133,6 @@ public final class Gson {
   private final boolean prettyPrinting;
   private final boolean lenient;
 
-  final JsonDeserializationContext deserializationContext = new JsonDeserializationContext() {
-    @SuppressWarnings("unchecked")
-    @Override public <T> T deserialize(JsonElement json, Type typeOfT) throws JsonParseException {
-      return (T) fromJson(json, typeOfT);
-    }
-  };
-
-  final JsonSerializationContext serializationContext = new JsonSerializationContext() {
-    @Override public JsonElement serialize(Object src) {
-      return toJsonTree(src);
-    }
-    @Override public JsonElement serialize(Object src, Type typeOfSrc) {
-      return toJsonTree(src, typeOfSrc);
-    }
-  };
-
   /**
    * Constructs a Gson object with default configuration. The default configuration has the
    * following settings:

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import com.google.gson.internal.$Gson$Preconditions;
 import com.google.gson.internal.Excluder;
+import com.google.gson.internal.bind.TreeTypeAdapter;
 import com.google.gson.internal.bind.TypeAdapters;
 import com.google.gson.reflect.TypeToken;
 

--- a/gson/src/main/java/com/google/gson/internal/bind/TreeTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TreeTypeAdapter.java
@@ -14,31 +14,42 @@
  * limitations under the License.
  */
 
-package com.google.gson;
+package com.google.gson.internal.bind;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
 import com.google.gson.internal.$Gson$Preconditions;
 import com.google.gson.internal.Streams;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
+import java.lang.reflect.Type;
 
 /**
  * Adapts a Gson 1.x tree-style adapter as a streaming TypeAdapter. Since the
  * tree adapter may be serialization-only or deserialization-only, this class
  * has a facility to lookup a delegate type adapter on demand.
  */
-final class TreeTypeAdapter<T> extends TypeAdapter<T> {
+public final class TreeTypeAdapter<T> extends TypeAdapter<T> {
   private final JsonSerializer<T> serializer;
   private final JsonDeserializer<T> deserializer;
   private final Gson gson;
   private final TypeToken<T> typeToken;
   private final TypeAdapterFactory skipPast;
+  private final GsonContextImpl context = new GsonContextImpl();
 
   /** The delegate is lazily created because it may not be needed, and creating it may fail. */
   private TypeAdapter<T> delegate;
 
-  TreeTypeAdapter(JsonSerializer<T> serializer, JsonDeserializer<T> deserializer,
+  public TreeTypeAdapter(JsonSerializer<T> serializer, JsonDeserializer<T> deserializer,
       Gson gson, TypeToken<T> typeToken, TypeAdapterFactory skipPast) {
     this.serializer = serializer;
     this.deserializer = deserializer;
@@ -55,7 +66,7 @@ final class TreeTypeAdapter<T> extends TypeAdapter<T> {
     if (value.isJsonNull()) {
       return null;
     }
-    return deserializer.deserialize(value, typeToken.getType(), gson.deserializationContext);
+    return deserializer.deserialize(value, typeToken.getType(), context);
   }
 
   @Override public void write(JsonWriter out, T value) throws IOException {
@@ -67,7 +78,7 @@ final class TreeTypeAdapter<T> extends TypeAdapter<T> {
       out.nullValue();
       return;
     }
-    JsonElement tree = serializer.serialize(value, typeToken.getType(), gson.serializationContext);
+    JsonElement tree = serializer.serialize(value, typeToken.getType(), context);
     Streams.write(tree, out);
   }
 
@@ -105,7 +116,7 @@ final class TreeTypeAdapter<T> extends TypeAdapter<T> {
     return new SingleTypeFactory(typeAdapter, null, false, hierarchyType);
   }
 
-  private static class SingleTypeFactory implements TypeAdapterFactory {
+  private static final class SingleTypeFactory implements TypeAdapterFactory {
     private final TypeToken<?> exactType;
     private final boolean matchRawType;
     private final Class<?> hierarchyType;
@@ -138,4 +149,17 @@ final class TreeTypeAdapter<T> extends TypeAdapter<T> {
           : null;
     }
   }
+
+  private final class GsonContextImpl implements JsonSerializationContext, JsonDeserializationContext {
+    @Override public JsonElement serialize(Object src) {
+      return gson.toJsonTree(src);
+    }
+    @Override public JsonElement serialize(Object src, Type typeOfSrc) {
+      return gson.toJsonTree(src, typeOfSrc);
+    }
+    @SuppressWarnings("unchecked")
+    @Override public <R> R deserialize(JsonElement json, Type typeOfT) throws JsonParseException {
+      return (R) gson.fromJson(json, typeOfT);
+    }
+  };
 }


### PR DESCRIPTION
…to where they are used.

Also moved TreeTypeAdapter to internal.bind package for potential use in JsonAdapterAnnotationFactory.