### PR TITLE
Add the exports for the internal packages for backwards compatibility

### DIFF
--- a/gson/bnd.bnd
+++ b/gson/bnd.bnd
@@ -11,4 +11,6 @@ Bundle-RequiredExecutionEnvironment: J2SE-1.5, JavaSE-1.6, JavaSE-1.7, JavaSE-1.
     com.google.gson,\
     com.google.gson.annotations,\
     com.google.gson.reflect,\
-    com.google.gson.stream
+    com.google.gson.stream,\
+    com.google.gson.internal,\
+    com.google.gson.internal.bind


### PR DESCRIPTION
Exports for the `com.google.gson.internal.*` packages where not added back in https://github.com/google/gson/pull/797.

Apache jclouds heavily relies on Gson and does many complex (de)serialization stuff at its core to leverage clean interfaces for the supported providers. It relies on [some classes in the internal packages](https://github.com/jclouds/jclouds/search?utf8=%E2%9C%93&q=%22com.google.gson.internal%22&type=Code) and it is now broken in OSGi, which is a real blocker to upgrade Apache jclouds to the latest version of Gson.

The classes and methods being used are all public, so I'm wondering whether they are really internal (as they provide some features that could be used by downstream consumers). Could the internal packages be added back again to the OSGi exports, to keep backwards compatibility? 