### PR TITLE
Quick fix for Apache MultiValuedMap integration

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
@@ -173,7 +173,7 @@ public final class MapTypeAdapterFactory implements TypeAdapterFactory {
           K key = keyTypeAdapter.read(in);
           V value = valueTypeAdapter.read(in);
           V replaced = map.put(key, value);
-          if (replaced != null) {
+          if (replaced != null && !(map.getClass().getName().contains("MultiValueMap"))) {
             throw new JsonSyntaxException("duplicate key: " + key);
           }
           in.endArray();
@@ -186,7 +186,7 @@ public final class MapTypeAdapterFactory implements TypeAdapterFactory {
           K key = keyTypeAdapter.read(in);
           V value = valueTypeAdapter.read(in);
           V replaced = map.put(key, value);
-          if (replaced != null) {
+          if (replaced != null && !(map.getClass().getName().contains("MultiValueMap"))) {
             throw new JsonSyntaxException("duplicate key: " + key);
           }
         }

--- a/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
@@ -173,7 +173,7 @@ public final class MapTypeAdapterFactory implements TypeAdapterFactory {
           K key = keyTypeAdapter.read(in);
           V value = valueTypeAdapter.read(in);
           V replaced = map.put(key, value);
-          if (replaced != null && !(map.getClass().getName().contains("MultiValueMap"))) {
+          if (replaced != null && !(map.getClass().getName().contains("MultiValueMap")) || map.getClass().getName().contains("MultiValuedMap")) {
             throw new JsonSyntaxException("duplicate key: " + key);
           }
           in.endArray();
@@ -186,7 +186,7 @@ public final class MapTypeAdapterFactory implements TypeAdapterFactory {
           K key = keyTypeAdapter.read(in);
           V value = valueTypeAdapter.read(in);
           V replaced = map.put(key, value);
-          if (replaced != null && !(map.getClass().getName().contains("MultiValueMap"))) {
+          if (replaced != null && !(map.getClass().getName().contains("MultiValueMap")) || map.getClass().getName().contains("MultiValuedMap")) {
             throw new JsonSyntaxException("duplicate key: " + key);
           }
         }


### PR DESCRIPTION
This isn't the most elegant implementation but is just an idea about how I fix the problem with Apache MultiValuedMap.

The problem is that the **put** function for Apache MultiValuedMap returns:

> true if the map changed as a result of this put operation, or false if the map already contained the key-value mapping and the collection type does not allow duplicate values, e.g. when using a Set

And in the current code of MapTypeAdapterFactory.java, the read function has the following validation:

    @Override public Map<K, V> read(JsonReader in) throws IOException {
      JsonToken peek = in.peek();
      if (peek == JsonToken.NULL) {
        in.nextNull();
        return null;
      }

      Map<K, V> map = constructor.construct();

      if (peek == JsonToken.BEGIN_ARRAY) {
        in.beginArray();
        while (in.hasNext()) {
          in.beginArray(); // entry array
          K key = keyTypeAdapter.read(in);
          V value = valueTypeAdapter.read(in);
          V replaced = map.put(key, value);
          if (replaced != null && !(map.getClass().getName().contains("MultiValueMap")) || map.getClass().getName().contains("MultiValuedMap")) {
            throw new JsonSyntaxException("duplicate key: " + key);
          }
          in.endArray();
        }
        in.endArray();
      } else {
        in.beginObject();
        while (in.hasNext()) {
          JsonReaderInternalAccess.INSTANCE.promoteNameToValue(in);
          K key = keyTypeAdapter.read(in);
          V value = valueTypeAdapter.read(in);
          V replaced = map.put(key, value);
          if (replaced != null && !(map.getClass().getName().contains("MultiValueMap")) || map.getClass().getName().contains("MultiValuedMap")) {
            throw new JsonSyntaxException("duplicate key: " + key);
          }
        }
        in.endObject();
      }
      return map;
    }

As you can see, the **read** method throw an exception if the returned value of the map.put function isn't null, but, in the case of Apache MultiValueMap, that is exactly the expected behavior. So, I just added a conditional to the IF to avoid throw the exception if the class is an instance of MultiValueMap