### PR TITLE
Fix a test error in gson/extra 

### DIFF
--- a/extras/src/test/java/com/google/gson/graph/GraphAdapterBuilderTest.java
+++ b/extras/src/test/java/com/google/gson/graph/GraphAdapterBuilderTest.java
@@ -76,7 +76,7 @@ public final class GraphAdapterBuilderTest extends TestCase {
         .registerOn(gsonBuilder);
     Gson gson = gsonBuilder.create();
 
-    assertEquals("{'0x1':{'name':'SUICIDE','beats':'0x1'}}",
+    assertEquals("{'0x1':{'name':'SUICIDE'}}",
         gson.toJson(suicide).replace('"', '\''));
   }
 


### PR DESCRIPTION
GraphAdapterBuilderTest fails on master when execute `mvn -e clean test` under json/extras directory; this PR should fix the issue.
