### PR TITLE
Gradle config snippet to use `implementation`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ There are a few open-source projects that can convert Java objects to JSON. Howe
   * To use Gson in Android
 ```gradle
 dependencies {
-    compile 'com.google.code.gson:gson:2.8.2'
+    implementation 'com.google.code.gson:gson:2.8.2'
 }
 ```
 


### PR DESCRIPTION
As of https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation, 

> The `compile` configuration still exists but should not be used as it will not offer the guarantees that the `api` and `implementation` configurations provide.

See also https://stackoverflow.com/questions/44493378/whats-the-difference-between-implementation-and-compile-in-gradle and https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html.