### PR TITLE
Nullable checker

### DIFF
--- a/gson/src/main/java/com/google/gson/DummyNullableChecker.java
+++ b/gson/src/main/java/com/google/gson/DummyNullableChecker.java
@@ -4,6 +4,8 @@ import java.lang.reflect.Field;
 
 /**
  * Dummy NullableChecker that does not check anything.
+ *
+ * @author Juan Luis Boya García
  */
 class DummyNullableChecker {
   private static NullableChecker nullableChecker = null;

--- a/gson/src/main/java/com/google/gson/DummyNullableChecker.java
+++ b/gson/src/main/java/com/google/gson/DummyNullableChecker.java
@@ -1,0 +1,23 @@
+package com.google.gson;
+
+import java.lang.reflect.Field;
+
+/**
+ * Dummy NullableChecker that does not check anything.
+ */
+class DummyNullableChecker {
+  private static NullableChecker nullableChecker = null;
+
+  static NullableChecker getInstance() {
+    if (nullableChecker == null) {
+      nullableChecker = new NullableChecker() {
+        @Override
+        public boolean fieldIsNullable(Field field) {
+          return true;
+        }
+      };
+    }
+
+    return nullableChecker;
+  }
+}

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -16,30 +16,19 @@
 
 package com.google.gson;
 
-import com.google.gson.stream.JsonReader;
-import java.lang.reflect.Type;
-import java.sql.Timestamp;
-import java.text.DateFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import com.google.gson.internal.$Gson$Preconditions;
 import com.google.gson.internal.Excluder;
 import com.google.gson.internal.bind.TreeTypeAdapter;
 import com.google.gson.internal.bind.TypeAdapters;
 import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
 
-import static com.google.gson.Gson.DEFAULT_COMPLEX_MAP_KEYS;
-import static com.google.gson.Gson.DEFAULT_ESCAPE_HTML;
-import static com.google.gson.Gson.DEFAULT_JSON_NON_EXECUTABLE;
-import static com.google.gson.Gson.DEFAULT_LENIENT;
-import static com.google.gson.Gson.DEFAULT_PRETTY_PRINT;
-import static com.google.gson.Gson.DEFAULT_SERIALIZE_NULLS;
-import static com.google.gson.Gson.DEFAULT_SPECIALIZE_FLOAT_VALUES;
+import java.lang.reflect.Type;
+import java.sql.Timestamp;
+import java.text.DateFormat;
+import java.util.*;
+
+import static com.google.gson.Gson.*;
 
 /**
  * <p>Use this builder to construct a {@link Gson} instance when you need to set configuration
@@ -94,6 +83,7 @@ public final class GsonBuilder {
   private boolean prettyPrinting = DEFAULT_PRETTY_PRINT;
   private boolean generateNonExecutableJson = DEFAULT_JSON_NON_EXECUTABLE;
   private boolean lenient = DEFAULT_LENIENT;
+  private NullableChecker nullableChecker = DummyNullableChecker.getInstance();
 
   /**
    * Creates a GsonBuilder instance that can be used to build Gson with various configuration
@@ -554,6 +544,18 @@ public final class GsonBuilder {
   }
 
   /**
+   * Enables a custom nullable checker that can use reflection to ensure fields annotated as not
+   * null never receive null values.
+   *
+   * @param nullableChecker A concrete nullableChecker. Gson does not provide any by default.
+   * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
+   */
+  public GsonBuilder setNullableChecker(NullableChecker nullableChecker) {
+    this.nullableChecker = nullableChecker;
+    return this;
+  }
+
+  /**
    * Creates a {@link Gson} instance based on the current configuration. This method is free of
    * side-effects to this {@code GsonBuilder} instance and hence can be called multiple times.
    *
@@ -569,7 +571,8 @@ public final class GsonBuilder {
     return new Gson(excluder, fieldNamingPolicy, instanceCreators,
         serializeNulls, complexMapKeySerialization,
         generateNonExecutableJson, escapeHtmlChars, prettyPrinting, lenient,
-        serializeSpecialFloatingPointValues, longSerializationPolicy, factories);
+        serializeSpecialFloatingPointValues, longSerializationPolicy, factories,
+      nullableChecker);
   }
 
   private void addTypeAdaptersForDate(String datePattern, int dateStyle, int timeStyle,

--- a/gson/src/main/java/com/google/gson/NullableChecker.java
+++ b/gson/src/main/java/com/google/gson/NullableChecker.java
@@ -1,0 +1,23 @@
+package com.google.gson;
+
+import java.lang.reflect.Field;
+
+/**
+ * This interface is used to check if a field supports null values.
+ *
+ * The implementor is expected to search for custom annotations in fields.
+ * For instance, the following example uses the
+ * {@code javax.validation.constraints.NotNull annotation}:
+ *
+ * <pre>{@code
+ * class AnnotationNullableChecker implements NullableChecker {
+ *   public boolean fieldIsNullable(Field field) {
+ *     return field.getAnnotation(javax.validation.constraints.NotNull.class)
+ *       != null;
+ *   }
+ * }
+ * }</pre>
+ */
+public interface NullableChecker {
+  boolean fieldIsNullable(Field field);
+}

--- a/gson/src/main/java/com/google/gson/NullableChecker.java
+++ b/gson/src/main/java/com/google/gson/NullableChecker.java
@@ -17,6 +17,8 @@ import java.lang.reflect.Field;
  *   }
  * }
  * }</pre>
+ *
+ * @author Juan Luis Boya García
  */
 public interface NullableChecker {
   boolean fieldIsNullable(Field field);


### PR DESCRIPTION
Crazy idea: ensure data marked as not null actually is not null when you deserialize it.

You can either use Java annotations (e.g. JetBrains, javax.validation, Java 8 `NotNull`) or any other metadata accesible with reflection. 

The following example uses Kotlin reflection:

```kotlin
data class MyNestedObject(
    val mayNotBeNull: String
)

data class MyEntity(
    val mayBeNull: String?,
    val nestedObject: MyNestedObject
)

fun main(args: Array<String>) {
    val kotlinNotNullCheker = object: NullableChecker {
        override fun fieldIsNullable(field: Field): Boolean {
            val property = field.kotlinProperty
            if (property != null) {
                return property.returnType.isMarkedNullable
            } else {
                return true;
            }
        }
    }

    val gson = GsonBuilder()
        .setNullableChecker(kotlinNotNullCheker)
        .create()

    val entity = gson.fromJson("""
        {"mayBeNull": null, "nestedObject": {"mayNotBeNull": null}}
        """, MyEntity::class.java)
}
```

The parser is able to detect the error:

```
Exception in thread "main" com.google.gson.JsonSyntaxException:
Non-nullable field was read as null: mayNotBeNull
```

Missing non-nullable properties are also catched. For instance, `{"mayBeNull": null}` throws:

```
Exception in thread "main" com.google.gson.JsonSyntaxException:
Missing required fields: nestedObject
```