### PR TITLE
Add option to let nulls through custom deserializers

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -106,6 +106,7 @@ public final class Gson {
   static final boolean DEFAULT_PRETTY_PRINT = false;
   static final boolean DEFAULT_ESCAPE_HTML = true;
   static final boolean DEFAULT_SERIALIZE_NULLS = false;
+  static final boolean DEFAULT_LET_NULLS_THROUGH_DESERIALIZERS = false;
   static final boolean DEFAULT_COMPLEX_MAP_KEYS = false;
   static final boolean DEFAULT_SPECIALIZE_FLOAT_VALUES = false;
 
@@ -130,6 +131,7 @@ public final class Gson {
   private final Excluder excluder;
   private final FieldNamingStrategy fieldNamingStrategy;
   private final boolean serializeNulls;
+  private final boolean letNullsThroughDeserializers;
   private final boolean htmlSafe;
   private final boolean generateNonExecutableJson;
   private final boolean prettyPrinting;
@@ -146,6 +148,8 @@ public final class Gson {
    *   kept as is since an array is an ordered list. Moreover, if a field is not null, but its
    *   generated JSON is empty, the field is kept. You can configure Gson to serialize null values
    *   by setting {@link GsonBuilder#serializeNulls()}.</li>
+   *   <li>When nulls are serialized, Gson does not let them through custom deserializers by
+   *   default. You can allow that by setting {@link GsonBuilder#letNullsThroughDeserializers()}</li>
    *   <li>Gson provides default serialization and deserialization for Enums, {@link Map},
    *   {@link java.net.URL}, {@link java.net.URI}, {@link java.util.Locale}, {@link java.util.Date},
    *   {@link java.math.BigDecimal}, and {@link java.math.BigInteger} classes. If you would prefer
@@ -172,21 +176,23 @@ public final class Gson {
   public Gson() {
     this(Excluder.DEFAULT, FieldNamingPolicy.IDENTITY,
         Collections.<Type, InstanceCreator<?>>emptyMap(), DEFAULT_SERIALIZE_NULLS,
-        DEFAULT_COMPLEX_MAP_KEYS, DEFAULT_JSON_NON_EXECUTABLE, DEFAULT_ESCAPE_HTML,
-        DEFAULT_PRETTY_PRINT, DEFAULT_LENIENT, DEFAULT_SPECIALIZE_FLOAT_VALUES,
-        LongSerializationPolicy.DEFAULT, Collections.<TypeAdapterFactory>emptyList());
+        DEFAULT_LET_NULLS_THROUGH_DESERIALIZERS, DEFAULT_COMPLEX_MAP_KEYS,
+        DEFAULT_JSON_NON_EXECUTABLE, DEFAULT_ESCAPE_HTML, DEFAULT_PRETTY_PRINT, DEFAULT_LENIENT,
+        DEFAULT_SPECIALIZE_FLOAT_VALUES, LongSerializationPolicy.DEFAULT,
+        Collections.<TypeAdapterFactory>emptyList());
   }
 
   Gson(final Excluder excluder, final FieldNamingStrategy fieldNamingStrategy,
-      final Map<Type, InstanceCreator<?>> instanceCreators, boolean serializeNulls,
-      boolean complexMapKeySerialization, boolean generateNonExecutableGson, boolean htmlSafe,
-      boolean prettyPrinting, boolean lenient, boolean serializeSpecialFloatingPointValues,
-      LongSerializationPolicy longSerializationPolicy,
-      List<TypeAdapterFactory> typeAdapterFactories) {
+       final Map<Type, InstanceCreator<?>> instanceCreators, boolean serializeNulls,
+       boolean letNullsThroughDeserializers, boolean complexMapKeySerialization,
+       boolean generateNonExecutableGson, boolean htmlSafe, boolean prettyPrinting, boolean lenient,
+       boolean serializeSpecialFloatingPointValues, LongSerializationPolicy longSerializationPolicy,
+       List<TypeAdapterFactory> typeAdapterFactories) {
     this.constructorConstructor = new ConstructorConstructor(instanceCreators);
     this.excluder = excluder;
     this.fieldNamingStrategy = fieldNamingStrategy;
     this.serializeNulls = serializeNulls;
+    this.letNullsThroughDeserializers = letNullsThroughDeserializers;
     this.generateNonExecutableJson = generateNonExecutableGson;
     this.htmlSafe = htmlSafe;
     this.prettyPrinting = prettyPrinting;
@@ -263,6 +269,10 @@ public final class Gson {
 
   public boolean serializeNulls() {
     return serializeNulls;
+  }
+
+  public boolean letNullsThroughDeserializers() {
+    return letNullsThroughDeserializers;
   }
 
   public boolean htmlSafe() {

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -37,6 +37,7 @@ import static com.google.gson.Gson.DEFAULT_COMPLEX_MAP_KEYS;
 import static com.google.gson.Gson.DEFAULT_ESCAPE_HTML;
 import static com.google.gson.Gson.DEFAULT_JSON_NON_EXECUTABLE;
 import static com.google.gson.Gson.DEFAULT_LENIENT;
+import static com.google.gson.Gson.DEFAULT_LET_NULLS_THROUGH_DESERIALIZERS;
 import static com.google.gson.Gson.DEFAULT_PRETTY_PRINT;
 import static com.google.gson.Gson.DEFAULT_SERIALIZE_NULLS;
 import static com.google.gson.Gson.DEFAULT_SPECIALIZE_FLOAT_VALUES;
@@ -55,6 +56,7 @@ import static com.google.gson.Gson.DEFAULT_SPECIALIZE_FLOAT_VALUES;
  *     .registerTypeAdapter(Id.class, new IdTypeAdapter())
  *     .enableComplexMapKeySerialization()
  *     .serializeNulls()
+ *     .letNullsThroughDeserializers()
  *     .setDateFormat(DateFormat.LONG)
  *     .setFieldNamingPolicy(FieldNamingPolicy.UPPER_CAMEL_CASE)
  *     .setPrettyPrinting()
@@ -85,6 +87,7 @@ public final class GsonBuilder {
   /** tree-style hierarchy factories. These come after factories for backwards compatibility. */
   private final List<TypeAdapterFactory> hierarchyFactories = new ArrayList<TypeAdapterFactory>();
   private boolean serializeNulls = DEFAULT_SERIALIZE_NULLS;
+  private boolean letNullsThroughDeserializers = DEFAULT_LET_NULLS_THROUGH_DESERIALIZERS;
   private String datePattern;
   private int dateStyle = DateFormat.DEFAULT;
   private int timeStyle = DateFormat.DEFAULT;
@@ -166,6 +169,17 @@ public final class GsonBuilder {
    */
   public GsonBuilder serializeNulls() {
     this.serializeNulls = true;
+    return this;
+  }
+
+  /**
+   * Configure Gson to let null values go through custom deserializers. By default, Gson
+   * automatically deserialize null values as null without calling the custom deserializer.
+   *
+   * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
+   */
+  public GsonBuilder letNullsThroughDeserializers() {
+    this.letNullsThroughDeserializers = true;
     return this;
   }
 
@@ -567,7 +581,7 @@ public final class GsonBuilder {
     addTypeAdaptersForDate(datePattern, dateStyle, timeStyle, factories);
 
     return new Gson(excluder, fieldNamingPolicy, instanceCreators,
-        serializeNulls, complexMapKeySerialization,
+        serializeNulls, letNullsThroughDeserializers, complexMapKeySerialization,
         generateNonExecutableJson, escapeHtmlChars, prettyPrinting, lenient,
         serializeSpecialFloatingPointValues, longSerializationPolicy, factories);
   }

--- a/gson/src/main/java/com/google/gson/internal/bind/TreeTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TreeTypeAdapter.java
@@ -63,7 +63,7 @@ public final class TreeTypeAdapter<T> extends TypeAdapter<T> {
       return delegate().read(in);
     }
     JsonElement value = Streams.parse(in);
-    if (value.isJsonNull()) {
+    if (value.isJsonNull() && !gson.letNullsThroughDeserializers()) {
       return null;
     }
     return deserializer.deserialize(value, typeToken.getType(), context);

--- a/gson/src/test/java/com/google/gson/GsonTest.java
+++ b/gson/src/test/java/com/google/gson/GsonTest.java
@@ -42,7 +42,7 @@ public final class GsonTest extends TestCase {
 
   public void testOverridesDefaultExcluder() {
     Gson gson = new Gson(CUSTOM_EXCLUDER, CUSTOM_FIELD_NAMING_STRATEGY,
-        new HashMap<Type, InstanceCreator<?>>(), true, false, true, false,
+        new HashMap<Type, InstanceCreator<?>>(), true, false, false, true, false,
         true, true, false, LongSerializationPolicy.DEFAULT,
         new ArrayList<TypeAdapterFactory>());
 

--- a/gson/src/test/java/com/google/gson/functional/CustomDeserializerTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CustomDeserializerTest.java
@@ -206,6 +206,35 @@ public class CustomDeserializerTest extends TestCase {
     assertNull(target.bases[1]);
   }
 
+  public void testCustomDeserializerIsPassedNull() {
+    Gson gson = new GsonBuilder()
+            .letNullsThroughDeserializers()
+            .registerTypeAdapter(Base.class, new JsonDeserializer<Base>() {
+              @Override
+              public Base deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+                      throws JsonParseException {
+                return new Base();
+              }
+            }).create();
+    String json = "{base:null}";
+    ClassWithBaseField target = gson.fromJson(json, ClassWithBaseField.class);
+    assertNotNull(target.base);
+  }
+
+  public void testCustomDeserializerIsNotPassedNull() {
+    Gson gson = new GsonBuilder()
+            .registerTypeAdapter(Base.class, new JsonDeserializer<Base>() {
+              @Override
+              public Base deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+                      throws JsonParseException {
+                return new Base();
+              }
+            }).create();
+    String json = "{base:null}";
+    ClassWithBaseField target = gson.fromJson(json, ClassWithBaseField.class);
+    assertNull(target.base);
+  }
+
   private static final class ClassWithBaseArray {
     Base[] bases;
   }


### PR DESCRIPTION
This option fixes the "bug" that custom deserializers don't get called for null values, but without breaking backwards compatibility.
The issue #171 was already marked as closed but the problem was never truly adressed.

Resolves:
https://github.com/google/gson/issues/171
