### PR TITLE
#1005 Gson default value handling

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -274,10 +274,6 @@ public final class Gson {
     return htmlSafe;
   }
 
-  public MissingFieldHandlingStrategy missingFieldHandler() {
-    return missingFieldHandlingStrategy;
-  }
-
   private TypeAdapter<Number> doubleAdapter(boolean serializeSpecialFloatingPointValues) {
     if (serializeSpecialFloatingPointValues) {
       return TypeAdapters.DOUBLE;

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -16,24 +16,6 @@
 
 package com.google.gson;
 
-import java.io.EOFException;
-import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.io.Writer;
-import java.lang.reflect.Type;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicLongArray;
-
 import com.google.gson.internal.ConstructorConstructor;
 import com.google.gson.internal.Excluder;
 import com.google.gson.internal.Primitives;
@@ -55,6 +37,24 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import com.google.gson.stream.MalformedJsonException;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicLongArray;
 
 /**
  * This is the main class for using Gson. Gson is typically used by first constructing a
@@ -134,6 +134,7 @@ public final class Gson {
   private final boolean generateNonExecutableJson;
   private final boolean prettyPrinting;
   private final boolean lenient;
+  private MissingFieldHandlingStrategy missingFieldHandlingStrategy;
   private final JsonAdapterAnnotationTypeAdapterFactory jsonAdapterFactory;
 
   /**
@@ -175,7 +176,7 @@ public final class Gson {
         Collections.<Type, InstanceCreator<?>>emptyMap(), DEFAULT_SERIALIZE_NULLS,
         DEFAULT_COMPLEX_MAP_KEYS, DEFAULT_JSON_NON_EXECUTABLE, DEFAULT_ESCAPE_HTML,
         DEFAULT_PRETTY_PRINT, DEFAULT_LENIENT, DEFAULT_SPECIALIZE_FLOAT_VALUES,
-        LongSerializationPolicy.DEFAULT, Collections.<TypeAdapterFactory>emptyList());
+        LongSerializationPolicy.DEFAULT, Collections.<TypeAdapterFactory>emptyList(), null);
   }
 
   Gson(final Excluder excluder, final FieldNamingStrategy fieldNamingStrategy,
@@ -183,7 +184,7 @@ public final class Gson {
       boolean complexMapKeySerialization, boolean generateNonExecutableGson, boolean htmlSafe,
       boolean prettyPrinting, boolean lenient, boolean serializeSpecialFloatingPointValues,
       LongSerializationPolicy longSerializationPolicy,
-      List<TypeAdapterFactory> typeAdapterFactories) {
+      List<TypeAdapterFactory> typeAdapterFactories, MissingFieldHandlingStrategy missingFieldHandlingStrategy) {
     this.constructorConstructor = new ConstructorConstructor(instanceCreators);
     this.excluder = excluder;
     this.fieldNamingStrategy = fieldNamingStrategy;
@@ -192,6 +193,7 @@ public final class Gson {
     this.htmlSafe = htmlSafe;
     this.prettyPrinting = prettyPrinting;
     this.lenient = lenient;
+    this.missingFieldHandlingStrategy = missingFieldHandlingStrategy;
 
     List<TypeAdapterFactory> factories = new ArrayList<TypeAdapterFactory>();
 
@@ -250,7 +252,8 @@ public final class Gson {
     factories.add(jsonAdapterFactory);
     factories.add(TypeAdapters.ENUM_FACTORY);
     factories.add(new ReflectiveTypeAdapterFactory(
-        constructorConstructor, fieldNamingStrategy, excluder, jsonAdapterFactory));
+        constructorConstructor, fieldNamingStrategy, excluder, jsonAdapterFactory,
+            this.missingFieldHandlingStrategy));
 
     this.factories = Collections.unmodifiableList(factories);
   }
@@ -269,6 +272,10 @@ public final class Gson {
 
   public boolean htmlSafe() {
     return htmlSafe;
+  }
+
+  public MissingFieldHandlingStrategy missingFieldHandler() {
+    return missingFieldHandlingStrategy;
   }
 
   private TypeAdapter<Number> doubleAdapter(boolean serializeSpecialFloatingPointValues) {

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -16,7 +16,13 @@
 
 package com.google.gson;
 
+import com.google.gson.internal.$Gson$Preconditions;
+import com.google.gson.internal.Excluder;
+import com.google.gson.internal.bind.TreeTypeAdapter;
+import com.google.gson.internal.bind.TypeAdapters;
+import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
+
 import java.lang.reflect.Type;
 import java.sql.Timestamp;
 import java.text.DateFormat;
@@ -26,12 +32,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import com.google.gson.internal.$Gson$Preconditions;
-import com.google.gson.internal.Excluder;
-import com.google.gson.internal.bind.TreeTypeAdapter;
-import com.google.gson.internal.bind.TypeAdapters;
-import com.google.gson.reflect.TypeToken;
 
 import static com.google.gson.Gson.DEFAULT_COMPLEX_MAP_KEYS;
 import static com.google.gson.Gson.DEFAULT_ESCAPE_HTML;
@@ -94,6 +94,7 @@ public final class GsonBuilder {
   private boolean prettyPrinting = DEFAULT_PRETTY_PRINT;
   private boolean generateNonExecutableJson = DEFAULT_JSON_NON_EXECUTABLE;
   private boolean lenient = DEFAULT_LENIENT;
+  private MissingFieldHandlingStrategy missingFieldHandlingStrategy;
 
   /**
    * Creates a GsonBuilder instance that can be used to build Gson with various configuration
@@ -352,6 +353,14 @@ public final class GsonBuilder {
   }
 
   /**
+   * adding MissingFieldHandlingStrategy
+   */
+  public GsonBuilder addMissingFieldHandlingStrategy(MissingFieldHandlingStrategy strategy) {
+    this.missingFieldHandlingStrategy = strategy;
+    return this;
+  }
+
+  /**
    * Configures Gson to output Json that fits in a page for pretty printing. This option only
    * affects Json serialization.
    *
@@ -569,7 +578,8 @@ public final class GsonBuilder {
     return new Gson(excluder, fieldNamingPolicy, instanceCreators,
         serializeNulls, complexMapKeySerialization,
         generateNonExecutableJson, escapeHtmlChars, prettyPrinting, lenient,
-        serializeSpecialFloatingPointValues, longSerializationPolicy, factories);
+        serializeSpecialFloatingPointValues, longSerializationPolicy, factories,
+            missingFieldHandlingStrategy);
   }
 
   private void addTypeAdaptersForDate(String datePattern, int dateStyle, int timeStyle,

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -353,7 +353,13 @@ public final class GsonBuilder {
   }
 
   /**
-   * adding MissingFieldHandlingStrategy
+   * Configures Gson to apply the passed in {@link MissingFieldHandlingStrategy} during deserialization.
+   *
+   * To maintain the backward compatibility, Gson still sets the missing fields as null if
+   * this strategy is not passed to the {@link GsonBuilder} while creating the {@link Gson} object.
+   *
+   * @param strategy a strategy to determine missing field's default values during deserialization.
+   * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
    */
   public GsonBuilder addMissingFieldHandlingStrategy(MissingFieldHandlingStrategy strategy) {
     this.missingFieldHandlingStrategy = strategy;

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -365,6 +365,9 @@ public final class GsonBuilder {
    * To maintain the backward compatibility, Gson still sets the missing fields as null if
    * this strategy is not passed to the {@link GsonBuilder} while creating the {@link Gson} object.
    *
+   * Note: If the user is providing his/her own custom strategy using this method, all the default values registered
+   * by {@link GsonBuilder#registerDefaultValue(Class, Object)} method will be ignored.
+   *
    * @param strategy a strategy to determine missing field's default values during deserialization.
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
    */

--- a/gson/src/main/java/com/google/gson/MissingFieldHandlingStrategy.java
+++ b/gson/src/main/java/com/google/gson/MissingFieldHandlingStrategy.java
@@ -1,8 +1,31 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.gson;
 
 import com.google.gson.reflect.TypeToken;
 
 /**
+ * A strategy that is used to determine the value to assign to the field whose node was
+ * missing in Json.
+ * This strategy is implemented by the user and should be passed to {@link GsonBuilder#addMissingFieldHandlingStrategy(MissingFieldHandlingStrategy)} method
+ * so that Gson can use it.
+ * The {@link #handle(TypeToken, String)} is used by the Gson to determine the default value
+ * for a field based on the {@link TypeToken} and fieldName passed.
+ *
  * @author Prateek Jain
  */
 public interface MissingFieldHandlingStrategy {

--- a/gson/src/main/java/com/google/gson/MissingFieldHandlingStrategy.java
+++ b/gson/src/main/java/com/google/gson/MissingFieldHandlingStrategy.java
@@ -21,7 +21,8 @@ import com.google.gson.reflect.TypeToken;
 /**
  * A strategy that is used to determine the value to assign to the field whose node was
  * missing in Json.
- * This strategy is implemented by the user and should be passed to {@link GsonBuilder#addMissingFieldHandlingStrategy(MissingFieldHandlingStrategy)} method
+ * This strategy is implemented by the user and should be passed to
+ * {@link GsonBuilder#useMissingFieldHandlingStrategy(MissingFieldHandlingStrategy)} method
  * so that Gson can use it.
  * The {@link #handle(TypeToken, String)} is used by the Gson to determine the default value
  * for a field based on the {@link TypeToken} and fieldName passed.
@@ -29,5 +30,5 @@ import com.google.gson.reflect.TypeToken;
  * @author Prateek Jain
  */
 public interface MissingFieldHandlingStrategy {
-    Object handle(TypeToken type, String fieldName);
+  Object handle(TypeToken type, String fieldName);
 }

--- a/gson/src/main/java/com/google/gson/MissingFieldHandlingStrategy.java
+++ b/gson/src/main/java/com/google/gson/MissingFieldHandlingStrategy.java
@@ -1,0 +1,10 @@
+package com.google.gson;
+
+import com.google.gson.reflect.TypeToken;
+
+/**
+ * @author Prateek Jain
+ */
+public interface MissingFieldHandlingStrategy {
+    Object handle(TypeToken type, String fieldName);
+}

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -19,6 +19,7 @@ package com.google.gson.internal.bind;
 import com.google.gson.FieldNamingStrategy;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
+import com.google.gson.MissingFieldHandlingStrategy;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
 import com.google.gson.annotations.JsonAdapter;
@@ -27,11 +28,11 @@ import com.google.gson.internal.$Gson$Types;
 import com.google.gson.internal.ConstructorConstructor;
 import com.google.gson.internal.Excluder;
 import com.google.gson.internal.ObjectConstructor;
-import com.google.gson.internal.Primitives;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
+
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
@@ -40,6 +41,9 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
+import static com.google.gson.internal.Primitives.isPrimitive;
 
 /**
  * Type adapter that reflects over the fields and methods of a class.
@@ -49,14 +53,17 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
   private final FieldNamingStrategy fieldNamingPolicy;
   private final Excluder excluder;
   private final JsonAdapterAnnotationTypeAdapterFactory jsonAdapterFactory;
+  private MissingFieldHandlingStrategy missingFieldHandlingStrategy;
 
   public ReflectiveTypeAdapterFactory(ConstructorConstructor constructorConstructor,
-      FieldNamingStrategy fieldNamingPolicy, Excluder excluder,
-      JsonAdapterAnnotationTypeAdapterFactory jsonAdapterFactory) {
+                                      FieldNamingStrategy fieldNamingPolicy, Excluder excluder,
+                                      JsonAdapterAnnotationTypeAdapterFactory jsonAdapterFactory,
+                                      MissingFieldHandlingStrategy missingFieldHandlingStrategy) {
     this.constructorConstructor = constructorConstructor;
     this.fieldNamingPolicy = fieldNamingPolicy;
     this.excluder = excluder;
     this.jsonAdapterFactory = jsonAdapterFactory;
+    this.missingFieldHandlingStrategy = missingFieldHandlingStrategy;
   }
 
   public boolean excludeField(Field f, boolean serialize) {
@@ -97,13 +104,13 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
     }
 
     ObjectConstructor<T> constructor = constructorConstructor.get(type);
-    return new Adapter<T>(constructor, getBoundFields(gson, type, raw));
+    return new Adapter<T>(constructor, getBoundFields(gson, type, raw), missingFieldHandlingStrategy);
   }
 
   private ReflectiveTypeAdapterFactory.BoundField createBoundField(
       final Gson context, final Field field, final String name,
       final TypeToken<?> fieldType, boolean serialize, boolean deserialize) {
-    final boolean isPrimitive = Primitives.isPrimitive(fieldType.getRawType());
+    final boolean isPrimitive = isPrimitive(fieldType.getRawType());
     // special casing primitives here saves ~5% on Android...
     JsonAdapter annotation = field.getAnnotation(JsonAdapter.class);
     TypeAdapter<?> mapped = null;
@@ -115,7 +122,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
     if (mapped == null) mapped = context.getAdapter(fieldType);
 
     final TypeAdapter<?> typeAdapter = mapped;
-    return new ReflectiveTypeAdapterFactory.BoundField(name, serialize, deserialize) {
+    return new ReflectiveTypeAdapterFactory.BoundField(name, field, fieldType, serialize, deserialize) {
       @SuppressWarnings({"unchecked", "rawtypes"}) // the type adapter and field type always agree
       @Override void write(JsonWriter writer, Object value)
           throws IOException, IllegalAccessException {
@@ -128,7 +135,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
           throws IOException, IllegalAccessException {
         Object fieldValue = typeAdapter.read(reader);
         if (fieldValue != null || !isPrimitive) {
-          field.set(value, fieldValue);
+          this.set(value, fieldValue);
         }
       }
       @Override public boolean writeField(Object value) throws IOException, IllegalAccessException {
@@ -178,27 +185,74 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
   }
 
   static abstract class BoundField {
+    boolean initialized;
+
     final String name;
+    final Field field;
+    final TypeToken typeToken;
     final boolean serialized;
     final boolean deserialized;
 
-    protected BoundField(String name, boolean serialized, boolean deserialized) {
+    protected BoundField(String name, Field field, TypeToken typeToken, boolean serialized, boolean deserialized) {
       this.name = name;
+      this.field = field;
+      this.typeToken = typeToken;
       this.serialized = serialized;
       this.deserialized = deserialized;
     }
     abstract boolean writeField(Object value) throws IOException, IllegalAccessException;
     abstract void write(JsonWriter writer, Object value) throws IOException, IllegalAccessException;
     abstract void read(JsonReader reader, Object value) throws IOException, IllegalAccessException;
+
+    boolean isInitialized() {
+      return this.initialized;
+    }
+
+    boolean isDeserializable() {
+      return this.deserialized &&
+          !isPrimitive(typeToken.getRawType());
+    }
+
+    void set(Object instance, Object value) throws IllegalAccessException {
+      this.field.setAccessible(true);
+      this.field.set(instance, value);
+      this.initialized = true;
+    }
   }
 
   public static final class Adapter<T> extends TypeAdapter<T> {
     private final ObjectConstructor<T> constructor;
     private final Map<String, BoundField> boundFields;
+    private MissingFieldHandlingStrategy missingFieldHandlingStrategy;
 
-    Adapter(ObjectConstructor<T> constructor, Map<String, BoundField> boundFields) {
+    Adapter(ObjectConstructor<T> constructor, Map<String, BoundField> boundFields, MissingFieldHandlingStrategy missingFieldHandlingStrategy) {
       this.constructor = constructor;
       this.boundFields = boundFields;
+      this.missingFieldHandlingStrategy = missingFieldHandlingStrategy;
+    }
+
+    private ArrayList<BoundField> getUninitializedFields() {
+      ArrayList<BoundField> uninitializedFields = new ArrayList<BoundField>();
+      Set<String> fieldNames = boundFields.keySet();
+      for (String fieldName : fieldNames) {
+        BoundField boundField = boundFields.get(fieldName);
+        if (boundField.isDeserializable() && !boundField.isInitialized()) {
+          uninitializedFields.add(boundField);
+        }
+      }
+      return uninitializedFields;
+    }
+
+    private void initializeMissingFields(T instance) {
+      ArrayList<BoundField> uninitializedFields = getUninitializedFields();
+      for (BoundField field : uninitializedFields) {
+        try {
+          Object defaultValue = missingFieldHandlingStrategy.handle(field.typeToken, field.name);
+          field.set(instance, defaultValue);
+        } catch (IllegalAccessException e) {
+          throw new AssertionError(e);
+        }
+      }
     }
 
     @Override public T read(JsonReader in) throws IOException {
@@ -226,6 +280,9 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
         throw new AssertionError(e);
       }
       in.endObject();
+      if (missingFieldHandlingStrategy != null) {
+        initializeMissingFields(instance);
+      }
       return instance;
     }
 

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -248,7 +248,9 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
       for (BoundField field : uninitializedFields) {
         try {
           Object defaultValue = missingFieldHandlingStrategy.handle(field.typeToken, field.name);
-          field.set(instance, defaultValue);
+          if (defaultValue != null) {
+            field.set(instance, defaultValue);
+          }
         } catch (IllegalAccessException e) {
           throw new AssertionError(e);
         }

--- a/gson/src/test/java/com/google/gson/GsonTest.java
+++ b/gson/src/test/java/com/google/gson/GsonTest.java
@@ -17,11 +17,12 @@
 package com.google.gson;
 
 import com.google.gson.internal.Excluder;
+import junit.framework.TestCase;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
-import junit.framework.TestCase;
 
 /**
  * Unit tests for {@link Gson}.
@@ -44,7 +45,7 @@ public final class GsonTest extends TestCase {
     Gson gson = new Gson(CUSTOM_EXCLUDER, CUSTOM_FIELD_NAMING_STRATEGY,
         new HashMap<Type, InstanceCreator<?>>(), true, false, true, false,
         true, true, false, LongSerializationPolicy.DEFAULT,
-        new ArrayList<TypeAdapterFactory>());
+        new ArrayList<TypeAdapterFactory>(), null);
 
     assertEquals(CUSTOM_EXCLUDER, gson.excluder());
     assertEquals(CUSTOM_FIELD_NAMING_STRATEGY, gson.fieldNamingStrategy());

--- a/gson/src/test/java/com/google/gson/functional/MissingFieldHandlingStrategyTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MissingFieldHandlingStrategyTest.java
@@ -1,0 +1,88 @@
+package com.google.gson.functional;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.google.gson.MissingFieldHandlingStrategy;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Prateek Jain
+ */
+public class MissingFieldHandlingStrategyTest {
+
+  @Test
+  public void shouldAssignFieldToDefaultValues() throws Exception {
+    MissingFieldHandlingStrategy missingFieldHandlingStrategy = getMissingFieldHandlingStrategy();
+    Gson gson = new GsonBuilder().
+        addMissingFieldHandlingStrategy(missingFieldHandlingStrategy).create();
+    JsonObject jsonObject = new JsonObject();
+
+    Protocol protocol = gson.fromJson(jsonObject, Protocol.class);
+
+    assertThat(protocol.name, is("HTTP"));
+    assertThat(protocol.version, is("1.1"));
+  }
+
+  @Test
+  public void shouldNotTreatNullFieldAsMissingField() throws Exception {
+    MissingFieldHandlingStrategy missingFieldHandlingStrategy = getMissingFieldHandlingStrategy();
+    Gson gson = new GsonBuilder().
+        addMissingFieldHandlingStrategy(missingFieldHandlingStrategy).create();
+
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.add("name", null);
+    jsonObject.add("version", null);
+
+    Protocol protocol = gson.fromJson(jsonObject, Protocol.class);
+
+    assertNull(protocol.name);
+    assertNull(protocol.version);
+  }
+
+  @Test
+  public void shouldRespectSerializedNameAnnotation() throws Exception {
+    MissingFieldHandlingStrategy strategy = new MissingFieldHandlingStrategy() {
+      @Override
+      public Object handle(TypeToken type, String fieldName) {
+        if ("f1".equals(fieldName))
+          return "1.1";
+        return "";
+      }
+    };
+    Gson gson = new GsonBuilder().
+        addMissingFieldHandlingStrategy(strategy).create();
+    JsonObject jsonObject = new JsonObject();
+
+    assertThat(gson.fromJson(jsonObject, ObjectWithSerializedAnnotatin.class).v, is("1.1"));
+  }
+
+  private MissingFieldHandlingStrategy getMissingFieldHandlingStrategy() {
+    return new MissingFieldHandlingStrategy() {
+      @Override
+      public Object handle(TypeToken type, String fieldName) {
+        if ("name".equals(fieldName))
+          return "HTTP";
+        if ("version".equals(fieldName))
+          return "1.1";
+        return "";
+      }
+    };
+  }
+
+  private static class Protocol {
+    private String name;
+    private String version;
+  }
+
+  private static class ObjectWithSerializedAnnotatin {
+    @SerializedName(value = "f1")
+    private String v;
+  }
+}

--- a/gson/src/test/java/com/google/gson/functional/MissingFieldHandlingStrategyTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MissingFieldHandlingStrategyTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.gson.functional;
 
 import com.google.gson.Gson;
@@ -13,6 +29,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 /**
+ * Unit tests for {@link MissingFieldHandlingStrategy}
+ *
  * @author Prateek Jain
  */
 public class MissingFieldHandlingStrategyTest {


### PR DESCRIPTION
Making gson capable of populating default values in Java models if the corresponding nodes are missing in Json.