### PR TITLE
Supporting Long numbers during desiralization

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/ObjectTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ObjectTypeAdapter.java
@@ -75,6 +75,9 @@ public final class ObjectTypeAdapter extends TypeAdapter<Object> {
     case STRING:
       return in.nextString();
 
+    case LONG_NUMBER:
+      return in.nextLong();
+
     case NUMBER:
       return in.nextDouble();
 

--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -90,6 +90,7 @@ public final class TypeAdapters {
       while (tokenType != JsonToken.END_ARRAY) {
         boolean set;
         switch (tokenType) {
+        case LONG_NUMBER:
         case NUMBER:
           set = in.nextInt() != 0;
           break;
@@ -350,6 +351,7 @@ public final class TypeAdapters {
       case NULL:
         in.nextNull();
         return null;
+      case LONG_NUMBER:
       case NUMBER:
       case STRING:
         return new LazilyParsedNumber(in.nextString());
@@ -700,6 +702,7 @@ public final class TypeAdapters {
       switch (in.peek()) {
       case STRING:
         return new JsonPrimitive(in.nextString());
+      case LONG_NUMBER:
       case NUMBER:
         String number = in.nextString();
         return new JsonPrimitive(new LazilyParsedNumber(number));

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -449,6 +449,7 @@ public class JsonReader implements Closeable {
     case PEEKED_BUFFERED:
       return JsonToken.STRING;
     case PEEKED_LONG:
+      return JsonToken.LONG_NUMBER;
     case PEEKED_NUMBER:
       return JsonToken.NUMBER;
     case PEEKED_EOF:

--- a/gson/src/main/java/com/google/gson/stream/JsonToken.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonToken.java
@@ -61,10 +61,14 @@ public enum JsonToken {
   STRING,
 
   /**
-   * A JSON number represented in this API by a Java {@code double}, {@code
-   * long}, or {@code int}.
+   * A JSON number represented in this API by a Java {@code double}.
    */
   NUMBER,
+
+  /**
+   * A JSON number represented in this API by a Java {@code long} or {@code int}.
+   */
+  LONG_NUMBER,
 
   /**
    * A JSON {@code true} or {@code false}.

--- a/gson/src/test/java/com/google/gson/ObjectTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/ObjectTypeAdapterTest.java
@@ -27,11 +27,12 @@ public final class ObjectTypeAdapterTest extends TestCase {
   private final TypeAdapter<Object> adapter = gson.getAdapter(Object.class);
 
   public void testDeserialize() throws Exception {
-    Map<?, ?> map = (Map<?, ?>) adapter.fromJson("{\"a\":5,\"b\":[1,2,null],\"c\":{\"x\":\"y\"}}");
-    assertEquals(5.0, map.get("a"));
-    assertEquals(Arrays.asList(1.0, 2.0, null), map.get("b"));
+    Map<?, ?> map = (Map<?, ?>) adapter.fromJson("{\"a\":5,\"b\":[1,2.0,null],\"c\":{\"x\":\"y\"},\"d\":1.3}");
+    assertEquals(5L, map.get("a"));
+    assertEquals(Arrays.asList(1L, 2.0, null), map.get("b"));
     assertEquals(Collections.singletonMap("x", "y"), map.get("c"));
-    assertEquals(3, map.size());
+    assertEquals(1.3, map.get("d"));
+    assertEquals(4, map.size());
   }
 
   public void testSerialize() throws Exception {

--- a/gson/src/test/java/com/google/gson/functional/CollectionTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CollectionTest.java
@@ -250,11 +250,10 @@ public class CollectionTest extends TestCase {
   }
 
   @SuppressWarnings("rawtypes")
-  public void testRawCollectionDeserializationNotAlllowed() {
+  public void testRawCollectionDeserializationAllowed() {
     String json = "[0,1,2,3,4,5,6,7,8,9]";
-    Collection integers = gson.fromJson(json, Collection.class);
-    // JsonReader converts numbers to double by default so we need a floating point comparison
-    assertEquals(Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0), integers);
+    Collection longs = gson.fromJson(json, Collection.class);
+    assertEquals(Arrays.asList(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L), longs);
 
     json = "[\"Hello\", \"World\"]";
     Collection strings = gson.fromJson(json, Collection.class);
@@ -263,7 +262,7 @@ public class CollectionTest extends TestCase {
   }
 
   @SuppressWarnings({"rawtypes", "unchecked"})
-  public void testRawCollectionOfBagOfPrimitivesNotAllowed() {
+  public void testRawCollectionOfBagOfPrimitivesAllowed() {
     BagOfPrimitives bag = new BagOfPrimitives(10, 20, false, "stringValue");
     String json = '[' + bag.getExpectedJson() + ',' + bag.getExpectedJson() + ']';
     Collection target = gson.fromJson(json, Collection.class);
@@ -271,8 +270,8 @@ public class CollectionTest extends TestCase {
     for (Object bag1 : target) {
       // Gson 2.0 converts raw objects into maps
       Map<String, Object> values = (Map<String, Object>) bag1;
-      assertTrue(values.containsValue(10.0));
-      assertTrue(values.containsValue(20.0));
+      assertTrue(values.containsValue(10L));
+      assertTrue(values.containsValue(20L));
       assertTrue(values.containsValue("stringValue"));
     }
   }

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -28,6 +28,7 @@ import static com.google.gson.stream.JsonToken.BEGIN_OBJECT;
 import static com.google.gson.stream.JsonToken.BOOLEAN;
 import static com.google.gson.stream.JsonToken.END_ARRAY;
 import static com.google.gson.stream.JsonToken.END_OBJECT;
+import static com.google.gson.stream.JsonToken.LONG_NUMBER;
 import static com.google.gson.stream.JsonToken.NAME;
 import static com.google.gson.stream.JsonToken.NULL;
 import static com.google.gson.stream.JsonToken.NUMBER;
@@ -525,7 +526,7 @@ public final class JsonReaderTest extends TestCase {
     JsonReader reader = new JsonReader(reader("[-9223372036854775808]"));
     reader.setLenient(true);
     reader.beginArray();
-    assertEquals(NUMBER, reader.peek());
+    assertEquals(LONG_NUMBER, reader.peek());
     assertEquals(-9223372036854775808L, reader.nextLong());
   }
 
@@ -533,8 +534,16 @@ public final class JsonReaderTest extends TestCase {
     JsonReader reader = new JsonReader(reader("[9223372036854775807]"));
     reader.setLenient(true);
     reader.beginArray();
-    assertEquals(NUMBER, reader.peek());
+    assertEquals(LONG_NUMBER, reader.peek());
     assertEquals(9223372036854775807L, reader.nextLong());
+  }
+
+  public void testPeekDoubleValue() throws IOException {
+    JsonReader reader = new JsonReader(reader("[1.12346]"));
+    reader.setLenient(true);
+    reader.beginArray();
+    assertEquals(NUMBER, reader.peek());
+    assertEquals(1.12346, reader.nextDouble());
   }
 
   public void testLongLargerThanMaxLongThatWrapsAround() throws IOException {
@@ -597,7 +606,7 @@ public final class JsonReaderTest extends TestCase {
     JsonReader reader = new JsonReader(reader("[-9223372036854775809]"));
     reader.setLenient(true);
     reader.beginArray();
-    assertEquals(NUMBER, reader.peek());
+    assertEquals(LONG_NUMBER, reader.peek());
     try {
       reader.nextLong();
       fail();
@@ -1747,6 +1756,8 @@ public final class JsonReaderTest extends TestCase {
         assertEquals(false, reader.nextBoolean());
       } else if (expectation == STRING) {
         assertEquals("string", reader.nextString());
+      } else if (expectation == LONG_NUMBER) {
+        assertEquals(123, reader.nextInt());
       } else if (expectation == NUMBER) {
         assertEquals(123, reader.nextInt());
       } else if (expectation == NULL) {


### PR DESCRIPTION
**Problem**: every number is being deserialized as Double, even if it doesn't have floating point: https://github.com/google/gson/blob/master/gson/src/main/java/com/google/gson/internal/bind/ObjectTypeAdapter.java#L79

**Solution**: added supporting for Long numbers:
- `1.0` and `1.2` will be deserialized as Doubles
- `1` will be deserialized as Long.