### PR TITLE
Display null-handling details as sublist

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -148,8 +148,8 @@ BagOfPrimitives obj2 = gson.fromJson(json, BagOfPrimitives.class);
 * There is no need to use any annotations to indicate a field is to be included for serialization and deserialization. All fields in the current class (and from all super classes) are included by default.
 * If a field is marked transient, (by default) it is ignored and not included in the JSON serialization or deserialization.
 * This implementation handles nulls correctly.
-* While serializing, a null field is omitted from the output.
-* While deserializing, a missing entry in JSON results in setting the corresponding field in the object to its default value: null for object types, zero for numeric types, and false for booleans.
+  * While serializing, a null field is omitted from the output.
+  * While deserializing, a missing entry in JSON results in setting the corresponding field in the object to its default value: null for object types, zero for numeric types, and false for booleans.
 * If a field is _synthetic_, it is ignored and not included in JSON serialization or deserialization.
 * Fields corresponding to the outer classes in inner classes, anonymous classes, and local classes are ignored and not included in serialization or deserialization.
 


### PR DESCRIPTION
Indent the details of null handling.

Comparing against the [old, Google Sites user guide][gsites] shows that the two items following the "handles nulls correctly" item are intended as a sublist under that item.

[gsites]: https://sites.google.com/site/gson/gson-user-guide#TOC-Finer-Points-with-Objects