### PR TITLE
fixed throwing RuntimeException instead of JsonIOException

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -679,7 +679,7 @@ public final class Gson {
       JsonWriter jsonWriter = newJsonWriter(Streams.writerForAppendable(writer));
       toJson(jsonElement, jsonWriter);
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new JsonIOException(e);
     }
   }
 


### PR DESCRIPTION
Javadoc says that JsonIOException will be thrown if any problem happened, but actually I'm getting RuntimeException only in that method.