### PR TITLE
Replace explicit synthetic field check with bitmask.

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/Excluder.java
+++ b/gson/src/main/java/com/google/gson/internal/Excluder.java
@@ -50,9 +50,10 @@ import java.util.List;
 public final class Excluder implements TypeAdapterFactory, Cloneable {
   private static final double IGNORE_VERSIONS = -1.0d;
   public static final Excluder DEFAULT = new Excluder();
+  private static final int MODIFIER_SYNTHETIC = 0x00001000;
 
   private double version = IGNORE_VERSIONS;
-  private int modifiers = Modifier.TRANSIENT | Modifier.STATIC;
+  private int modifiers = Modifier.TRANSIENT | Modifier.STATIC | MODIFIER_SYNTHETIC;
   private boolean serializeInnerClasses = true;
   private boolean requireExpose;
   private List<ExclusionStrategy> serializationStrategies = Collections.emptyList();
@@ -155,10 +156,6 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
 
     if (version != Excluder.IGNORE_VERSIONS
         && !isValidVersion(field.getAnnotation(Since.class), field.getAnnotation(Until.class))) {
-      return true;
-    }
-
-    if (field.isSynthetic()) {
       return true;
     }
 


### PR DESCRIPTION
Lower the cyclomatic complexity by adding the *synthetic* modifier initially to the `modifiers` value. That way, the method can keep its truthfulness while lowering the amount of statements. Currently, the fields bitmask is checked twice, wheras the last check is a call to the `isSynthetic()`method of the Field class. With this little addition, just the first check is required.

```java
static final int SYNTHETIC = 0x00001000;
```

^ *Integer constant in the Modifier class.*


The reason why Javas `Modifier` class doesn't publish its bitmask
for the *synthetic* modifier, is that there is no such keyword in
the language:

```
Bits not (yet) exposed in the public API either because they
have different meanings for fields and methods and there is no
way to distinguish between the two in this class, or because
they are not Java programming language keywords
```

^ *The original comment (Modifier.java Line 333 - 336).*

As you can see, the fact that the original constant is not public should not prevent us from using it.