### PR TITLE
Allow JsonValue writer without String usage

### DIFF
--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -438,6 +438,23 @@ public class JsonWriter implements Closeable, Flushable {
   }
 
   /**
+   * Writes {@code value} directly to the writer without quoting or
+   * escaping.
+   *
+   * @param value the char array value to write, or null to encode a null literal.
+   * @return this writer.
+   */
+  public JsonWriter jsonValue(char[] value) throws IOException {
+    if (value == null) {
+      return nullValue();
+    }
+    writeDeferredName();
+    beforeValue();
+    out.write(value);
+    return this;
+  }
+
+  /**
    * Encodes {@code null}.
    *
    * @return this writer.

--- a/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
@@ -160,7 +160,19 @@ public final class JsonWriterTest extends TestCase {
     assertEquals("{\"a\":null}", stringWriter.toString());
   }
 
-  public void testJsonValue() throws IOException {
+  public void testJsonValueChar() throws IOException {
+    StringWriter stringWriter = new StringWriter();
+    JsonWriter jsonWriter = new JsonWriter(stringWriter);
+    jsonWriter.beginObject();
+    jsonWriter.name("a");
+    jsonWriter.jsonValue(new char[] {'{', '"', 'b', '"', ':','t','r','u','e','}'});
+    jsonWriter.name("c");
+    jsonWriter.value(1);
+    jsonWriter.endObject();
+    assertEquals("{\"a\":{\"b\":true},\"c\":1}", stringWriter.toString());
+  }
+
+  public void testJsonValueString() throws IOException {
     StringWriter stringWriter = new StringWriter();
     JsonWriter jsonWriter = new JsonWriter(stringWriter);
     jsonWriter.beginObject();


### PR DESCRIPTION
The "jsonValue" API was created to write a raw JSON content into the output writer.
However, the API depends on String and the goal of this MR would be to remove String dependency. (To allow zeroisation on specific values)

Another way to proceed would be to use a "CharSequence" instead of a String but the writer would convert it to a String later.