### PR TITLE
Allow JSONArray to return a blank string if empty

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonArray.java
+++ b/gson/src/main/java/com/google/gson/JsonArray.java
@@ -209,6 +209,9 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
    */
   @Override
   public String getAsString() {
+    if (elements.isEmpty()){
+      return "";
+    }
     if (elements.size() == 1) {
       return elements.get(0).getAsString();
     }

--- a/gson/src/test/java/com/google/gson/JsonArrayTest.java
+++ b/gson/src/test/java/com/google/gson/JsonArrayTest.java
@@ -99,4 +99,9 @@ public final class JsonArrayTest extends TestCase {
     assertEquals(1, original.get(0).getAsJsonArray().size());
     assertEquals(0, copy.get(0).getAsJsonArray().size());
   }
+
+  public void testEmptyArray(){
+      JsonArray jsonArray = new JsonArray();
+      assertEquals("", jsonArray.getAsString());
+  }
 }


### PR DESCRIPTION
The purpose of this PR is to satisfy the issue #884 

Changes include:
- Returning a blank string if a `JSONArray` instance does not have any elements in it.
- The respective unit test for it.
