### PR TITLE
JsonWriter null dereference issue #1252 resolved.

### DIFF
--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -351,7 +351,7 @@ public class JsonWriter implements Closeable, Flushable {
   }
 
   private void push(int newTop) {
-    if (stackSize == stack.length) {
+    if (stack!=null && stackSize == stack.length) {
       int[] newStack = new int[stackSize * 2];
       System.arraycopy(stack, 0, newStack, 0, stackSize);
       stack = newStack;


### PR DESCRIPTION
Based on static tool analysis of Issue #1252. 