### PR TITLE
Minor documentation fix on RuntimeTypeAdapterFactory

### DIFF
--- a/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
@@ -97,7 +97,7 @@ import com.google.gson.stream.JsonWriter;
  * Create a {@code RuntimeTypeAdapterFactory} by passing the base type and type field
  * name to the {@link #of} factory method. If you don't supply an explicit type
  * field name, {@code "type"} will be used. <pre>   {@code
- *   RuntimeTypeAdapterFactory<Shape> shapeAdapter
+ *   RuntimeTypeAdapterFactory<Shape> shapeAdapterFactory
  *       = RuntimeTypeAdapterFactory.of(Shape.class, "type");
  * }</pre>
  * Next register all of your subtypes. Every subtype must be explicitly
@@ -108,14 +108,14 @@ import com.google.gson.stream.JsonWriter;
  *   shapeAdapter.registerSubtype(Circle.class, "Circle");
  *   shapeAdapter.registerSubtype(Diamond.class, "Diamond");
  * }</pre>
- * Finally, register the type adapter in your application's GSON builder:
+ * Finally, register the type adapter factory in your application's GSON builder:
  * <pre>   {@code
  *   Gson gson = new GsonBuilder()
- *       .registerTypeAdapter(Shape.class, shapeAdapter)
+ *       .registerTypeAdapterFactory(Shape.class, shapeAdapterFactory)
  *       .create();
  * }</pre>
  * Like {@code GsonBuilder}, this API supports chaining: <pre>   {@code
- *   RuntimeTypeAdapterFactory<Shape> shapeAdapter = RuntimeTypeAdapterFactory.of(Shape.class)
+ *   RuntimeTypeAdapterFactory<Shape> shapeAdapterFactory = RuntimeTypeAdapterFactory.of(Shape.class)
  *       .registerSubtype(Rectangle.class)
  *       .registerSubtype(Circle.class)
  *       .registerSubtype(Diamond.class);


### PR DESCRIPTION
Instances of classes that implement `RuntimeTypeAdapterFactory` should be registered using the `registerTypeAdapterFactory` method instead of `registerTypeAdapter` method on `GsonBuilder`.

Note that since `registerTypeAdapter(Type type, Object typeAdapter)` accepts an `Object`. Therefore, users of this class might not notice this until runtime.