### PR TITLE
Printing more debugging information to help track an invalid JsonAdap…

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonObject.java
+++ b/gson/src/main/java/com/google/gson/JsonObject.java
@@ -136,6 +136,7 @@ public final class JsonObject extends JsonElement {
    * Returns a set of members key values.
    *
    * @return a set of member keys as Strings
+   * @since 2.8.1
    */
   public Set<String> keySet() {
     return members.keySet();

--- a/gson/src/main/java/com/google/gson/internal/bind/JsonAdapterAnnotationTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonAdapterAnnotationTypeAdapterFactory.java
@@ -68,9 +68,10 @@ public final class JsonAdapterAnnotationTypeAdapterFactory implements TypeAdapte
           : null;
       typeAdapter = new TreeTypeAdapter(serializer, deserializer, gson, type, null);
     } else {
-      throw new IllegalArgumentException(
-          "@JsonAdapter value must be TypeAdapter, TypeAdapterFactory, "
-              + "JsonSerializer or JsonDeserializer reference.");
+      throw new IllegalArgumentException("Invalid attempt to bind an instance of "
+          + instance.getClass().getName() + " as a @JsonAdapter for " + type.toString()
+          + ". @JsonAdapter value must be a TypeAdapter, TypeAdapterFactory,"
+          + " JsonSerializer or JsonDeserializer.");
     }
 
     if (typeAdapter != null && annotation.nullSafe()) {

--- a/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java
@@ -249,4 +249,15 @@ public final class JsonAdapterAnnotationOnClassesTest extends TestCase {
       return Foo.valueOf(in.nextString().toUpperCase(Locale.US));
     }
   }
+
+  public void testIncorrectJsonAdapterType() {
+    try {
+      new Gson().toJson(new D());
+      fail();
+    } catch (IllegalArgumentException expected) {}
+  }
+  @JsonAdapter(Integer.class)
+  private static final class D {
+    @SuppressWarnings("unused") final String value = "a";
+  }
 }


### PR DESCRIPTION
…ter.

Now the thrown exception carries this information:
java.lang.IllegalArgumentException: Invalid attempt to bind an instance of java.lang.Integer as a @JsonAdapter for com.google.gson.functional.JsonAdapterAnnotationOnClassesTest$D. @JsonAdapter value must be a TypeAdapter, TypeAdapterFactory, JsonSerializer or JsonDeserializer.