### PR TITLE
Java 9 module

### DIFF
--- a/gson/src/main/java/com.google.gson/module-info.java
+++ b/gson/src/main/java/com.google.gson/module-info.java
@@ -1,0 +1,8 @@
+module com.google.gson {
+	exports com.google.gson;
+	exports com.google.gson.annotations;
+	exports com.google.gson.reflect;
+	exports com.google.gson.stream;
+
+	requires java.sql;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.7.0</version>
           <configuration>
+            <excludes>**/module-info.java</excludes>
             <source>${java.version}</source>
             <target>${java.version}</target>
           </configuration>


### PR DESCRIPTION
I've added a module-info.java file. Right now it's disabled by default-- I'm no maven wizard, so I didn't want to mess with the pom more than absolutely necessary. To try compiling the GSON as a jigsaw module, delete `<excludes>**/module-info.java</excludes>` and set java.version to 1.9, then run mvn compile.