### PR TITLE
Prevent Proguard from stripping interface info from @JsonAdapter classes

### DIFF
--- a/examples/android-proguard-example/proguard.cfg
+++ b/examples/android-proguard-example/proguard.cfg
@@ -13,4 +13,10 @@
 # Application classes that will be serialized/deserialized over Gson
 -keep class com.google.gson.examples.android.model.** { *; }
 
+# Prevent proguard from stripping interface information from TypeAdapterFactory,
+# JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)
+-keep class * implements com.google.gson.TypeAdapterFactory
+-keep class * implements com.google.gson.JsonSerializer
+-keep class * implements com.google.gson.JsonDeserializer
+
 ##---------------End: proguard configuration for Gson  ----------


### PR DESCRIPTION
Previously after Proguard, the classes would no longer implement the interfaces, leading to `JsonAdapterAnnotationTypeAdapterFactory` throwing.

Fixes #925