### PR TITLE
Add constructor to UtcDateTypeAdapter

### DIFF
--- a/extras/src/main/java/com/google/gson/typeadapters/UtcDateTypeAdapter.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/UtcDateTypeAdapter.java
@@ -32,13 +32,22 @@ import com.google.gson.stream.JsonWriter;
 
 public final class UtcDateTypeAdapter extends TypeAdapter<Date> {
   private final TimeZone UTC_TIME_ZONE = TimeZone.getTimeZone("UTC");
+  private final boolean displayMilliseconds;
+
+  public UtcDateTypeAdapter() {
+    this(true);
+  }
+
+  public UtcDateTypeAdapter(boolean displayMilliseconds) {
+    this.displayMilliseconds = displayMilliseconds;
+  }
 
   @Override
   public void write(JsonWriter out, Date date) throws IOException {
     if (date == null) {
       out.nullValue();
     } else {
-      String value = format(date, true, UTC_TIME_ZONE);
+      String value = format(date, displayMilliseconds, UTC_TIME_ZONE);
       out.value(value);
     }
   }

--- a/extras/src/test/java/com/google/gson/typeadapters/UtcDateTypeAdapterTest.java
+++ b/extras/src/test/java/com/google/gson/typeadapters/UtcDateTypeAdapterTest.java
@@ -72,6 +72,27 @@ public final class UtcDateTypeAdapterTest extends TestCase {
     assertEquals(expected.getTime(), actual.getTime());
   }
 
+  public void testMilliseconds() {
+    // Default = use milliseconds
+    Gson gson = new GsonBuilder()
+      .registerTypeAdapter(Date.class, new UtcDateTypeAdapter())
+      .create();
+    Date in = gson.fromJson("'2014-12-05T04:00:00.000Z'", Date.class);
+    assertEquals("Date should include milliseconds", "\"2014-12-05T04:00:00.000Z\"", gson.toJson(in));
+
+    // Explicitly use milliseconds
+    gson = new GsonBuilder()
+      .registerTypeAdapter(Date.class, new UtcDateTypeAdapter(true))
+      .create();
+    assertEquals("Date should include milliseconds", "\"2014-12-05T04:00:00.000Z\"", gson.toJson(in));
+
+    // Explicitly NOT use milliseconds
+    gson = new GsonBuilder()
+      .registerTypeAdapter(Date.class, new UtcDateTypeAdapter(false))
+      .create();
+    assertEquals("Date should NOT include milliseconds", "\"2014-12-05T04:00:00Z\"", gson.toJson(in));
+  }
+
   public void testNullDateSerialization() {
     String json = gson.toJson(null, Date.class);
     assertEquals("null", json);


### PR DESCRIPTION
…  to allow setting of the boolean 'millis' flag that was present in the format() method.