### PR TITLE
Add missing comma in toString()

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -981,7 +981,7 @@ public final class Gson {
   public String toString() {
     return new StringBuilder("{serializeNulls:")
         .append(serializeNulls)
-        .append("factories:").append(factories)
+        .append(",factories:").append(factories)
         .append(",instanceCreators:").append(constructorConstructor)
         .append("}")
         .toString();


### PR DESCRIPTION
I noticed `Gson#toString()` prints  a bit unreadable string.
Though I don't know why `toString()` is printing such 3 fields only, this PR fixes missing comma only.