### PR TITLE
Use json element tree directly in type adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Change Log
 ==========
 
 ## Version 2.8
-_2016-10-26_  [GitHub Diff](https://github.com/google/gson/compare/gson-parent-2.7...gson-parent-2.8)
+_2016-10-26_  [GitHub Diff](https://github.com/google/gson/compare/gson-parent-2.7...gson-parent-2.8.0)
  * New: `TypeToken.getParameterized()` and `TypeToken.getArray()` make it easier to
    register or look up a `TypeAdapter`.
  * New: `@JsonAdapter(nullSafe=true)` to specify that a custom type adapter handles null.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+## Version 2.8
+_2016-10-26_  [GitHub Diff](https://github.com/google/gson/compare/gson-parent-2.7...gson-parent-2.8)
+ * New: `TypeToken.getParameterized()` and `TypeToken.getArray()` make it easier to
+   register or look up a `TypeAdapter`.
+ * New: `@JsonAdapter(nullSafe=true)` to specify that a custom type adapter handles null.
+
 ## Version 2.7
 _2016-06-14_  [GitHub Diff](https://github.com/google/gson/compare/gson-parent-2.6.2...gson-parent-2.7)
  * Added support for JsonSerializer/JsonDeserializer in @JsonAdapter annotation

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Please use the [google-gson Google group](http://groups.google.com/group/google-
 
 ###*Gson-related Content Created by Third Parties*
   * [Gson Tutorial](http://www.studytrails.com/java/json/java-google-json-introduction.jsp) by `StudyTrails`
+  * [Gson Tutorial Series](https://futurestud.io/tutorials/gson-getting-started-with-java-json-serialization-deserialization) by `Future Studio`
 
 ###*License*
 

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -79,7 +79,7 @@ To use Gson with Maven2/3, you can use the Gson version available in Maven Centr
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.7</version>
+      <version>2.8</version>
       <scope>compile</scope>
     </dependency>
 </dependencies>

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -79,7 +79,7 @@ To use Gson with Maven2/3, you can use the Gson version available in Maven Centr
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8</version>
+      <version>2.8.0</version>
       <scope>compile</scope>
     </dependency>
 </dependencies>

--- a/examples/android-proguard-example/proguard.cfg
+++ b/examples/android-proguard-example/proguard.cfg
@@ -13,4 +13,10 @@
 # Application classes that will be serialized/deserialized over Gson
 -keep class com.google.gson.examples.android.model.** { *; }
 
+# Prevent proguard from stripping interface information from TypeAdapterFactory,
+# JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)
+-keep class * implements com.google.gson.TypeAdapterFactory
+-keep class * implements com.google.gson.JsonSerializer
+-keep class * implements com.google.gson.JsonDeserializer
+
 ##---------------End: proguard configuration for Gson  ----------

--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -40,8 +40,13 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.3.1</version>
+      <version>2.7</version>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>jsr250-api</artifactId>
+      <version>1.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -86,16 +91,16 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.2</version>
+        <version>3.5.1</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.5</version>
+        <version>3.0.2</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -113,7 +118,7 @@
       <plugin>
          <groupId>org.apache.maven.plugins</groupId>
          <artifactId>maven-source-plugin</artifactId>
-         <version>2.4</version>
+         <version>3.0.1</version>
          <executions>
            <execution>
              <id>attach-sources</id>
@@ -127,7 +132,7 @@
        <plugin>
          <groupId>org.apache.maven.plugins</groupId>
          <artifactId>maven-javadoc-plugin</artifactId>
-         <version>2.10.1</version>
+         <version>2.10.4</version>
          <executions>
            <execution>
              <id>attach-javadocs</id>
@@ -147,7 +152,7 @@
        <plugin>
          <groupId>org.apache.maven.plugins</groupId>
          <artifactId>maven-eclipse-plugin</artifactId>
-         <version>2.9</version>
+         <version>2.10</version>
          <configuration>
            <downloadSources>true</downloadSources>
            <downloadJavadocs>true</downloadJavadocs>

--- a/extras/src/main/java/com/google/gson/typeadapters/BaseRuntimeTypeAdapterFactory.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/BaseRuntimeTypeAdapterFactory.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2011 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson.typeadapters;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.internal.Streams;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+public class BaseRuntimeTypeAdapterFactory<T,S> implements TypeAdapterFactory {
+    private final Class<T> baseType;
+    private final String typeFieldName;
+    private Class<S> labelType;
+    private final TypeToLabelConverter<T,S> converter;
+    private final Map<S, Class<?>> labelToSubtype = new LinkedHashMap<S, Class<?>>();
+    private final Map<Class<?>, S> subtypeToLabel = new LinkedHashMap<Class<?>, S>();
+    private boolean useBaseType;
+
+    protected BaseRuntimeTypeAdapterFactory(Class<T> baseType, String typeFieldName, Class<S> labelType, boolean useBaseType, TypeToLabelConverter<T,S> aConverter) {
+        if (typeFieldName == null || baseType == null) {
+            throw new NullPointerException();
+        }
+        this.baseType = baseType;
+        this.typeFieldName = typeFieldName;
+        this.converter = aConverter;
+        this.useBaseType = useBaseType;
+        this.labelType = labelType;
+    }
+
+    public interface TypeToLabelConverter<T,S> {
+        S Transform(Class<? extends T> aType);
+    }
+
+    /**
+     * Creates a new runtime type adapter using for {@code baseType} using {@code
+     * typeFieldName} as the type field name. Type field names are case sensitive.
+     */
+    public static <T,S> BaseRuntimeTypeAdapterFactory<T,S> of(Class<T> baseType, String typeFieldName, Class<S> labelType, boolean useBaseType, TypeToLabelConverter<T,S> aConverter) {
+        return new BaseRuntimeTypeAdapterFactory<T,S>(baseType, typeFieldName, labelType, useBaseType, aConverter);
+    }
+
+    /**
+     * Creates a new runtime type adapter for {@code baseType} using {@code "type"} as
+     * the type field name.
+     */
+    public static <T,S> BaseRuntimeTypeAdapterFactory<T,S> of(Class<T> baseType, Class<S> labelType, boolean useBaseType, TypeToLabelConverter<T,S> aConverter) {
+        return new BaseRuntimeTypeAdapterFactory<T,S>(baseType, "type", labelType, useBaseType, aConverter);
+    }
+
+    /**
+     * Registers {@code type} identified by {@code label}. Labels are case
+     * sensitive.
+     *
+     * @throws IllegalArgumentException if either {@code type} or {@code label}
+     *     have already been registered on this type adapter.
+     */
+    public BaseRuntimeTypeAdapterFactory<T,S> registerSubtype(Class<? extends T> type, S label) {
+        if (type == null || label == null) {
+            throw new NullPointerException();
+        }
+        if (subtypeToLabel.containsKey(type) || labelToSubtype.containsKey(label)) {
+            throw new IllegalArgumentException("types and labels must be unique");
+        }
+        labelToSubtype.put(label, type);
+        subtypeToLabel.put(type, label);
+
+        return this;
+    }
+
+    /**
+     * Registers {@code type} identified by its {@link Class#getSimpleName simple
+     * name}. Labels are case sensitive.
+     *
+     * @throws IllegalArgumentException if either {@code type} or its simple name
+     *     have already been registered on this type adapter.
+     */
+    public BaseRuntimeTypeAdapterFactory<T,S> registerSubtype(Class<? extends T> type) {
+        if (converter == null){
+            throw new NullPointerException();
+        }
+
+        return registerSubtype(type, converter.Transform(type));
+    }
+
+    public <R> TypeAdapter<R> create(Gson gson, TypeToken<R> type) {
+        if (!baseType.isAssignableFrom(type.getRawType())) {
+            return null;
+        }
+
+        if (labelToSubtype.size() == 0) {
+            throw new JsonParseException("No sub-types have been registered for " + this);
+        }
+
+        final TypeAdapter<S> labelTypeAdapter = gson.getAdapter(labelType);
+        final Map<S, TypeAdapter<?>> labelToDelegate = new LinkedHashMap<S, TypeAdapter<?>>();
+        final Map<Class<?>, TypeAdapter<?>> subtypeToDelegate = new LinkedHashMap<Class<?>, TypeAdapter<?>>();
+
+        for (Map.Entry<S, Class<?>> entry : labelToSubtype.entrySet()) {
+            TypeAdapter<?> delegate = gson.getDelegateAdapter(this, TypeToken.get(entry.getValue()));
+            labelToDelegate.put(entry.getKey(), delegate);
+            subtypeToDelegate.put(entry.getValue(), delegate);
+        }
+
+        return new TypeAdapter<R>() {
+            @Override public R read(JsonReader in) throws IOException {
+                return fromJsonTree(Streams.parse(in));
+            }
+
+            @Override public R fromJsonTree(JsonElement jsonTree) {
+                TypeAdapter<R> delegate;
+                S label = null;
+
+                JsonElement labelJsonElement = jsonTree.getAsJsonObject().remove(typeFieldName);
+                if (labelJsonElement == null)
+                {
+                    if (useBaseType) {
+                        delegate = (TypeAdapter<R>) subtypeToDelegate.get(baseType);
+                    } else {
+                        throw new JsonParseException("cannot deserialize " + baseType
+                                + " because it does not define a field named " + typeFieldName);
+                    }
+                }
+                else
+                {
+                    label = labelTypeAdapter.fromJsonTree(labelJsonElement);
+                    // @SuppressWarnings("unchecked") // registration requires that subtype extends T
+                    delegate = (TypeAdapter<R>) labelToDelegate.get(label);
+                }
+
+                if (delegate == null) {
+                    throw new JsonParseException("cannot deserialize " + baseType + " subtype named "
+                            + label + "; did you forget to register a subtype?");
+                }
+                return delegate.fromJsonTree(jsonTree);
+            }
+
+            @Override public void write(JsonWriter out, R value) throws IOException {
+                Streams.write(toJsonTree(value), out);
+            }
+
+            @Override public JsonElement toJsonTree(R value) {
+                Class<?> srcType = value.getClass();
+                S label = subtypeToLabel.get(srcType);
+                @SuppressWarnings("unchecked") // registration requires that subtype extends T
+                        TypeAdapter<R> delegate = (TypeAdapter<R>) subtypeToDelegate.get(srcType);
+                if (delegate == null) {
+                    throw new JsonParseException("cannot serialize " + srcType.getName()
+                            + "; did you forget to register a subtype?");
+                }
+                JsonElement element = delegate.toJsonTree(value);
+                if (!element.isJsonObject()){
+                    throw new JsonParseException(element + " is not a json object");
+                }
+
+                JsonObject jsonObject = element.getAsJsonObject();
+                if (jsonObject.has(typeFieldName)) {
+                    throw new JsonParseException("cannot serialize " + srcType.getName()
+                            + " because it already defines a field named " + typeFieldName);
+                }
+                JsonObject clone = new JsonObject();
+                clone.add(typeFieldName, labelTypeAdapter.toJsonTree(label));
+                for (Map.Entry<String, JsonElement> e : jsonObject.entrySet()) {
+                    clone.add(e.getKey(), e.getValue());
+                }
+
+                return clone;
+            }
+        }.nullSafe();
+    }
+}

--- a/extras/src/main/java/com/google/gson/typeadapters/PostConstructAdapterFactory.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/PostConstructAdapterFactory.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2016 Gson Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson.typeadapters;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import javax.annotation.PostConstruct;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+public class PostConstructAdapterFactory implements TypeAdapterFactory {
+    // copied from https://gist.github.com/swankjesse/20df26adaf639ed7fd160f145a0b661a
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+        for (Class<?> t = type.getRawType(); t != Object.class; t = t.getSuperclass()) {
+            for (Method m : t.getDeclaredMethods()) {
+                if (m.isAnnotationPresent(PostConstruct.class)) {
+                    m.setAccessible(true);
+                    TypeAdapter<T> delegate = gson.getDelegateAdapter(this, type);
+                    return new PostConstructAdapter<T>(delegate, m);
+                }
+            }
+        }
+        return null;
+    }
+
+    final static class PostConstructAdapter<T> extends TypeAdapter<T> {
+        private final TypeAdapter<T> delegate;
+        private final Method method;
+
+        public PostConstructAdapter(TypeAdapter<T> delegate, Method method) {
+            this.delegate = delegate;
+            this.method = method;
+        }
+
+        @Override public T read(JsonReader in) throws IOException {
+            T result = delegate.read(in);
+            if (result != null) {
+                try {
+                    method.invoke(result);
+                } catch (IllegalAccessException e) {
+                    throw new AssertionError();
+                } catch (InvocationTargetException e) {
+                    if (e.getCause() instanceof RuntimeException) throw (RuntimeException) e.getCause();
+                    throw new RuntimeException(e.getCause());
+                }
+            }
+            return result;
+        }
+
+        @Override public void write(JsonWriter out, T value) throws IOException {
+            delegate.write(out, value);
+        }
+    }
+}

--- a/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
@@ -198,42 +198,50 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
 
     return new TypeAdapter<R>() {
       @Override public R read(JsonReader in) throws IOException {
-        JsonElement jsonElement = Streams.parse(in);
-        JsonElement labelJsonElement = jsonElement.getAsJsonObject().remove(typeFieldName);
+        return fromJsonTree(Streams.parse(in));
+      }
+
+      @Override public R fromJsonTree(JsonElement jsonTree) {
+        JsonElement labelJsonElement = jsonTree.getAsJsonObject().remove(typeFieldName);
         if (labelJsonElement == null) {
           throw new JsonParseException("cannot deserialize " + baseType
-              + " because it does not define a field named " + typeFieldName);
+                  + " because it does not define a field named " + typeFieldName);
         }
         String label = labelJsonElement.getAsString();
         @SuppressWarnings("unchecked") // registration requires that subtype extends T
         TypeAdapter<R> delegate = (TypeAdapter<R>) labelToDelegate.get(label);
         if (delegate == null) {
           throw new JsonParseException("cannot deserialize " + baseType + " subtype named "
-              + label + "; did you forget to register a subtype?");
+                  + label + "; did you forget to register a subtype?");
         }
-        return delegate.fromJsonTree(jsonElement);
+        return delegate.fromJsonTree(jsonTree);
       }
 
       @Override public void write(JsonWriter out, R value) throws IOException {
+        Streams.write(toJsonTree(value), out);
+      }
+
+      @Override public JsonElement toJsonTree(R value) {
         Class<?> srcType = value.getClass();
         String label = subtypeToLabel.get(srcType);
         @SuppressWarnings("unchecked") // registration requires that subtype extends T
         TypeAdapter<R> delegate = (TypeAdapter<R>) subtypeToDelegate.get(srcType);
         if (delegate == null) {
           throw new JsonParseException("cannot serialize " + srcType.getName()
-              + "; did you forget to register a subtype?");
+                  + "; did you forget to register a subtype?");
         }
         JsonObject jsonObject = delegate.toJsonTree(value).getAsJsonObject();
         if (jsonObject.has(typeFieldName)) {
           throw new JsonParseException("cannot serialize " + srcType.getName()
-              + " because it already defines a field named " + typeFieldName);
+                  + " because it already defines a field named " + typeFieldName);
         }
         JsonObject clone = new JsonObject();
         clone.add(typeFieldName, new JsonPrimitive(label));
         for (Map.Entry<String, JsonElement> e : jsonObject.entrySet()) {
           clone.add(e.getKey(), e.getValue());
         }
-        Streams.write(clone, out);
+
+        return clone;
       }
     }.nullSafe();
   }

--- a/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
@@ -24,7 +24,6 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
-import com.google.gson.JsonPrimitive;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
 import com.google.gson.internal.Streams;
@@ -121,128 +120,32 @@ import com.google.gson.stream.JsonWriter;
  *       .registerSubtype(Diamond.class);
  * }</pre>
  */
-public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
-  private final Class<?> baseType;
-  private final String typeFieldName;
-  private final Map<String, Class<?>> labelToSubtype = new LinkedHashMap<String, Class<?>>();
-  private final Map<Class<?>, String> subtypeToLabel = new LinkedHashMap<Class<?>, String>();
-
-  private RuntimeTypeAdapterFactory(Class<?> baseType, String typeFieldName) {
-    if (typeFieldName == null || baseType == null) {
-      throw new NullPointerException();
-    }
-    this.baseType = baseType;
-    this.typeFieldName = typeFieldName;
+public class RuntimeTypeAdapterFactory<T> extends BaseRuntimeTypeAdapterFactory<T,String> {
+  private RuntimeTypeAdapterFactory(Class<T> baseType, String typeFieldName) {
+    super(baseType, typeFieldName, String.class, false,
+            new TypeToLabelConverter<T,String>()
+            {
+              public String Transform(Class<? extends T> aType)
+              {
+                return aType.getSimpleName();
+              }
+            }
+    );
   }
 
   /**
    * Creates a new runtime type adapter using for {@code baseType} using {@code
    * typeFieldName} as the type field name. Type field names are case sensitive.
    */
-  public static <T> RuntimeTypeAdapterFactory<T> of(Class<T> baseType, String typeFieldName) {
-    return new RuntimeTypeAdapterFactory<T>(baseType, typeFieldName);
+  public static <T> RuntimeTypeAdapterFactory of(Class<T> baseType, String typeFieldName) {
+    return new RuntimeTypeAdapterFactory(baseType, typeFieldName);
   }
 
   /**
    * Creates a new runtime type adapter for {@code baseType} using {@code "type"} as
    * the type field name.
    */
-  public static <T> RuntimeTypeAdapterFactory<T> of(Class<T> baseType) {
-    return new RuntimeTypeAdapterFactory<T>(baseType, "type");
-  }
-
-  /**
-   * Registers {@code type} identified by {@code label}. Labels are case
-   * sensitive.
-   *
-   * @throws IllegalArgumentException if either {@code type} or {@code label}
-   *     have already been registered on this type adapter.
-   */
-  public RuntimeTypeAdapterFactory<T> registerSubtype(Class<? extends T> type, String label) {
-    if (type == null || label == null) {
-      throw new NullPointerException();
-    }
-    if (subtypeToLabel.containsKey(type) || labelToSubtype.containsKey(label)) {
-      throw new IllegalArgumentException("types and labels must be unique");
-    }
-    labelToSubtype.put(label, type);
-    subtypeToLabel.put(type, label);
-    return this;
-  }
-
-  /**
-   * Registers {@code type} identified by its {@link Class#getSimpleName simple
-   * name}. Labels are case sensitive.
-   *
-   * @throws IllegalArgumentException if either {@code type} or its simple name
-   *     have already been registered on this type adapter.
-   */
-  public RuntimeTypeAdapterFactory<T> registerSubtype(Class<? extends T> type) {
-    return registerSubtype(type, type.getSimpleName());
-  }
-
-  public <R> TypeAdapter<R> create(Gson gson, TypeToken<R> type) {
-    if (type.getRawType() != baseType) {
-      return null;
-    }
-
-    final Map<String, TypeAdapter<?>> labelToDelegate
-        = new LinkedHashMap<String, TypeAdapter<?>>();
-    final Map<Class<?>, TypeAdapter<?>> subtypeToDelegate
-        = new LinkedHashMap<Class<?>, TypeAdapter<?>>();
-    for (Map.Entry<String, Class<?>> entry : labelToSubtype.entrySet()) {
-      TypeAdapter<?> delegate = gson.getDelegateAdapter(this, TypeToken.get(entry.getValue()));
-      labelToDelegate.put(entry.getKey(), delegate);
-      subtypeToDelegate.put(entry.getValue(), delegate);
-    }
-
-    return new TypeAdapter<R>() {
-      @Override public R read(JsonReader in) throws IOException {
-        return fromJsonTree(Streams.parse(in));
-      }
-
-      @Override public R fromJsonTree(JsonElement jsonTree) {
-        JsonElement labelJsonElement = jsonTree.getAsJsonObject().remove(typeFieldName);
-        if (labelJsonElement == null) {
-          throw new JsonParseException("cannot deserialize " + baseType
-                  + " because it does not define a field named " + typeFieldName);
-        }
-        String label = labelJsonElement.getAsString();
-        @SuppressWarnings("unchecked") // registration requires that subtype extends T
-        TypeAdapter<R> delegate = (TypeAdapter<R>) labelToDelegate.get(label);
-        if (delegate == null) {
-          throw new JsonParseException("cannot deserialize " + baseType + " subtype named "
-                  + label + "; did you forget to register a subtype?");
-        }
-        return delegate.fromJsonTree(jsonTree);
-      }
-
-      @Override public void write(JsonWriter out, R value) throws IOException {
-        Streams.write(toJsonTree(value), out);
-      }
-
-      @Override public JsonElement toJsonTree(R value) {
-        Class<?> srcType = value.getClass();
-        String label = subtypeToLabel.get(srcType);
-        @SuppressWarnings("unchecked") // registration requires that subtype extends T
-        TypeAdapter<R> delegate = (TypeAdapter<R>) subtypeToDelegate.get(srcType);
-        if (delegate == null) {
-          throw new JsonParseException("cannot serialize " + srcType.getName()
-                  + "; did you forget to register a subtype?");
-        }
-        JsonObject jsonObject = delegate.toJsonTree(value).getAsJsonObject();
-        if (jsonObject.has(typeFieldName)) {
-          throw new JsonParseException("cannot serialize " + srcType.getName()
-                  + " because it already defines a field named " + typeFieldName);
-        }
-        JsonObject clone = new JsonObject();
-        clone.add(typeFieldName, new JsonPrimitive(label));
-        for (Map.Entry<String, JsonElement> e : jsonObject.entrySet()) {
-          clone.add(e.getKey(), e.getValue());
-        }
-
-        return clone;
-      }
-    }.nullSafe();
+  public static <T> RuntimeTypeAdapterFactory of(Class<T> baseType) {
+    return of(baseType, "type");
   }
 }

--- a/extras/src/test/java/com/google/gson/typeadapters/PostConstructAdapterFactoryTest.java
+++ b/extras/src/test/java/com/google/gson/typeadapters/PostConstructAdapterFactoryTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2016 Gson Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson.typeadapters;
+
+import javax.annotation.PostConstruct;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import junit.framework.TestCase;
+
+public class PostConstructAdapterFactoryTest extends TestCase {
+    public void test() throws Exception {
+        Gson gson = new GsonBuilder()
+                .registerTypeAdapterFactory(new PostConstructAdapterFactory())
+                .create();
+        gson.fromJson("{\"bread\": \"white\", \"cheese\": \"cheddar\"}", Sandwich.class);
+        try {
+            gson.fromJson("{\"bread\": \"cheesey bread\", \"cheese\": \"swiss\"}", Sandwich.class);
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertEquals("too cheesey", expected.getMessage());
+        }
+    }
+
+    static class Sandwich {
+        String bread;
+        String cheese;
+
+        @PostConstruct void validate() {
+            if (bread.equals("cheesey bread") && cheese != null) {
+                throw new IllegalArgumentException("too cheesey");
+            }
+        }
+    }
+}

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.code.gson</groupId>
     <artifactId>gson-parent</artifactId>
-    <version>2.8.0</version>
+    <version>2.8.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>gson</artifactId>

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.code.gson</groupId>
     <artifactId>gson-parent</artifactId>
-    <version>2.7.1-SNAPSHOT</version>
+    <version>2.8.0</version>
   </parent>
 
   <artifactId>gson</artifactId>

--- a/gson/src/main/java/com/google/gson/TypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/TypeAdapter.java
@@ -191,12 +191,29 @@ public abstract class TypeAdapter<T> {
           TypeAdapter.this.write(out, value);
         }
       }
+
+      @Override public JsonElement toJsonTree(T value) {
+        if (value == null) {
+          return JsonNull.INSTANCE;
+        } else {
+          return TypeAdapter.this.toJsonTree(value);
+        }
+      }
+
       @Override public T read(JsonReader reader) throws IOException {
         if (reader.peek() == JsonToken.NULL) {
           reader.nextNull();
           return null;
         }
         return TypeAdapter.this.read(reader);
+      }
+
+      @Override public T fromJsonTree(JsonElement jsonTree) {
+        if (jsonTree.isJsonNull()) {
+          return null;
+        } else {
+          return TypeAdapter.this.fromJsonTree(jsonTree);
+        }
       }
     };
   }

--- a/gson/src/main/java/com/google/gson/TypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/TypeAdapter.java
@@ -228,7 +228,7 @@ public abstract class TypeAdapter<T> {
    * @return the converted JSON tree. May be {@link JsonNull}.
    * @since 2.2
    */
-  public final JsonElement toJsonTree(T value) {
+  public JsonElement toJsonTree(T value) {
     try {
       JsonTreeWriter jsonWriter = new JsonTreeWriter();
       write(jsonWriter, value);
@@ -279,7 +279,7 @@ public abstract class TypeAdapter<T> {
    * @param jsonTree the Java object to convert. May be {@link JsonNull}.
    * @since 2.2
    */
-  public final T fromJsonTree(JsonElement jsonTree) {
+  public T fromJsonTree(JsonElement jsonTree) {
     try {
       JsonReader jsonReader = new JsonTreeReader(jsonTree);
       return read(jsonReader);

--- a/gson/src/main/java/com/google/gson/annotations/Expose.java
+++ b/gson/src/main/java/com/google/gson/annotations/Expose.java
@@ -16,6 +16,7 @@
 
 package com.google.gson.annotations;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -57,6 +58,7 @@ import java.lang.annotation.Target;
  * @author Inderjeet Singh
  * @author Joel Leitch
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface Expose {

--- a/gson/src/main/java/com/google/gson/annotations/SerializedName.java
+++ b/gson/src/main/java/com/google/gson/annotations/SerializedName.java
@@ -16,6 +16,7 @@
 
 package com.google.gson.annotations;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -76,6 +77,7 @@ import java.lang.annotation.Target;
  * @author Inderjeet Singh
  * @author Joel Leitch
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.METHOD})
 public @interface SerializedName {

--- a/gson/src/main/java/com/google/gson/annotations/Since.java
+++ b/gson/src/main/java/com/google/gson/annotations/Since.java
@@ -16,6 +16,7 @@
 
 package com.google.gson.annotations;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -50,6 +51,7 @@ import java.lang.annotation.Target;
  * @author Inderjeet Singh
  * @author Joel Leitch
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.TYPE})
 public @interface Since {

--- a/gson/src/main/java/com/google/gson/annotations/Until.java
+++ b/gson/src/main/java/com/google/gson/annotations/Until.java
@@ -16,6 +16,7 @@
 
 package com.google.gson.annotations;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -54,6 +55,7 @@ import java.lang.annotation.Target;
  * @author Joel Leitch
  * @since 1.3
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.TYPE})
 public @interface Until {

--- a/gson/src/main/java/com/google/gson/internal/bind/TreeTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TreeTypeAdapter.java
@@ -20,6 +20,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
@@ -98,7 +99,7 @@ public final class TreeTypeAdapter<T> extends TypeAdapter<T> {
     }
 
     if (value == null) {
-      return null;
+      return JsonNull.INSTANCE;
     }
 
     return serializer.serialize(value, typeToken.getType(), context);

--- a/gson/src/main/java/com/google/gson/reflect/TypeToken.java
+++ b/gson/src/main/java/com/google/gson/reflect/TypeToken.java
@@ -302,4 +302,19 @@ public class TypeToken<T> {
   public static <T> TypeToken<T> get(Class<T> type) {
     return new TypeToken<T>(type);
   }
+
+  /**
+   * Gets type literal for the parameterized type represented by applying {@code typeArguments} to
+   * {@code rawType}.
+   */
+  public static TypeToken<?> getParameterized(Type rawType, Type... typeArguments) {
+    return new TypeToken<Object>($Gson$Types.newParameterizedTypeWithOwner(null, rawType, typeArguments));
+  }
+
+  /**
+   * Gets type literal for the array type whose elements are all instances of {@code componentType}.
+   */
+  public static TypeToken<?> getArray(Type componentType) {
+    return new TypeToken<Object>($Gson$Types.arrayOf(componentType));
+  }
 }

--- a/gson/src/test/java/com/google/gson/reflect/TypeTokenTest.java
+++ b/gson/src/test/java/com/google/gson/reflect/TypeTokenTest.java
@@ -19,6 +19,7 @@ package com.google.gson.reflect;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.RandomAccess;
 import java.util.Set;
 import junit.framework.TestCase;
@@ -78,5 +79,27 @@ public final class TypeTokenTest extends TestCase {
     assertFalse(TypeToken.get(a).isAssignableFrom(b));
     // listOfSetOfUnknown = listOfSetOfString; // doesn't compile; must be false
     assertFalse(TypeToken.get(b).isAssignableFrom(a));
+  }
+
+  public void testArrayFactory() {
+    TypeToken<?> expectedStringArray = new TypeToken<String[]>() {};
+    assertEquals(expectedStringArray, TypeToken.getArray(String.class));
+
+    TypeToken<?> expectedListOfStringArray = new TypeToken<List<String>[]>() {};
+    Type listOfString = new TypeToken<List<String>>() {}.getType();
+    assertEquals(expectedListOfStringArray, TypeToken.getArray(listOfString));
+  }
+
+  public void testParameterizedFactory() {
+    TypeToken<?> expectedListOfString = new TypeToken<List<String>>() {};
+    assertEquals(expectedListOfString, TypeToken.getParameterized(List.class, String.class));
+
+    TypeToken<?> expectedMapOfStringToString = new TypeToken<Map<String, String>>() {};
+    assertEquals(expectedMapOfStringToString, TypeToken.getParameterized(Map.class, String.class, String.class));
+
+    TypeToken<?> expectedListOfListOfListOfString = new TypeToken<List<List<List<String>>>>() {};
+    Type listOfString = TypeToken.getParameterized(List.class, String.class).getType();
+    Type listOfListOfString = TypeToken.getParameterized(List.class, listOfString).getType();
+    assertEquals(expectedListOfListOfListOfString, TypeToken.getParameterized(List.class, listOfListOfString));
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -77,9 +77,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <configuration>
-            <useDefaultManifestFile>true</useDefaultManifestFile>
-          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.google.code.gson</groupId>
   <artifactId>gson-parent</artifactId>
-  <version>2.8.0</version>
+  <version>2.8.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Gson Parent</name>
@@ -31,7 +31,7 @@
     <url>https://github.com/google/gson/</url>
     <connection>scm:git:https://github.com/google/gson.git</connection>
     <developerConnection>scm:git:git@github.com:google/gson.git</developerConnection>
-    <tag>gson-parent-2.8.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.google.code.gson</groupId>
   <artifactId>gson-parent</artifactId>
-  <version>2.7.1-SNAPSHOT</version>
+  <version>2.8.0</version>
   <packaging>pom</packaging>
 
   <name>Gson Parent</name>
@@ -31,7 +31,7 @@
     <url>https://github.com/google/gson/</url>
     <connection>scm:git:https://github.com/google/gson.git</connection>
     <developerConnection>scm:git:git@github.com:google/gson.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>gson-parent-2.8.0</tag>
   </scm>
 
   <issueManagement>


### PR DESCRIPTION
The Tree type adapter and Runtime type adapter use a json element to perform serialization/deserialization. Parsing a json reader into a tree structure and then back into a reader for consumption by other adapters is inefficient. e.g the RuntimeTypeAdapter uses the tree structure to find the class "type" and then finds another registered (possibly the Tree type) adapter to serialize/deserialize the descendant class. 

These changes allow the tree structure to be consumed directly by a type adapter.
