### PR TITLE
Added support for customising non-executable prefix for json 

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -102,6 +102,7 @@ import com.google.gson.stream.MalformedJsonException;
  */
 public final class Gson {
   static final boolean DEFAULT_JSON_NON_EXECUTABLE = false;
+  static final String DEFAULT_JSON_NON_EXECUTABLE_PREFIX = ")]}'\n";
   static final boolean DEFAULT_LENIENT = false;
   static final boolean DEFAULT_PRETTY_PRINT = false;
   static final boolean DEFAULT_ESCAPE_HTML = true;
@@ -110,7 +111,6 @@ public final class Gson {
   static final boolean DEFAULT_SPECIALIZE_FLOAT_VALUES = false;
 
   private static final TypeToken<?> NULL_KEY_SURROGATE = new TypeToken<Object>() {};
-  private static final String JSON_NON_EXECUTABLE_PREFIX = ")]}'\n";
 
   /**
    * This thread local guards against reentrant calls to getAdapter(). In
@@ -132,6 +132,7 @@ public final class Gson {
   private final boolean serializeNulls;
   private final boolean htmlSafe;
   private final boolean generateNonExecutableJson;
+  private final String jsonNonExecutablePrefix;
   private final boolean prettyPrinting;
   private final boolean lenient;
   private final JsonAdapterAnnotationTypeAdapterFactory jsonAdapterFactory;
@@ -168,20 +169,23 @@ public final class Gson {
    *   <li>By default, Gson excludes <code>transient</code> or <code>static</code> fields from
    *   consideration for serialization and deserialization. You can change this behavior through
    *   {@link GsonBuilder#excludeFieldsWithModifiers(int...)}.</li>
+   *   <li>By default, Gson uses <code>)]}'\n</code> as a prefix for generating as well as reading
+   *   non-executable json. You can change this behavior through
+   *   {@link GsonBuilder#setJsonNonExecutablePrefix(String)}.</li>
    * </ul>
    */
   public Gson() {
     this(Excluder.DEFAULT, FieldNamingPolicy.IDENTITY,
         Collections.<Type, InstanceCreator<?>>emptyMap(), DEFAULT_SERIALIZE_NULLS,
-        DEFAULT_COMPLEX_MAP_KEYS, DEFAULT_JSON_NON_EXECUTABLE, DEFAULT_ESCAPE_HTML,
-        DEFAULT_PRETTY_PRINT, DEFAULT_LENIENT, DEFAULT_SPECIALIZE_FLOAT_VALUES,
+        DEFAULT_COMPLEX_MAP_KEYS, DEFAULT_JSON_NON_EXECUTABLE, DEFAULT_JSON_NON_EXECUTABLE_PREFIX,
+        DEFAULT_ESCAPE_HTML, DEFAULT_PRETTY_PRINT, DEFAULT_LENIENT, DEFAULT_SPECIALIZE_FLOAT_VALUES,
         LongSerializationPolicy.DEFAULT, Collections.<TypeAdapterFactory>emptyList());
   }
 
   Gson(final Excluder excluder, final FieldNamingStrategy fieldNamingStrategy,
       final Map<Type, InstanceCreator<?>> instanceCreators, boolean serializeNulls,
-      boolean complexMapKeySerialization, boolean generateNonExecutableGson, boolean htmlSafe,
-      boolean prettyPrinting, boolean lenient, boolean serializeSpecialFloatingPointValues,
+      boolean complexMapKeySerialization, boolean generateNonExecutableGson, String jsonNonExecutablePrefix,
+      boolean htmlSafe, boolean prettyPrinting, boolean lenient, boolean serializeSpecialFloatingPointValues,
       LongSerializationPolicy longSerializationPolicy,
       List<TypeAdapterFactory> typeAdapterFactories) {
     this.constructorConstructor = new ConstructorConstructor(instanceCreators);
@@ -189,6 +193,7 @@ public final class Gson {
     this.fieldNamingStrategy = fieldNamingStrategy;
     this.serializeNulls = serializeNulls;
     this.generateNonExecutableJson = generateNonExecutableGson;
+    this.jsonNonExecutablePrefix = jsonNonExecutablePrefix;
     this.htmlSafe = htmlSafe;
     this.prettyPrinting = prettyPrinting;
     this.lenient = lenient;
@@ -711,7 +716,7 @@ public final class Gson {
    */
   public JsonWriter newJsonWriter(Writer writer) throws IOException {
     if (generateNonExecutableJson) {
-      writer.write(JSON_NON_EXECUTABLE_PREFIX);
+      writer.write(jsonNonExecutablePrefix);
     }
     JsonWriter jsonWriter = new JsonWriter(writer);
     if (prettyPrinting) {
@@ -727,6 +732,7 @@ public final class Gson {
   public JsonReader newJsonReader(Reader reader) {
     JsonReader jsonReader = new JsonReader(reader);
     jsonReader.setLenient(lenient);
+    jsonReader.setNonExecutePrefix(jsonNonExecutablePrefix);
     return jsonReader;
   }
 

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -36,6 +36,7 @@ import com.google.gson.reflect.TypeToken;
 import static com.google.gson.Gson.DEFAULT_COMPLEX_MAP_KEYS;
 import static com.google.gson.Gson.DEFAULT_ESCAPE_HTML;
 import static com.google.gson.Gson.DEFAULT_JSON_NON_EXECUTABLE;
+import static com.google.gson.Gson.DEFAULT_JSON_NON_EXECUTABLE_PREFIX;
 import static com.google.gson.Gson.DEFAULT_LENIENT;
 import static com.google.gson.Gson.DEFAULT_PRETTY_PRINT;
 import static com.google.gson.Gson.DEFAULT_SERIALIZE_NULLS;
@@ -93,6 +94,7 @@ public final class GsonBuilder {
   private boolean escapeHtmlChars = DEFAULT_ESCAPE_HTML;
   private boolean prettyPrinting = DEFAULT_PRETTY_PRINT;
   private boolean generateNonExecutableJson = DEFAULT_JSON_NON_EXECUTABLE;
+  private String jsonNonExecutablePrefix = DEFAULT_JSON_NON_EXECUTABLE_PREFIX;
   private boolean lenient = DEFAULT_LENIENT;
 
   /**
@@ -143,6 +145,20 @@ public final class GsonBuilder {
    */
   public GsonBuilder generateNonExecutableJson() {
     this.generateNonExecutableJson = true;
+    return this;
+  }
+
+  /**
+   * Sets the non-executable prefix for both generated and parsed JSON. This prevents
+   * attacks from third-party sites through script sourcing. See
+   * <a href="http://code.google.com/p/google-gson/issues/detail?id=42">Gson Issue 42</a>
+   * and <a href="http://code.google.com/p/google-gson/issues/detail?id=551">Gson Issue 551</a>
+   * for details.
+   *
+   * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
+   */
+  public GsonBuilder setJsonNonExecutablePrefix(String jsonNonExecutablePrefix) {
+    this.jsonNonExecutablePrefix = jsonNonExecutablePrefix;
     return this;
   }
 
@@ -568,8 +584,8 @@ public final class GsonBuilder {
 
     return new Gson(excluder, fieldNamingPolicy, instanceCreators,
         serializeNulls, complexMapKeySerialization,
-        generateNonExecutableJson, escapeHtmlChars, prettyPrinting, lenient,
-        serializeSpecialFloatingPointValues, longSerializationPolicy, factories);
+        generateNonExecutableJson, jsonNonExecutablePrefix, escapeHtmlChars, prettyPrinting,
+        lenient, serializeSpecialFloatingPointValues, longSerializationPolicy, factories);
   }
 
   private void addTypeAdaptersForDate(String datePattern, int dateStyle, int timeStyle,

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -188,8 +188,7 @@ import java.io.Reader;
  * @since 1.6
  */
 public class JsonReader implements Closeable {
-  /** The only non-execute prefix this parser permits */
-  private static final char[] NON_EXECUTE_PREFIX = ")]}'\n".toCharArray();
+
   private static final long MIN_INCOMPLETE_INTEGER = Long.MIN_VALUE / 10;
 
   private static final int PEEKED_NONE = 0;
@@ -228,6 +227,7 @@ public class JsonReader implements Closeable {
 
   /** True to accept non-spec compliant JSON */
   private boolean lenient = false;
+  private char[] nonExecutePrefix = ")]}'\n".toCharArray();
 
   /**
    * Use a manual buffer to easily read and unread upcoming characters, and
@@ -331,6 +331,13 @@ public class JsonReader implements Closeable {
    */
   public final boolean isLenient() {
     return lenient;
+  }
+
+  /**
+   * Configure the non-executable prefix assumed in lenient mode.
+   */
+  public final void setNonExecutePrefix(String nonExecutePrefix) {
+    this.nonExecutePrefix = nonExecutePrefix.toCharArray();
   }
 
   /**
@@ -1567,18 +1574,18 @@ public class JsonReader implements Closeable {
     nextNonWhitespace(true);
     pos--;
 
-    if (pos + NON_EXECUTE_PREFIX.length > limit && !fillBuffer(NON_EXECUTE_PREFIX.length)) {
+    if (pos + nonExecutePrefix.length > limit && !fillBuffer(nonExecutePrefix.length)) {
       return;
     }
 
-    for (int i = 0; i < NON_EXECUTE_PREFIX.length; i++) {
-      if (buffer[pos + i] != NON_EXECUTE_PREFIX[i]) {
+    for (int i = 0; i < nonExecutePrefix.length; i++) {
+      if (buffer[pos + i] != nonExecutePrefix[i]) {
         return; // not a security token!
       }
     }
 
     // we consumed a security token!
-    pos += NON_EXECUTE_PREFIX.length;
+    pos += nonExecutePrefix.length;
   }
 
   static {

--- a/gson/src/test/java/com/google/gson/GsonTest.java
+++ b/gson/src/test/java/com/google/gson/GsonTest.java
@@ -42,8 +42,8 @@ public final class GsonTest extends TestCase {
 
   public void testOverridesDefaultExcluder() {
     Gson gson = new Gson(CUSTOM_EXCLUDER, CUSTOM_FIELD_NAMING_STRATEGY,
-        new HashMap<Type, InstanceCreator<?>>(), true, false, true, false,
-        true, true, false, LongSerializationPolicy.DEFAULT,
+        new HashMap<Type, InstanceCreator<?>>(), true, false, true, ")]}'\n",
+        false, true, true, false, LongSerializationPolicy.DEFAULT,
         new ArrayList<TypeAdapterFactory>());
 
     assertEquals(CUSTOM_EXCLUDER, gson.excluder());

--- a/gson/src/test/java/com/google/gson/functional/SecurityTest.java
+++ b/gson/src/test/java/com/google/gson/functional/SecurityTest.java
@@ -29,7 +29,7 @@ import junit.framework.TestCase;
  */
 public class SecurityTest extends TestCase {
   /**
-   * Keep this in sync with Gson.JSON_NON_EXECUTABLE_PREFIX
+   * Keep this in sync with Gson.DEFAULT_JSON_NON_EXECUTABLE_PREFIX
    */
   private static final String JSON_NON_EXECUTABLE_PREFIX = ")]}'\n";
 
@@ -50,6 +50,21 @@ public class SecurityTest extends TestCase {
   public void testNonExecutableJsonDeserialization() {
     String json = JSON_NON_EXECUTABLE_PREFIX + "{longValue:1}";
     Gson gson = gsonBuilder.create();
+    BagOfPrimitives target = gson.fromJson(json, BagOfPrimitives.class);
+    assertEquals(1, target.longValue);
+  }
+  
+  public void testNonExecutableJsonSerializationWithCustomPrefix() {
+    String prefix = "while(1);\n";
+    Gson gson = gsonBuilder.generateNonExecutableJson().setJsonNonExecutablePrefix(prefix).create();
+    String json = gson.toJson(new BagOfPrimitives());
+    assertTrue(json.startsWith(prefix));
+  }
+  
+  public void testNonExecutableJsonDeserializationWithCustomPrefix() {
+    String prefix = "while(1);\n";
+    String json = prefix + "{longValue:1}";
+    Gson gson = gsonBuilder.setJsonNonExecutablePrefix(prefix).create();
     BagOfPrimitives target = gson.fromJson(json, BagOfPrimitives.class);
     assertEquals(1, target.longValue);
   }


### PR DESCRIPTION
This adds support for setting a custom non-executable prefix, during generation of JSON as well as during parsing.

Fixes #551 

P.S. Criticisms and suggestions welcome.
