### PR TITLE
add possibility to set default subtype in RuntimeTypeAdapterFactory

### DIFF
--- a/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
@@ -218,7 +218,7 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
     return new TypeAdapter<R>() {
       @Override public R read(JsonReader in) throws IOException {
         JsonElement jsonElement = Streams.parse(in);
-        JsonElement labelJsonElement = jsonElement.getAsJsonObject().remove(typeFieldName);
+        JsonElement labelJsonElement = jsonElement.getAsJsonObject().get(typeFieldName);
         if (labelJsonElement == null) {
           throw new JsonParseException("cannot deserialize " + baseType
               + " because it does not define a field named " + typeFieldName);


### PR DESCRIPTION
use case: server released new version of API and added new subtypes to json. All not updated clients will 

`throw new JsonParseException("cannot deserialize " + baseType + " subtype named "+ label + "; did you forget to register a subtype?");`

this change adds possibility to set default type for using in such cases