### PR TITLE
made nullSafe wrapper of JsonAdapter optional

### DIFF
--- a/gson/src/main/java/com/google/gson/annotations/JsonAdapter.java
+++ b/gson/src/main/java/com/google/gson/annotations/JsonAdapter.java
@@ -94,4 +94,6 @@ public @interface JsonAdapter {
   /** Either a {@link TypeAdapter} or {@link TypeAdapterFactory}. */
   Class<?> value();
 
+  boolean nullSafe() default true;
+
 }

--- a/gson/src/main/java/com/google/gson/annotations/JsonAdapter.java
+++ b/gson/src/main/java/com/google/gson/annotations/JsonAdapter.java
@@ -94,6 +94,7 @@ public @interface JsonAdapter {
   /** Either a {@link TypeAdapter} or {@link TypeAdapterFactory}. */
   Class<?> value();
 
+  /** false, to be able to handle {@code null} values within the adapter, default value is true. */
   boolean nullSafe() default true;
 
 }

--- a/gson/src/main/java/com/google/gson/internal/bind/JsonAdapterAnnotationTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonAdapterAnnotationTypeAdapterFactory.java
@@ -64,7 +64,7 @@ public final class JsonAdapterAnnotationTypeAdapterFactory implements TypeAdapte
       throw new IllegalArgumentException(
           "@JsonAdapter value must be TypeAdapter or TypeAdapterFactory reference.");
     }
-    if (typeAdapter != null) {
+    if (typeAdapter != null && annotation.nullSafe()) {
       typeAdapter = typeAdapter.nullSafe();
     }
     return typeAdapter;


### PR DESCRIPTION
as there could be the need of handling `null` values within a custom adapter (which is added via the `@JsonAdapter` annotation), the `nullSafe` wrapper is made optional now.

as the annotation has a default value, it is no problem to specify the adapter as before
`@JsonAdapter(MyCustomAdapter.class)`

to remove the nullSafe wrapper, call
`@JsonAdapter(value = MyCustomAdapter.class, nullSafe = false);
