### PR TITLE
Adding maven-bundle-plugin.

### DIFF
--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -52,6 +52,10 @@
           </archive>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,12 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
         </plugin>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>3.2.0</version>
+          <inherited>true</inherited>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>


### PR DESCRIPTION
This patch adds OSGi support to GSON, without changing the packaging type to "bundle".  It also uses a more recent version of the maven-bundle-plugin, 3.2.0 (3.3.0 is having some issues right now with CDNs or something).