### PR TITLE
Enable subclassing of ReflectiveTypeAdapterFactory

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -255,6 +255,10 @@ public final class Gson {
     this.factories = Collections.unmodifiableList(factories);
   }
 
+  public ConstructorConstructor constructorConstructor() {
+    return constructorConstructor;
+  }
+
   public Excluder excluder() {
     return excluder;
   }

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -139,7 +139,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
     };
   }
 
-  private Map<String, BoundField> getBoundFields(Gson context, TypeToken<?> type, Class<?> raw) {
+  protected Map<String, BoundField> getBoundFields(Gson context, TypeToken<?> type, Class<?> raw) {
     Map<String, BoundField> result = new LinkedHashMap<String, BoundField>();
     if (raw.isInterface()) {
       return result;
@@ -177,7 +177,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
     return result;
   }
 
-  static abstract class BoundField {
+  protected static abstract class BoundField {
     final String name;
     final boolean serialized;
     final boolean deserialized;


### PR DESCRIPTION
Usecase: I need to serialize a subclass of a collection which adds additional fields, see https://github.com/F43nd1r/Multitool/blob/master/app/src/main/java/com/google/gson/internal/bind/CollectionReflectiveTypeAdapter.java .
As you can see, this requires a lot of duplicated code from ReflectiveTypeAdapter.
To prevent this, it would be nice to be able to access this method and inner class from subclasses.
(ReflectiveTypeAdapterFactory requires a ConstructorConstructor in its constructor, which is why it is necessary that gson exposes its ConstructorConstructor.)