### PR TITLE
Make GsonBuilder.create() factory order idempotent.

### DIFF
--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -562,8 +562,12 @@ public final class GsonBuilder {
     List<TypeAdapterFactory> factories = new ArrayList<TypeAdapterFactory>(this.factories.size() + this.hierarchyFactories.size() + 3);
     factories.addAll(this.factories);
     Collections.reverse(factories);
-    Collections.reverse(this.hierarchyFactories);
-    factories.addAll(this.hierarchyFactories);
+
+    List<TypeAdapterFactory> hierarchyFactories = new ArrayList<TypeAdapterFactory>(this.hierarchyFactories.size());
+    hierarchyFactories.addAll(this.hierarchyFactories);
+    Collections.reverse(hierarchyFactories);
+    factories.addAll(hierarchyFactories);
+
     addTypeAdaptersForDate(datePattern, dateStyle, timeStyle, factories);
 
     return new Gson(excluder, fieldNamingPolicy, instanceCreators,

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -563,8 +563,7 @@ public final class GsonBuilder {
     factories.addAll(this.factories);
     Collections.reverse(factories);
 
-    List<TypeAdapterFactory> hierarchyFactories = new ArrayList<TypeAdapterFactory>(this.hierarchyFactories.size());
-    hierarchyFactories.addAll(this.hierarchyFactories);
+    List<TypeAdapterFactory> hierarchyFactories = new ArrayList<TypeAdapterFactory>(this.hierarchyFactories);
     Collections.reverse(hierarchyFactories);
     factories.addAll(hierarchyFactories);
 


### PR DESCRIPTION
Calling `GsonBuilder.create()` multiple times results in the builder's underlying hierarchy factory list being reversed.

This change copies hierarchy factories to a new local list when `GsonBuilder.create()` is called so subsequently calls don't result in a change in factory ordering.