### PR TITLE
support hidden fields, fix IllegalArgumentException "... declares multiple JSON fields named ..."

### DIFF
--- a/gson/src/test/java/com/google/gson/functional/ObjectTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ObjectTest.java
@@ -500,30 +500,30 @@ public class ObjectTest extends TestCase {
   }
 
   private static class C1 {
-    String f;
-    C1(String f1) { this.f = f1; }
-    String getC1Field() { return f; }
+    private String f;
+    public C1(String f1) { this.f = f1; }
+    public String getC1Field() { return f; }
   }
 
   private static class C2 extends C1 {
-    C2(String f1) { super(f1); }
+    public C2(String f1) { super(f1); }
   }
 
   private static class C3 extends C2 {
-    String f;
+    private String f;
 
-    C3(String f1, String f3) {
+    public C3(String f1, String f3) {
       super(f1);
       this.f = f3;
     }
 
-    String getC3Field() { return f; }
+    public String getC3Field() { return f; }
   }
 
   private static class C4 extends C3 {
-    String f;
+    private String f;
 
-    C4(String f1, String f3, String f4) {
+    public C4(String f1, String f3, String f4) {
       super(f1, f3);
       this.f = f4;
     }

--- a/gson/src/test/java/com/google/gson/functional/ObjectTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ObjectTest.java
@@ -498,4 +498,53 @@ public class ObjectTest extends TestCase {
     private List<String> attributes = new ArrayList<String>();
     private List<Department> departments = new ArrayList<Department>();
   }
+
+  private static class C1 {
+    String f;
+    C1(String f1) { this.f = f1; }
+    String getC1Field() { return f; }
+  }
+
+  private static class C2 extends C1 {
+    C2(String f1) { super(f1); }
+  }
+
+  private static class C3 extends C2 {
+    String f;
+
+    C3(String f1, String f3) {
+      super(f1);
+      this.f = f3;
+    }
+
+    String getC3Field() { return f; }
+  }
+
+  private static class C4 extends C3 {
+    String f;
+
+    C4(String f1, String f3, String f4) {
+      super(f1, f3);
+      this.f = f4;
+    }
+  }
+
+  public void testHiddenFieldSerialization() {
+    C4 obj = new C4("c1Field", "c3Field", "c4Field");
+
+    String json = gson.toJson(obj);
+    assertTrue(json.contains("c1Field"));
+    assertTrue(json.contains("c3Field"));
+    assertTrue(json.contains("c4Field"));
+  }
+
+  public void testHiddenFieldDeserialization() {
+    C4 initial = new C4("c1Field", "c3Field", "c4Field");
+    String json = gson.toJson(initial);
+
+    C4 c4 = gson.fromJson(json, C4.class);
+    assertEquals("c4Field", c4.f);
+    assertEquals("c3Field", c4.getC3Field());
+    assertEquals("c1Field", c4.getC1Field());
+  }
 }


### PR DESCRIPTION
Before this fix, an attempt to serialize a class with a hidden field
(e.g. class C2 defined as below:
  class C1 { String f; }
  class C2 extends C1 { String f; }
)
failed with IllegalArgumentException with a message like "C2 declares multiple JSON fields named f".

This is fixed by mangling the hidden fields with a "^i" suffix, where i is the number of the field-declaring class in the chain of super-classes, e.g. "f^1" stands for the hidden field "f" declared in the first super-class of the class being serialized.

So, JSON for C2 now may look like {"f":"c2Field", "f^1":"c1Field"}