### PR TITLE
Updated copyright year in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Please use the 'gson' tag on StackOverflow or the [google-gson Google group](htt
 Gson is released under the [Apache 2.0 license](LICENSE).
 
 ```
-Copyright 2008 Google Inc.
+Copyright 2018 Google Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
updated the copyright information in this central readme file because an outdated copyright year imposes license issues in using this software correctly