### PR TITLE
Memory optimisation in JsonReader

### DIFF
--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -1024,7 +1024,6 @@ public class JsonReader implements Closeable {
 
       if(null == builder) {
         int len = (p - start) * 2;
-        initialLength = len;
         builder = new StringBuilder(len < 16 ? 16 : len);
       }
       builder.append(buffer, start, p - start);

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -997,7 +997,7 @@ public class JsonReader implements Closeable {
         if (c == quote) {
           pos = p;
           int len = p - start - 1;
-          if(null == builder) {
+          if (builder == null) {
             return new String(buffer, start, len);
           } else {
             builder.append(buffer, start, len);
@@ -1007,9 +1007,9 @@ public class JsonReader implements Closeable {
           pos = p;
           int len = p - start - 1;
           char escapeChar = readEscapeCharacter();
-          if(null == builder) {
+          if (builder == null) {
             int estimatedLength = (len + pos - p) * 2;
-            builder = new StringBuilder(estimatedLength < 16 ? 16 : estimatedLength);
+            builder = new StringBuilder(Math.max(estimatedLength, 16));
           }
           builder.append(buffer, start, len);
           builder.append(escapeChar);
@@ -1022,9 +1022,9 @@ public class JsonReader implements Closeable {
         }
       }
 
-      if(null == builder) {
-        int len = (p - start) * 2;
-        builder = new StringBuilder(len < 16 ? 16 : len);
+      if (builder == null) {
+        int estimatedLength = (p - start) * 2;
+        builder = new StringBuilder(Math.max(estimatedLength, 16));
       }
       builder.append(buffer, start, p - start);
       pos = p;


### PR DESCRIPTION
The default constructor of StringReader gives a capacity of 16. It expands and does an array copy in the event of the capacity being exceeded while appending characters.

JsonReader.nextQuotedValue was initializing the default constructor. If the entire string was in buffer and there were no characters to be escaped then we can directly create a string object and return it back (based on the profiling for our sample JSON payload this was the flow this code goes into for 90% of the times).


In the event of it going into other code paths trying to estimate a length to be the double of the current length and ensure it is not less than 16. 