### PR TITLE
handle explicit null values in JSON

### DIFF
--- a/proto/src/main/java/com/google/gson/protobuf/ProtoTypeAdapter.java
+++ b/proto/src/main/java/com/google/gson/protobuf/ProtoTypeAdapter.java
@@ -262,8 +262,8 @@ public class ProtoTypeAdapter
           String jsonFieldName =
               getCustSerializedName(fieldDescriptor.getOptions(), fieldDescriptor.getName());
 
-          if (jsonObject.has(jsonFieldName)) {
-            JsonElement jsonElement = jsonObject.get(jsonFieldName);
+          JsonElement jsonElement = jsonObject.get(jsonFieldName);
+          if (jsonElement != null && !jsonElement.isJsonNull()) {
             // Do not reuse jsonFieldName here, it might have a custom value
             Object fieldValue;
             if (fieldDescriptor.getType() == ENUM_TYPE) {

--- a/proto/src/test/java/com/google/gson/protobuf/functional/ProtosWithPrimitiveTypesTest.java
+++ b/proto/src/test/java/com/google/gson/protobuf/functional/ProtosWithPrimitiveTypesTest.java
@@ -66,4 +66,11 @@ public class ProtosWithPrimitiveTypesTest extends TestCase {
     assertEquals("foo", proto.getMsg());
     assertEquals(3, proto.getCount());
   }
+
+  public void testDeserializeWithExplicitNullValue() {
+    SimpleProto proto = gson.fromJson("{msg:'foo',count:null}", SimpleProto.class);
+    assertEquals("foo", proto.getMsg());
+    assertEquals(0, proto.getCount());
+  }
+
 }


### PR DESCRIPTION
Fix error when trying deserialize JSON with explicit `NULL` value.

```
{msg:'foo', count:null}
```