### PR TITLE
workaround for enums corrupted by ProGuard

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -814,6 +814,10 @@ public final class TypeAdapters {
       if (!rawType.isEnum()) {
         rawType = rawType.getSuperclass(); // handle anonymous subclasses
       }
+      if (rawType.getEnumConstants() == null) {
+        // invalid enum class, probably corrupted by ProGuard (e.g. with missing values() method)
+        return null;
+      }
       return (TypeAdapter<T>) new EnumTypeAdapter(rawType);
     }
   };


### PR DESCRIPTION
Default ProGuard configuration removes valueOf() and values() from the
processed enum classes. As a result, type.getEnumConstants() == null for
such classes, and NullPointerException was thrown from the constructor
of EnumTypeAdapter.

As an example of the corrupted enum classes, see Predicates.ObjectPredicates
from jersey-guava (up to 2.25.1 so far).
Also see https://www.guardsquare.com/en/proguard/manual/examples#enumerations

No unit tests are provided now, but you can reproduce the exception using
code like this:
  import jersey.repackaged.com.google.common.base.Predicates;
  ...
  new Gson().toJson(Predicates.alwaysTrue());