### PR TITLE
Simplified access of getSimpleName

### DIFF
--- a/gson/src/main/java/com/google/gson/DefaultDateTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/DefaultDateTypeAdapter.java
@@ -37,11 +37,12 @@ import com.google.gson.internal.bind.util.ISO8601Utils;
 final class DefaultDateTypeAdapter implements JsonSerializer<Date>, JsonDeserializer<Date> {
 
   // TODO: migrate to streaming adapter
-
+  
+  private static final String SIMPLE_NAME = "DefaultDateTypeAdapter";
+  
   private final DateFormat enUsFormat;
   private final DateFormat localFormat;
-  private final static String SIMPLE_NAME = "DefaultDateTypeAdapter";
-
+  
   DefaultDateTypeAdapter() {
     this(DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.DEFAULT, Locale.US),
         DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.DEFAULT));

--- a/gson/src/main/java/com/google/gson/DefaultDateTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/DefaultDateTypeAdapter.java
@@ -40,7 +40,7 @@ final class DefaultDateTypeAdapter implements JsonSerializer<Date>, JsonDeserial
 
   private final DateFormat enUsFormat;
   private final DateFormat localFormat;
-  private final String SIMPLE_NAME = "DefaultDateTypeAdapter";
+  private final static String SIMPLE_NAME = "DefaultDateTypeAdapter";
 
   DefaultDateTypeAdapter() {
     this(DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.DEFAULT, Locale.US),

--- a/gson/src/main/java/com/google/gson/DefaultDateTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/DefaultDateTypeAdapter.java
@@ -40,6 +40,7 @@ final class DefaultDateTypeAdapter implements JsonSerializer<Date>, JsonDeserial
 
   private final DateFormat enUsFormat;
   private final DateFormat localFormat;
+  private final String SIMPLE_NAME = "DefaultDateTypeAdapter";
 
   DefaultDateTypeAdapter() {
     this(DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.DEFAULT, Locale.US),
@@ -111,7 +112,7 @@ final class DefaultDateTypeAdapter implements JsonSerializer<Date>, JsonDeserial
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append(DefaultDateTypeAdapter.class.getSimpleName());
+    sb.append(SIMPLE_NAME);
     sb.append('(').append(localFormat.getClass().getSimpleName()).append(')');
     return sb.toString();
   }


### PR DESCRIPTION
instead of calling getClass.getSimpleName() that will check too many conditions inside , we can make it as final String and use it directly.