### PR TITLE
Optimized no of iterations for copying values.

### DIFF
--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -1271,9 +1271,11 @@ public class JsonReader implements Closeable {
       int[] newStack = new int[stackSize * 2];
       int[] newPathIndices = new int[stackSize * 2];
       String[] newPathNames = new String[stackSize * 2];
-      System.arraycopy(stack, 0, newStack, 0, stackSize);
-      System.arraycopy(pathIndices, 0, newPathIndices, 0, stackSize);
-      System.arraycopy(pathNames, 0, newPathNames, 0, stackSize);
+      for (int i = 0 ; i < stackSize; i++) {
+          newStack[i] = stack[i];
+          newPathIndices[i] = pathIndices[i];
+          newPathNames[i] = pathNames[i];
+      }
       stack = newStack;
       pathIndices = newPathIndices;
       pathNames = newPathNames;


### PR DESCRIPTION
For copying the values we are iterating 3 times over the stackSize with the use of arrayCopy individually for stack,patchIndices and pathNames instead of that we can run a single for loop that will iterate till stackSize and copy all the values of stack,pathIndixes and pathNames in new array.