### PR TITLE
Fix StackOverflowError on resolving recursive types by collapsing chains of type bounds

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
+++ b/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
@@ -75,7 +75,13 @@ public final class $Gson$Types {
    * this returns {@code ?}, which is shorthand for {@code ? extends Object}.
    */
   public static WildcardType subtypeOf(Type bound) {
-    return new WildcardTypeImpl(new Type[] { bound }, EMPTY_TYPE_ARRAY);
+    Type[] upperBounds;
+    if (bound instanceof WildcardType) {
+      upperBounds = ((WildcardType) bound).getUpperBounds();
+    } else {
+      upperBounds = new Type[] { bound };
+    }
+    return new WildcardTypeImpl(upperBounds, EMPTY_TYPE_ARRAY);
   }
 
   /**
@@ -84,7 +90,13 @@ public final class $Gson$Types {
    * super String}.
    */
   public static WildcardType supertypeOf(Type bound) {
-    return new WildcardTypeImpl(new Type[] { Object.class }, new Type[] { bound });
+    Type[] lowerBounds;
+    if (bound instanceof WildcardType) {
+      lowerBounds = ((WildcardType) bound).getLowerBounds();
+    } else {
+      lowerBounds = new Type[] { bound };
+    }
+    return new WildcardTypeImpl(new Type[] { Object.class }, lowerBounds);
   }
 
   /**

--- a/gson/src/test/java/com/google/gson/internal/bind/RecursiveTypesResolveTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/RecursiveTypesResolveTest.java
@@ -1,16 +1,17 @@
 package com.google.gson.internal.bind;
 
 import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
 import com.google.gson.internal.$Gson$Types;
 import junit.framework.TestCase;
 
 import java.io.PrintStream;
 import java.lang.ref.WeakReference;
-import java.lang.reflect.Type;
 
 /**
- * Test fixes for infinite recursion on {@link $Gson$Types#resolve(Type, Class, Type)}, described at
- * <a href="https://github.com/google/gson/issues/440">Issue #440</a> and similar issues.
+ * Test fixes for infinite recursion on {@link $Gson$Types#resolve(java.lang.reflect.Type, Class,
+ * java.lang.reflect.Type)}, described at <a href="https://github.com/google/gson/issues/440">Issue #440</a>
+ * and similar issues.
  * <p>
  * These tests originally caused {@link StackOverflowError} because of infinite recursion on attempts to
  * resolve generics on types, with an intermediate types like 'Foo2&lt;? extends ? super ? extends ... ? extends A&gt;'
@@ -18,29 +19,32 @@ import java.lang.reflect.Type;
 public class RecursiveTypesResolveTest extends TestCase {
 
   private static class Foo1<A> {
-    Foo2<? extends A> foo2;
+    public Foo2<? extends A> foo2;
   }
 
   private static class Foo2<B> {
-    Foo1<? super B> foo1;
+    public Foo1<? super B> foo1;
   }
 
   /**
    * Test simplest case of recursion.
    */
   public void testRecursiveResolveSimple() {
-    new Gson().getAdapter(Foo1.class);
+    TypeAdapter<Foo1> adapter = new Gson().getAdapter(Foo1.class);
+    assertNotNull(adapter);
   }
 
   //
   // Real-world samples, found in Issues #603 and #440.
   //
-  public void testIssue603_PrintStream() {
-    new Gson().getAdapter(PrintStream.class);
+  public void testIssue603PrintStream() {
+    TypeAdapter<PrintStream> adapter = new Gson().getAdapter(PrintStream.class);
+    assertNotNull(adapter);
   }
 
-  public void testIssue440_WeakReference() throws Exception {
-    new Gson().getAdapter(WeakReference.class);
+  public void testIssue440WeakReference() throws Exception {
+    TypeAdapter<WeakReference> adapter = new Gson().getAdapter(WeakReference.class);
+    assertNotNull(adapter);
   }
 
   //

--- a/gson/src/test/java/com/google/gson/internal/bind/RecursiveTypesResolveTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/RecursiveTypesResolveTest.java
@@ -1,0 +1,69 @@
+package com.google.gson.internal.bind;
+
+import com.google.gson.Gson;
+import com.google.gson.internal.$Gson$Types;
+import junit.framework.TestCase;
+
+import java.io.PrintStream;
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Type;
+
+/**
+ * Test fixes for infinite recursion on {@link $Gson$Types#resolve(Type, Class, Type)}, described at
+ * <a href="https://github.com/google/gson/issues/440">Issue #440</a> and similar issues.
+ * <p>
+ * These tests originally caused {@link StackOverflowError} because of infinite recursion on attempts to
+ * resolve generics on types, with an intermediate types like 'Foo2&lt;? extends ? super ? extends ... ? extends A&gt;'
+ */
+public class RecursiveTypesResolveTest extends TestCase {
+
+  private static class Foo1<A> {
+    Foo2<? extends A> foo2;
+  }
+
+  private static class Foo2<B> {
+    Foo1<? super B> foo1;
+  }
+
+  /**
+   * Test simplest case of recursion.
+   */
+  public void testRecursiveResolveSimple() {
+    new Gson().getAdapter(Foo1.class);
+  }
+
+  //
+  // Real-world samples, found in Issues #603 and #440.
+  //
+  public void testIssue603_PrintStream() {
+    new Gson().getAdapter(PrintStream.class);
+  }
+
+  public void testIssue440_WeakReference() throws Exception {
+    new Gson().getAdapter(WeakReference.class);
+  }
+
+  //
+  // Tests belows check the behaviour of the methods changed for the fix
+  //
+
+  public void testDoubleSupertype() {
+    assertEquals($Gson$Types.supertypeOf(Number.class),
+            $Gson$Types.supertypeOf($Gson$Types.supertypeOf(Number.class)));
+  }
+
+  public void testDoubleSubtype() {
+    assertEquals($Gson$Types.subtypeOf(Number.class),
+            $Gson$Types.subtypeOf($Gson$Types.subtypeOf(Number.class)));
+  }
+
+  public void testSuperSubtype() {
+    assertEquals($Gson$Types.subtypeOf(Object.class),
+            $Gson$Types.supertypeOf($Gson$Types.subtypeOf(Number.class)));
+  }
+
+  public void testSubSupertype() {
+    assertEquals($Gson$Types.subtypeOf(Object.class),
+            $Gson$Types.subtypeOf($Gson$Types.supertypeOf(Number.class)));
+  }
+}

--- a/gson/src/test/java/com/google/gson/internal/bind/RecursiveTypesResolveTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/RecursiveTypesResolveTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2017 Gson Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.gson.internal.bind;
 
 import com.google.gson.Gson;


### PR DESCRIPTION
As described in Issue #1074, $Gson$Types.resolve() shall collapse chains of super/extends type bounds to avoid StackOverflowError on attempts to serialize objects of such types or just obtain the type adapter.

The suggested change fixes StackOverflowError's in a number of issues, including Issue #440 and Issue #603.