### PR TITLE
enhance ObjectTypeBinder to works with number type 'int'

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/ObjectTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ObjectTypeAdapter.java
@@ -76,7 +76,12 @@ public final class ObjectTypeAdapter extends TypeAdapter<Object> {
       return in.nextString();
 
     case NUMBER:
-      return in.nextDouble();
+      String number = in.nextString();
+      if (number.contains(".")) {
+        return new Double(number);
+      } else {
+        return new Integer(number).intValue();
+      }
 
     case BOOLEAN:
       return in.nextBoolean();

--- a/gson/src/test/java/com/google/gson/JsonParserTest.java
+++ b/gson/src/test/java/com/google/gson/JsonParserTest.java
@@ -108,9 +108,9 @@ public class JsonParserTest extends TestCase {
   public void testReadWriteTwoObjects() throws Exception {
     Gson gson = new Gson();
     CharArrayWriter writer = new CharArrayWriter();
-    BagOfPrimitives expectedOne = new BagOfPrimitives(1, 1, true, "one");
+    BagOfPrimitives expectedOne = new BagOfPrimitives(1, 1, 1.0, true, "one");
     writer.write(gson.toJson(expectedOne).toCharArray());
-    BagOfPrimitives expectedTwo = new BagOfPrimitives(2, 2, false, "two");
+    BagOfPrimitives expectedTwo = new BagOfPrimitives(2, 2, 2.0, false, "two");
     writer.write(gson.toJson(expectedTwo).toCharArray());
     CharArrayReader reader = new CharArrayReader(writer.toCharArray());
 

--- a/gson/src/test/java/com/google/gson/ObjectTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/ObjectTypeAdapterTest.java
@@ -27,9 +27,9 @@ public final class ObjectTypeAdapterTest extends TestCase {
   private final TypeAdapter<Object> adapter = gson.getAdapter(Object.class);
 
   public void testDeserialize() throws Exception {
-    Map<?, ?> map = (Map<?, ?>) adapter.fromJson("{\"a\":5,\"b\":[1,2,null],\"c\":{\"x\":\"y\"}}");
-    assertEquals(5.0, map.get("a"));
-    assertEquals(Arrays.asList(1.0, 2.0, null), map.get("b"));
+    Map<?, ?> map = (Map<?, ?>) adapter.fromJson("{\"a\":5,\"b\":[1,2.0,null],\"c\":{\"x\":\"y\"}}");
+    assertEquals(5, map.get("a"));
+    assertEquals(Arrays.asList(1, 2.0, null), map.get("b"));
     assertEquals(Collections.singletonMap("x", "y"), map.get("c"));
     assertEquals(3, map.size());
   }

--- a/gson/src/test/java/com/google/gson/common/TestTypes.java
+++ b/gson/src/test/java/com/google/gson/common/TestTypes.java
@@ -106,16 +106,18 @@ public class TestTypes {
     public static final long DEFAULT_VALUE = 0;
     public long longValue;
     public int intValue;
+    public double doubleValue;
     public boolean booleanValue;
     public String stringValue;
 
     public BagOfPrimitives() {
-      this(DEFAULT_VALUE, 0, false, "");
+      this(DEFAULT_VALUE, 0, 0.0, false, "");
     }
 
-    public BagOfPrimitives(long longValue, int intValue, boolean booleanValue, String stringValue) {
+    public BagOfPrimitives(long longValue, int intValue, double doubleValue, boolean booleanValue, String stringValue) {
       this.longValue = longValue;
       this.intValue = intValue;
+      this.doubleValue = doubleValue;
       this.booleanValue = booleanValue;
       this.stringValue = stringValue;
     }
@@ -129,6 +131,7 @@ public class TestTypes {
       sb.append("{");
       sb.append("\"longValue\":").append(longValue).append(",");
       sb.append("\"intValue\":").append(intValue).append(",");
+      sb.append("\"doubleValue\":").append(doubleValue).append(",");
       sb.append("\"booleanValue\":").append(booleanValue).append(",");
       sb.append("\"stringValue\":\"").append(stringValue).append("\"");
       sb.append("}");
@@ -142,6 +145,7 @@ public class TestTypes {
       result = prime * result + (booleanValue ? 1231 : 1237);
       result = prime * result + intValue;
       result = prime * result + (int) (longValue ^ (longValue >>> 32));
+      result = prime * result + (int) doubleValue;
       result = prime * result + ((stringValue == null) ? 0 : stringValue.hashCode());
       return result;
     }
@@ -161,6 +165,8 @@ public class TestTypes {
         return false;
       if (longValue != other.longValue)
         return false;
+      if (doubleValue != other.doubleValue)
+        return false;
       if (stringValue == null) {
         if (other.stringValue != null)
           return false;
@@ -171,19 +177,21 @@ public class TestTypes {
 
     @Override
     public String toString() {
-      return String.format("(longValue=%d,intValue=%d,booleanValue=%b,stringValue=%s)",
-          longValue, intValue, booleanValue, stringValue);
+      return String.format("(longValue=%d,intValue=%d,doubleValue=%f,booleanValue=%b,stringValue=%s)",
+          longValue, intValue, doubleValue, booleanValue, stringValue);
     }
   }
 
   public static class BagOfPrimitiveWrappers {
     private final Long longValue;
     private final Integer intValue;
+    private final Double doubleValue;
     private final Boolean booleanValue;
 
-    public BagOfPrimitiveWrappers(Long longValue, Integer intValue, Boolean booleanValue) {
+    public BagOfPrimitiveWrappers(Long longValue, Integer intValue, Double doubleValue, Boolean booleanValue) {
       this.longValue = longValue;
       this.intValue = intValue;
+      this.doubleValue = doubleValue;
       this.booleanValue = booleanValue;
     }
 
@@ -192,6 +200,7 @@ public class TestTypes {
       sb.append("{");
       sb.append("\"longValue\":").append(longValue).append(",");
       sb.append("\"intValue\":").append(intValue).append(",");
+      sb.append("\"doubleValue\":").append(doubleValue).append(",");
       sb.append("\"booleanValue\":").append(booleanValue);
       sb.append("}");
       return sb.toString();
@@ -302,7 +311,7 @@ public class TestTypes {
     }
 
     public ClassWithCustomTypeConverter(int value) {
-      this(new BagOfPrimitives(value, value, false, ""), value);
+      this(new BagOfPrimitives(value, value, (double)value, false, ""), value);
     }
 
     public ClassWithCustomTypeConverter(BagOfPrimitives bag, int value) {
@@ -328,7 +337,7 @@ public class TestTypes {
     public ArrayOfObjects() {
       elements = new BagOfPrimitives[3];
       for (int i = 0; i < elements.length; ++i) {
-        elements[i] = new BagOfPrimitives(i, i+2, false, "i"+i);
+        elements[i] = new BagOfPrimitives(i, i+2, i+0.1, false, "i"+i);
       }
     }
     public String getExpectedJson() {

--- a/gson/src/test/java/com/google/gson/functional/CollectionTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CollectionTest.java
@@ -214,8 +214,8 @@ public class CollectionTest extends TestCase {
 
   public void testCollectionOfBagOfPrimitivesSerialization() {
     List<BagOfPrimitives> target = new ArrayList<BagOfPrimitives>();
-    BagOfPrimitives objA = new BagOfPrimitives(3L, 1, true, "blah");
-    BagOfPrimitives objB = new BagOfPrimitives(2L, 6, false, "blahB");
+    BagOfPrimitives objA = new BagOfPrimitives(3L, 1, 1.0, true, "blah");
+    BagOfPrimitives objB = new BagOfPrimitives(2L, 6, 1.0, false, "blahB");
     target.add(objA);
     target.add(objB);
 
@@ -251,7 +251,7 @@ public class CollectionTest extends TestCase {
 
   @SuppressWarnings("rawtypes")
   public void testRawCollectionDeserializationNotAlllowed() {
-    String json = "[0,1,2,3,4,5,6,7,8,9]";
+    String json = "[0.0,1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0]";
     Collection integers = gson.fromJson(json, Collection.class);
     // JsonReader converts numbers to double by default so we need a floating point comparison
     assertEquals(Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0), integers);
@@ -264,15 +264,16 @@ public class CollectionTest extends TestCase {
 
   @SuppressWarnings({"rawtypes", "unchecked"})
   public void testRawCollectionOfBagOfPrimitivesNotAllowed() {
-    BagOfPrimitives bag = new BagOfPrimitives(10, 20, false, "stringValue");
+    BagOfPrimitives bag = new BagOfPrimitives(10, 20, 30.0, false, "stringValue");
     String json = '[' + bag.getExpectedJson() + ',' + bag.getExpectedJson() + ']';
     Collection target = gson.fromJson(json, Collection.class);
     assertEquals(2, target.size());
     for (Object bag1 : target) {
       // Gson 2.0 converts raw objects into maps
       Map<String, Object> values = (Map<String, Object>) bag1;
-      assertTrue(values.containsValue(10.0));
-      assertTrue(values.containsValue(20.0));
+      assertTrue(values.containsValue(10));
+      assertTrue(values.containsValue(20));
+      assertTrue(values.containsValue(30.0));
       assertTrue(values.containsValue("stringValue"));
     }
   }
@@ -298,8 +299,8 @@ public class CollectionTest extends TestCase {
 
   public void testWildcardCollectionField() throws Exception {
     Collection<BagOfPrimitives> collection = new ArrayList<BagOfPrimitives>();
-    BagOfPrimitives objA = new BagOfPrimitives(3L, 1, true, "blah");
-    BagOfPrimitives objB = new BagOfPrimitives(2L, 6, false, "blahB");
+    BagOfPrimitives objA = new BagOfPrimitives(3L, 1, 1.0, true, "blah");
+    BagOfPrimitives objB = new BagOfPrimitives(2L, 6, 1.0, false, "blahB");
     collection.add(objA);
     collection.add(objB);
 

--- a/gson/src/test/java/com/google/gson/functional/CustomTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CustomTypeAdaptersTest.java
@@ -77,7 +77,7 @@ public class CustomTypeAdaptersTest extends TestCase {
         JsonObject jsonObject = json.getAsJsonObject();
         int value = jsonObject.get("bag").getAsInt();
         return new ClassWithCustomTypeConverter(new BagOfPrimitives(value,
-            value, false, ""), value);
+            value, (double)value, false, ""), value);
       }
     }).create();
     String json = "{\"bag\":5,\"value\":25}";
@@ -124,7 +124,7 @@ public class CustomTypeAdaptersTest extends TestCase {
           @Override public BagOfPrimitives deserialize(JsonElement json, Type typeOfT,
           JsonDeserializationContext context) throws JsonParseException {
         int value = json.getAsInt();
-        return new BagOfPrimitives(value, value, false, "");
+        return new BagOfPrimitives(value, value, value, false, "");
       }
     }).create();
     String json = "{\"bag\":7,\"value\":25}";

--- a/gson/src/test/java/com/google/gson/functional/DelegateTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DelegateTypeAdapterTest.java
@@ -52,13 +52,13 @@ public class DelegateTypeAdapterTest extends TestCase {
   public void testDelegateInvoked() {
     List<BagOfPrimitives> bags = new ArrayList<BagOfPrimitives>();
     for (int i = 0; i < 10; ++i) {
-      bags.add(new BagOfPrimitives(i, i, i % 2 == 0, String.valueOf(i)));
+      bags.add(new BagOfPrimitives(i, i, (double)i, i % 2 == 0, String.valueOf(i)));
     }
     String json = gson.toJson(bags);
     bags = gson.fromJson(json, new TypeToken<List<BagOfPrimitives>>(){}.getType());
-    // 11: 1 list object, and 10 entries. stats invoked on all 5 fields
-    assertEquals(51, stats.numReads);
-    assertEquals(51, stats.numWrites);
+    // 11: 1 list object, and 10 entries. stats invoked on all 6 fields
+    assertEquals(61, stats.numReads);
+    assertEquals(61, stats.numWrites);
   }
 
   public void testDelegateInvokedOnStrings() {

--- a/gson/src/test/java/com/google/gson/functional/EscapingTest.java
+++ b/gson/src/test/java/com/google/gson/functional/EscapingTest.java
@@ -59,7 +59,7 @@ public class EscapingTest extends TestCase {
   }
 
   public void testEscapingObjectFields() throws Exception {
-    BagOfPrimitives objWithPrimitives = new BagOfPrimitives(1L, 1, true, "test with\" <script>");
+    BagOfPrimitives objWithPrimitives = new BagOfPrimitives(1L, 1, 1.0, true, "test with\" <script>");
     String jsonRepresentation = gson.toJson(objWithPrimitives);
     assertFalse(jsonRepresentation.contains("<"));
     assertFalse(jsonRepresentation.contains(">"));
@@ -73,7 +73,7 @@ public class EscapingTest extends TestCase {
     Gson escapeHtmlGson = new GsonBuilder().create();
     Gson noEscapeHtmlGson = new GsonBuilder().disableHtmlEscaping().create();
     
-    BagOfPrimitives target = new BagOfPrimitives(1L, 1, true, "test' / w'ith\" / \\ <script>");
+    BagOfPrimitives target = new BagOfPrimitives(1L, 1, 1.0, true, "test' / w'ith\" / \\ <script>");
     String escapedJsonForm = escapeHtmlGson.toJson(target);
     String nonEscapedJsonForm = noEscapeHtmlGson.toJson(target);
     assertFalse(escapedJsonForm.equals(nonEscapedJsonForm));
@@ -83,7 +83,7 @@ public class EscapingTest extends TestCase {
   }
 
   public void testGsonDoubleDeserialization() {
-    BagOfPrimitives expected = new BagOfPrimitives(3L, 4, true, "value1");
+    BagOfPrimitives expected = new BagOfPrimitives(3L, 4, 5.0, true, "value1");
     String json = gson.toJson(gson.toJson(expected));
     String value = gson.fromJson(json, String.class);
     BagOfPrimitives actual = gson.fromJson(value, BagOfPrimitives.class);

--- a/gson/src/test/java/com/google/gson/functional/InheritanceTest.java
+++ b/gson/src/test/java/com/google/gson/functional/InheritanceTest.java
@@ -55,15 +55,15 @@ public class InheritanceTest extends TestCase {
   }
 
   public void testSubClassSerialization() throws Exception {
-    SubTypeOfNested target = new SubTypeOfNested(new BagOfPrimitives(10, 20, false, "stringValue"),
-        new BagOfPrimitives(30, 40, true, "stringValue"));
+    SubTypeOfNested target = new SubTypeOfNested(new BagOfPrimitives(10, 20, 30.0, false, "stringValue"),
+        new BagOfPrimitives(40, 50, 60.0, true, "stringValue"));
     assertEquals(target.getExpectedJson(), gson.toJson(target));
   }
 
   public void testSubClassDeserialization() throws Exception {
-    String json = "{\"value\":5,\"primitive1\":{\"longValue\":10,\"intValue\":20,"
+    String json = "{\"value\":5,\"primitive1\":{\"longValue\":10,\"intValue\":20,\"doubleValue\":30.0,"
         + "\"booleanValue\":false,\"stringValue\":\"stringValue\"},\"primitive2\":"
-        + "{\"longValue\":30,\"intValue\":40,\"booleanValue\":true,"
+        + "{\"longValue\":40,\"intValue\":50,\"doubleValue\":60.0,\"booleanValue\":true,"
         + "\"stringValue\":\"stringValue\"}}";
     SubTypeOfNested target = gson.fromJson(json, SubTypeOfNested.class);
     assertEquals(json, target.getExpectedJson());

--- a/gson/src/test/java/com/google/gson/functional/JsonTreeTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonTreeTest.java
@@ -27,14 +27,15 @@ public class JsonTreeTest extends TestCase {
   }
 
   public void testToJsonTree() {
-    BagOfPrimitives bag = new BagOfPrimitives(10L, 5, false, "foo");
+    BagOfPrimitives bag = new BagOfPrimitives(10L, 5, 1.0, false, "foo");
     JsonElement json = gson.toJsonTree(bag);
     assertTrue(json.isJsonObject());
     JsonObject obj = json.getAsJsonObject();
     Set<Entry<String, JsonElement>> children = obj.entrySet();
-    assertEquals(4, children.size());
+    assertEquals(5, children.size());
     assertContains(obj, new JsonPrimitive(10L));
     assertContains(obj, new JsonPrimitive(5));
+    assertContains(obj, new JsonPrimitive(1.0));
     assertContains(obj, new JsonPrimitive(false));
     assertContains(obj, new JsonPrimitive("foo"));
   }
@@ -45,7 +46,7 @@ public class JsonTreeTest extends TestCase {
     assertTrue(json.isJsonObject());
     JsonObject obj = json.getAsJsonObject();
     Set<Entry<String, JsonElement>> children = obj.entrySet();
-    assertEquals(4, children.size());
+    assertEquals(5, children.size());
     assertContains(obj, new JsonPrimitive(10L));
     assertContains(obj, new JsonPrimitive(5));
     assertContains(obj, new JsonPrimitive(false));
@@ -61,7 +62,7 @@ public class JsonTreeTest extends TestCase {
   }
 
   public void testJsonTreeNull() {
-    BagOfPrimitives bag = new BagOfPrimitives(10L, 5, false, null);
+    BagOfPrimitives bag = new BagOfPrimitives(10L, 5, 1.0, false, null);
     JsonObject jsonElement = (JsonObject) gson.toJsonTree(bag, BagOfPrimitives.class);
     assertFalse(jsonElement.has("stringValue"));
   }
@@ -82,7 +83,7 @@ public class JsonTreeTest extends TestCase {
     @SuppressWarnings("unused")
     float f = 1.2F;
     public SubTypeOfBagOfPrimitives(long l, int i, boolean b, String string, float f) {
-      super(l, i, b, string);
+      super(l, i, f, b, string);
       this.f = f;
     }
   }

--- a/gson/src/test/java/com/google/gson/functional/ObjectTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ObjectTest.java
@@ -70,11 +70,12 @@ public class ObjectTest extends TestCase {
     super.tearDown();
   }
   public void testJsonInSingleQuotesDeserialization() {
-    String json = "{'stringValue':'no message','intValue':10,'longValue':20}";
+    String json = "{'stringValue':'no message','intValue':10,'longValue':20,'doubleValue':30.0}";
     BagOfPrimitives target = gson.fromJson(json, BagOfPrimitives.class);
     assertEquals("no message", target.stringValue);
     assertEquals(10, target.intValue);
     assertEquals(20, target.longValue);
+    assertEquals(30.0, target.doubleValue);
   }
 
   public void testJsonInMixedQuotesDeserialization() {
@@ -86,24 +87,24 @@ public class ObjectTest extends TestCase {
   }
 
   public void testBagOfPrimitivesSerialization() throws Exception {
-    BagOfPrimitives target = new BagOfPrimitives(10, 20, false, "stringValue");
+    BagOfPrimitives target = new BagOfPrimitives(10, 20, 30.0, false, "stringValue");
     assertEquals(target.getExpectedJson(), gson.toJson(target));
   }
 
   public void testBagOfPrimitivesDeserialization() throws Exception {
-    BagOfPrimitives src = new BagOfPrimitives(10, 20, false, "stringValue");
+    BagOfPrimitives src = new BagOfPrimitives(10, 20, 30.0, false, "stringValue");
     String json = src.getExpectedJson();
     BagOfPrimitives target = gson.fromJson(json, BagOfPrimitives.class);
     assertEquals(json, target.getExpectedJson());
   }
 
   public void testBagOfPrimitiveWrappersSerialization() throws Exception {
-    BagOfPrimitiveWrappers target = new BagOfPrimitiveWrappers(10L, 20, false);
+    BagOfPrimitiveWrappers target = new BagOfPrimitiveWrappers(10L, 20, 1.0, false);
     assertEquals(target.getExpectedJson(), gson.toJson(target));
   }
 
   public void testBagOfPrimitiveWrappersDeserialization() throws Exception {
-    BagOfPrimitiveWrappers target = new BagOfPrimitiveWrappers(10L, 20, false);
+    BagOfPrimitiveWrappers target = new BagOfPrimitiveWrappers(10L, 20, 1.0, false);
     String jsonString = target.getExpectedJson();
     target = gson.fromJson(jsonString, BagOfPrimitiveWrappers.class);
     assertEquals(jsonString, target.getExpectedJson());
@@ -141,14 +142,14 @@ public class ObjectTest extends TestCase {
   }
 
   public void testNestedSerialization() throws Exception {
-    Nested target = new Nested(new BagOfPrimitives(10, 20, false, "stringValue"),
-       new BagOfPrimitives(30, 40, true, "stringValue"));
+    Nested target = new Nested(new BagOfPrimitives(10, 20, 30.0, false, "stringValue"),
+       new BagOfPrimitives(40, 50, 60.0, true, "stringValue"));
     assertEquals(target.getExpectedJson(), gson.toJson(target));
   }
 
   public void testNestedDeserialization() throws Exception {
-    String json = "{\"primitive1\":{\"longValue\":10,\"intValue\":20,\"booleanValue\":false,"
-        + "\"stringValue\":\"stringValue\"},\"primitive2\":{\"longValue\":30,\"intValue\":40,"
+    String json = "{\"primitive1\":{\"longValue\":10,\"intValue\":20,\"doubleValue\":30.0,\"booleanValue\":false,"
+        + "\"stringValue\":\"stringValue\"},\"primitive2\":{\"longValue\":40,\"intValue\":50,\"doubleValue\":60.0,"
         + "\"booleanValue\":true,\"stringValue\":\"stringValue\"}}";
     Nested target = gson.fromJson(json, Nested.class);
     assertEquals(json, target.getExpectedJson());
@@ -177,12 +178,12 @@ public class ObjectTest extends TestCase {
   }
 
   public void testNullFieldsSerialization() throws Exception {
-    Nested target = new Nested(new BagOfPrimitives(10, 20, false, "stringValue"), null);
+    Nested target = new Nested(new BagOfPrimitives(10, 20, 30.0, false, "stringValue"), null);
     assertEquals(target.getExpectedJson(), gson.toJson(target));
   }
 
   public void testNullFieldsDeserialization() throws Exception {
-    String json = "{\"primitive1\":{\"longValue\":10,\"intValue\":20,\"booleanValue\":false"
+    String json = "{\"primitive1\":{\"longValue\":10,\"intValue\":20,\"doubleValue\":30.0,\"booleanValue\":false"
         + ",\"stringValue\":\"stringValue\"}}";
     Nested target = gson.fromJson(json, Nested.class);
     assertEquals(json, target.getExpectedJson());
@@ -359,7 +360,7 @@ public class ObjectTest extends TestCase {
       for (int i = 0; i < elements.length; ++i) {
         BagOfPrimitives[] row = elements[i];
         for (int j = 0; j < row.length; ++j) {
-          row[j] = new BagOfPrimitives(i+j, i*j, false, i+"_"+j);
+          row[j] = new BagOfPrimitives(i+j, i*j, i*j+.1, false, i+"_"+j);
         }
       }
     }

--- a/gson/src/test/java/com/google/gson/functional/ParameterizedTypesTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ParameterizedTypesTest.java
@@ -80,7 +80,7 @@ public class ParameterizedTypesTest extends TestCase {
         BagOfPrimitives>>() {}.getType();
     String json = gson.toJson(src, typeOfSrc);
     String expected = "{\"a\":10,\"b\":1.0,\"c\":2.1,\"d\":\"abc\","
-        + "\"e\":{\"longValue\":0,\"intValue\":0,\"booleanValue\":false,\"stringValue\":\"\"}}";
+        + "\"e\":{\"longValue\":0,\"intValue\":0,\"doubleValue\":0.0,\"booleanValue\":false,\"stringValue\":\"\"}}";
     assertEquals(expected, json);
   }
 

--- a/gson/src/test/java/com/google/gson/functional/ReadersWritersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ReadersWritersTest.java
@@ -104,9 +104,9 @@ public class ReadersWritersTest extends TestCase {
   public void testReadWriteTwoObjects() throws IOException {
     Gson gson= new Gson();
     CharArrayWriter writer= new CharArrayWriter();
-    BagOfPrimitives expectedOne = new BagOfPrimitives(1, 1, true, "one");
+    BagOfPrimitives expectedOne = new BagOfPrimitives(1, 1, 1.0, true, "one");
     writer.write(gson.toJson(expectedOne).toCharArray());
-    BagOfPrimitives expectedTwo = new BagOfPrimitives(2, 2, false, "two");
+    BagOfPrimitives expectedTwo = new BagOfPrimitives(2, 2, 2.0, false, "two");
     writer.write(gson.toJson(expectedTwo).toCharArray());
     CharArrayReader reader = new CharArrayReader(writer.toCharArray());
     JsonStreamParser parser = new JsonStreamParser(reader);

--- a/gson/src/test/java/com/google/gson/functional/VersioningTest.java
+++ b/gson/src/test/java/com/google/gson/functional/VersioningTest.java
@@ -96,7 +96,7 @@ public class VersioningTest extends TestCase {
 
   public void testVersionedGsonWithUnversionedClassesSerialization() {
     Gson gson = builder.setVersion(1.0).create();
-    BagOfPrimitives target = new BagOfPrimitives(10, 20, false, "stringValue");
+    BagOfPrimitives target = new BagOfPrimitives(10, 20, 1.0, false, "stringValue");
     assertEquals(target.getExpectedJson(), gson.toJson(target));
   }
 


### PR DESCRIPTION
- number double or integer #525
- integer values of array become a float values #559

### the reason I pr this:
- Spring's `@RequestBody` parses integer params to double values
- this behavior is not right when you parse HTTP request body parameters. 
  - Web App never knows whether the parameter type is wrong or not
  - `int` should be parsed `int`, not `double`
- [RFC-4627](http://www.ietf.org/rfc/rfc4627.txt) and [JSON](http://json.org) defines type `int`,
so I hope this PR does not violate any rules.

### related issues
- number double or integer #525
- integer values of array become a float values #559
