### PR TITLE
Fixes #485

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonElement.java
+++ b/gson/src/main/java/com/google/gson/JsonElement.java
@@ -19,6 +19,7 @@ package com.google.gson;
 import com.google.gson.internal.Streams;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
+import java.io.Serializable;
 import java.io.StringWriter;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -30,7 +31,7 @@ import java.math.BigInteger;
  * @author Inderjeet Singh
  * @author Joel Leitch
  */
-public abstract class JsonElement {
+public abstract class JsonElement implements Serializable {
   /**
    * Returns a deep copy of this element. Immutable elements like primitives
    * and nulls are not copied.

--- a/gson/src/main/java/com/google/gson/JsonNull.java
+++ b/gson/src/main/java/com/google/gson/JsonNull.java
@@ -64,4 +64,8 @@ public final class JsonNull extends JsonElement {
   public boolean equals(Object other) {
     return this == other || other instanceof JsonNull;
   }
+
+  private Object readResolve() {
+    return INSTANCE;
+  }
 }

--- a/gson/src/main/java/com/google/gson/JsonObject.java
+++ b/gson/src/main/java/com/google/gson/JsonObject.java
@@ -18,6 +18,11 @@ package com.google.gson;
 
 import com.google.gson.internal.LinkedTreeMap;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -30,7 +35,7 @@ import java.util.Set;
  * @author Joel Leitch
  */
 public final class JsonObject extends JsonElement {
-  private final LinkedTreeMap<String, JsonElement> members =
+  private LinkedTreeMap<String, JsonElement> members =
       new LinkedTreeMap<String, JsonElement>();
 
   /**
@@ -214,5 +219,18 @@ public final class JsonObject extends JsonElement {
   @Override
   public int hashCode() {
     return members.hashCode();
+  }
+
+  @SuppressWarnings("unchecked")
+  private void readObject(ObjectInputStream aInputStream) throws ClassNotFoundException, IOException {
+    // custom deserializer since LinkedTreeMap serializes to LinkedHashMap!
+    members = new LinkedTreeMap<String, JsonElement>();
+    members.putAll(((Map<String, JsonElement>) aInputStream.readObject()));
+  }
+
+  private void writeObject(ObjectOutputStream aOutputStream) throws IOException {
+    // custom deserializer since LinkedTreeMap serializes to LinkedHashMap and thus deserialization would fail with
+    // java.lang.ClassCastException: cannot assign instance of java.util.LinkedHashMap to field com.google.gson.JsonObject.members of type com.google.gson.internal.LinkedTreeMap in instance of com.google.gson.JsonObject
+    aOutputStream.writeObject(members); // this actually writes LinkedHashMap.
   }
 }

--- a/gson/src/test/java/com/google/gson/JavaSerializationTest.java
+++ b/gson/src/test/java/com/google/gson/JavaSerializationTest.java
@@ -63,7 +63,7 @@ public final class JavaSerializationTest extends TestCase {
   }
 
   @SuppressWarnings("unchecked") // Serialization promises to return the same type.
-  private <T> T serializedCopy(T object) throws IOException, ClassNotFoundException {
+  public static <T> T serializedCopy(T object) throws IOException, ClassNotFoundException {
     ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
     ObjectOutputStream out = new ObjectOutputStream(bytesOut);
     out.writeObject(object);

--- a/gson/src/test/java/com/google/gson/JsonArrayTest.java
+++ b/gson/src/test/java/com/google/gson/JsonArrayTest.java
@@ -20,6 +20,11 @@ import junit.framework.TestCase;
 
 import com.google.gson.common.MoreAsserts;
 
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+
+import static com.google.gson.JavaSerializationTest.serializedCopy;
+
 /**
  * @author Jesse Wilson
  */
@@ -98,5 +103,30 @@ public final class JsonArrayTest extends TestCase {
 
     assertEquals(1, original.get(0).getAsJsonArray().size());
     assertEquals(0, copy.get(0).getAsJsonArray().size());
+  }
+
+  public void testSerialization() throws Exception {
+    assertEquals(new JsonArray(), serializedCopy(new JsonArray()));
+    JsonArray original = new JsonArray();
+    original.add(false);
+    assertEquals(original, serializedCopy(original));
+    original.add('a');
+    assertEquals(original, serializedCopy(original));
+    original.add((String) null);
+    assertEquals(original, serializedCopy(original));
+    original.add("b");
+    assertEquals(original, serializedCopy(original));
+    original.add(20L);
+    assertEquals(original, serializedCopy(original));
+    original.add(20);
+    assertEquals(original, serializedCopy(original));
+    original.add(20f);
+    assertEquals(original, serializedCopy(original));
+    original.add(20d);
+    assertEquals(original, serializedCopy(original));
+    original.add((short) 20);
+    assertEquals(original, serializedCopy(original));
+    original.add((byte) 20);
+    assertEquals(original, serializedCopy(original));
   }
 }

--- a/gson/src/test/java/com/google/gson/JsonNullTest.java
+++ b/gson/src/test/java/com/google/gson/JsonNullTest.java
@@ -19,6 +19,11 @@ package com.google.gson;
 import com.google.gson.common.MoreAsserts;
 import junit.framework.TestCase;
 
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+
+import static com.google.gson.JavaSerializationTest.serializedCopy;
+
 /**
  * @author Jesse Wilson
  */
@@ -36,5 +41,9 @@ public final class JsonNullTest extends TestCase {
     JsonNull a = new JsonNull();
     assertSame(JsonNull.INSTANCE, a.deepCopy());
     assertSame(JsonNull.INSTANCE, JsonNull.INSTANCE.deepCopy());
+  }
+
+  public void testSerialization() throws Exception {
+    assertSame(JsonNull.INSTANCE, serializedCopy(JsonNull.INSTANCE));
   }
 }

--- a/gson/src/test/java/com/google/gson/JsonObjectTest.java
+++ b/gson/src/test/java/com/google/gson/JsonObjectTest.java
@@ -20,6 +20,8 @@ import com.google.gson.common.MoreAsserts;
 
 import junit.framework.TestCase;
 
+import static com.google.gson.JavaSerializationTest.serializedCopy;
+
 /**
  * Unit test for the {@link JsonObject} class.
  *
@@ -197,5 +199,12 @@ public class JsonObjectTest extends TestCase {
     assertEquals(2, a.keySet().size());
     assertTrue(a.keySet().contains("foo"));
     assertTrue(a.keySet().contains("bar"));
+  }
+
+  public void testSerialization() throws Exception {
+    JsonObject a = new JsonObject();
+    a.add("foo", new JsonArray());
+    a.add("bar", new JsonObject());
+    assertEquals(a, serializedCopy(a));
   }
 }

--- a/gson/src/test/java/com/google/gson/JsonPrimitiveTest.java
+++ b/gson/src/test/java/com/google/gson/JsonPrimitiveTest.java
@@ -23,6 +23,8 @@ import junit.framework.TestCase;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
+import static com.google.gson.JavaSerializationTest.serializedCopy;
+
 /**
  * Unit test for the {@link JsonPrimitive} class.
  *
@@ -243,5 +245,15 @@ public class JsonPrimitiveTest extends TestCase {
   public void testDeepCopy() {
     JsonPrimitive a = new JsonPrimitive("a");
     assertSame(a, a.deepCopy()); // Primitives are immutable!
+  }
+
+  public void testSerialization() throws Exception {
+    assertEquals(new JsonPrimitive(false), serializedCopy(new JsonPrimitive(false)));
+    assertEquals(new JsonPrimitive("a"), serializedCopy(new JsonPrimitive("a")));
+    assertEquals(new JsonPrimitive(Float.NaN), serializedCopy(new JsonPrimitive(Float.NaN)));
+    assertEquals(new JsonPrimitive(1d), serializedCopy(new JsonPrimitive(1d)));
+    assertEquals(new JsonPrimitive(2f), serializedCopy(new JsonPrimitive(2f)));
+    assertEquals(new JsonPrimitive(3), serializedCopy(new JsonPrimitive(3)));
+    assertEquals(new JsonPrimitive('q'), serializedCopy(new JsonPrimitive('q')));
   }
 }


### PR DESCRIPTION
The `JsonElement` class now implements Serializable; I've added tests for all four implementors so that the serialization works. A special hack is added to `JsonNull` so that the deserialization preserves its singleton property; a workaround for `JsonObject` has been added, since `LinkedTreeMap` serializes to `LinkedHashMap` and using the default serialization causes `java.lang.ClassCastException: cannot assign instance of java.util.LinkedHashMap to field com.google.gson.JsonObject.members of type com.google.gson.internal.LinkedTreeMap in instance of com.google.gson.JsonObject`