### PR TITLE
Fix for RuntimeTypeAdapterFactory.

### DIFF
--- a/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
@@ -182,7 +182,7 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
   }
 
   public <R> TypeAdapter<R> create(Gson gson, TypeToken<R> type) {
-    if (type.getRawType() != baseType) {
+    if (!baseType.isAssignableFrom(type.getRawType())) {
       return null;
     }
 


### PR DESCRIPTION
RuntimeTypeAdapterFactory stopped working since the 2.0 release. This should fix it, I can provide the corresponding test cases if needed.
