### PR TITLE
Enhancing the json reader, adding corresponding test case for it; #824

### DIFF
--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -1561,8 +1561,11 @@ public class JsonReader implements Closeable {
     case '\'':
     case '"':
     case '\\':
+    case '/':	
+    	return escaped;
     default:
-      return escaped;
+    	// throw error when none of the above cases are matched
+    	throw syntaxError("Invalid escape sequence");
     }
   }
 

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -173,7 +173,22 @@ public final class JsonReaderTest extends TestCase {
     reader.endObject();
     assertEquals(JsonToken.END_DOCUMENT, reader.peek());
   }
+  
+  public void testInvalidJsonInput() throws IOException {
+	  String json = "{\n" +
+		        "   \"h\\ello\": true,\n" +
+		        "   \"foo\": [\"world\"]\n" +
+		        "}";
 
+	  try {
+		  JsonReader reader = new JsonReader(reader(json));
+		  reader.beginObject();
+		  assertEquals("hello", reader.nextName());
+	      fail();
+	    } catch (IOException expected) {
+	    }
+  }
+  
   public void testNulls() {
     try {
       new JsonReader(null);

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -175,18 +175,19 @@ public final class JsonReaderTest extends TestCase {
   }
   
   public void testInvalidJsonInput() throws IOException {
-	  String json = "{\n" +
-		        "   \"h\\ello\": true,\n" +
-		        "   \"foo\": [\"world\"]\n" +
-		        "}";
-
-	  try {
-		  JsonReader reader = new JsonReader(reader(json));
-		  reader.beginObject();
-		  assertEquals("hello", reader.nextName());
-	      fail();
-	    } catch (IOException expected) {
-	    }
+	String json = "{\n" +
+	     "   \"h\\ello\": true,\n" +
+		 "   \"foo\": [\"world\"]\n" +
+	     "}";
+	
+	JsonReader reader = new JsonReader(reader(json));
+    reader.beginObject();
+	
+    try {
+	  reader.nextName();
+      fail();
+	} catch (IOException expected) {
+	}
   }
   
   public void testNulls() {

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -175,19 +175,19 @@ public final class JsonReaderTest extends TestCase {
   }
   
   public void testInvalidJsonInput() throws IOException {
-	String json = "{\n" +
-	     "   \"h\\ello\": true,\n" +
-		 "   \"foo\": [\"world\"]\n" +
-	     "}";
+    String json = "{\n" +
+	"   \"h\\ello\": true,\n" +
+   	"   \"foo\": [\"world\"]\n" +
+	"}";
 
-	JsonReader reader = new JsonReader(reader(json));
-	reader.beginObject();
+    JsonReader reader = new JsonReader(reader(json));
+    reader.beginObject();
 
-	try {
-	  reader.nextName();
-	  fail();
-	} catch (IOException expected) {
-	}
+    try {
+      reader.nextName();
+      fail();
+    } catch (IOException expected) {
+    }
   }
   
   public void testNulls() {

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -179,13 +179,13 @@ public final class JsonReaderTest extends TestCase {
 	     "   \"h\\ello\": true,\n" +
 		 "   \"foo\": [\"world\"]\n" +
 	     "}";
-	
+
 	JsonReader reader = new JsonReader(reader(json));
-    reader.beginObject();
-	
-    try {
+	reader.beginObject();
+
+	try {
 	  reader.nextName();
-      fail();
+	  fail();
 	} catch (IOException expected) {
 	}
   }


### PR DESCRIPTION
As discussed in the issue #824, when invalid escape sequences are provided the parse is still successful.

eg. " \"h\\ello\": true",  the parser never used to complain; but after making the below enhancement when ever an unknown escape is encountered then the code will throw syntax error and rightfully inform the user rather than making assumptions.

Also added a test case to demonstrate this. Have executed all the existing tests to avoid any regression bugs.