### PR TITLE
Make GsonBuilder non-final

### DIFF
--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -75,7 +75,7 @@ import static com.google.gson.Gson.DEFAULT_SPECIALIZE_FLOAT_VALUES;
  * @author Joel Leitch
  * @author Jesse Wilson
  */
-public final class GsonBuilder {
+public class GsonBuilder {
   private Excluder excluder = Excluder.DEFAULT;
   private LongSerializationPolicy longSerializationPolicy = LongSerializationPolicy.DEFAULT;
   private FieldNamingStrategy fieldNamingPolicy = FieldNamingPolicy.IDENTITY;


### PR DESCRIPTION
This allows for projects to store common project-specific settings in the constructor of a derived class, which in some scenarios feels more natural than a static method which creates a new builder instance.

Or is there a reason the builder has to be final? Unfortunately the public history doesn't extend that far into the past, so the git log doesn't help answering that question.