### PR TITLE
Update RuntimeTypeAdapterFactory.java

### DIFF
--- a/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
@@ -199,7 +199,7 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
     return new TypeAdapter<R>() {
       @Override public R read(JsonReader in) throws IOException {
         JsonElement jsonElement = Streams.parse(in);
-        // using get instead of remove lets other typeadater registered for this field in json to work.
+        // using get instead of remove lets other typeadpaters registered for this field in json to work.
         JsonElement labelJsonElement = jsonElement.getAsJsonObject().get(typeFieldName);
         if (labelJsonElement == null) {
           throw new JsonParseException("cannot deserialize " + baseType

--- a/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
@@ -199,7 +199,8 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
     return new TypeAdapter<R>() {
       @Override public R read(JsonReader in) throws IOException {
         JsonElement jsonElement = Streams.parse(in);
-        JsonElement labelJsonElement = jsonElement.getAsJsonObject().remove(typeFieldName);
+        // using get instead of remove lets other typeadater registered for this field in json to work.
+        JsonElement labelJsonElement = jsonElement.getAsJsonObject().get(typeFieldName);
         if (labelJsonElement == null) {
           throw new JsonParseException("cannot deserialize " + baseType
               + " because it does not define a field named " + typeFieldName);


### PR DESCRIPTION
Any other type adapter registered to typeFieldName does not work as its removed.
Using get instead allows any type adapter registered for this field to do its job.
For example register runtime type adapter on a parent class with "type" to be an enum and have a type adapter registered on the enum to convert string value in response to appropriate enum in java class.
It won't work as the field "type" was removed.
Order of registering type adapter and type adapter factory does not help.