### PR TITLE
ProtoTypeAdapter uses wrong case format to find repeated field's generic type via reflection

### DIFF
--- a/proto/src/main/protobuf/bag.proto
+++ b/proto/src/main/protobuf/bag.proto
@@ -24,6 +24,11 @@ message SimpleProto {
   optional int32 count = 2;
 }
 
+message ProtoWithDifferentCaseFormat {
+  repeated string name_that_tests_case_format = 1;
+  optional string another_field = 2;
+}
+
 message ProtoWithRepeatedFields {
   repeated int64 numbers = 1;
   repeated SimpleProto simples = 2;


### PR DESCRIPTION
`fieldNameSerializationFormat` is a converter from protobuf case format -> json case format.

When deserializing json -> protobuf, `ProtoTypeAdapter` uses reflection to determine the Java field name of a repeated protobuf field (to obtain its generic type).

The Java protobuf implementation always uses lower camel case for its field names, but `ProtoTypeAdapter` was using the caller-specified proto->json converter. 

Before this PR, if the JSON case format didn't produce the same name as lower camel, deserialization would fail.

This PR:
* Removes the `Converter` and instead stores both proto and json `CaseFormat`s so the json `CaseFormat` can be referenced.
* Fixes the field name translation used in reflection so it always converts to lower camel.
* Adds deserialization and serialization unit tests on a protobuf with a repeated field name that exposes the error.