### PR TITLE
Enum with abstract methods

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -573,12 +573,21 @@ public final class Gson {
    * {@link #toJson(Object, Type)} instead. If you want to write out the object to a
    * {@link Writer}, use {@link #toJson(Object, Appendable)} instead.
    *
+   * For enums having  abstract methods , {@link Class#getClass()} will not return the Class
+   * object corresponding to the enum constant. Instead of it will return a runtime Enum class
+   * of the enum variable. This fails when creating custom {@link TypeAdapter} for that enum.
+   * So the Type of the enum can be obtained by {@link Enum#getDeclaringClass()} call.
+   *
    * @param src the object for which Json representation is to be created setting for Gson
    * @return Json representation of {@code src}.
    */
   public String toJson(Object src) {
     if (src == null) {
       return toJson(JsonNull.INSTANCE);
+    }
+    if (src instanceof Enum) {
+      Enum anEnum = (Enum) src;
+      return toJson(src, anEnum.getDeclaringClass());
     }
     return toJson(src, src.getClass());
   }

--- a/gson/src/test/java/com/google/gson/functional/EnumTest.java
+++ b/gson/src/test/java/com/google/gson/functional/EnumTest.java
@@ -160,6 +160,19 @@ public class EnumTest extends TestCase {
     assertFalse(bar.contains(Roshambo.SCISSORS));
   }
 
+  public void testEnumWithAbstractMethods () {
+    Gson gson = new GsonBuilder()
+            .registerTypeAdapter(Countries.class , new OnePlusDevicesAdapter())
+            .create();
+    Countries onePlusDevices = Countries.UNITED_STATES_OF_AMERICA;
+    String json = gson.toJson(onePlusDevices);
+    assertEquals("\"USD\"" , json);
+
+    String jsonValue = "\"INR\"";
+    Countries parsed = gson.fromJson(jsonValue , Countries.class);
+    assertEquals(Countries.INDIA , parsed);
+  }
+
   public enum Roshambo {
     ROCK {
       @Override Roshambo defeats() {
@@ -198,5 +211,56 @@ public class EnumTest extends TestCase {
 
     @SerializedName("girl")
     FEMALE
+  }
+
+  public enum Countries {
+      AUSTRALIA {
+      @Override
+      String getCurrencyCode() {
+        return "AUD";
+      }
+    },
+      INDIA {
+      @Override
+      String getCurrencyCode() {
+        return "INR";
+      }
+    },
+      UNITED_STATES_OF_AMERICA {
+      @Override
+      String getCurrencyCode() {
+        return "USD";
+      }
+    },
+      GERMANY {
+      @Override
+      String getCurrencyCode() {
+        return "EUR";
+      }
+    };
+
+    abstract String getCurrencyCode();
+
+    public static Countries getDeviceFromDeviceCode (String currencyCode) {
+        for (Countries country : Countries.values()) {
+            if (country.getCurrencyCode().equals(currencyCode)) {
+                return country;
+            }
+        }
+        return null;
+    }
+  }
+
+  private static class OnePlusDevicesAdapter implements JsonSerializer<Countries> , JsonDeserializer<Countries> {
+
+    @Override
+    public JsonElement serialize(Countries src, Type typeOfSrc, JsonSerializationContext context) {
+      return new JsonPrimitive(src.getCurrencyCode());
+    }
+
+    @Override
+    public Countries deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+      return Countries.getDeviceFromDeviceCode(json.getAsString());
+    }
   }
 }

--- a/gson/src/test/java/com/google/gson/functional/EnumTest.java
+++ b/gson/src/test/java/com/google/gson/functional/EnumTest.java
@@ -162,7 +162,7 @@ public class EnumTest extends TestCase {
 
   public void testEnumWithAbstractMethods () {
     Gson gson = new GsonBuilder()
-            .registerTypeAdapter(Countries.class , new OnePlusDevicesAdapter())
+            .registerTypeAdapter(Countries.class , new CountriesAdapter())
             .create();
     Countries onePlusDevices = Countries.UNITED_STATES_OF_AMERICA;
     String json = gson.toJson(onePlusDevices);
@@ -251,7 +251,7 @@ public class EnumTest extends TestCase {
     }
   }
 
-  private static class OnePlusDevicesAdapter implements JsonSerializer<Countries> , JsonDeserializer<Countries> {
+  private static class CountriesAdapter implements JsonSerializer<Countries> , JsonDeserializer<Countries> {
 
     @Override
     public JsonElement serialize(Countries src, Type typeOfSrc, JsonSerializationContext context) {


### PR DESCRIPTION
##  Fix on creating TypeAdapter for Enum having abstract methods.

For enums having abstract methods, the `Cass.getClass()` will not return the Class object corresponding to the `enum `constant. Instead of it will return a runtime `Enum `class of the enum variable. This fails when creating custom `TypeAdapter `for that enum. So the Type of the enum can be obtained by `Enum.getDeclaringClass()` call.


