### PR TITLE
#957 OSGi headers from the bnd.bnd will be included in the jar

### DIFF
--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -43,6 +43,15 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
This would ensure that the headers created by the bnd maven plugin where included in the jar (as per the documentation found here https://github.com/bndtools/bnd/tree/master/maven/bnd-maven-plugin#important-note).