### PR TITLE
Support custom annotation processing

### DIFF
--- a/gson/src/main/java/com/google/gson/FieldAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/FieldAdapterFactory.java
@@ -1,0 +1,32 @@
+package com.google.gson;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+
+import com.google.gson.annotations.JsonAdapter;
+
+/**
+ * Factory for producing {@link TypeAdapter} that only read / write specific fields
+ * with some given annotation.
+ * <p>
+ * Configured through {@link GsonBuilder#registerFieldAdapterFactory}.
+ * <p>
+ * Normally a field needs only one adapter, so it doesn't make sense if both this
+ * and {@link JsonAdapter} are applied with a single field. In that case, this will
+ * be ignored.
+ *
+ * @author Floyd Wan
+ * @since 2.8.1
+ */
+public interface FieldAdapterFactory {
+
+  /**
+   * Create a {@link TypeAdapter} for a field with a special annotation.
+   *
+   * @param annotation the annotation instance on the given {@code field}
+   * @param field the field needs to be investigated
+   * @param <T> the target type of {@link TypeAdapter}
+   * @return a {@link TypeAdapter} to read / write this very field.
+   */
+  <T> TypeAdapter<T> create(Annotation annotation, Field field);
+}

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -22,6 +22,8 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -135,6 +137,7 @@ public final class Gson {
   private final boolean prettyPrinting;
   private final boolean lenient;
   private final JsonAdapterAnnotationTypeAdapterFactory jsonAdapterFactory;
+  private final Map<Class<? extends Annotation>, FieldAdapterFactory> fieldAdapterFactories;
 
   /**
    * Constructs a Gson object with default configuration. The default configuration has the
@@ -175,15 +178,16 @@ public final class Gson {
         Collections.<Type, InstanceCreator<?>>emptyMap(), DEFAULT_SERIALIZE_NULLS,
         DEFAULT_COMPLEX_MAP_KEYS, DEFAULT_JSON_NON_EXECUTABLE, DEFAULT_ESCAPE_HTML,
         DEFAULT_PRETTY_PRINT, DEFAULT_LENIENT, DEFAULT_SPECIALIZE_FLOAT_VALUES,
-        LongSerializationPolicy.DEFAULT, Collections.<TypeAdapterFactory>emptyList());
+        LongSerializationPolicy.DEFAULT, Collections.<TypeAdapterFactory>emptyList(),
+        Collections.<Class<? extends Annotation>, FieldAdapterFactory>emptyMap());
   }
 
   Gson(final Excluder excluder, final FieldNamingStrategy fieldNamingStrategy,
       final Map<Type, InstanceCreator<?>> instanceCreators, boolean serializeNulls,
       boolean complexMapKeySerialization, boolean generateNonExecutableGson, boolean htmlSafe,
       boolean prettyPrinting, boolean lenient, boolean serializeSpecialFloatingPointValues,
-      LongSerializationPolicy longSerializationPolicy,
-      List<TypeAdapterFactory> typeAdapterFactories) {
+      LongSerializationPolicy longSerializationPolicy, List<TypeAdapterFactory> typeAdapterFactories,
+      Map<Class<? extends Annotation>, FieldAdapterFactory> fieldAdapterFactories) {
     this.constructorConstructor = new ConstructorConstructor(instanceCreators);
     this.excluder = excluder;
     this.fieldNamingStrategy = fieldNamingStrategy;
@@ -253,6 +257,7 @@ public final class Gson {
         constructorConstructor, fieldNamingStrategy, excluder, jsonAdapterFactory));
 
     this.factories = Collections.unmodifiableList(factories);
+    this.fieldAdapterFactories = fieldAdapterFactories;
   }
 
   public Excluder excluder() {
@@ -509,6 +514,28 @@ public final class Gson {
       }
     }
     throw new IllegalArgumentException("GSON cannot serialize " + type);
+  }
+
+  /**
+   * This method is used to get the {@link TypeAdapter} for the specified field. The type
+   * adapter needs to be configured by {@link GsonBuilder#registerFieldAdapterFactory}.
+   *
+   * @param field the field needs to be investigated
+   * @return the {@link TypeAdapter} for the given {@code field}
+   * @since 2.8.1
+   */
+  public <T> TypeAdapter<T> getFieldAdapter(Field field) {
+    if (fieldAdapterFactories.isEmpty()) {
+      return null;
+    }
+    for (Annotation fieldAnnotation : field.getAnnotations()) {
+      Class<? extends Annotation> annotationType = fieldAnnotation.annotationType();
+      if (fieldAdapterFactories.containsKey(annotationType)) {
+        FieldAdapterFactory fieldAdapterFactory = fieldAdapterFactories.get(annotationType);
+        return fieldAdapterFactory.create(fieldAnnotation, field);
+      }
+    }
+    return null;
   }
 
   /**

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -16,7 +16,9 @@
 
 package com.google.gson;
 
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.sql.Timestamp;
 import java.text.DateFormat;
@@ -82,6 +84,8 @@ public final class GsonBuilder {
   private final Map<Type, InstanceCreator<?>> instanceCreators
       = new HashMap<Type, InstanceCreator<?>>();
   private final List<TypeAdapterFactory> factories = new ArrayList<TypeAdapterFactory>();
+  private final Map<Class<? extends Annotation>, FieldAdapterFactory> fieldAdapterFactories
+      = new HashMap<Class<? extends Annotation>, FieldAdapterFactory>();
   /** tree-style hierarchy factories. These come after factories for backwards compatibility. */
   private final List<TypeAdapterFactory> hierarchyFactories = new ArrayList<TypeAdapterFactory>();
   private boolean serializeNulls = DEFAULT_SERIALIZE_NULLS;
@@ -500,6 +504,22 @@ public final class GsonBuilder {
   }
 
   /**
+   * Configures Gson for custom serialization or deserialization. This method registers
+   * {@link TypeAdapter}s only for fields which annotated with given {@code annotationClass}.
+   * This is useful when you want to override the way Gson read/write your types with custom
+   * annotations, and/or {@link JsonAdapter} is not preferred to be mixed with them.
+   *
+   * @param annotationClass with which those fields need to be handled by the adapter
+   * @param fieldAdapterFactory the factory to be registered
+   * @since 2.8.1
+   */
+  public GsonBuilder registerFieldAdapterFactory(Class<? extends Annotation> annotationClass,
+      FieldAdapterFactory fieldAdapterFactory) {
+    fieldAdapterFactories.put(annotationClass, fieldAdapterFactory);
+    return this;
+  }
+
+  /**
    * Configures Gson for custom serialization or deserialization for an inheritance type hierarchy.
    * This method combines the registration of a {@link TypeAdapter}, {@link JsonSerializer} and
    * a {@link JsonDeserializer}. If a type adapter was previously registered for the specified
@@ -569,7 +589,8 @@ public final class GsonBuilder {
     return new Gson(excluder, fieldNamingPolicy, instanceCreators,
         serializeNulls, complexMapKeySerialization,
         generateNonExecutableJson, escapeHtmlChars, prettyPrinting, lenient,
-        serializeSpecialFloatingPointValues, longSerializationPolicy, factories);
+        serializeSpecialFloatingPointValues, longSerializationPolicy, factories,
+        fieldAdapterFactories);
   }
 
   private void addTypeAdaptersForDate(String datePattern, int dateStyle, int timeStyle,

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -110,6 +110,9 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
     if (annotation != null) {
       mapped = jsonAdapterFactory.getTypeAdapter(
           constructorConstructor, context, fieldType, annotation);
+    } else {
+      // find a custom type adapter for the field then
+      mapped = context.getFieldAdapter(field);
     }
     final boolean jsonAdapterPresent = mapped != null;
     if (mapped == null) mapped = context.getAdapter(fieldType);

--- a/gson/src/test/java/com/google/gson/CustomAnnotationTest.java
+++ b/gson/src/test/java/com/google/gson/CustomAnnotationTest.java
@@ -1,0 +1,79 @@
+package com.google.gson;
+
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import junit.framework.TestCase;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Field;
+
+/**
+ * @author Floyd Wan
+ */
+public class CustomAnnotationTest extends TestCase {
+
+  /**
+   * Most modern browsers fail to give right output on this:
+   * <pre>var i = 123456789123456789; alert(i);</pre>
+   * Attach this to a long/Long field to make it browser-friendly.
+   */
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.FIELD)
+  private static @interface BrowserFriendly {}
+
+  private static class BeingBrowserFriendly implements FieldAdapterFactory {
+    @Override
+    public <T> TypeAdapter<T> create(Annotation annotation, Field field) {
+      Class<?> fieldType = field.getType();
+      if (long.class.equals(fieldType) || Long.class.equals(fieldType)) {
+        if (field.isAnnotationPresent(BrowserFriendly.class)) {
+          @SuppressWarnings("unchecked")
+          TypeAdapter<T> longToString = (TypeAdapter<T>) new TypeAdapter<Long>(){
+            @Override
+            public void write(JsonWriter out, Long value) throws IOException {
+              if (null == value) {
+                out.nullValue();
+              } else {
+                out.value(String.valueOf(value));
+              }
+            }
+
+            @Override
+            public Long read(JsonReader in) throws IOException {
+              throw new UnsupportedOperationException();
+            }
+          };
+          return longToString;
+        }
+      }
+      return null;
+    }
+  }
+
+  private static class Person {
+    @BrowserFriendly
+    long id1;
+
+    @BrowserFriendly
+    Long id2;
+
+    Long id3;
+  }
+
+  public void testCustomAnnotationMakes() {
+    GsonBuilder gb = new GsonBuilder();
+    gb.registerFieldAdapterFactory(BrowserFriendly.class, new BeingBrowserFriendly());
+    Gson gson = gb.create();
+
+    Person p = new Person();
+    p.id1 = p.id2 = p.id3 = 123456789123456789L;
+    String json = gson.toJson(p);
+    assertTrue(json.contains("\"id1\":\"123456789123456789\""));
+    assertTrue(json.contains("\"id2\":\"123456789123456789\""));
+    assertTrue(json.contains("\"id3\":123456789123456789"));
+  }
+}

--- a/gson/src/test/java/com/google/gson/GsonTest.java
+++ b/gson/src/test/java/com/google/gson/GsonTest.java
@@ -17,6 +17,7 @@
 package com.google.gson;
 
 import com.google.gson.internal.Excluder;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -44,7 +45,8 @@ public final class GsonTest extends TestCase {
     Gson gson = new Gson(CUSTOM_EXCLUDER, CUSTOM_FIELD_NAMING_STRATEGY,
         new HashMap<Type, InstanceCreator<?>>(), true, false, true, false,
         true, true, false, LongSerializationPolicy.DEFAULT,
-        new ArrayList<TypeAdapterFactory>());
+        new ArrayList<TypeAdapterFactory>(),
+        new HashMap<Class<? extends Annotation>, FieldAdapterFactory>());
 
     assertEquals(CUSTOM_EXCLUDER, gson.excluder());
     assertEquals(CUSTOM_FIELD_NAMING_STRATEGY, gson.fieldNamingStrategy());


### PR DESCRIPTION
This [discuss](https://groups.google.com/forum/#!topic/google-gson/Y-NoyrqEpgo) and issue #269 talks about the same problem I want to tackle with. And I commented under issue #269 to state my reason. Generally speaking, I'd like to see a feature that let me use custom annotations in my data object freely without exposing Gson stuff there, and change the behaviors of reading/writing the fields with those annotations by Gson.

PS: I'm not so confident with the javadoc I put on added methods. I'll be glad to discuss with the reviewer to make it more comprehensive.