### PR TITLE
Optimization of TypeToken Generation

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -155,14 +155,15 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
           continue;
         }
         field.setAccessible(true);
-        Type fieldType = $Gson$Types.resolve(type.getType(), raw, field.getGenericType());
+        Type fieldType = $Gson$Types.resolve(declaredType, raw, field.getGenericType());
         List<String> fieldNames = getFieldNames(field);
         BoundField previous = null;
+        TypeToken<?> typeToken = TypeToken.get(fieldType);
         for (int i = 0, size = fieldNames.size(); i < size; ++i) {
           String name = fieldNames.get(i);
           if (i != 0) serialize = false; // only serialize the default name
           BoundField boundField = createBoundField(context, field, name,
-              TypeToken.get(fieldType), serialize, deserialize);
+              TypeToken.get(typeToken.getType(),typeToken.getRawType(),typeToken.hashCode()), serialize, deserialize);
           BoundField replaced = result.put(name, boundField);
           if (previous == null) previous = replaced;
         }
@@ -171,7 +172,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
               + " declares multiple JSON fields named " + previous.name);
         }
       }
-      type = TypeToken.get($Gson$Types.resolve(type.getType(), raw, raw.getGenericSuperclass()));
+      type = TypeToken.get($Gson$Types.resolve(declaredType, raw, raw.getGenericSuperclass()));
       raw = type.getRawType();
     }
     return result;

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -163,7 +163,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
           String name = fieldNames.get(i);
           if (i != 0) serialize = false; // only serialize the default name
           BoundField boundField = createBoundField(context, field, name,
-              TypeToken.get(typeToken.getType(),typeToken.getRawType(),typeToken.hashCode()), serialize, deserialize);
+              TypeToken.get(typeToken.getType(), typeToken.getRawType(), typeToken.hashCode()), serialize, deserialize);
           BoundField replaced = result.put(name, boundField);
           if (previous == null) previous = replaced;
         }

--- a/gson/src/main/java/com/google/gson/reflect/TypeToken.java
+++ b/gson/src/main/java/com/google/gson/reflect/TypeToken.java
@@ -73,6 +73,17 @@ public class TypeToken<T> {
     this.rawType = (Class<? super T>) $Gson$Types.getRawType(this.type);
     this.hashCode = this.type.hashCode();
   }
+  
+  /**
+   * Unsafe. Constructs a type literal manually given type , rawtype and
+   * hashCode as arguments.
+   */
+  @SuppressWarnings("unchecked")
+  TypeToken(Type type, Class<?> rawType, int hashCode) {
+    this.type = type;
+    this.rawType = (Class<? super T>) rawType;
+    this.hashCode = hashCode;
+  }
 
   /**
    * Returns the type from super class's type parameter in {@link $Gson$Types#canonicalize
@@ -289,6 +300,13 @@ public class TypeToken<T> {
     return $Gson$Types.typeToString(type);
   }
 
+  /**
+   * Gets type literal for the given {@code Type,rawType, hashCode} instance.
+   */
+  public static TypeToken<?> get(Type type, Class<?> rawType, int hashCode) {
+    return new TypeToken<Object>(type, rawType, hashCode);
+  }
+  
   /**
    * Gets type literal for the given {@code Type} instance.
    */


### PR DESCRIPTION
in createBoundFiled , while creating new TypeToken we are generating type , rawType and hashCode every time , instead of that we can generate it once and use the same.