### PR TITLE
return Long instead of Double if number has no dot

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/ObjectTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ObjectTypeAdapter.java
@@ -76,7 +76,11 @@ public final class ObjectTypeAdapter extends TypeAdapter<Object> {
       return in.nextString();
 
     case NUMBER:
-      return in.nextDouble();
+      String s = in.nextString();
+      if(s.contains("."))
+        return Double.valueOf(s);
+      else
+        return Long.valueOf(s);
 
     case BOOLEAN:
       return in.nextBoolean();


### PR DESCRIPTION
e.g., "1.0" is parsed as Double while "1" is parsed as Long.