### PR TITLE
Add tests that shows JsonReader#skipValue() in an infinite loop.

### DIFF
--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -1254,7 +1254,7 @@ public class JsonReader implements Closeable {
         pos += peekedNumberLength;
       }
       peeked = PEEKED_NONE;
-    } while (count != 0);
+    } while (count > 0);
 
     pathIndices[stackSize - 1]++;
     pathNames[stackSize - 1] = "null";

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -1594,17 +1594,17 @@ public final class JsonReaderTest extends TestCase {
     assertEquals(JsonToken.END_DOCUMENT, reader.peek());
   }
 
-  public void test_skipValueInfiniteLoopOnObjectEnd() throws IOException {
+  public void testSkipValueInfiniteLoopOnObjectEnd() throws IOException {
       final String json = "{\"input\":{\"authToken\":\"7f79v2fav7jj48t70vh2jfo84h\",\"packageId\":\"649b1fa1-d323-499a-99b2-fb00da8b1f12\",\"version\":\"1.0.0\"},\"requestId\":\"0a7bd76f-6a3c-417d-b2c8-022e17ea46c0\",\"name\":\"com.seagullsw.appinterface.server.admin.Reconfigure\",\"type\":\"BasicRequest\"}";
       final String search = "AMissingValue";
       final JsonReader jsonReader = new JsonReader(new StringReader(json));
       try {
-          if (jsonReader.peek() == JsonToken.BEGIN_OBJECT) {
+          if (jsonReader.peek() == BEGIN_OBJECT) {
               jsonReader.beginObject();
-              while (jsonReader.peek() == JsonToken.NAME) {
+              while (jsonReader.peek() == NAME) {
                   final String jsonName = jsonReader.nextName();
                   if ("type".equals(jsonName)) {
-                      if (jsonReader.peek() == JsonToken.STRING && search.equals(jsonReader.nextString())) {
+                      if (jsonReader.peek() == STRING && search.equals(jsonReader.nextString())) {
                           Assert.fail();
                       }
                   }

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -16,13 +16,6 @@
 
 package com.google.gson.stream;
 
-import java.io.EOFException;
-import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
-import java.util.Arrays;
-import junit.framework.TestCase;
-
 import static com.google.gson.stream.JsonToken.BEGIN_ARRAY;
 import static com.google.gson.stream.JsonToken.BEGIN_OBJECT;
 import static com.google.gson.stream.JsonToken.BOOLEAN;
@@ -32,6 +25,16 @@ import static com.google.gson.stream.JsonToken.NAME;
 import static com.google.gson.stream.JsonToken.NULL;
 import static com.google.gson.stream.JsonToken.NUMBER;
 import static com.google.gson.stream.JsonToken.STRING;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.Arrays;
+
+import org.junit.Assert;
+
+import junit.framework.TestCase;
 
 @SuppressWarnings("resource")
 public final class JsonReaderTest extends TestCase {
@@ -1589,6 +1592,28 @@ public final class JsonReaderTest extends TestCase {
     reader.setLenient(true);
     reader.skipValue();
     assertEquals(JsonToken.END_DOCUMENT, reader.peek());
+  }
+
+  public void test_skipValueInfiniteLoopOnObjectEnd() throws IOException {
+      final String json = "{\"input\":{\"authToken\":\"7f79v2fav7jj48t70vh2jfo84h\",\"packageId\":\"649b1fa1-d323-499a-99b2-fb00da8b1f12\",\"version\":\"1.0.0\"},\"requestId\":\"0a7bd76f-6a3c-417d-b2c8-022e17ea46c0\",\"name\":\"com.seagullsw.appinterface.server.admin.Reconfigure\",\"type\":\"BasicRequest\"}";
+      final String search = "AMissingValue";
+      final JsonReader jsonReader = new JsonReader(new StringReader(json));
+      try {
+          if (jsonReader.peek() == JsonToken.BEGIN_OBJECT) {
+              jsonReader.beginObject();
+              while (jsonReader.peek() == JsonToken.NAME) {
+                  final String jsonName = jsonReader.nextName();
+                  if ("type".equals(jsonName)) {
+                      if (jsonReader.peek() == JsonToken.STRING && search.equals(jsonReader.nextString())) {
+                          Assert.fail();
+                      }
+                  }
+                  jsonReader.skipValue();
+              }
+          }
+      } finally {
+    	  jsonReader.close();
+      }
   }
 
   public void testSkipVeryLongQuotedString() throws IOException {


### PR DESCRIPTION
This PR adds tests that shows JsonReader#skipValue() in an infinite loop. I should not be able to cause GSON to loose its marbles.