### PR TITLE
gson builder perf improvement and code corrections

### DIFF
--- a/gson/src/main/java/com/google/gson/FieldNamingPolicy.java
+++ b/gson/src/main/java/com/google/gson/FieldNamingPolicy.java
@@ -139,17 +139,18 @@ public enum FieldNamingPolicy implements FieldNamingStrategy {
     StringBuilder fieldNameBuilder = new StringBuilder();
     int index = 0;
     char firstCharacter = name.charAt(index);
-
-    while (index < name.length() - 1) {
-      if (Character.isLetter(firstCharacter)) {
-        break;
+    int nameLength = name.length();
+    if (!Character.isLetter(firstCharacter)) {
+      while (index < nameLength - 1) {
+        fieldNameBuilder.append(firstCharacter);
+        firstCharacter = name.charAt(++index);
+        if (Character.isLetter(firstCharacter)) {
+          break;
+        }
       }
-
-      fieldNameBuilder.append(firstCharacter);
-      firstCharacter = name.charAt(++index);
     }
 
-    if (index == name.length()) {
+    if (index == nameLength) {
       return fieldNameBuilder.toString();
     }
 

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -16,24 +16,6 @@
 
 package com.google.gson;
 
-import java.io.EOFException;
-import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.io.Writer;
-import java.lang.reflect.Type;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicLongArray;
-
 import com.google.gson.internal.ConstructorConstructor;
 import com.google.gson.internal.Excluder;
 import com.google.gson.internal.Primitives;
@@ -55,6 +37,24 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import com.google.gson.stream.MalformedJsonException;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicLongArray;
 
 /**
  * This is the main class for using Gson. Gson is typically used by first constructing a
@@ -249,8 +249,7 @@ public final class Gson {
     this.jsonAdapterFactory = new JsonAdapterAnnotationTypeAdapterFactory(constructorConstructor);
     factories.add(jsonAdapterFactory);
     factories.add(TypeAdapters.ENUM_FACTORY);
-    factories.add(new ReflectiveTypeAdapterFactory(
-        constructorConstructor, fieldNamingStrategy, excluder, jsonAdapterFactory));
+    factories.add(new ReflectiveTypeAdapterFactory(constructorConstructor, fieldNamingStrategy, excluder, jsonAdapterFactory));
 
     this.factories = Collections.unmodifiableList(factories);
   }
@@ -288,8 +287,7 @@ public final class Gson {
           out.nullValue();
           return;
         }
-        double doubleValue = value.doubleValue();
-        checkValidFloatingPoint(doubleValue);
+        checkValidFloatingPoint(value.doubleValue());
         out.value(value);
       }
     };

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -16,7 +16,13 @@
 
 package com.google.gson;
 
+import com.google.gson.internal.$Gson$Preconditions;
+import com.google.gson.internal.Excluder;
+import com.google.gson.internal.bind.TreeTypeAdapter;
+import com.google.gson.internal.bind.TypeAdapters;
+import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
+
 import java.lang.reflect.Type;
 import java.sql.Timestamp;
 import java.text.DateFormat;
@@ -26,12 +32,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import com.google.gson.internal.$Gson$Preconditions;
-import com.google.gson.internal.Excluder;
-import com.google.gson.internal.bind.TreeTypeAdapter;
-import com.google.gson.internal.bind.TypeAdapters;
-import com.google.gson.reflect.TypeToken;
 
 import static com.google.gson.Gson.DEFAULT_COMPLEX_MAP_KEYS;
 import static com.google.gson.Gson.DEFAULT_ESCAPE_HTML;
@@ -519,8 +519,7 @@ public final class GsonBuilder {
         || typeAdapter instanceof JsonDeserializer<?>
         || typeAdapter instanceof TypeAdapter<?>);
     if (typeAdapter instanceof JsonDeserializer || typeAdapter instanceof JsonSerializer) {
-      hierarchyFactories.add(0,
-          TreeTypeAdapter.newTypeHierarchyFactory(baseType, typeAdapter));
+      hierarchyFactories.add(TreeTypeAdapter.newTypeHierarchyFactory(baseType, typeAdapter));
     }
     if (typeAdapter instanceof TypeAdapter<?>) {
       factories.add(TypeAdapters.newTypeHierarchyFactory(baseType, (TypeAdapter)typeAdapter));
@@ -562,8 +561,13 @@ public final class GsonBuilder {
   public Gson create() {
     List<TypeAdapterFactory> factories = new ArrayList<TypeAdapterFactory>();
     factories.addAll(this.factories);
-    Collections.reverse(factories);
-    factories.addAll(this.hierarchyFactories);
+    reversList(factories);
+
+    List<TypeAdapterFactory> hierarchyFactories = new ArrayList<TypeAdapterFactory>(this.hierarchyFactories.size());
+    hierarchyFactories.addAll(this.hierarchyFactories);
+    reversList(hierarchyFactories);
+    factories.addAll(hierarchyFactories);
+
     addTypeAdaptersForDate(datePattern, dateStyle, timeStyle, factories);
 
     return new Gson(excluder, fieldNamingPolicy, instanceCreators,
@@ -575,7 +579,7 @@ public final class GsonBuilder {
   private void addTypeAdaptersForDate(String datePattern, int dateStyle, int timeStyle,
       List<TypeAdapterFactory> factories) {
     DefaultDateTypeAdapter dateTypeAdapter;
-    if (datePattern != null && !"".equals(datePattern.trim())) {
+    if (datePattern != null && datePattern.trim().length() != 0) {
       dateTypeAdapter = new DefaultDateTypeAdapter(datePattern);
     } else if (dateStyle != DateFormat.DEFAULT && timeStyle != DateFormat.DEFAULT) {
       dateTypeAdapter = new DefaultDateTypeAdapter(dateStyle, timeStyle);
@@ -586,5 +590,9 @@ public final class GsonBuilder {
     factories.add(TreeTypeAdapter.newFactory(TypeToken.get(Date.class), dateTypeAdapter));
     factories.add(TreeTypeAdapter.newFactory(TypeToken.get(Timestamp.class), dateTypeAdapter));
     factories.add(TreeTypeAdapter.newFactory(TypeToken.get(java.sql.Date.class), dateTypeAdapter));
+  }
+
+  private void reversList(List list) {
+        Collections.reverse(list);
   }
 }

--- a/gson/src/main/java/com/google/gson/JsonArray.java
+++ b/gson/src/main/java/com/google/gson/JsonArray.java
@@ -40,13 +40,20 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
     elements = new ArrayList<JsonElement>();
   }
 
+  public JsonArray(int capactiy) {
+    elements = new ArrayList<JsonElement>(capactiy);
+  }
+
   @Override
   JsonArray deepCopy() {
-    JsonArray result = new JsonArray();
-    for (JsonElement element : elements) {
-      result.add(element.deepCopy());
+    if (!elements.isEmpty()) {
+      JsonArray result = new JsonArray(elements.size());
+      for (JsonElement element : elements) {
+        result.add(element.deepCopy());
+      }
+      return result;
     }
-    return result;
+    return new JsonArray();
   }
 
   /**

--- a/gson/src/main/java/com/google/gson/JsonElement.java
+++ b/gson/src/main/java/com/google/gson/JsonElement.java
@@ -322,6 +322,7 @@ public abstract class JsonElement {
       JsonWriter jsonWriter = new JsonWriter(stringWriter);
       jsonWriter.setLenient(true);
       Streams.write(this, jsonWriter);
+      jsonWriter.close();
       return stringWriter.toString();
     } catch (IOException e) {
       throw new AssertionError(e);

--- a/gson/src/main/java/com/google/gson/JsonObject.java
+++ b/gson/src/main/java/com/google/gson/JsonObject.java
@@ -30,14 +30,15 @@ import java.util.Set;
  * @author Joel Leitch
  */
 public final class JsonObject extends JsonElement {
-  private final LinkedTreeMap<String, JsonElement> members =
-      new LinkedTreeMap<String, JsonElement>();
+  private final LinkedTreeMap<String, JsonElement> members = new LinkedTreeMap<String, JsonElement>();
 
   @Override
   JsonObject deepCopy() {
     JsonObject result = new JsonObject();
-    for (Map.Entry<String, JsonElement> entry : members.entrySet()) {
-      result.add(entry.getKey(), entry.getValue().deepCopy());
+    if (!members.isEmpty()) {
+      for (Map.Entry<String, JsonElement> entry : members.entrySet()) {
+        result.add(entry.getKey(), entry.getValue().deepCopy());
+      }
     }
     return result;
   }

--- a/gson/src/main/java/com/google/gson/JsonPrimitive.java
+++ b/gson/src/main/java/com/google/gson/JsonPrimitive.java
@@ -16,11 +16,12 @@
 
 package com.google.gson;
 
+import com.google.gson.internal.$Gson$Preconditions;
+import com.google.gson.internal.LazilyParsedNumber;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
-import com.google.gson.internal.$Gson$Preconditions;
-import com.google.gson.internal.LazilyParsedNumber;
 
 /**
  * A class representing a Json primitive value. A primitive value
@@ -94,8 +95,7 @@ public final class JsonPrimitive extends JsonElement {
     if (primitive instanceof Character) {
       // convert characters to strings since in JSON, characters are represented as a single
       // character string
-      char c = ((Character) primitive).charValue();
-      this.value = String.valueOf(c);
+      this.value = String.valueOf(((Character) primitive).charValue(););
     } else {
       $Gson$Preconditions.checkArgument(primitive instanceof Number
               || isPrimitiveOrString(primitive));
@@ -174,7 +174,7 @@ public final class JsonPrimitive extends JsonElement {
   @Override
   public String getAsString() {
     if (isNumber()) {
-      return getAsNumber().toString();
+      return value.toString();
     } else if (isBoolean()) {
       return getAsBooleanWrapper().toString();
     } else {
@@ -309,14 +309,14 @@ public final class JsonPrimitive extends JsonElement {
     if (obj == null || getClass() != obj.getClass()) {
       return false;
     }
-    JsonPrimitive other = (JsonPrimitive)obj;
+    JsonPrimitive other = (JsonPrimitive) obj;
     if (value == null) {
       return other.value == null;
     }
-    if (isIntegral(this) && isIntegral(other)) {
-      return getAsNumber().longValue() == other.getAsNumber().longValue();
-    }
     if (value instanceof Number && other.value instanceof Number) {
+      if (isIntegral(this) && isIntegral(other)) {
+        return getAsNumber().longValue() == other.getAsNumber().longValue();
+      }
       double a = getAsNumber().doubleValue();
       // Java standard types other than double return true for two NaN. So, need
       // special handling for double.

--- a/gson/src/main/java/com/google/gson/JsonPrimitive.java
+++ b/gson/src/main/java/com/google/gson/JsonPrimitive.java
@@ -95,7 +95,7 @@ public final class JsonPrimitive extends JsonElement {
     if (primitive instanceof Character) {
       // convert characters to strings since in JSON, characters are represented as a single
       // character string
-      this.value = String.valueOf(((Character) primitive).charValue(););
+      this.value = String.valueOf(((Character) primitive).charValue());
     } else {
       $Gson$Preconditions.checkArgument(primitive instanceof Number
               || isPrimitiveOrString(primitive));


### PR DESCRIPTION
**Changes done** -:
**FieldNamingPolicy** -: Validating the condition before starting while loop.
**GsonBuilder** -: Instead of keep adding item at first position in hierarchyList , its more performance efficient to add all the items in last and then reverse at once while adding them all in the factories. As reversing a list is 15-16 times more faster than adding the item at first position and moving all the pointers when ever a new insert happens.
Along with that datePattern.trim.length() is much faster to check as compare to equal which will check if both objects are instanceof String then check length and then iterate over while loop.
**JsonArray/JsonObject** -: While making deepCopy of array , we know the size of the array that needs to be copy.
**JsonElement** -: No closure of JsonWriter.
**JsonPrimitve** -: getAsString is creating new instance of LazilyParsedNumber which is not needed , if we want to only access the string.