### PR TITLE
Update TypeAdapters.java

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -391,7 +391,15 @@ public final class TypeAdapters {
       }
       String str = in.nextString();
       if (str.length() != 1) {
-        throw new JsonSyntaxException("Expecting character, got: " + str);
+        // maybe the input string is a number representing a char (like 102 for 'f')
+        try {
+          // so try returning a Character from its value, 
+          // first make in a real int, because JsonReader.nextString() returns String
+          return Character.valueOf((char) Integer.parseInt(str)); 
+        } catch (IllegalFormatException ex) {
+          // or ... my bad ...
+          throw new JsonSyntaxException("Expecting character, got: " + str);
+        }
       }
       return str.charAt(0);
     }


### PR DESCRIPTION
This will made it legal to use char primitive (like 'f') as input, instead of Character.valueOf('f').
It's because we should consider using primitives as long as we can, the Character class is far bigger than a 2 bytes char in Java, 