### PR TITLE
Allow deserialization of a Number represented as a String

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -368,6 +368,7 @@ public final class TypeAdapters {
         in.nextNull();
         return null;
       case NUMBER:
+      case STRING:
         return new LazilyParsedNumber(in.nextString());
       default:
         throw new JsonSyntaxException("Expecting number, got: " + jsonToken);

--- a/gson/src/test/java/com/google/gson/functional/PrimitiveTest.java
+++ b/gson/src/test/java/com/google/gson/functional/PrimitiveTest.java
@@ -158,6 +158,11 @@ public class PrimitiveTest extends TestCase {
     assertEquals(1L, actual.longValue());
   }
 
+  public void testNumberAsStringDeserialization() {
+    Number value = gson.fromJson("\"18\"", Number.class);
+    assertEquals(18, value.intValue());
+  }
+
   public void testPrimitiveDoubleAutoboxedSerialization() {
     assertEquals("-122.08234335", gson.toJson(-122.08234335));
     assertEquals("122.08112002", gson.toJson(new Double(122.08112002)));


### PR DESCRIPTION
This works:
```
gson.fromJson("\"15\"", int.class)
```

This doesn't:
```
gson.fromJson("\"15\"", Number.class)
```

This PR makes it so the second case works too.