### PR TITLE
Allow existing type field name if it serializes to the same value

### DIFF
--- a/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
@@ -16,10 +16,6 @@
 
 package com.google.gson.typeadapters;
 
-import java.io.IOException;
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -31,6 +27,10 @@ import com.google.gson.internal.Streams;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * Adapts values whose runtime type may differ from their declaration type. This
@@ -223,10 +223,12 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
           throw new JsonParseException("cannot serialize " + srcType.getName()
               + "; did you forget to register a subtype?");
         }
-        JsonObject jsonObject = delegate.toJsonTree(value).getAsJsonObject();
-        if (jsonObject.has(typeFieldName)) {
+        final JsonObject jsonObject = delegate.toJsonTree(value).getAsJsonObject();
+        if (jsonObject.has(typeFieldName) && !jsonObject.get(typeFieldName).getAsString().equals(label)) {
           throw new JsonParseException("cannot serialize " + srcType.getName()
-              + " because it already defines a field named " + typeFieldName);
+              + " because it already defines a field named " + typeFieldName
+              + " with a value of " + jsonObject.get(typeFieldName).getAsString()
+              + " different from " + label);
         }
         JsonObject clone = new JsonObject();
         clone.add(typeFieldName, new JsonPrimitive(label));


### PR DESCRIPTION
Instead of failing in `RuntimeTypeAdapterFactory` when there is an existing `type` field name, only fail if its value differs from the computed value. This allows to store the type name in the serialized object's type field.
