### PR TITLE
Added a check for use of type variable to TypeToken constructor.

### DIFF
--- a/gson/src/test/java/com/google/gson/reflect/TypeTokenTest.java
+++ b/gson/src/test/java/com/google/gson/reflect/TypeTokenTest.java
@@ -101,5 +101,35 @@ public final class TypeTokenTest extends TestCase {
     Type listOfString = TypeToken.getParameterized(List.class, String.class).getType();
     Type listOfListOfString = TypeToken.getParameterized(List.class, listOfString).getType();
     assertEquals(expectedListOfListOfListOfString, TypeToken.getParameterized(List.class, listOfListOfString));
+  }  
+  
+  public <T> void testRejectsTypeVariable() {
+	 try {
+		 new TypeToken<T>() {};
+	 } catch(RuntimeException e) {
+		 return;
+	 }
+	 
+	 throw new AssertionError("Expected exception");
+  }
+  
+  public <T> void testRejectsNestedTypeVariable() {
+	 try {
+		 new TypeToken<List<T>>()  {};
+	 } catch(RuntimeException e) {
+		 return;
+	 }
+	 
+	 throw new AssertionError("Expected exception");
+  }
+  
+  public <T> void testRejectsGenericArrayWithTypeVariable() {
+	 try {
+		 new TypeToken<List<T>[]>() {};
+	 } catch(RuntimeException e) {
+		 return;
+	 }
+	 
+	 throw new AssertionError("Expected exception");
   }
 }

--- a/gson/src/test/java/com/google/gson/reflect/TypeTokenTest.java
+++ b/gson/src/test/java/com/google/gson/reflect/TypeTokenTest.java
@@ -110,7 +110,7 @@ public final class TypeTokenTest extends TestCase {
 		 return;
 	 }
 	 
-	 throw new AssertionError("Expected exception");
+	 fail("Expected exception");
   }
   
   public <T> void testRejectsNestedTypeVariable() {
@@ -120,7 +120,7 @@ public final class TypeTokenTest extends TestCase {
 		 return;
 	 }
 	 
-	 throw new AssertionError("Expected exception");
+	 fail("Expected exception");
   }
   
   public <T> void testRejectsGenericArrayWithTypeVariable() {
@@ -130,6 +130,6 @@ public final class TypeTokenTest extends TestCase {
 		 return;
 	 }
 	 
-	 throw new AssertionError("Expected exception");
+	 fail("Expected exception");
   }
 }


### PR DESCRIPTION
A pull request that addresses my earlier issue #1219.

This adds a check to the protected `TypeToken` constructor that will now throw a runtime exception if the `TypeToken` uses a type variable. So that this design time error produces a more clear error earlier during execution.