### PR TITLE
Give FieldNamingStrategy the ability to translate Strings

### DIFF
--- a/gson/src/main/java/com/google/gson/FieldNamingPolicy.java
+++ b/gson/src/main/java/com/google/gson/FieldNamingPolicy.java
@@ -36,8 +36,12 @@ public enum FieldNamingPolicy implements FieldNamingStrategy {
    */
   IDENTITY() {
     @Override public String translateName(Field f) {
-      return f.getName();
+      return translateName(f.getName());
     }
+    @Override public String translateName(String s) {
+      return s;
+    }
+
   },
 
   /**
@@ -52,7 +56,10 @@ public enum FieldNamingPolicy implements FieldNamingStrategy {
    */
   UPPER_CAMEL_CASE() {
     @Override public String translateName(Field f) {
-      return upperCaseFirstLetter(f.getName());
+      return translateName(f.getName());
+    }
+    @Override public String translateName(String s) {
+      return upperCaseFirstLetter(s);
     }
   },
 
@@ -71,7 +78,10 @@ public enum FieldNamingPolicy implements FieldNamingStrategy {
    */
   UPPER_CAMEL_CASE_WITH_SPACES() {
     @Override public String translateName(Field f) {
-      return upperCaseFirstLetter(separateCamelCase(f.getName(), " "));
+      return translateName(f.getName());
+    }
+    @Override public String translateName(String s) {
+      return upperCaseFirstLetter(separateCamelCase(s, " "));
     }
   },
 
@@ -89,7 +99,10 @@ public enum FieldNamingPolicy implements FieldNamingStrategy {
    */
   LOWER_CASE_WITH_UNDERSCORES() {
     @Override public String translateName(Field f) {
-      return separateCamelCase(f.getName(), "_").toLowerCase(Locale.ENGLISH);
+      return translateName(f.getName());
+    }
+    @Override public String translateName(String s) {
+      return separateCamelCase(s, "_").toLowerCase(Locale.ENGLISH);
     }
   },
 
@@ -112,7 +125,10 @@ public enum FieldNamingPolicy implements FieldNamingStrategy {
    */
   LOWER_CASE_WITH_DASHES() {
     @Override public String translateName(Field f) {
-      return separateCamelCase(f.getName(), "-").toLowerCase(Locale.ENGLISH);
+      return translateName(f.getName());
+    }
+    @Override public String translateName(String s) {
+      return separateCamelCase(s, "-").toLowerCase(Locale.ENGLISH);
     }
   };
 

--- a/gson/src/main/java/com/google/gson/FieldNamingStrategy.java
+++ b/gson/src/main/java/com/google/gson/FieldNamingStrategy.java
@@ -37,4 +37,13 @@ public interface FieldNamingStrategy {
    * @since 1.3
    */
   public String translateName(Field f);
+
+  /**
+   * Translates the string into its JSON field name representation.
+   *
+   * @param s the string object that we are translating
+   * @return the translated field name.
+   * @since 2.7.1
+   */
+  public String translateName(String s);
 }

--- a/gson/src/test/java/com/google/gson/GsonTest.java
+++ b/gson/src/test/java/com/google/gson/GsonTest.java
@@ -36,7 +36,12 @@ public final class GsonTest extends TestCase {
 
   private static final FieldNamingStrategy CUSTOM_FIELD_NAMING_STRATEGY = new FieldNamingStrategy() {
     @Override public String translateName(Field f) {
-      return "foo";
+      return translateName("foo");
+    }
+
+    @Override
+    public String translateName(final String s) {
+      return s;
     }
   };
 

--- a/gson/src/test/java/com/google/gson/functional/NamingPolicyTest.java
+++ b/gson/src/test/java/com/google/gson/functional/NamingPolicyTest.java
@@ -156,8 +156,12 @@ public class NamingPolicyTest extends TestCase {
   private static final class UpperCaseNamingStrategy implements FieldNamingStrategy {
     @Override
     public String translateName(Field f) {
-      return f.getName().toUpperCase();
+      return translateName(f.getName());
     }
+    public String translateName(String s) {
+      return s.toUpperCase();
+    }
+
   }
 
   @SuppressWarnings("unused")


### PR DESCRIPTION
This opens up the possibility of translating objects that aren't
fields but when there is need to know the JSON field representation
of it. For example data classes where the methods are annotated with
@SerializedName.

Currently I have to copy paste code and modify it to take strings:
https://github.com/danielnorberg/auto-matter/pull/39
This is unfortunate as that code will diverge as soon as something changes in gsons FieldNamingPolicies.