### PR TITLE
Update UserGuide.md

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -421,7 +421,7 @@ class IdInstanceCreator implements InstanceCreator<Id<?>> {
   public Id<?> createInstance(Type type) {
     Type[] typeParameters = ((ParameterizedType)type).getActualTypeArguments();
     Type idType = typeParameters[0]; // Id has only one parameterized type T
-    return Id.get((Class)idType, 0L);
+    return new Id((Class)idType, 0L);
   }
 }
 ```

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -564,7 +564,7 @@ public class SampleObjectForTest {
   @Foo private final int annotatedField;
   private final String stringField;
   private final long longField;
-  private final Class<?> clazzField;
+  private Class<?> clazzField;
 
   public SampleObjectForTest() {
     annotatedField = 5;
@@ -603,7 +603,7 @@ public static void main(String[] args) {
 The output is:
 
 ```
-{"longField":1234}
+{"longField":1234,"clazzField":null}
 ```
 
 ### <a name="TOC-JSON-Field-Naming-Support"></a>JSON Field Naming Support

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -421,7 +421,7 @@ class IdInstanceCreator implements InstanceCreator<Id<?>> {
   public Id<?> createInstance(Type type) {
     Type[] typeParameters = ((ParameterizedType)type).getActualTypeArguments();
     Type idType = typeParameters[0]; // Id has only one parameterized type T
-    return new Id((Class)idType, 0L);
+    return new Id<>((Class<?>)idType, 0L);
   }
 }
 ```


### PR DESCRIPTION
Correct code for two examples:
- Custom exclusion strategy. The final field `clazzField` is not initialized in the example. Removing the final modifier makes necessary to modify the json output to `{"longField":1234,"clazzField":null}`.
- Custom instance creator. The static method `Id.get` does not exist; instead of that, a regular object instantiation should be used: `return new Id((Class)idType, 0L);`
