### PR TITLE
Performance fix to do lazy initialization of null key surrogate

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -394,6 +394,7 @@ public final class Gson {
       if(null == sNullKeySurrogate) {
         sNullKeySurrogate = new TypeToken<Object>() {};
       }
+      return sNullKeySurrogate;
     }
   }
 

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -109,9 +109,9 @@ public final class Gson {
   static final boolean DEFAULT_COMPLEX_MAP_KEYS = false;
   static final boolean DEFAULT_SPECIALIZE_FLOAT_VALUES = false;
 
-  private static final TypeToken<?> NULL_KEY_SURROGATE = new TypeToken<Object>() {};
   private static final String JSON_NON_EXECUTABLE_PREFIX = ")]}'\n";
 
+  private static TypeToken<Object> sNullKeySurrogate;
   /**
    * This thread local guards against reentrant calls to getAdapter(). In
    * certain object graphs, creating an adapter for a type may recursively
@@ -135,6 +135,7 @@ public final class Gson {
   private final boolean prettyPrinting;
   private final boolean lenient;
   private final JsonAdapterAnnotationTypeAdapterFactory jsonAdapterFactory;
+
 
   /**
    * Constructs a Gson object with default configuration. The default configuration has the
@@ -388,6 +389,14 @@ public final class Gson {
     }.nullSafe();
   }
 
+  private static TypeToken<Object> getNullKeySurrogate() {
+    synchronized (Gson.class) {
+      if(null == sNullKeySurrogate) {
+        sNullKeySurrogate = new TypeToken<Object>() {};
+      }
+    }
+  }
+
   /**
    * Returns the type adapter for {@code} type.
    *
@@ -396,7 +405,7 @@ public final class Gson {
    */
   @SuppressWarnings("unchecked")
   public <T> TypeAdapter<T> getAdapter(TypeToken<T> type) {
-    TypeAdapter<?> cached = typeTokenCache.get(type == null ? NULL_KEY_SURROGATE : type);
+    TypeAdapter<?> cached = typeTokenCache.get(type == null ? Gson.getNullKeySurrogate() : type);
     if (cached != null) {
       return (TypeAdapter<T>) cached;
     }

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -111,7 +111,6 @@ public final class Gson {
 
   private static final String JSON_NON_EXECUTABLE_PREFIX = ")]}'\n";
 
-  private static TypeToken<Object> sNullKeySurrogate;
   /**
    * This thread local guards against reentrant calls to getAdapter(). In
    * certain object graphs, creating an adapter for a type may recursively
@@ -135,7 +134,6 @@ public final class Gson {
   private final boolean prettyPrinting;
   private final boolean lenient;
   private final JsonAdapterAnnotationTypeAdapterFactory jsonAdapterFactory;
-
 
   /**
    * Constructs a Gson object with default configuration. The default configuration has the
@@ -389,15 +387,6 @@ public final class Gson {
     }.nullSafe();
   }
 
-  private static TypeToken<Object> getNullKeySurrogate() {
-    synchronized (Gson.class) {
-      if(null == sNullKeySurrogate) {
-        sNullKeySurrogate = new TypeToken<Object>() {};
-      }
-      return sNullKeySurrogate;
-    }
-  }
-
   /**
    * Returns the type adapter for {@code} type.
    *
@@ -406,7 +395,7 @@ public final class Gson {
    */
   @SuppressWarnings("unchecked")
   public <T> TypeAdapter<T> getAdapter(TypeToken<T> type) {
-    TypeAdapter<?> cached = typeTokenCache.get(type == null ? Gson.getNullKeySurrogate() : type);
+    TypeAdapter<?> cached = typeTokenCache.get(type == null ? TypeToken.get(Object.class) : type);
     if (cached != null) {
       return (TypeAdapter<T>) cached;
     }

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -109,6 +109,7 @@ public final class Gson {
   static final boolean DEFAULT_COMPLEX_MAP_KEYS = false;
   static final boolean DEFAULT_SPECIALIZE_FLOAT_VALUES = false;
 
+  private static final TypeToken<?> NULL_KEY_SURROGATE = TypeToken.get(Object.class);
   private static final String JSON_NON_EXECUTABLE_PREFIX = ")]}'\n";
 
   /**
@@ -395,7 +396,7 @@ public final class Gson {
    */
   @SuppressWarnings("unchecked")
   public <T> TypeAdapter<T> getAdapter(TypeToken<T> type) {
-    TypeAdapter<?> cached = typeTokenCache.get(type == null ? TypeToken.get(Object.class) : type);
+    TypeAdapter<?> cached = typeTokenCache.get(type == null ? NULL_KEY_SURROGATE : type);
     if (cached != null) {
       return (TypeAdapter<T>) cached;
     }


### PR DESCRIPTION
Fixes issue #1063

![image](https://cloud.githubusercontent.com/assets/13655724/24973945/41484432-1fde-11e7-835b-2451c8478a16.png)

This is because of the static initialisation of NULL_KEY_SURROGATE in Gson class.
Given this is quite expensive and this is required only when someone passes in a null for the type parameter (which would be very rare, we should look at lazy initialisation of this variable)