### PR TITLE
Clean up the README a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,48 @@
-# google-gson
-
-[![Build Status](https://travis-ci.org/google/gson.svg?branch=master)](https://travis-ci.org/google/gson)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.google.code.gson/gson/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.google.code.gson/gson)
-[![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.google.code.gson/gson/badge.svg)](http://www.javadoc.io/doc/com.google.code.gson/gson)
+# Gson
 
 Gson is a Java library that can be used to convert Java Objects into their JSON representation. It can also be used to convert a JSON string to an equivalent Java object.
 Gson can work with arbitrary Java objects including pre-existing objects that you do not have source-code of.
 
 There are a few open-source projects that can convert Java objects to JSON. However, most of them require that you place Java annotations in your classes; something that you can not do if you do not have access to the source-code. Most also do not fully support the use of Java Generics. Gson considers both of these as very important design goals.
 
-### Gson Goals
+### Goals
   * Provide simple `toJson()` and `fromJson()` methods to convert Java objects to JSON and vice-versa
   * Allow pre-existing unmodifiable objects to be converted to and from JSON
   * Extensive support of Java Generics
   * Allow custom representations for objects
   * Support arbitrarily complex objects (with deep inheritance hierarchies and extensive use of generic types)
 
-### Gson Download and Maven
-  * To use Gson in Android
+### Download
+
+Gradle:
 ```gradle
 dependencies {
-    implementation 'com.google.code.gson:gson:2.8.5'
+  implementation 'com.google.code.gson:gson:2.8.5'
 }
 ```
 
-  * [Gson Download](https://maven-badges.herokuapp.com/maven-central/com.google.code.gson/gson) downloads at Maven Central
-  * To use Gson with Maven
-  ```xml
+Maven:
+```xml
 <dependency>
-    <groupId>com.google.code.gson</groupId>
-    <artifactId>gson</artifactId>
-    <version>2.8.5</version>
+  <groupId>com.google.code.gson</groupId>
+  <artifactId>gson</artifactId>
+  <version>2.8.5</version>
 </dependency>
 ```
 
-### Gson Documentation
-  * Gson [API](http://www.javadoc.io/doc/com.google.code.gson/gson): Javadocs for the current Gson release
-  * Gson [user guide](https://github.com/google/gson/blob/master/UserGuide.md): This guide contains examples on how to use Gson in your code.
-  * Gson [Roadmap](https://github.com/google/gson/blob/master/CHANGELOG.md): Details of changes in the recent versions
-  * Gson [design document](https://github.com/google/gson/blob/master/GsonDesignDocument.md): This document discusses issues we faced while designing Gson. It also includes a comparison of Gson with other Java libraries that can be used for Json conversion
+[Gson jar downloads](https://maven-badges.herokuapp.com/maven-central/com.google.code.gson/gson) are available from Maven Central.
 
-Please use the [google-gson Google group](http://groups.google.com/group/google-gson) to discuss Gson, or to post questions.
+[![Build Status](https://travis-ci.org/google/gson.svg?branch=master)](https://travis-ci.org/google/gson)
 
-### Gson-related Content Created by Third Parties
+### Documentation
+  * [API Javadoc](http://www.javadoc.io/doc/com.google.code.gson/gson): Documentation for the current release
+  * [User guide](https://github.com/google/gson/blob/master/UserGuide.md): This guide contains examples on how to use Gson in your code.
+  * [Change log](https://github.com/google/gson/blob/master/CHANGELOG.md): Changes in the recent versions
+  * [Design document](https://github.com/google/gson/blob/master/GsonDesignDocument.md): This document discusses issues we faced while designing Gson. It also includes a comparison of Gson with other Java libraries that can be used for Json conversion
+
+Please use the 'gson' tag on StackOverflow or the [google-gson Google group](http://groups.google.com/group/google-gson) to discuss Gson or to post questions.
+
+### Related Content Created by Third Parties
   * [Gson Tutorial](http://www.studytrails.com/java/json/java-google-json-introduction.jsp) by `StudyTrails`
   * [Gson Tutorial Series](https://futurestud.io/tutorials/gson-getting-started-with-java-json-serialization-deserialization) by `Future Studio`
   * [Gson API Report](https://abi-laboratory.pro/java/tracker/timeline/gson/)
@@ -66,3 +66,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
+
+### Disclaimer
+
+This is not an officially supported Google product.


### PR DESCRIPTION
* Remove a lot of "Gson" as it's implied nearly everywhere.
* Remove broken Javadoc badge. Move other badges to be near the content to which they apply
* Not an official Google product
* Make download section more general. People other than Android developers use Gradle, for example.