### PR TITLE
Change 'compile' to 'implementation'

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -74,7 +74,7 @@ The Gson instance does not maintain any state while invoking Json operations. So
 ## <a name="TOC-Gson-With-Gradle"></a>Using Gson with Gradle/Android
 ```
 dependencies {
-    compile 'com.google.code.gson:gson:2.8.5'
+    implementation 'com.google.code.gson:gson:2.8.5'
 }
 ```
 ## <a name="TOC-Gson-With-Maven"></a>Using Gson with Maven


### PR DESCRIPTION
Fix for issue https://github.com/google/gson/issues/1372.

Summarised here again:
Changed the obsolete 'compile' to 'implementation' in the Gradle dependency section