### PR TITLE
Fixed DefaultDateTypeAdapter nullability issue and JSON primitives contract

### DIFF
--- a/gson/src/main/java/com/google/gson/DefaultDateTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/DefaultDateTypeAdapter.java
@@ -84,6 +84,10 @@ final class DefaultDateTypeAdapter extends TypeAdapter<Date> {
   // See issue 162
   @Override
   public void write(JsonWriter out, Date value) throws IOException {
+    if (value == null) {
+      out.nullValue();
+      return;
+    }
     synchronized (localFormat) {
       String dateFormatAsString = enUsFormat.format(value);
       out.value(dateFormatAsString);

--- a/gson/src/main/java/com/google/gson/DefaultDateTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/DefaultDateTypeAdapter.java
@@ -92,8 +92,9 @@ final class DefaultDateTypeAdapter extends TypeAdapter<Date> {
 
   @Override
   public Date read(JsonReader in) throws IOException {
-    if (in.peek() != JsonToken.STRING) {
-      throw new JsonParseException("The date should be a string value");
+    if (in.peek() == JsonToken.NULL) {
+      in.nextNull();
+      return null;
     }
     Date date = deserializeToDate(in.nextString());
     if (dateType == Date.class) {

--- a/gson/src/test/java/com/google/gson/DefaultDateTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/DefaultDateTypeAdapterTest.java
@@ -164,6 +164,7 @@ public class DefaultDateTypeAdapterTest extends TestCase {
   public void testNullValue() throws Exception {
     DefaultDateTypeAdapter adapter = new DefaultDateTypeAdapter(Date.class);
     assertNull(adapter.fromJson("null"));
+    assertEquals("null", adapter.toJson(null));
   }
 
   public void testUnexpectedToken() throws Exception {

--- a/gson/src/test/java/com/google/gson/DefaultDateTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/DefaultDateTypeAdapterTest.java
@@ -161,6 +161,19 @@ public class DefaultDateTypeAdapterTest extends TestCase {
     } catch (IllegalArgumentException expected) { }
   }
 
+  public void testNullValue() throws Exception {
+    DefaultDateTypeAdapter adapter = new DefaultDateTypeAdapter(Date.class);
+    assertNull(adapter.fromJson("null"));
+  }
+
+  public void testUnexpectedToken() throws Exception {
+    try {
+      DefaultDateTypeAdapter adapter = new DefaultDateTypeAdapter(Date.class);
+      adapter.fromJson("{}");
+      fail("Unexpected token should fail.");
+    } catch (IllegalStateException expected) { }
+  }
+
   private void assertFormatted(String formatted, DefaultDateTypeAdapter adapter) {
     assertEquals(toLiteral(formatted), adapter.toJson(new Date(0)));
   }


### PR DESCRIPTION
Regression in:

* b8f616c939c652b8540c95fa2b377b8c628ef3ff - Migrate DefaultDateTypeAdapter to streaming adapter (#1070)

Bug reports:

* #1096 - 2.8.1 can't serialize and deserialize date null (2.8.0 works fine)
* #1098 - Gson 2.8.1 DefaultDateTypeAdapter is not null safe.
* #1095 - serialize date sometimes TreeTypeAdapter, sometimes DefaultDateTypeAdapter?