### PR TITLE
Avoid NPE in PostConstructAdapterFactory

### DIFF
--- a/extras/src/main/java/com/google/gson/typeadapters/PostConstructAdapterFactory.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/PostConstructAdapterFactory.java
@@ -33,7 +33,7 @@ public class PostConstructAdapterFactory implements TypeAdapterFactory {
     // copied from https://gist.github.com/swankjesse/20df26adaf639ed7fd160f145a0b661a
     @Override
     public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
-        for (Class<?> t = type.getRawType(); t != Object.class; t = t.getSuperclass()) {
+        for (Class<?> t = type.getRawType(); (t != Object.class) && (t.getSuperclass() != null); t = t.getSuperclass()) {
             for (Method m : t.getDeclaredMethods()) {
                 if (m.isAnnotationPresent(PostConstruct.class)) {
                     m.setAccessible(true);

--- a/extras/src/test/java/com/google/gson/typeadapters/PostConstructAdapterFactoryTest.java
+++ b/extras/src/test/java/com/google/gson/typeadapters/PostConstructAdapterFactoryTest.java
@@ -16,12 +16,12 @@
 
 package com.google.gson.typeadapters;
 
-import javax.annotation.PostConstruct;
-
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-
 import junit.framework.TestCase;
+
+import javax.annotation.PostConstruct;
+import java.util.List;
 
 public class PostConstructAdapterFactoryTest extends TestCase {
     public void test() throws Exception {
@@ -37,6 +37,14 @@ public class PostConstructAdapterFactoryTest extends TestCase {
         }
     }
 
+    public void testList() {
+        Gson gson = new GsonBuilder()
+            .registerTypeAdapterFactory(new PostConstructAdapterFactory())
+            .create();
+
+        gson.fromJson("{\"sandwiches\": [{\"bread\": \"white\", \"cheese\": \"cheddar\"},{\"bread\": \"white\", \"cheese\": \"swiss\"}]}", NotableSandwiches.class);
+    }
+
     static class Sandwich {
         String bread;
         String cheese;
@@ -46,5 +54,9 @@ public class PostConstructAdapterFactoryTest extends TestCase {
                 throw new IllegalArgumentException("too cheesey");
             }
         }
+    }
+
+    static class NotableSandwiches {
+        List<Sandwich> sandwiches;
     }
 }

--- a/extras/src/test/java/com/google/gson/typeadapters/PostConstructAdapterFactoryTest.java
+++ b/extras/src/test/java/com/google/gson/typeadapters/PostConstructAdapterFactoryTest.java
@@ -50,8 +50,7 @@ public class PostConstructAdapterFactoryTest extends TestCase {
 
         // Throws NullPointerException without the fix in https://github.com/google/gson/pull/1103
         String json = gson.toJson(sandwiches);
-        Assert.assertEquals(
-            "{\"sandwiches\":[{\"bread\":\"white\",\"cheese\":\"cheddar\"},{\"bread\":\"whole wheat\",\"cheese\":\"swiss\"}]}", json);
+        Assert.assertEquals("{\"sandwiches\":[{\"bread\":\"white\",\"cheese\":\"cheddar\"},{\"bread\":\"whole wheat\",\"cheese\":\"swiss\"}]}", json);
 
         MultipleSandwiches sandwichesFromJson = gson.fromJson(json, MultipleSandwiches.class);
         Assert.assertEquals(sandwiches, sandwichesFromJson);

--- a/extras/src/test/java/com/google/gson/typeadapters/PostConstructAdapterFactoryTest.java
+++ b/extras/src/test/java/com/google/gson/typeadapters/PostConstructAdapterFactoryTest.java
@@ -16,18 +16,20 @@
 
 package com.google.gson.typeadapters;
 
+import javax.annotation.PostConstruct;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import junit.framework.TestCase;
 
-import javax.annotation.PostConstruct;
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+import java.util.Arrays;
 import java.util.List;
 
 public class PostConstructAdapterFactoryTest extends TestCase {
     public void test() throws Exception {
-        Gson gson = new GsonBuilder()
-                .registerTypeAdapterFactory(new PostConstructAdapterFactory())
-                .create();
+        Gson gson = new GsonBuilder().registerTypeAdapterFactory(new PostConstructAdapterFactory()).create();
         gson.fromJson("{\"bread\": \"white\", \"cheese\": \"cheddar\"}", Sandwich.class);
         try {
             gson.fromJson("{\"bread\": \"cheesey bread\", \"cheese\": \"swiss\"}", Sandwich.class);
@@ -38,25 +40,74 @@ public class PostConstructAdapterFactoryTest extends TestCase {
     }
 
     public void testList() {
-        Gson gson = new GsonBuilder()
-            .registerTypeAdapterFactory(new PostConstructAdapterFactory())
-            .create();
+        MultipleSandwiches sandwiches = new MultipleSandwiches(Arrays.asList(
+            new Sandwich("white", "cheddar"),
+            new Sandwich("whole wheat", "swiss")));
 
-        gson.fromJson("{\"sandwiches\": [{\"bread\": \"white\", \"cheese\": \"cheddar\"},{\"bread\": \"white\", \"cheese\": \"swiss\"}]}", NotableSandwiches.class);
+        Gson gson = new GsonBuilder().registerTypeAdapterFactory(new PostConstructAdapterFactory()).create();
+
+        // Throws NullPointerException without the fix in https://github.com/google/gson/pull/1103
+        String json = gson.toJson(sandwiches);
+        Assert.assertEquals(
+            "{\"sandwiches\":[{\"bread\":\"white\",\"cheese\":\"cheddar\"},{\"bread\":\"whole wheat\",\"cheese\":\"swiss\"}]}", json);
+
+        MultipleSandwiches sandwichesFromJson = gson.fromJson(json, MultipleSandwiches.class);
+        Assert.assertEquals(sandwiches, sandwichesFromJson);
     }
 
     static class Sandwich {
-        String bread;
-        String cheese;
+        public String bread;
+        public String cheese;
 
-        @PostConstruct void validate() {
+        public Sandwich(String bread, String cheese) {
+            this.bread = bread;
+            this.cheese = cheese;
+        }
+
+        @PostConstruct private void validate() {
             if (bread.equals("cheesey bread") && cheese != null) {
                 throw new IllegalArgumentException("too cheesey");
             }
         }
+
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            }
+            if (!(o instanceof Sandwich)) {
+                return false;
+            }
+            final Sandwich other = (Sandwich) o;
+            if (this.bread == null ? other.bread != null : !this.bread.equals(other.bread)) {
+                return false;
+            }
+            if (this.cheese == null ? other.cheese != null : !this.cheese.equals(other.cheese)) {
+                return false;
+            }
+            return true;
+        }
     }
 
-    static class NotableSandwiches {
-        List<Sandwich> sandwiches;
+
+    static class MultipleSandwiches {
+        public List<Sandwich> sandwiches;
+
+        public MultipleSandwiches(List<Sandwich> sandwiches) {
+            this.sandwiches = sandwiches;
+        }
+
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            }
+            if (!(o instanceof MultipleSandwiches)) {
+                return false;
+            }
+            final MultipleSandwiches other = (MultipleSandwiches) o;
+            if (this.sandwiches == null ? other.sandwiches != null : !this.sandwiches.equals(other.sandwiches)) {
+                return false;
+            }
+            return true;
+        }
     }
 }

--- a/extras/src/test/java/com/google/gson/typeadapters/PostConstructAdapterFactoryTest.java
+++ b/extras/src/test/java/com/google/gson/typeadapters/PostConstructAdapterFactoryTest.java
@@ -29,7 +29,9 @@ import java.util.List;
 
 public class PostConstructAdapterFactoryTest extends TestCase {
     public void test() throws Exception {
-        Gson gson = new GsonBuilder().registerTypeAdapterFactory(new PostConstructAdapterFactory()).create();
+        Gson gson = new GsonBuilder()
+                .registerTypeAdapterFactory(new PostConstructAdapterFactory())
+                .create();
         gson.fromJson("{\"bread\": \"white\", \"cheese\": \"cheddar\"}", Sandwich.class);
         try {
             gson.fromJson("{\"bread\": \"cheesey bread\", \"cheese\": \"swiss\"}", Sandwich.class);
@@ -87,7 +89,6 @@ public class PostConstructAdapterFactoryTest extends TestCase {
             return true;
         }
     }
-
 
     static class MultipleSandwiches {
         public List<Sandwich> sandwiches;


### PR DESCRIPTION
The RawType's Superclass might be null. This happens, for example, when the type is a collection.