### PR TITLE
Optimised the create() call for Excluder TypeAdapterFactory

### DIFF
--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -287,6 +287,17 @@ public final class GsonBuilder {
   }
 
   /**
+   * Configures Gson to exclude anonymous and local classes during serialization.
+   *
+   * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
+   * @since 2.8.2
+   */
+  public GsonBuilder disableAnonymousAndLocalClassSerialization() {
+    excluder = excluder.disableAnonymousAndLocalClassSerialization();
+    return this;
+  }
+
+  /**
    * Configures Gson to apply a specific serialization policy for {@code Long} and {@code long}
    * objects.
    *

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -287,13 +287,13 @@ public final class GsonBuilder {
   }
 
   /**
-   * Configures Gson to exclude anonymous and local classes during serialization.
+   * Configures Gson to include anonymous and local classes during serialization.
    *
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
    * @since 2.8.2
    */
-  public GsonBuilder disableAnonymousAndLocalClassSerialization() {
-    excluder = excluder.disableAnonymousAndLocalClassSerialization();
+  public GsonBuilder enableAnonymousAndLocalClassSerialization() {
+    excluder = excluder.enableAnonymousAndLocalClassSerialization();
     return this;
   }
 

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -287,17 +287,6 @@ public final class GsonBuilder {
   }
 
   /**
-   * Configures Gson to include anonymous and local classes during serialization.
-   *
-   * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
-   * @since 2.8.2
-   */
-  public GsonBuilder enableAnonymousAndLocalClassSerialization() {
-    excluder = excluder.enableAnonymousAndLocalClassSerialization();
-    return this;
-  }
-
-  /**
    * Configures Gson to apply a specific serialization policy for {@code Long} and {@code long}
    * objects.
    *

--- a/gson/src/main/java/com/google/gson/internal/Excluder.java
+++ b/gson/src/main/java/com/google/gson/internal/Excluder.java
@@ -54,7 +54,6 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
   private double version = IGNORE_VERSIONS;
   private int modifiers = Modifier.TRANSIENT | Modifier.STATIC;
   private boolean serializeInnerClasses = true;
-  private boolean serializeAnonymousAndLocalClasses = false;
   private boolean requireExpose;
   private List<ExclusionStrategy> serializationStrategies = Collections.emptyList();
   private List<ExclusionStrategy> deserializationStrategies = Collections.emptyList();
@@ -85,12 +84,6 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
   public Excluder disableInnerClassSerialization() {
     Excluder result = clone();
     result.serializeInnerClasses = false;
-    return result;
-  }
-
-  public com.google.gson.internal.Excluder enableAnonymousAndLocalClassSerialization() {
-    com.google.gson.internal.Excluder result = clone();
-    result.serializeAnonymousAndLocalClasses = true;
     return result;
   }
 
@@ -180,7 +173,7 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
       return true;
     }
 
-    if (!serializeAnonymousAndLocalClasses && isAnonymousOrLocal(field.getType())) {
+    if (isAnonymousOrLocal(field.getType())) {
       return true;
     }
 
@@ -206,7 +199,7 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
           return true;
       }
 
-      if (!serializeAnonymousAndLocalClasses && isAnonymousOrLocal(clazz)) {
+      if (isAnonymousOrLocal(clazz)) {
           return true;
       }
 

--- a/gson/src/main/java/com/google/gson/internal/Excluder.java
+++ b/gson/src/main/java/com/google/gson/internal/Excluder.java
@@ -90,7 +90,7 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
 
   public com.google.gson.internal.Excluder enableAnonymousAndLocalClassSerialization() {
     com.google.gson.internal.Excluder result = clone();
-    result.serializeAnonymousAndLocalClasses = false;
+    result.serializeAnonymousAndLocalClasses = true;
     return result;
   }
 

--- a/gson/src/main/java/com/google/gson/internal/Excluder.java
+++ b/gson/src/main/java/com/google/gson/internal/Excluder.java
@@ -54,7 +54,7 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
   private double version = IGNORE_VERSIONS;
   private int modifiers = Modifier.TRANSIENT | Modifier.STATIC;
   private boolean serializeInnerClasses = true;
-  private boolean serializeAnonymousAndLocalClasses = false;
+  private boolean serializeAnonymousAndLocalClasses = true;
   private boolean requireExpose;
   private List<ExclusionStrategy> serializationStrategies = Collections.emptyList();
   private List<ExclusionStrategy> deserializationStrategies = Collections.emptyList();
@@ -88,9 +88,9 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
     return result;
   }
 
-  public com.google.gson.internal.Excluder enableAnonymousAndLocalClassSerialization() {
+  public com.google.gson.internal.Excluder disableAnonymousAndLocalClassSerialization() {
     com.google.gson.internal.Excluder result = clone();
-    result.serializeAnonymousAndLocalClasses = true;
+    result.serializeAnonymousAndLocalClasses = false;
     return result;
   }
 
@@ -118,12 +118,9 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
   public <T> TypeAdapter<T> create(final Gson gson, final TypeToken<T> type) {
     Class<?> rawType = type.getRawType();
     boolean excludeClass = excludeClassChecks(rawType);
-    if (excludeClass) {
-        return null;
-    }
 
-    final boolean skipSerialize = excludeClassInStrategy(rawType, true);
-    final boolean skipDeserialize = excludeClassInStrategy(rawType, false);
+    final boolean skipSerialize = excludeClass || excludeClassInStrategy(rawType, true);
+    final boolean skipDeserialize = excludeClass ||  excludeClassInStrategy(rawType, false);
 
     if (!skipSerialize && !skipDeserialize) {
       return null;
@@ -183,7 +180,7 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
       return true;
     }
 
-    if (isAnonymousOrLocal(field.getType())) {
+    if (serializeAnonymousAndLocalClasses && isAnonymousOrLocal(field.getType())) {
       return true;
     }
 
@@ -217,7 +214,7 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
   }
 
   public boolean excludeClass(Class<?> clazz, boolean serialize) {
-      return excludeClassChecks(clazz) &&
+      return excludeClassChecks(clazz) ||
               excludeClassInStrategy(clazz, serialize);
   }
 

--- a/gson/src/main/java/com/google/gson/internal/Excluder.java
+++ b/gson/src/main/java/com/google/gson/internal/Excluder.java
@@ -54,7 +54,7 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
   private double version = IGNORE_VERSIONS;
   private int modifiers = Modifier.TRANSIENT | Modifier.STATIC;
   private boolean serializeInnerClasses = true;
-  private boolean serializeAnonymousAndLocalClasses = true;
+  private boolean serializeAnonymousAndLocalClasses = false;
   private boolean requireExpose;
   private List<ExclusionStrategy> serializationStrategies = Collections.emptyList();
   private List<ExclusionStrategy> deserializationStrategies = Collections.emptyList();
@@ -88,7 +88,7 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
     return result;
   }
 
-  public com.google.gson.internal.Excluder disableAnonymousAndLocalClassSerialization() {
+  public com.google.gson.internal.Excluder enableAnonymousAndLocalClassSerialization() {
     com.google.gson.internal.Excluder result = clone();
     result.serializeAnonymousAndLocalClasses = false;
     return result;
@@ -180,7 +180,7 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
       return true;
     }
 
-    if (serializeAnonymousAndLocalClasses && isAnonymousOrLocal(field.getType())) {
+    if (!serializeAnonymousAndLocalClasses && isAnonymousOrLocal(field.getType())) {
       return true;
     }
 
@@ -206,7 +206,7 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
           return true;
       }
 
-      if (serializeAnonymousAndLocalClasses && isAnonymousOrLocal(clazz)) {
+      if (!serializeAnonymousAndLocalClasses && isAnonymousOrLocal(clazz)) {
           return true;
       }
 

--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -133,10 +133,11 @@ public final class TypeAdapters {
   public static final TypeAdapter<Boolean> BOOLEAN = new TypeAdapter<Boolean>() {
     @Override
     public Boolean read(JsonReader in) throws IOException {
-      if (in.peek() == JsonToken.NULL) {
+      JsonToken peek = in.peek();
+      if (peek == JsonToken.NULL) {
         in.nextNull();
         return null;
-      } else if (in.peek() == JsonToken.STRING) {
+      } else if (peek == JsonToken.STRING) {
         // support strings for compatibility with GSON 1.7
         return Boolean.parseBoolean(in.nextString());
       }


### PR DESCRIPTION
excludeClass used to get called twice, which internally used to check if class is a innerClass, or an anonymous or local class. Attaching the CPU Profiler snapshot.

<img width="646" alt="screen shot 2017-11-30 at 2 51 22 pm" src="https://user-images.githubusercontent.com/16556984/33430061-2b37aa3e-d5f5-11e7-85fb-54882606579e.png">

With this change, we only check once and return if the class has to be excluded.