### PR TITLE
Add keySet method and test

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonObject.java
+++ b/gson/src/main/java/com/google/gson/JsonObject.java
@@ -133,6 +133,15 @@ public final class JsonObject extends JsonElement {
   }
 
   /**
+   * Returns a set of members key values.
+   *
+   * @return a set of member keys as Strings
+   */
+  public Set<String> keySet() {
+    return members.keySet();
+  }
+
+  /**
    * Returns the number of key/value pairs in the object.
    *
    * @return the number of key/value pairs in the object.

--- a/gson/src/test/java/com/google/gson/JsonObjectTest.java
+++ b/gson/src/test/java/com/google/gson/JsonObjectTest.java
@@ -183,4 +183,19 @@ public class JsonObjectTest extends TestCase {
     assertEquals(1, original.get("key").getAsJsonArray().size());
     assertEquals(0, copy.get("key").getAsJsonArray().size());
   }
+
+  /**
+   * From issue 941
+   */
+  public void testKeySet() {
+    JsonObject a = new JsonObject();
+
+    a.add("foo", new JsonArray());
+    a.add("bar", new JsonObject());
+
+    assertEquals(2, a.size());
+    assertEquals(2, a.keySet().size());
+    assertTrue(a.keySet().contains("foo"));
+    assertTrue(a.keySet().contains("bar"));
+  }
 }


### PR DESCRIPTION
# Overview

Adds keySet method similar to that of Java Map.  Since all Map.entries utilize strings as a key.  Test method also included.
