### PR TITLE
Add newBuilder() API

### DIFF
--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -105,6 +105,31 @@ public final class GsonBuilder {
   }
 
   /**
+   * Constructs a GsonBuilder instance from a Gson instance. The newly constructed GsonBuilder
+   * has the same configuration as the previously built Gson instance.
+   *
+   * @param gson the gson instance whose configuration should by applied to a new GsonBuilder.
+   */
+  public GsonBuilder(Gson gson) {
+    this.excluder = gson.excluder;
+    this.fieldNamingPolicy = gson.fieldNamingStrategy;
+    this.instanceCreators.putAll(gson.instanceCreators);
+    this.serializeNulls = gson.serializeNulls;
+    this.complexMapKeySerialization = gson.complexMapKeySerialization;
+    this.generateNonExecutableJson = gson.generateNonExecutableJson;
+    this.escapeHtmlChars = gson.htmlSafe;
+    this.prettyPrinting = gson.prettyPrinting;
+    this.lenient = gson.lenient;
+    this.serializeSpecialFloatingPointValues = gson.serializeSpecialFloatingPointValues;
+    this.longSerializationPolicy = gson.longSerializationPolicy;
+    this.datePattern = gson.datePattern;
+    this.dateStyle = gson.dateStyle;
+    this.timeStyle = gson.timeStyle;
+    this.factories.addAll(gson.builderFactories);
+    this.hierarchyFactories.addAll(gson.builderHierarchyFactories);
+  }
+
+  /**
    * Configures Gson to enable versioning support.
    *
    * @param ignoreVersionsAfter any field or type marked with a version higher than this value
@@ -572,7 +597,9 @@ public final class GsonBuilder {
     return new Gson(excluder, fieldNamingPolicy, instanceCreators,
         serializeNulls, complexMapKeySerialization,
         generateNonExecutableJson, escapeHtmlChars, prettyPrinting, lenient,
-        serializeSpecialFloatingPointValues, longSerializationPolicy, factories);
+        serializeSpecialFloatingPointValues, longSerializationPolicy,
+        datePattern, dateStyle, timeStyle,
+        this.factories, this.hierarchyFactories, factories);
   }
 
   @SuppressWarnings("unchecked")

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -110,7 +110,7 @@ public final class GsonBuilder {
    *
    * @param gson the gson instance whose configuration should by applied to a new GsonBuilder.
    */
-  public GsonBuilder(Gson gson) {
+  GsonBuilder(Gson gson) {
     this.excluder = gson.excluder;
     this.fieldNamingPolicy = gson.fieldNamingStrategy;
     this.instanceCreators.putAll(gson.instanceCreators);

--- a/gson/src/test/java/com/google/gson/GsonTest.java
+++ b/gson/src/test/java/com/google/gson/GsonTest.java
@@ -17,7 +17,6 @@
 package com.google.gson;
 
 import com.google.gson.internal.Excluder;
-import com.google.gson.internal.bind.ObjectTypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -73,7 +72,9 @@ public final class GsonTest extends TestCase {
   }
 
   private static final class TestTypeAdapter extends TypeAdapter<Object> {
-    @Override public void write(JsonWriter out, Object value) throws IOException { }
+    @Override public void write(JsonWriter out, Object value) throws IOException {
+      // Test stub.
+    }
     @Override public Object read(JsonReader in) throws IOException { return null; }
   }
 }

--- a/gson/src/test/java/com/google/gson/GsonTest.java
+++ b/gson/src/test/java/com/google/gson/GsonTest.java
@@ -72,18 +72,6 @@ public final class GsonTest extends TestCase {
     assertEquals(original.factories.size() + 1, clone.factories.size());
   }
 
-  public void testClonedTypeAdapterFactoryListsAreSame() {
-    Gson original = new Gson(CUSTOM_EXCLUDER, CUSTOM_FIELD_NAMING_STRATEGY,
-        new HashMap<Type, InstanceCreator<?>>(), true, false, true, false,
-        true, true, false, LongSerializationPolicy.DEFAULT, null, DateFormat.DEFAULT,
-        DateFormat.DEFAULT, new ArrayList<TypeAdapterFactory>(),
-        new ArrayList<TypeAdapterFactory>(), new ArrayList<TypeAdapterFactory>());
-
-    Gson clone = original.newBuilder().create();
-
-    assertEquals(original.factories.size(), clone.factories.size());
-  }
-
   private static final class TestTypeAdapter extends TypeAdapter<Object> {
     @Override public void write(JsonWriter out, Object value) throws IOException { }
     @Override public Object read(JsonReader in) throws IOException { return null; }

--- a/gson/src/test/java/com/google/gson/GsonTest.java
+++ b/gson/src/test/java/com/google/gson/GsonTest.java
@@ -17,8 +17,13 @@
 package com.google.gson;
 
 import com.google.gson.internal.Excluder;
+import com.google.gson.internal.bind.ObjectTypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
+import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import junit.framework.TestCase;
@@ -43,12 +48,44 @@ public final class GsonTest extends TestCase {
   public void testOverridesDefaultExcluder() {
     Gson gson = new Gson(CUSTOM_EXCLUDER, CUSTOM_FIELD_NAMING_STRATEGY,
         new HashMap<Type, InstanceCreator<?>>(), true, false, true, false,
-        true, true, false, LongSerializationPolicy.DEFAULT,
-        new ArrayList<TypeAdapterFactory>());
+        true, true, false, LongSerializationPolicy.DEFAULT, null, DateFormat.DEFAULT,
+        DateFormat.DEFAULT, new ArrayList<TypeAdapterFactory>(),
+        new ArrayList<TypeAdapterFactory>(), new ArrayList<TypeAdapterFactory>());
 
     assertEquals(CUSTOM_EXCLUDER, gson.excluder());
     assertEquals(CUSTOM_FIELD_NAMING_STRATEGY, gson.fieldNamingStrategy());
     assertEquals(true, gson.serializeNulls());
     assertEquals(false, gson.htmlSafe());
+  }
+
+  public void testClonedTypeAdapterFactoryListsAreIndependent() {
+    Gson original = new Gson(CUSTOM_EXCLUDER, CUSTOM_FIELD_NAMING_STRATEGY,
+        new HashMap<Type, InstanceCreator<?>>(), true, false, true, false,
+        true, true, false, LongSerializationPolicy.DEFAULT, null, DateFormat.DEFAULT,
+        DateFormat.DEFAULT, new ArrayList<TypeAdapterFactory>(),
+        new ArrayList<TypeAdapterFactory>(), new ArrayList<TypeAdapterFactory>());
+
+    Gson clone = original.newBuilder()
+        .registerTypeAdapter(Object.class, new TestTypeAdapter())
+        .create();
+
+    assertEquals(original.factories.size() + 1, clone.factories.size());
+  }
+
+  public void testClonedTypeAdapterFactoryListsAreSame() {
+    Gson original = new Gson(CUSTOM_EXCLUDER, CUSTOM_FIELD_NAMING_STRATEGY,
+        new HashMap<Type, InstanceCreator<?>>(), true, false, true, false,
+        true, true, false, LongSerializationPolicy.DEFAULT, null, DateFormat.DEFAULT,
+        DateFormat.DEFAULT, new ArrayList<TypeAdapterFactory>(),
+        new ArrayList<TypeAdapterFactory>(), new ArrayList<TypeAdapterFactory>());
+
+    Gson clone = original.newBuilder().create();
+
+    assertEquals(original.factories.size(), clone.factories.size());
+  }
+
+  private static final class TestTypeAdapter extends TypeAdapter<Object> {
+    @Override public void write(JsonWriter out, Object value) throws IOException { }
+    @Override public Object read(JsonReader in) throws IOException { return null; }
   }
 }


### PR DESCRIPTION
Addresses #1139 

`Gson.newBuilder()` returns `GsonBuilder`

Few changes here:
- Increases visibility of `Gson` member variables so they can be seen by `GsonBuilder`
- Adds additional member variables to `Gson` to save state required to transform `Gson` back to `GsonBuilder`