### PR TITLE
Edit MalformedJsonException.java avoid mistake

### DIFF
--- a/gson/src/main/java/com/google/gson/stream/MalformedJsonException.java
+++ b/gson/src/main/java/com/google/gson/stream/MalformedJsonException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (C) 2010 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Welcome!
There would be a problem with MalformedJsonException.java. When I start a server, sometimes this error is present:
> [14:29:10] [Server thread/WARN]:    at sun.reflect.GeneratedMethodAccessor101.invoke(Unknown Source)
> [14:29:10] [Server thread/WARN]:    at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
> [14:29:10] [Server thread/WARN]: Caused by: com.google.gson.JsonSyntaxException: com.google.gson.stream.MalformedJsonException: Unterminated object at line 1 column 60
> [14:29:10] [Server thread/WARN]: Caused by: com.google.gson.stream.MalformedJsonException: Unterminated object at line 1 column 60
> [14:29:10] [Server thread/WARN]:    ... 18 more
**I think this is just a mistake I've transcribed.**