### PR TITLE
Adding support for using getter/setter methods based on user choice #232

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -108,6 +108,7 @@ public final class Gson {
   static final boolean DEFAULT_SERIALIZE_NULLS = false;
   static final boolean DEFAULT_COMPLEX_MAP_KEYS = false;
   static final boolean DEFAULT_SPECIALIZE_FLOAT_VALUES = false;
+  static final boolean DEFAULT_USE_GETTER_SETTER = false;
 
   private static final TypeToken<?> NULL_KEY_SURROGATE = TypeToken.get(Object.class);
   private static final String JSON_NON_EXECUTABLE_PREFIX = ")]}'\n";
@@ -135,6 +136,7 @@ public final class Gson {
   private final boolean prettyPrinting;
   private final boolean lenient;
   private final JsonAdapterAnnotationTypeAdapterFactory jsonAdapterFactory;
+  private final boolean useGetterSetter;
 
   /**
    * Constructs a Gson object with default configuration. The default configuration has the
@@ -175,7 +177,7 @@ public final class Gson {
         Collections.<Type, InstanceCreator<?>>emptyMap(), DEFAULT_SERIALIZE_NULLS,
         DEFAULT_COMPLEX_MAP_KEYS, DEFAULT_JSON_NON_EXECUTABLE, DEFAULT_ESCAPE_HTML,
         DEFAULT_PRETTY_PRINT, DEFAULT_LENIENT, DEFAULT_SPECIALIZE_FLOAT_VALUES,
-        LongSerializationPolicy.DEFAULT, Collections.<TypeAdapterFactory>emptyList());
+        LongSerializationPolicy.DEFAULT, Collections.<TypeAdapterFactory>emptyList(), DEFAULT_USE_GETTER_SETTER);
   }
 
   Gson(final Excluder excluder, final FieldNamingStrategy fieldNamingStrategy,
@@ -183,7 +185,7 @@ public final class Gson {
       boolean complexMapKeySerialization, boolean generateNonExecutableGson, boolean htmlSafe,
       boolean prettyPrinting, boolean lenient, boolean serializeSpecialFloatingPointValues,
       LongSerializationPolicy longSerializationPolicy,
-      List<TypeAdapterFactory> typeAdapterFactories) {
+      List<TypeAdapterFactory> typeAdapterFactories, boolean useGetterSetter) {
     this.constructorConstructor = new ConstructorConstructor(instanceCreators);
     this.excluder = excluder;
     this.fieldNamingStrategy = fieldNamingStrategy;
@@ -192,6 +194,7 @@ public final class Gson {
     this.htmlSafe = htmlSafe;
     this.prettyPrinting = prettyPrinting;
     this.lenient = lenient;
+    this.useGetterSetter = useGetterSetter;
 
     List<TypeAdapterFactory> factories = new ArrayList<TypeAdapterFactory>();
 
@@ -269,6 +272,10 @@ public final class Gson {
 
   public boolean htmlSafe() {
     return htmlSafe;
+  }
+
+  public boolean useGetterSetter() {
+    return useGetterSetter;
   }
 
   private TypeAdapter<Number> doubleAdapter(boolean serializeSpecialFloatingPointValues) {

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -40,6 +40,7 @@ import static com.google.gson.Gson.DEFAULT_LENIENT;
 import static com.google.gson.Gson.DEFAULT_PRETTY_PRINT;
 import static com.google.gson.Gson.DEFAULT_SERIALIZE_NULLS;
 import static com.google.gson.Gson.DEFAULT_SPECIALIZE_FLOAT_VALUES;
+import static com.google.gson.Gson.DEFAULT_USE_GETTER_SETTER;
 
 /**
  * <p>Use this builder to construct a {@link Gson} instance when you need to set configuration
@@ -94,6 +95,7 @@ public final class GsonBuilder {
   private boolean prettyPrinting = DEFAULT_PRETTY_PRINT;
   private boolean generateNonExecutableJson = DEFAULT_JSON_NON_EXECUTABLE;
   private boolean lenient = DEFAULT_LENIENT;
+  private boolean useGetterSetter = DEFAULT_USE_GETTER_SETTER;
 
   /**
    * Creates a GsonBuilder instance that can be used to build Gson with various configuration
@@ -553,6 +555,19 @@ public final class GsonBuilder {
   }
 
   /**
+   * By default, Gson uses reflection to get/set values of the fields. Use this option to configure
+   * Gson to use getter/setter methods whenever possible. If no method is found,
+   * it will fallback to using reflection.
+   *
+   * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
+   * @since 1.8
+   */
+  public GsonBuilder useGetterSetter() {
+    this.useGetterSetter = true;
+    return this;
+  }
+
+  /**
    * Creates a {@link Gson} instance based on the current configuration. This method is free of
    * side-effects to this {@code GsonBuilder} instance and hence can be called multiple times.
    *
@@ -569,7 +584,7 @@ public final class GsonBuilder {
     return new Gson(excluder, fieldNamingPolicy, instanceCreators,
         serializeNulls, complexMapKeySerialization,
         generateNonExecutableJson, escapeHtmlChars, prettyPrinting, lenient,
-        serializeSpecialFloatingPointValues, longSerializationPolicy, factories);
+        serializeSpecialFloatingPointValues, longSerializationPolicy, factories, useGetterSetter);
   }
 
   @SuppressWarnings("unchecked")

--- a/gson/src/test/java/com/google/gson/GsonTest.java
+++ b/gson/src/test/java/com/google/gson/GsonTest.java
@@ -44,11 +44,12 @@ public final class GsonTest extends TestCase {
     Gson gson = new Gson(CUSTOM_EXCLUDER, CUSTOM_FIELD_NAMING_STRATEGY,
         new HashMap<Type, InstanceCreator<?>>(), true, false, true, false,
         true, true, false, LongSerializationPolicy.DEFAULT,
-        new ArrayList<TypeAdapterFactory>());
+        new ArrayList<TypeAdapterFactory>(), true);
 
     assertEquals(CUSTOM_EXCLUDER, gson.excluder());
     assertEquals(CUSTOM_FIELD_NAMING_STRATEGY, gson.fieldNamingStrategy());
     assertEquals(true, gson.serializeNulls());
     assertEquals(false, gson.htmlSafe());
+    assertEquals(true, gson.useGetterSetter());
   }
 }

--- a/gson/src/test/java/com/google/gson/functional/UseGetterSetterTest.java
+++ b/gson/src/test/java/com/google/gson/functional/UseGetterSetterTest.java
@@ -1,0 +1,63 @@
+package com.google.gson.functional;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import junit.framework.TestCase;
+
+/**
+ * Functional Test exercising serialization/deserialization using getter/setter methods.
+ *
+ * @author Raj Srivastava
+ */
+public class UseGetterSetterTest extends TestCase {
+
+  private static final int    INITIAL_INT    = 100;
+  private static final int    GETTER_OFFSET  = 20;
+  private static final int    SETTER_OFFSET  = 40;
+  private static final String INITIAL_STRING = "initial";
+  private static final String GETTER_SUFFIX  = "-g";
+  private static final String SETTER_SUFFIX  = "-s";
+
+  private Gson gson;
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    gson = new GsonBuilder().useGetterSetter().create();
+  }
+
+  public void testGetterSetterUse() throws Exception {
+    ClassWithGetterSetter request = new ClassWithGetterSetter(INITIAL_INT, INITIAL_STRING);
+    String json = gson.toJson(request);
+
+    ClassWithGetterSetter response = gson.fromJson(json, ClassWithGetterSetter.class);
+    assertEquals(response.primitiveField, INITIAL_INT + GETTER_OFFSET + SETTER_OFFSET);
+    assertEquals(response.nonPrimitiveField, INITIAL_STRING + GETTER_SUFFIX + SETTER_SUFFIX);
+  }
+
+  public static class ClassWithGetterSetter {
+    int     primitiveField;
+    String  nonPrimitiveField;
+
+    public ClassWithGetterSetter(int primitiveField, String nonPrimitiveField) {
+      this.primitiveField = primitiveField;
+      this.nonPrimitiveField = nonPrimitiveField;
+    }
+
+    public int getPrimitiveField() {
+      return primitiveField + GETTER_OFFSET;
+    }
+
+    public void setPrimitiveField(int primitiveField) {
+      this.primitiveField = primitiveField + SETTER_OFFSET;
+    }
+
+    public String getNonPrimitiveField() {
+      return nonPrimitiveField + GETTER_SUFFIX;
+    }
+
+    public void setNonPrimitiveField(String nonPrimitiveField) {
+      this.nonPrimitiveField = nonPrimitiveField + SETTER_SUFFIX;
+    }
+  }
+}


### PR DESCRIPTION
This PR contains changes to use getter/setter methods instead of field level reflection methods for serialization/deserialization of objects, if the user has specified this preference while instantiating Gson.