### PR TITLE
Add a convenience builder method to register a collection of TypeAdapterFactories

### DIFF
--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Type;
 import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -500,6 +500,17 @@ public final class GsonBuilder {
   }
 
   /**
+   * Register a collection of factories for type adapters. Registering a factory is useful when
+   * the type adapter needs to be configured based on the type of the field being processed. Gson
+   * is designed to handle a large number of factories, so you should consider registering
+   * them to be at par with registering an individual type adapter.
+   */
+  public GsonBuilder registerTypeAdapterFactories(Collection<TypeAdapterFactory> factories) {
+    this.factories.addAll(factories);
+    return this;
+  }
+
+  /**
    * Configures Gson for custom serialization or deserialization for an inheritance type hierarchy.
    * This method combines the registration of a {@link TypeAdapter}, {@link JsonSerializer} and
    * a {@link JsonDeserializer}. If a type adapter was previously registered for the specified


### PR DESCRIPTION
To use us as an example: We have cases where we hand down a set of factories (via Dagger 2's multibindings) downstream, so this is a nice convenience.

Note that I didn't see where the appropriate place to add tests for this were, as `GsonBuilderTest` seems more focused on its construction semantics rather than verifying that its builder methods behave correctly. Let me know if there's a place where I should add any.