### PR TITLE
Proposal fix for #566

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/UnsafeAllocator.java
+++ b/gson/src/main/java/com/google/gson/internal/UnsafeAllocator.java
@@ -21,6 +21,8 @@ import java.io.ObjectStreamClass;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 
 /**
  * Do sneaky things to allocate objects without invoking their constructors.
@@ -31,7 +33,18 @@ import java.lang.reflect.Modifier;
 public abstract class UnsafeAllocator {
   public abstract <T> T newInstance(Class<T> c) throws Exception;
 
+  /**
+   * Sneaky things require priviledged access when run under security manager.
+   */
   public static UnsafeAllocator create() {
+    return AccessController.doPrivileged(new PrivilegedAction<UnsafeAllocator>() {
+      public UnsafeAllocator run() {
+        return createImpl();
+      }
+    });
+  }
+
+  private static UnsafeAllocator createImpl() {
     // try JVM
     // public class Unsafe {
     //   public Object allocateInstance(Class<?> type);

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -36,6 +36,8 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -149,7 +151,12 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
 
     Type declaredType = type.getType();
     while (raw != Object.class) {
-      Field[] fields = raw.getDeclaredFields();
+      final Class<?> privilegedRaw = raw;
+      Field[] fields = AccessController.doPrivileged(new PrivilegedAction<Field[]>() {
+        public Field[] run() {
+          return privilegedRaw.getDeclaredFields();
+        }
+      });
       for (Field field : fields) {
         boolean serialize = excludeField(field, true);
         boolean deserialize = excludeField(field, false);

--- a/gson/src/main/java/com/google/gson/internal/reflect/PreJava9ReflectionAccessor.java
+++ b/gson/src/main/java/com/google/gson/internal/reflect/PreJava9ReflectionAccessor.java
@@ -16,6 +16,8 @@
 package com.google.gson.internal.reflect;
 
 import java.lang.reflect.AccessibleObject;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 
 /**
  * A basic implementation of {@link ReflectionAccessor} which is suitable for Java 8 and below.
@@ -27,7 +29,12 @@ final class PreJava9ReflectionAccessor extends ReflectionAccessor {
 
   /** {@inheritDoc} */
   @Override
-  public void makeAccessible(AccessibleObject ao) {
-    ao.setAccessible(true);
+  public void makeAccessible(final AccessibleObject ao) {
+    AccessController.doPrivileged(new PrivilegedAction<Void>() {
+      public Void run() {
+        ao.setAccessible(true);
+        return null;
+      }
+    });
   }
 }

--- a/gson/src/test/java/com/google/gson/DefaultDateTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/DefaultDateTypeAdapterTest.java
@@ -17,6 +17,8 @@
 package com.google.gson;
 
 import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -34,6 +36,23 @@ import junit.framework.TestCase;
  */
 public class DefaultDateTypeAdapterTest extends TestCase {
 
+  protected void setTimeZone(final TimeZone tz) {
+    AccessController.doPrivileged(new PrivilegedAction<Void>() {
+      public Void run() {
+        TimeZone.setDefault(tz);
+        return null;
+      }
+    });
+  }
+  protected void setLocale(final Locale l) {
+    AccessController.doPrivileged(new PrivilegedAction<Void>() {
+      public Void run() {
+        Locale.setDefault(l);
+        return null;
+      }
+    });
+  }
+
   public void testFormattingInEnUs() {
     assertFormattingAlwaysEmitsUsLocale(Locale.US);
   }
@@ -44,9 +63,9 @@ public class DefaultDateTypeAdapterTest extends TestCase {
 
   private void assertFormattingAlwaysEmitsUsLocale(Locale locale) {
     TimeZone defaultTimeZone = TimeZone.getDefault();
-    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    setTimeZone(TimeZone.getTimeZone("UTC"));
     Locale defaultLocale = Locale.getDefault();
-    Locale.setDefault(locale);
+    setLocale(locale);
     try {
       String afterYearSep = JavaVersion.isJava9OrLater() ? ", " : " ";
       String afterYearLongSep = JavaVersion.isJava9OrLater() ? " at " : " ";
@@ -65,16 +84,16 @@ public class DefaultDateTypeAdapterTest extends TestCase {
       assertFormatted(String.format("Thursday, January 1, 1970%s12:00:00 AM %s", afterYearLongSep, utcFull),
           new DefaultDateTypeAdapter(DateFormat.FULL, DateFormat.FULL));
     } finally {
-      TimeZone.setDefault(defaultTimeZone);
-      Locale.setDefault(defaultLocale);
+      setTimeZone(defaultTimeZone);
+      setLocale(defaultLocale);
     }
   }
 
   public void testParsingDatesFormattedWithSystemLocale() throws Exception {
     TimeZone defaultTimeZone = TimeZone.getDefault();
-    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    setTimeZone(TimeZone.getTimeZone("UTC"));
     Locale defaultLocale = Locale.getDefault();
-    Locale.setDefault(Locale.FRANCE);
+    setLocale(Locale.FRANCE);
     try {
       String afterYearSep = JavaVersion.isJava9OrLater() ? " à " : " ";
       assertParsed(String.format("1 janv. 1970%s00:00:00", afterYearSep),
@@ -93,16 +112,16 @@ public class DefaultDateTypeAdapterTest extends TestCase {
                       "jeudi 1 janvier 1970 00 h 00 UTC",
           new DefaultDateTypeAdapter(DateFormat.FULL, DateFormat.FULL));
     } finally {
-      TimeZone.setDefault(defaultTimeZone);
-      Locale.setDefault(defaultLocale);
+      setTimeZone(defaultTimeZone);
+      setLocale(defaultLocale);
     }
   }
 
   public void testParsingDatesFormattedWithUsLocale() throws Exception {
     TimeZone defaultTimeZone = TimeZone.getDefault();
-    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    setTimeZone(TimeZone.getTimeZone("UTC"));
     Locale defaultLocale = Locale.getDefault();
-    Locale.setDefault(Locale.US);
+    setLocale(Locale.US);
     try {
       assertParsed("Jan 1, 1970 0:00:00 AM", new DefaultDateTypeAdapter(Date.class));
       assertParsed("1/1/70", new DefaultDateTypeAdapter(Date.class, DateFormat.SHORT));
@@ -117,24 +136,24 @@ public class DefaultDateTypeAdapterTest extends TestCase {
       assertParsed("Thursday, January 1, 1970 0:00:00 AM UTC",
           new DefaultDateTypeAdapter(DateFormat.FULL, DateFormat.FULL));
     } finally {
-      TimeZone.setDefault(defaultTimeZone);
-      Locale.setDefault(defaultLocale);
+      setTimeZone(defaultTimeZone);
+      setLocale(defaultLocale);
     }
   }
 
   public void testFormatUsesDefaultTimezone() throws Exception {
     TimeZone defaultTimeZone = TimeZone.getDefault();
-    TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
+    setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"));
     Locale defaultLocale = Locale.getDefault();
-    Locale.setDefault(Locale.US);
+    setLocale(Locale.US);
     try {
       String afterYearSep = JavaVersion.isJava9OrLater() ? ", " : " ";
       assertFormatted(String.format("Dec 31, 1969%s4:00:00 PM", afterYearSep),
               new DefaultDateTypeAdapter(Date.class));
       assertParsed("Dec 31, 1969 4:00:00 PM", new DefaultDateTypeAdapter(Date.class));
     } finally {
-      TimeZone.setDefault(defaultTimeZone);
-      Locale.setDefault(defaultLocale);
+      setTimeZone(defaultTimeZone);
+      setLocale(defaultLocale);
     }
   }
 

--- a/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
@@ -39,6 +39,8 @@ import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URL;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.text.DateFormat;
@@ -70,18 +72,35 @@ public class DefaultTypeAdaptersTest extends TestCase {
   private Gson gson;
   private TimeZone oldTimeZone;
 
+  protected void setTimeZone(final TimeZone tz) {
+    AccessController.doPrivileged(new PrivilegedAction<Void>() {
+      public Void run() {
+        TimeZone.setDefault(tz);
+        return null;
+      }
+    });
+  }
+  protected void setLocale(final Locale l) {
+    AccessController.doPrivileged(new PrivilegedAction<Void>() {
+      public Void run() {
+        Locale.setDefault(l);
+        return null;
+      }
+    });
+  }
+
   @Override
   protected void setUp() throws Exception {
     super.setUp();
     this.oldTimeZone = TimeZone.getDefault();
-    TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
-    Locale.setDefault(Locale.US);
+    setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"));
+    setLocale(Locale.US);
     gson = new Gson();
   }
 
   @Override
   protected void tearDown() throws Exception {
-    TimeZone.setDefault(oldTimeZone);
+    setTimeZone(oldTimeZone);
     super.tearDown();
   }
 
@@ -509,9 +528,9 @@ public class DefaultTypeAdaptersTest extends TestCase {
   public void testDateSerializationInCollection() throws Exception {
     Type listOfDates = new TypeToken<List<Date>>() {}.getType();
     TimeZone defaultTimeZone = TimeZone.getDefault();
-    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    setTimeZone(TimeZone.getTimeZone("UTC"));
     Locale defaultLocale = Locale.getDefault();
-    Locale.setDefault(Locale.US);
+    setLocale(Locale.US);
     try {
       Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd").create();
       List<Date> dates = Arrays.asList(new Date(0));
@@ -519,17 +538,17 @@ public class DefaultTypeAdaptersTest extends TestCase {
       assertEquals("[\"1970-01-01\"]", json);
       assertEquals(0L, gson.<List<Date>>fromJson("[\"1970-01-01\"]", listOfDates).get(0).getTime());
     } finally {
-      TimeZone.setDefault(defaultTimeZone);
-      Locale.setDefault(defaultLocale);
+      setTimeZone(defaultTimeZone);
+      setLocale(defaultLocale);
     }
   }
 
   // http://code.google.com/p/google-gson/issues/detail?id=230
   public void testTimestampSerialization() throws Exception {
     TimeZone defaultTimeZone = TimeZone.getDefault();
-    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    setTimeZone(TimeZone.getTimeZone("UTC"));
     Locale defaultLocale = Locale.getDefault();
-    Locale.setDefault(Locale.US);
+    setLocale(Locale.US);
     try {
       Timestamp timestamp = new Timestamp(0L);
       Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd").create();
@@ -537,17 +556,17 @@ public class DefaultTypeAdaptersTest extends TestCase {
       assertEquals("\"1970-01-01\"", json);
       assertEquals(0, gson.fromJson("\"1970-01-01\"", Timestamp.class).getTime());
     } finally {
-      TimeZone.setDefault(defaultTimeZone);
-      Locale.setDefault(defaultLocale);
+      setTimeZone(defaultTimeZone);
+      setLocale(defaultLocale);
     }
   }
 
   // http://code.google.com/p/google-gson/issues/detail?id=230
   public void testSqlDateSerialization() throws Exception {
     TimeZone defaultTimeZone = TimeZone.getDefault();
-    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    setTimeZone(TimeZone.getTimeZone("UTC"));
     Locale defaultLocale = Locale.getDefault();
-    Locale.setDefault(Locale.US);
+    setLocale(Locale.US);
     try {
       java.sql.Date sqlDate = new java.sql.Date(0L);
       Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd").create();
@@ -555,8 +574,8 @@ public class DefaultTypeAdaptersTest extends TestCase {
       assertEquals("\"1970-01-01\"", json);
       assertEquals(0, gson.fromJson("\"1970-01-01\"", java.sql.Date.class).getTime());
     } finally {
-      TimeZone.setDefault(defaultTimeZone);
-      Locale.setDefault(defaultLocale);
+      setTimeZone(defaultTimeZone);
+      setLocale(defaultLocale);
     }
   }
 

--- a/gson/src/test/java/com/google/gson/functional/ObjectTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ObjectTest.java
@@ -36,6 +36,8 @@ import com.google.gson.common.TestTypes.PrimitiveArray;
 import com.google.gson.internal.JavaVersion;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -62,13 +64,23 @@ public class ObjectTest extends TestCase {
     super.setUp();
     gson = new Gson();
 
-    TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
-    Locale.setDefault(Locale.US);
+    AccessController.doPrivileged(new PrivilegedAction<Void>() {
+      public Void run() {
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
+        Locale.setDefault(Locale.US);
+        return null;
+      }
+    });
   }
 
   @Override
   protected void tearDown() throws Exception {
-    TimeZone.setDefault(oldTimeZone);
+    AccessController.doPrivileged(new PrivilegedAction<Void>() {
+      public Void run() {
+        TimeZone.setDefault(oldTimeZone);
+        return null;
+      }
+    });
     super.tearDown();
   }
   public void testJsonInSingleQuotesDeserialization() {

--- a/gson/src/test/resources/java.policy
+++ b/gson/src/test/resources/java.policy
@@ -1,0 +1,16 @@
+// Give permission to maven test plugins (surefire, junit, etc..)
+grant codeBase "file:${localrepo}/-" {
+        permission java.security.AllPermission;
+};
+
+// Give permission to gson
+grant codeBase "file:${basedir}/target/classes/-" {
+        permission java.security.AllPermission;
+};
+
+// Give special permissions for some testcases requiring special priviledges
+// Note: Be sure to not give too much permissions as will change test criteria/expected results.
+grant codeBase "file:${basedir}/target/test-classes/-" {
+        permission java.util.PropertyPermission "user.timezone", "read,write";
+        permission java.util.PropertyPermission "user.language", "read,write";
+};

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,23 @@
           <autoVersionSubmodules>true</autoVersionSubmodules>
         </configuration>
       </plugin>
+       <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.12.4</version>
+          <executions>
+            <execution>
+              <id>default-test</id>
+              <phase>test</phase>
+              <goals>
+                <goal>test</goal>
+              </goals>
+              <configuration>
+                <!-- Enable security manager.  Pass basedir/localrepo to be refernced by java.policy file (see test/resources/java.policy). -->
+                <argLine>-Dbasedir=${basedir} -Dlocalrepo=${user.home}/.m2/repository -Djava.security.policy=${basedir}/src/test/resources/java.policy -Djava.security.manager</argLine>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
     </plugins>
   </build>
   <profiles>


### PR DESCRIPTION
Hi @inder123 and @JochenHiller.  I've run into a similar problem to Issue #566 running gson under a default SecurityManager enabled runtime environment and like to propose a fix PR for it.

The fix is simply by surrounding certain portions of code with privileged access where was missing and needed (like the ones proposed in #566 [gson.diff](https://storage.googleapis.com/google-code-attachments/google-gson/issue-566/comment-0/gson.diff), just needed to apply changes to match latest code).  I've also configured unit tests to run under default SecurityManager + Maven surefire + Junit4 which is the current unit test configuration for gson (needed to add java.policy to test resources and surefire test settings in pom.xml) and all 1050 tests pass.

Could you please review and see if it looks good or have any concerns needing some work?  Would be happy to fix as needed.  Either way, it would be great if a fix could be pulled in so that gson would work under security manager without any special hacks (i.e. - giving extra permissions to application code).  Thanks.