### PR TITLE
Add FieldNamingPolicy.LOWER_CASE_WITH_DOTS

### DIFF
--- a/gson/src/main/java/com/google/gson/FieldNamingPolicy.java
+++ b/gson/src/main/java/com/google/gson/FieldNamingPolicy.java
@@ -114,6 +114,29 @@ public enum FieldNamingPolicy implements FieldNamingStrategy {
     @Override public String translateName(Field f) {
       return separateCamelCase(f.getName(), "-").toLowerCase(Locale.ENGLISH);
     }
+  },
+
+  /**
+   * Using this naming policy with Gson will modify the Java Field name from its camel cased
+   * form to a lower case field name where each word is separated by a dot (.).
+   *
+   * <p>Here's a few examples of the form "Java Field Name" ---> "JSON Field Name":</p>
+   * <ul>
+   *   <li>someFieldName ---> some.field.name</li>
+   *   <li>_someFieldName ---> _some.field.name</li>
+   *   <li>aStringField ---> a.string.field</li>
+   *   <li>aURL ---> a.u.r.l</li>
+   * </ul>
+   * Using dots in JavaScript is not recommended since dot is also used for a member sign in
+   * expressions. This requires that a field named with dots is always accessed as a quoted
+   * property like {@code myobject['my.field']}. Accessing it as an object field
+   * {@code myobject.my.field} will result in an unintended javascript expression.
+   * @since 2.8
+   */
+  LOWER_CASE_WITH_DOTS() {
+    @Override public String translateName(Field f) {
+      return separateCamelCase(f.getName(), ".").toLowerCase(Locale.ENGLISH);
+    }
   };
 
   /**

--- a/gson/src/test/java/com/google/gson/functional/NamingPolicyTest.java
+++ b/gson/src/test/java/com/google/gson/functional/NamingPolicyTest.java
@@ -63,6 +63,14 @@ public class NamingPolicyTest extends TestCase {
         + target.someConstantStringInstanceField + "\"}", gson.toJson(target));
   }
 
+  public void testGsonWithLowerCaseDotPolicySerialization() {
+    Gson gson = builder.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_DOTS).create();
+    StringWrapper target = new StringWrapper("blah");
+    assertEquals("{\"some.constant.string.instance.field\":\""
+          + target.someConstantStringInstanceField + "\"}", gson.toJson(target));
+  }
+
+
   public void testGsonWithLowerCaseDashPolicyDeserialiation() {
     Gson gson = builder.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_DASHES).create();
     String target = "{\"some-constant-string-instance-field\":\"someValue\"}";


### PR DESCRIPTION
Dot separated property naming is one of the most common field naming policies, used in many products like Spark, hadoop, log4j etc, e.g., `spark.executors.memory`, which is mapped to `sparkExecutorsMemory` as class field name.
This is very similar to LOWER_CASE_WITH_DASHES, the only difference is using `.` instead of `-`.