### PR TITLE
fix issue #1107: resolve element type in wildcard collection types

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
+++ b/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
@@ -275,6 +275,10 @@ public final class $Gson$Types {
    * @param supertype a superclass of, or interface implemented by, this.
    */
   static Type getSupertype(Type context, Class<?> contextRawType, Class<?> supertype) {
+    if (context instanceof WildcardType) {
+      // wildcards are useless for resolving supertypes. As the upper bound has the same raw type, use it instead
+      context = ((WildcardType)context).getUpperBounds()[0];
+    }
     checkArgument(supertype.isAssignableFrom(contextRawType));
     return resolve(context, contextRawType,
         $Gson$Types.getGenericSupertype(context, contextRawType, supertype));

--- a/gson/src/test/java/com/google/gson/functional/CollectionTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CollectionTest.java
@@ -394,9 +394,9 @@ public class CollectionTest extends TestCase {
     }
   }
 
-  private class BigClass { Map<String, ? extends List<SmallClass>> inBig; }
+  private class BigClass { private Map<String, ? extends List<SmallClass>> inBig; }
 
-  private class SmallClass { String inSmall; }
+  private class SmallClass { private String inSmall; }
 
   public void testIssue1107() {
     String json = "{\n" +

--- a/gson/src/test/java/com/google/gson/functional/CollectionTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CollectionTest.java
@@ -393,4 +393,23 @@ public class CollectionTest extends TestCase {
       assertTrue(entry.value == 1 || entry.value == 2);
     }
   }
+
+  class BigClass { Map<String, ? extends List<SmallClass>> inBig; }
+
+  class SmallClass { String inSmall; }
+
+  public void testIssue1107() {
+    String json = "{\n" +
+            "  \"inBig\": {\n" +
+            "    \"key\": [\n" +
+            "      { \"inSmall\": \"hello\" }\n" +
+            "    ]\n" +
+            "  }\n" +
+            "}";
+    BigClass bigClass = new Gson().fromJson(json, BigClass.class);
+    SmallClass small = bigClass.inBig.get("key").get(0);
+    assertNotNull(small);
+    assertEquals("hello", small.inSmall);
+  }
+
 }

--- a/gson/src/test/java/com/google/gson/functional/CollectionTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CollectionTest.java
@@ -394,9 +394,9 @@ public class CollectionTest extends TestCase {
     }
   }
 
-  class BigClass { Map<String, ? extends List<SmallClass>> inBig; }
+  private class BigClass { Map<String, ? extends List<SmallClass>> inBig; }
 
-  class SmallClass { String inSmall; }
+  private class SmallClass { String inSmall; }
 
   public void testIssue1107() {
     String json = "{\n" +


### PR DESCRIPTION
This change fixes of detecting element types by method $Gson$Types.getCollectionElementType() when the generic collection type is declared using wildcards. For example, for the collection type "? extends List&lt;Something&gt;" it shall extract "Something" as the element type. 

This change fixes issue #1107.
