### PR TITLE
Add annotation that enables null serialization per field

### DIFF
--- a/gson/src/main/java/com/google/gson/annotations/Serialize.java
+++ b/gson/src/main/java/com/google/gson/annotations/Serialize.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2016 Markus Pfeiffer.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+/**
+ * An annotation that defines additional conditions to apply when serializing a member that is
+ * {@code null}.
+ * <p>
+ * This annotation has no effect if a member is excluded from serialization. A member may be
+ * excluded from serialization if it has a {@code transient} modifier or if it does not have an
+ * {@link Expose} annotation and {@link com.google.gson.Gson} has been built with a
+ * {@link com.google.gson.GsonBuilder} and the
+ * {@link com.google.gson.GsonBuilder#excludeFieldsWithoutExposeAnnotation()} method has been
+ * invoked.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Serialize {
+
+    /**
+     * Returns a value indicating whether the field should be serialized if it is {@code null}.
+     * @return the desired inclusion of the field when it is serialized.
+     */
+    Inclusion value() default Inclusion.DEFAULT;
+
+    /**
+     * Indicates the conditions under which a member should be serialized.
+     */
+    public static enum Inclusion {
+
+        /**
+         * Use Gson's default behavior.
+         * <p>
+         * The value is included unless it is {@code null} or {@link com.google.gson.Gson} has been
+         * built with a {@link com.google.gson.GsonBuilder} and the
+         * {@link com.google.gson.GsonBuilder#serializeNulls()} method has been invoked.
+         */
+        DEFAULT,
+
+        /**
+         * The value is excluded if it is {@code null}.
+         * <p>
+         * Note that this matches the default behavior unless {@link com.google.gson.Gson} has been
+         * built with a {@link com.google.gson.GsonBuilder} and the
+         * {@link com.google.gson.GsonBuilder#serializeNulls()} method has been invoked.
+         */
+        NON_NULL,
+
+        /**
+         * The value is always included, even if it is {@code null}.
+         * <p>
+         * Note that this has no effect if {@link com.google.gson.Gson} has been built with a
+         * {@link com.google.gson.GsonBuilder} and the
+         * {@link com.google.gson.GsonBuilder#serializeNulls()} method has been invoked.
+         */
+        ALWAYS
+    }
+}

--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeWriter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeWriter.java
@@ -21,7 +21,9 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import com.google.gson.annotations.Serialize.Inclusion;
 import com.google.gson.stream.JsonWriter;
+
 import java.io.IOException;
 import java.io.Writer;
 import java.util.ArrayList;
@@ -141,6 +143,10 @@ public final class JsonTreeWriter extends JsonWriter {
     throw new IllegalStateException();
   }
 
+  @Override public JsonWriter inclusion(final Inclusion inclusion) {
+      return this;
+  }
+  
   @Override public JsonWriter value(String value) throws IOException {
     if (value == null) {
       return nullValue();

--- a/gson/src/test/java/com/google/gson/functional/SerializeFieldsTest.java
+++ b/gson/src/test/java/com/google/gson/functional/SerializeFieldsTest.java
@@ -1,0 +1,140 @@
+
+package com.google.gson.functional;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.annotations.Serialize;
+import com.google.gson.annotations.Serialize.Inclusion;
+
+import junit.framework.TestCase;
+
+
+public class SerializeFieldsTest extends TestCase {
+
+    private static void assertIncludes(final String json, final String field, final Object value) {
+        JsonParser parser = new JsonParser();
+        JsonObject obj = parser.parse(json).getAsJsonObject();
+
+        assertTrue(obj.has(field));
+        JsonElement element = obj.get(field);
+
+        if (value == null) {
+            assertTrue(element.isJsonNull());
+        } else if (element.isJsonPrimitive()) {
+            JsonPrimitive primitive = element.getAsJsonPrimitive();
+            assertEquals(String.valueOf(value), primitive.getAsString());
+        } else if (element.isJsonObject()) {
+            JsonObject object = element.getAsJsonObject();
+            assertNotNull(object);
+            assertEquals(value, object.toString());
+        }
+    }
+
+    private static void assertExcludes(final String json, final String field) {
+        JsonParser parser = new JsonParser();
+        JsonObject obj = parser.parse(json).getAsJsonObject();
+
+        assertFalse(obj.has(field));
+    }
+
+    public void testSerializeDefaultExclusion() {
+        final Gson gson = new GsonBuilder().create();
+        final TestObject obj = new TestObject();
+
+        final String json = gson.toJson(obj);
+
+        assertExcludes(json, "empty_1");
+        assertExcludes(json, "empty_2");
+        assertIncludes(json, "empty_3", null);
+        assertExcludes(json, "empty_4");
+        assertIncludes(json, "value_1", "value-1");
+        assertIncludes(json, "value_2", 2L);
+        assertIncludes(json, "value_3", 3);
+        assertIncludes(json, "value_4", "{\"value\":1}");
+    }
+
+    public void testSerializeNonNullExclusion() {
+        final Gson gson = new GsonBuilder().serializeNulls().create();
+        final TestObject obj = new TestObject();
+
+        final String json = gson.toJson(obj);
+
+        assertIncludes(json, "empty_1", null);
+        assertIncludes(json, "empty_2", null);
+        assertIncludes(json, "empty_3", null);
+        assertExcludes(json, "empty_4");
+        assertIncludes(json, "value_1", "value-1");
+        assertIncludes(json, "value_2", 2L);
+        assertIncludes(json, "value_3", 3);
+        assertIncludes(json, "value_4", "{\"value\":1}");
+    }
+
+    public void testDeserializeDefaultExclusion() {
+        final Gson gson = new GsonBuilder().create();
+        final TestObject source = new TestObject();
+
+        final String json = gson.toJson(source);
+        final TestObject target = gson.fromJson(json, TestObject.class);
+
+        assertEquals(null, target.empty_1);
+        assertEquals(null, target.empty_2);
+        assertEquals(null, target.empty_3);
+        assertEquals(null, target.empty_4);
+        assertEquals("value-1", target.value_1);
+        assertEquals(2L, target.value_2);
+        assertEquals(3, target.value_3);
+        assertEquals(NestedObject.class, target.value_4.getClass());
+    }
+
+    public void testDeserializeNonNullExclusion() {
+        final Gson gson = new GsonBuilder().serializeNulls().create();
+        final TestObject source = new TestObject();
+
+        final String json = gson.toJson(source);
+        final TestObject target = gson.fromJson(json, TestObject.class);
+
+        assertEquals(null, target.empty_1);
+        assertEquals(null, target.empty_2);
+        assertEquals(null, target.empty_3);
+        assertEquals(null, target.empty_4);
+        assertEquals("value-1", target.value_1);
+        assertEquals(2L, target.value_2);
+        assertEquals(3, target.value_3);
+        assertNotNull(target.value_4);
+        assertEquals(NestedObject.class, target.value_4.getClass());
+    }
+
+    public static class TestObject {
+
+        public final String       empty_1 = null;
+
+        @Serialize(Inclusion.DEFAULT)
+        public final Long         empty_2 = null;
+
+        @Serialize(Inclusion.ALWAYS)
+        public final Integer      empty_3 = null;
+
+        @Serialize(Inclusion.NON_NULL)
+        public final Object       empty_4 = null;
+
+        public final String       value_1 = "value-1";
+
+        @Serialize(Inclusion.DEFAULT)
+        public final long         value_2 = 2L;
+
+        @Serialize(Inclusion.ALWAYS)
+        public final int          value_3 = 3;
+
+        @Serialize(Inclusion.NON_NULL)
+        public final NestedObject value_4 = new NestedObject();
+    }
+
+    public static class NestedObject {
+
+        public final int value = 1;
+    }
+}


### PR DESCRIPTION
This adds the ability to specify whether to serialize a `null` value on a per-field basis, using the new `@Serialize` annotation.

If the `@Serialize` annotation is not specified, or its value is set to `Inclusion.DEFAULT` the behavior of Gson remains unchanged. A class member's value will be included in the JSON if it has a value other than `null`. If Gson has been configured to always include null values the member's value will be included even if it's `null`.

By adding `@Serialize(Inclusion.ALWAYS)` to a class member, it will always be included in the JSON even if its value is `null`. Basically this annotation makes it possible to enable inclusion of nulls on a per-field basis. If Gson has been configured to always include null values adding the annotation in this form does nothing.

By adding `@Serialize(Inclusion.NON_NULL)` to a class member, it will always be excluded from the JSON if its value is `null`. Normally this matches Gson's default behavior, unless Gson has been configured to include null values. In this case the annotation allows to exclude nulls on a per-field basis.

**Be aware** that this does not change any other of Gson's rules. If a member is excluded for any other reason, for example if it has a `transient` modifier, this annotation will not change this. Also if Gson has been configured to exclude fields that do not have an `@Expose` annotation you will still need to add @Expose to class members that should be serialized. In other words the `@Serialize` annotation only works on members that are serialized under normal circumstances and only changes the behavior of Gson in regards to `null`.

**Examples**
```
public class Main {

    public static class Example {

        @Serialize(Inclusion.ALWAYS)
        public String field1 = null;

		 @Serialize(Inclusion.NON_NULL)
        public String field2 = null;

		 //@Serialize(Inclusion.DEFAULT)
		 public String field3 = null;

        public String field4 = "Field 4";
    }

    public static void main(final String[] args) {

        final Gson gson1 = new GsonBuilder().create();
        final Gson gson2 = new GsonBuilder().serializeNulls().create();

        final Example example1 = new Example();
        
        final String json1 = gson1.toJson(example1);
        System.out.println(json1);
        
        final String json2 = gson2.toJson(example1);
        System.out.println(json2);
    }
}
```

Without support for `@Serialize` the output of Gson would be:
```
// Output for gson1 (don't serialize nulls)
{ "field4": "Field 4" }

// Output for gson2 (serialize nulls)
{ "field1": null, "field2": null, "field3": null, "field4": "Field 4" }
```

**With** support for `@Serialize` its output instead becomes:
```
// Output for gson1 (don't serialize nulls)
{ "field1": null, "field4": "Field 4" }

// Output for gson2 (serialize nulls)
{ "field1": null, "field3": null, "field4": "Field 4" }
```