### PR TITLE
Simplify maintainType logic.

### DIFF
--- a/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
@@ -243,7 +243,8 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
         JsonObject jsonObject = delegate.toJsonTree(value).getAsJsonObject();
 
         if (maintainType) {
-          return jsonObject;
+          Streams.write(jsonObject, out);
+          return;
         }
 
         JsonObject clone = new JsonObject();

--- a/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
@@ -241,15 +241,18 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
               + "; did you forget to register a subtype?");
         }
         JsonObject jsonObject = delegate.toJsonTree(value).getAsJsonObject();
-        JsonObject clone = new JsonObject();
-        
-        if (!maintainType) {
-            if (jsonObject.has(typeFieldName)) {
-              throw new JsonParseException("cannot serialize " + srcType.getName()
-                  + " because it already defines a field named " + typeFieldName);
-            }
-            clone.add(typeFieldName, new JsonPrimitive(label));
+
+        if (maintainType) {
+          return jsonObject;
         }
+
+        JsonObject clone = new JsonObject();
+
+        if (jsonObject.has(typeFieldName)) {
+          throw new JsonParseException("cannot serialize " + srcType.getName()
+              + " because it already defines a field named " + typeFieldName);
+        }
+        clone.add(typeFieldName, new JsonPrimitive(label));
         
         for (Map.Entry<String, JsonElement> e : jsonObject.entrySet()) {
           clone.add(e.getKey(), e.getValue());


### PR DESCRIPTION
When we maintain the label value, we do not need to make a new JsonObject and copy over the keys and values when writing. The ordering will change, though. Before this change, it always put the label first.