### PR TITLE
RuntimeFieldName: Add annotation and strategy class for runtime field

### DIFF
--- a/gson/src/main/java/com/google/gson/RuntimeFieldNamingStrategy.java
+++ b/gson/src/main/java/com/google/gson/RuntimeFieldNamingStrategy.java
@@ -1,0 +1,44 @@
+package com.google.gson;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import com.google.gson.annotations.RuntimeSerializedName;
+
+/**
+ * Naming strategy that uses the annotation {@link RuntimeSerializedName}
+ * If the annotation exists, it attempts to get a real serialized name from the source field mappings.
+ * An {@link IllegalArgumentException} is thrown if no mapping exists.
+ * A default naming strategy is used if no annotation is present.
+ * The default for this is {@link FieldNamingPolicy#IDENTITY}
+ *
+ * @author Damien Biggs
+ */
+public class RuntimeFieldNamingStrategy implements FieldNamingStrategy {
+
+    private Map<String, String> runtimeFieldNameMappings;
+
+    private FieldNamingStrategy defaultStrategy;
+
+    public RuntimeFieldNamingStrategy(Map<String, String> runtimeFieldNameMappings) {
+        this(runtimeFieldNameMappings, FieldNamingPolicy.IDENTITY);
+    }
+
+    public RuntimeFieldNamingStrategy(Map<String, String> runtimeFieldNameMappings, FieldNamingStrategy defaultStrategy) {
+        this.runtimeFieldNameMappings = runtimeFieldNameMappings;
+        this.defaultStrategy = defaultStrategy != null ? defaultStrategy : FieldNamingPolicy.IDENTITY;
+    }
+
+    @Override
+    public String translateName(Field field) {
+        RuntimeSerializedName runtimeFieldNameAnnotation = field.getAnnotation(RuntimeSerializedName.class);
+        if (runtimeFieldNameAnnotation == null) {
+            return defaultStrategy.translateName(field);
+        }
+        String runtimeFieldName = runtimeFieldNameAnnotation.value();
+        if (!runtimeFieldNameMappings.containsKey(runtimeFieldName)) {
+            throw new IllegalArgumentException("No field name mapping for runtime field name " + runtimeFieldName);
+        }
+        return runtimeFieldNameMappings.get(runtimeFieldName);
+    }
+}

--- a/gson/src/main/java/com/google/gson/annotations/RuntimeSerializedName.java
+++ b/gson/src/main/java/com/google/gson/annotations/RuntimeSerializedName.java
@@ -1,0 +1,65 @@
+package com.google.gson.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation that is used to determine the serialized field name at runtime.
+ * This works in conjunction with {@link com.google.gson.RuntimeFieldNamingStrategy}.
+ *
+ * {@link com.google.gson.annotations.SerializedName} will take precedence over this annotation.
+ * This annotation is only intended for use cases where you want the ability to set the serialized name dynamically.
+ *
+ * <p>Here is an example of how this annotation is meant to be used:</p>
+ * <pre>
+ * public class Issue {
+ *   String name;
+ *   &#64RuntimeSerializedName("acceptanceCriteria") String acceptanceCriteria;
+ *
+ *   public Issue(String name, String acceptanceCriteria) {
+ *     this.name = name;
+ *     this.acceptanceCriteria = acceptanceCriteria;
+ *   }
+ * }
+ * </pre>
+ *
+ * <p>The following shows the output that is generated when serializing an instance of the
+ * above example class:</p>
+ * <pre>
+ * Issue target = new Issue("dummyIssue", "ensure site starts up");
+ * Map<String, String> fieldNames = new HashMap<>();
+ * fieldNames.put("acceptanceCriteria", "customfield_10100");
+ * GsonBuilder builder = new GsonBuilder();
+ * builder.setFieldNamingStrategy(new RuntimeFieldNamingStrategy(fieldNames));
+ * Gson gson = builder.create();
+ * String json = gson.toJson(target);
+ * System.out.println(json);
+ *
+ * ===== OUTPUT =====
+ * {"name":"dummyIssue","customfield_10100":"ensure site starts up"}
+ * </pre>
+ *
+ * While deserializing, the annotation is used as well
+ * For example:
+ * <pre>
+ *   Issue target = gson.fromJson("{'name':'dummyIssue','customfield_10100':'ensure site starts up'}", Issue.class);
+ *   assertEquals("dummyIssue", target.name);
+ *   assertEquals("ensure site starts up", target.acceptanceCriteria);
+ * </pre>
+ *
+ *
+ * @author Damien Biggs
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD})
+public @interface RuntimeSerializedName {
+
+    /**
+     * @return the name used to look up the real serialized name for the property.
+     */
+    String value();
+}

--- a/gson/src/test/java/com/google/gson/functional/RuntimeSerializedNameTest.java
+++ b/gson/src/test/java/com/google/gson/functional/RuntimeSerializedNameTest.java
@@ -1,0 +1,108 @@
+package com.google.gson.functional;
+
+import java.util.HashMap;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.FieldNamingStrategy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.RuntimeFieldNamingStrategy;
+import com.google.gson.annotations.RuntimeSerializedName;
+import com.google.gson.annotations.SerializedName;
+import junit.framework.TestCase;
+
+public final class RuntimeSerializedNameTest extends TestCase {
+    private Gson gson;
+    private HashMap<String, String> fieldNames;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        fieldNames = new HashMap<String, String>();
+        fieldNames.put("acceptanceCriteria", "customfield_10100");
+        gson = createGson(null);
+    }
+
+    public void testIssueIsSerializedCorrectly() {
+        Issue target = new Issue("dummyIssue", "ensure site starts up");
+        assertEquals("{\"issueName\":\"dummyIssue\",\"customfield_10100\":\"ensure site starts up\"}", gson.toJson
+                (target));
+    }
+
+    public void testIssueIsDeserializedCorrectly() {
+        Issue target = gson.fromJson("{\"issueName\":\"dummyIssue\",\"customfield_10100\":\"ensure site starts " +
+                "up\"}", Issue.class);
+        assertEquals("dummyIssue", target.issueName);
+        assertEquals("ensure site starts up", target.acceptanceCriteria);
+    }
+
+    public void testCanUseDifferentDefaultNamingPolicy() {
+        Gson gson = createGson(FieldNamingPolicy.UPPER_CAMEL_CASE_WITH_SPACES);
+        Issue target = new Issue("dummyIssue", "ensure site starts up");
+        assertEquals("{\"Issue Name\":\"dummyIssue\",\"customfield_10100\":\"ensure site starts up\"}", gson.toJson
+                (target));
+    }
+
+    public void testCanDeserializeUsingDifferentDefaultNamingPolicy() {
+        Gson gson = createGson(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES);
+        Issue target = gson.fromJson("{\"issue_name\":\"dummyIssue\",\"customfield_10100\":\"ensure site starts " +
+                "up\"}", Issue.class);
+        assertEquals("dummyIssue", target.issueName);
+        assertEquals("ensure site starts up", target.acceptanceCriteria);
+    }
+
+    public void testSerializedNameAnnotationTakesPrecedence() {
+        IssueWithSerializedNameAnnotation target = new IssueWithSerializedNameAnnotation("dummyIssue", "ensure site starts up");
+        assertEquals("{\"issueName\":\"dummyIssue\",\"criteria\":\"ensure site starts up\"}", gson.toJson
+                (target));
+    }
+
+    public void testIssueWillFailSerializationIfFieldNameNotFound() {
+        try {
+            gson.toJson(new IssueWithUnknownRuntimeField("dummyIssue", "ensure site starts up"));
+            fail("Expected serialization to fail");
+        } catch (IllegalArgumentException iae) {
+            assertEquals("No field name mapping for runtime field name unknownFieldName", iae.getMessage());
+        }
+    }
+
+    private Gson createGson(FieldNamingStrategy defaultStrategy) {
+        GsonBuilder builder = new GsonBuilder();
+        builder.setFieldNamingStrategy(new RuntimeFieldNamingStrategy(fieldNames, defaultStrategy));
+        return builder.create();
+    }
+
+    private static final class Issue {
+        String issueName;
+        @RuntimeSerializedName("acceptanceCriteria")
+        String acceptanceCriteria;
+
+        public Issue(String issueName, String acceptanceCriteria) {
+            this.issueName = issueName;
+            this.acceptanceCriteria = acceptanceCriteria;
+        }
+    }
+
+    private static final class IssueWithUnknownRuntimeField {
+        String issueName;
+        @RuntimeSerializedName("unknownFieldName")
+        String acceptanceCriteria;
+
+        public IssueWithUnknownRuntimeField(String issueName, String acceptanceCriteria) {
+            this.issueName = issueName;
+            this.acceptanceCriteria = acceptanceCriteria;
+        }
+    }
+
+    private static final class IssueWithSerializedNameAnnotation {
+        String issueName;
+        @RuntimeSerializedName("acceptanceCriteria")
+        @SerializedName("criteria")
+        String acceptanceCriteria;
+
+        public IssueWithSerializedNameAnnotation(String issueName, String acceptanceCriteria) {
+            this.issueName = issueName;
+            this.acceptanceCriteria = acceptanceCriteria;
+        }
+    }
+}


### PR DESCRIPTION
Some users have a use case where they would like to set the serialized name for certain fields at
runtime. In my own company's case, there are custom field names for certain Jira projects.
We needed a way to make these configurable as different teams might have different custom field names.

Testing Done: Added test class to show how serialization and deserialization works.