### PR TITLE
don't throw JsonSyntaxException where it should be IOException instead

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -898,8 +898,7 @@ public final class Gson {
     } catch (IllegalStateException e) {
       throw new JsonSyntaxException(e);
     } catch (IOException e) {
-      // TODO(inder): Figure out whether it is indeed right to rethrow this as JsonSyntaxException
-      throw new JsonSyntaxException(e);
+      throw new JsonIOException(e);
     } finally {
       reader.setLenient(oldLenient);
     }


### PR DESCRIPTION
This is (was) just insane. When underlying stream breaks (due to socket timeout for example), how it's a syntax error?