### PR TITLE
adding @DateFormat annotation to accept date formats

### DIFF
--- a/gson/src/main/java/com/google/gson/DefaultDateTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/DefaultDateTypeAdapter.java
@@ -24,7 +24,6 @@ import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
-import java.util.TimeZone;
 
 import com.google.gson.internal.bind.util.ISO8601Utils;
 
@@ -35,7 +34,7 @@ import com.google.gson.internal.bind.util.ISO8601Utils;
  * @author Inderjeet Singh
  * @author Joel Leitch
  */
-final class DefaultDateTypeAdapter implements JsonSerializer<Date>, JsonDeserializer<Date> {
+public final class DefaultDateTypeAdapter implements JsonSerializer<Date>, JsonDeserializer<Date> {
 
   // TODO: migrate to streaming adapter
 
@@ -47,7 +46,7 @@ final class DefaultDateTypeAdapter implements JsonSerializer<Date>, JsonDeserial
         DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.DEFAULT));
   }
 
-  DefaultDateTypeAdapter(String datePattern) {
+  public DefaultDateTypeAdapter(String datePattern) {
     this(new SimpleDateFormat(datePattern, Locale.US), new SimpleDateFormat(datePattern));
   }
 

--- a/gson/src/main/java/com/google/gson/annotations/DateFormat.java
+++ b/gson/src/main/java/com/google/gson/annotations/DateFormat.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson.annotations;
+
+import com.google.gson.DefaultDateTypeAdapter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation that accept a date format that GSON need to parse and format
+ * dates while deserialization and serialization.
+ *
+ * <p>Here is an example of how this annotation is used:</p>
+ * <pre>
+ * public class Trip {
+ *   &#64DateFormat("yyyy-MM-dd")
+ *   private Date date;
+ *
+ *   private User(Date date) {
+ *     this.date = date;
+ *   }
+ * }
+ * </pre>
+ *
+ * Since Trip class specified date format in &#64DateFormat annotation, this format
+ * will automatically be used to serialize/deserialize date field of Trip class. <br>
+ *
+ * Note: This annotation uses {@link DefaultDateTypeAdapter} internally, any other adapter
+ * provided with {@link JsonAdapter} annotation will be ignored.
+ */
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface DateFormat {
+  String value();
+}

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -16,11 +16,13 @@
 
 package com.google.gson.internal.bind;
 
+import com.google.gson.DefaultDateTypeAdapter;
 import com.google.gson.FieldNamingStrategy;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.DateFormat;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.internal.$Gson$Types;
@@ -32,16 +34,20 @@ import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
+
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 import static com.google.gson.internal.bind.JsonAdapterAnnotationTypeAdapterFactory.getTypeAdapter;
+import static com.google.gson.internal.bind.TreeTypeAdapter.newFactory;
 
 /**
  * Type adapter that reflects over the fields and methods of a class.
@@ -130,12 +136,30 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
   }
 
   TypeAdapter<?> getFieldAdapter(Gson gson, Field field, TypeToken<?> fieldType) {
+    if(isDateFormatPresentOnField(field) && isDateType(fieldType)){
+      return adapterForProvidedDateFormat(gson, field, fieldType);
+    }
     JsonAdapter annotation = field.getAnnotation(JsonAdapter.class);
     if (annotation != null) {
       TypeAdapter<?> adapter = getTypeAdapter(constructorConstructor, gson, fieldType, annotation);
       if (adapter != null) return adapter;
     }
     return gson.getAdapter(fieldType);
+  }
+
+  private TypeAdapter<?> adapterForProvidedDateFormat(Gson gson, Field field, TypeToken<?> fieldType) {
+    DateFormat dateFormatAnnotation = field.getAnnotation(DateFormat.class);
+    String dateFormat = dateFormatAnnotation.value();
+    return newFactory(fieldType, new DefaultDateTypeAdapter(dateFormat)).create(gson, fieldType);
+  }
+
+  private boolean isDateFormatPresentOnField(Field field) {
+    return field.getAnnotation(DateFormat.class) != null;
+  }
+
+  private boolean isDateType(TypeToken<?> fieldType) {
+    Class<?> type = fieldType.getRawType();
+    return Arrays.asList(Date.class, java.sql.Date.class).contains(type);
   }
 
   private Map<String, BoundField> getBoundFields(Gson context, TypeToken<?> type, Class<?> raw) {

--- a/gson/src/test/java/com/google/gson/functional/DateFormatAnnotationTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DateFormatAnnotationTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson.functional;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.DateFormat;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import junit.framework.TestCase;
+
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.Date;
+
+/**
+ * Functional tests for the {@link DateFormat} annotation on fields.
+ */
+public final class DateFormatAnnotationTest extends TestCase {
+  public void testDateFormatShouldBePickedFromAnnotation() {
+    Date expectedDate = getDate(2015, 12, 11);
+    String expectedJson = "{\"startDate\":\"2015-12-10\",\"endDate\":\"2015/12/14\"}";
+    Gson gson = new Gson();
+
+    String json = gson.toJson(new Trip(getDate(2015, 12, 10), getDate(2015, 12, 14)));
+    assertEquals(json, expectedJson);
+
+    Trip trip = gson.fromJson("{\"startDate\":\"2015-12-11\",\"endDate\":\"2015/12/11\"}", Trip.class);
+    assertEqualsDate(expectedDate, trip.startDate);
+    assertEqualsDate(expectedDate, trip.endDate);
+  }
+
+  public void testDateFormatShouldBePickedFromAnnotationForSqlDateType() {
+    Date expectedDate = getDate(2015, 12, 11);
+    Gson gson = new Gson();
+    DBTrip trip = gson.fromJson("{\"startDate\":\"2015-12-11\",\"endDate\":\"2015/12/11\"}", DBTrip.class);
+    assertEqualsDate(expectedDate, trip.startDate);
+    assertEqualsDate(expectedDate, trip.endDate);
+  }
+
+  public void testDateFormatAnnotationTakesPrecedenceOverGivenAdapter() {
+    Date expectedDate = getDate(2015, 12, 11);
+    Gson gson = new Gson();
+    Item item = gson.fromJson("{\"date\":\"2015-12-11\"}", Item.class);
+    assertEqualsDate(expectedDate, item.date);
+  }
+
+  private Date getDate(int year, int month, int date) {
+    Calendar instance = Calendar.getInstance();
+    instance.set(year, month - 1, date);
+    return instance.getTime();
+  }
+
+  @SuppressWarnings("deprecation")
+  private void assertEqualsDate(Date expectedDate, Date date) {
+    assertEquals(expectedDate.getYear(), date.getYear());
+    assertEquals(expectedDate.getMonth(), date.getMonth());
+    assertEquals(expectedDate.getDate(), date.getDate());
+  }
+
+
+  private static final class Trip {
+
+    @DateFormat("yyyy-MM-dd")
+    final Date startDate;
+
+    @DateFormat("yyyy/MM/dd")
+    final Date endDate;
+
+    public Trip(Date startDate, Date endDate) {
+      this.startDate = startDate;
+      this.endDate = endDate;
+    }
+  }
+
+  private static final class DBTrip {
+
+    @DateFormat("yyyy-MM-dd")
+    final java.sql.Date startDate;
+
+    @DateFormat("yyyy/MM/dd")
+    final java.sql.Date endDate;
+
+    public DBTrip(java.sql.Date startDate, java.sql.Date endDate) {
+      this.startDate = startDate;
+      this.endDate = endDate;
+    }
+  }
+
+  private static final class Item {
+
+    @DateFormat("yyyy-MM-dd")
+    @JsonAdapter(DummyDateAdapter.class)
+    final Date date;
+
+    public Item(Date date) {
+      this.date = date;
+    }
+  }
+
+  private static class DummyDateAdapter extends TypeAdapter<Date> {
+    @Override public void write(JsonWriter out, Date user) throws IOException {
+      out.value(new Date(0).toString());
+    }
+    @Override public Date read(JsonReader in) throws IOException {
+      in.nextString();
+      return new Date(0);
+    }
+  }
+
+
+}


### PR DESCRIPTION
this field annotation will allow passing date formats to GSON in order to parse/format
date strings while deserialization/serialization. It will work for `java.util.Date` and `java.sql.Date` type fields.

  
    public class Trip {
        @DateFormat("yyyy-MM-dd")
        private Date startDate;

        @DateFormat("yyyy/MM/dd")
        private Date endDate;

        public Trip(Date startDate, Date endDate) {
          this.startDate = startDate;
          this.endDate = endDate;
        }
    }

that's how we can pass date formats for different fields to Gson.