### PR TITLE
Expose JsonObject size.

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonObject.java
+++ b/gson/src/main/java/com/google/gson/JsonObject.java
@@ -133,6 +133,15 @@ public final class JsonObject extends JsonElement {
   }
 
   /**
+   * Returns the number of key/value pairs in the object.
+   *
+   * @return the number of key/value pairs in the object.
+   */
+  public int size() {
+    return members.size();
+  }
+
+  /**
    * Convenience method to check if a member with the specified name is present in this object.
    *
    * @param memberName name of the member that is being checked for presence.

--- a/gson/src/test/java/com/google/gson/JsonObjectTest.java
+++ b/gson/src/test/java/com/google/gson/JsonObjectTest.java
@@ -158,6 +158,20 @@ public class JsonObjectTest extends TestCase {
     assertFalse(b.equals(a));
   }
 
+  public void testSize() {
+    JsonObject o = new JsonObject();
+    assertEquals(0, o.size());
+
+    o.add("Hello", new JsonPrimitive(1));
+    assertEquals(1, o.size());
+
+    o.add("Hi", new JsonPrimitive(1));
+    assertEquals(2, o.size());
+
+    o.remove("Hello");
+    assertEquals(1, o.size());
+  }
+
   public void testDeepCopy() {
     JsonObject original = new JsonObject();
     JsonArray firstEntry = new JsonArray();


### PR DESCRIPTION
I ran into this being absent when attempting to pre-size a collection based on the contents of a `JsonObject`.