### PR TITLE
Deserialize JSON non-fp literals to Long by default

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
@@ -203,6 +203,24 @@ public final class JsonTreeReader extends JsonReader {
     }
   }
 
+  @Override public Number nextNumber() throws IOException {
+    JsonToken token = peek();
+    if (token != JsonToken.NUMBER && token != JsonToken.STRING) {
+      throw new IllegalStateException(
+              "Expected " + JsonToken.NUMBER + " but was " + token + locationString());
+    }
+    Number result = ((JsonPrimitive) peekStack()).getAsNumber();
+    if (!isLenient() && result instanceof Double &&
+            (Double.isNaN(result.doubleValue()) || Double.isInfinite(result.doubleValue()))) {
+      throw new NumberFormatException("JSON forbids NaN and infinities: " + result);
+    }
+    popStack();
+    if (stackSize > 0) {
+      pathIndices[stackSize - 1]++;
+    }
+    return result;
+  }
+
   @Override public double nextDouble() throws IOException {
     JsonToken token = peek();
     if (token != JsonToken.NUMBER && token != JsonToken.STRING) {

--- a/gson/src/main/java/com/google/gson/internal/bind/ObjectTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ObjectTypeAdapter.java
@@ -76,7 +76,7 @@ public final class ObjectTypeAdapter extends TypeAdapter<Object> {
       return in.nextString();
 
     case NUMBER:
-      return in.nextDouble();
+      return in.nextNumber();
 
     case BOOLEAN:
       return in.nextBoolean();

--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -350,6 +350,7 @@ public final class TypeAdapters {
         in.nextNull();
         return null;
       case NUMBER:
+        return in.nextNumber();
       case STRING:
         return new LazilyParsedNumber(in.nextString());
       default:

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -874,6 +874,29 @@ public class JsonReader implements Closeable {
   }
 
   /**
+   * Returns the Number value of the next token, which is either {@link Long} or {@link Double},
+   * depending on whether the next literal is floating-point or integer.
+   *
+   * @throws IllegalStateException if the next token is not a literal value.
+   * @throws NumberFormatException if the next literal value cannot be parsed
+   *     as a double or as a long, or is non-finite.
+   */
+  public Number nextNumber() throws IOException {
+    int p = peeked;
+    if (p == PEEKED_NONE) {
+      p = doPeek();
+    }
+
+    if (p == PEEKED_LONG) {
+      peeked = PEEKED_NONE;
+      pathIndices[stackSize - 1]++;
+      return peekedLong;
+    } else {
+      return nextDouble();
+    }
+  }
+
+  /**
    * Returns the {@link com.google.gson.stream.JsonToken#NUMBER double} value of the next token,
    * consuming it. If the next token is a string, this method will attempt to
    * parse it as a double using {@link Double#parseDouble(String)}.

--- a/gson/src/test/java/com/google/gson/ObjectTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/ObjectTypeAdapterTest.java
@@ -16,10 +16,8 @@
 
 package com.google.gson;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
+
 import junit.framework.TestCase;
 
 public final class ObjectTypeAdapterTest extends TestCase {
@@ -28,10 +26,20 @@ public final class ObjectTypeAdapterTest extends TestCase {
 
   public void testDeserialize() throws Exception {
     Map<?, ?> map = (Map<?, ?>) adapter.fromJson("{\"a\":5,\"b\":[1,2,null],\"c\":{\"x\":\"y\"}}");
-    assertEquals(5.0, map.get("a"));
-    assertEquals(Arrays.asList(1.0, 2.0, null), map.get("b"));
+    assertEquals(5L, map.get("a"));
+    assertEquals(Arrays.asList(1L, 2L, null), map.get("b"));
     assertEquals(Collections.singletonMap("x", "y"), map.get("c"));
     assertEquals(3, map.size());
+  }
+
+  public void testDeserializeNumbers() throws Exception {
+    Number longNum = (Number) adapter.fromJson("2");
+    assertTrue(longNum instanceof Long);
+    assertEquals(2L, longNum);
+
+    Number fpNum = (Number) adapter.fromJson("2.0");
+    assertTrue(fpNum instanceof Double);
+    assertEquals(2.0, fpNum);
   }
 
   public void testSerialize() throws Exception {

--- a/gson/src/test/java/com/google/gson/functional/CollectionTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CollectionTest.java
@@ -17,19 +17,7 @@
 package com.google.gson.functional;
 
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.PriorityQueue;
-import java.util.Queue;
-import java.util.Set;
-import java.util.Stack;
-import java.util.Vector;
+import java.util.*;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -253,8 +241,8 @@ public class CollectionTest extends TestCase {
   public void testRawCollectionDeserializationNotAlllowed() {
     String json = "[0,1,2,3,4,5,6,7,8,9]";
     Collection integers = gson.fromJson(json, Collection.class);
-    // JsonReader converts numbers to double by default so we need a floating point comparison
-    assertEquals(Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0), integers);
+    // JsonReader converts non-fp numbers to long by default so we need long comparison
+    assertEquals(Arrays.asList(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L), integers);
 
     json = "[\"Hello\", \"World\"]";
     Collection strings = gson.fromJson(json, Collection.class);
@@ -271,8 +259,8 @@ public class CollectionTest extends TestCase {
     for (Object bag1 : target) {
       // Gson 2.0 converts raw objects into maps
       Map<String, Object> values = (Map<String, Object>) bag1;
-      assertTrue(values.containsValue(10.0));
-      assertTrue(values.containsValue(20.0));
+      assertTrue(values.containsValue(10L));
+      assertTrue(values.containsValue(20L));
       assertTrue(values.containsValue("stringValue"));
     }
   }
@@ -392,5 +380,13 @@ public class CollectionTest extends TestCase {
     for (Entry entry : set) {
       assertTrue(entry.value == 1 || entry.value == 2);
     }
+  }
+
+  public void testIssue1084() throws Exception {
+    String json = "{\"first\":6906764140092371368}";
+
+    Map map = gson.fromJson(json, Map.class);
+    Number number = (Number) map.get("first");
+    assertEquals(6906764140092371368L, number);
   }
 }


### PR DESCRIPTION
See issue #1084.

Before this fix, ObjectTypeAdapter deserialized both fp and non-fp
literals to Double. In case of very big numbers, it caused undesired
rounding, as Double cannot fit large integers without loosing precision.

From now on, a JSON integer literal (without a decimal point) is mapped
to Long if it fits into Long ranges. The JSON literals with decimal
point, and out-of-range integer literals are still mapped to Double.