### PR TITLE
Infer type in generic instance creation.

### DIFF
--- a/codegen/src/main/java/com/google/gson/codegen/JavaWriter.java
+++ b/codegen/src/main/java/com/google/gson/codegen/JavaWriter.java
@@ -38,7 +38,7 @@ public final class JavaWriter {
   private final Map<String, String> importedTypes = new HashMap<String, String>();
 
   private String packagePrefix;
-  private final List<Scope> scopes = new ArrayList<Scope>();
+  private final List<Scope> scopes = new ArrayList<>();
   private final Writer out;
 
   /**

--- a/examples/android-proguard-example/src/com/google/gson/examples/android/GsonProguardExampleActivity.java
+++ b/examples/android-proguard-example/src/com/google/gson/examples/android/GsonProguardExampleActivity.java
@@ -53,7 +53,7 @@ public class GsonProguardExampleActivity extends Activity {
   }
 
   private Cart buildCart() {
-    List<LineItem> lineItems = new ArrayList<LineItem>();
+    List<LineItem> lineItems = new ArrayList<>();
     lineItems.add(new LineItem("hammer", 1, 12000000, "USD"));
     return new Cart(lineItems, "Happy Buyer", "4111-1111-1111-1111");
   }

--- a/extras/src/test/java/com/google/gson/graph/GraphAdapterBuilderTest.java
+++ b/extras/src/test/java/com/google/gson/graph/GraphAdapterBuilderTest.java
@@ -98,7 +98,7 @@ public final class GraphAdapterBuilderTest extends TestCase {
     Type listOfListsType = new TypeToken<List<List<?>>>() {}.getType();
     Type listOfAnyType = new TypeToken<List<?>>() {}.getType();
 
-    List<List<?>> listOfLists = new ArrayList<List<?>>();
+    List<List<?>> listOfLists = new ArrayList<>();
     listOfLists.add(listOfLists);
     listOfLists.add(new ArrayList<Object>());
 
@@ -189,7 +189,7 @@ public final class GraphAdapterBuilderTest extends TestCase {
 
   static class Company {
     final String name;
-    final List<Employee> employees = new ArrayList<Employee>();
+    final List<Employee> employees = new ArrayList<>();
     Company(String name) {
       this.name = name;
     }

--- a/gson/src/main/java/com/google/gson/DefaultDateTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/DefaultDateTypeAdapter.java
@@ -51,7 +51,7 @@ final class DefaultDateTypeAdapter extends TypeAdapter<Date> {
    * List of 1 or more different date formats used for de-serialization attempts.
    * The first of them is used for serialization as well.
    */
-  private final List<DateFormat> dateFormats = new ArrayList<DateFormat>();
+  private final List<DateFormat> dateFormats = new ArrayList<>();
 
   DefaultDateTypeAdapter(Class<? extends Date> dateType) {
     this.dateType = verifyDateType(dateType);

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -218,7 +218,7 @@ public final class Gson {
     this.builderFactories = builderFactories;
     this.builderHierarchyFactories = builderHierarchyFactories;
 
-    List<TypeAdapterFactory> factories = new ArrayList<TypeAdapterFactory>();
+    List<TypeAdapterFactory> factories = new ArrayList<>();
 
     // built-in type adapters that cannot be overridden
     factories.add(TypeAdapters.JSON_ELEMENT_FACTORY);
@@ -406,7 +406,7 @@ public final class Gson {
         out.endArray();
       }
       @Override public AtomicLongArray read(JsonReader in) throws IOException {
-        List<Long> list = new ArrayList<Long>();
+        List<Long> list = new ArrayList<>();
         in.beginArray();
         while (in.hasNext()) {
             long value = longAdapter.read(in).longValue();

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -81,9 +81,9 @@ public final class GsonBuilder {
   private FieldNamingStrategy fieldNamingPolicy = FieldNamingPolicy.IDENTITY;
   private final Map<Type, InstanceCreator<?>> instanceCreators
       = new HashMap<Type, InstanceCreator<?>>();
-  private final List<TypeAdapterFactory> factories = new ArrayList<TypeAdapterFactory>();
+  private final List<TypeAdapterFactory> factories = new ArrayList<>();
   /** tree-style hierarchy factories. These come after factories for backwards compatibility. */
-  private final List<TypeAdapterFactory> hierarchyFactories = new ArrayList<TypeAdapterFactory>();
+  private final List<TypeAdapterFactory> hierarchyFactories = new ArrayList<>();
   private boolean serializeNulls = DEFAULT_SERIALIZE_NULLS;
   private String datePattern;
   private int dateStyle = DateFormat.DEFAULT;
@@ -584,11 +584,11 @@ public final class GsonBuilder {
    * @return an instance of Gson configured with the options currently set in this builder
    */
   public Gson create() {
-    List<TypeAdapterFactory> factories = new ArrayList<TypeAdapterFactory>(this.factories.size() + this.hierarchyFactories.size() + 3);
+    List<TypeAdapterFactory> factories = new ArrayList<>(this.factories.size() + this.hierarchyFactories.size() + 3);
     factories.addAll(this.factories);
     Collections.reverse(factories);
 
-    List<TypeAdapterFactory> hierarchyFactories = new ArrayList<TypeAdapterFactory>(this.hierarchyFactories);
+    List<TypeAdapterFactory> hierarchyFactories = new ArrayList<>(this.hierarchyFactories);
     Collections.reverse(hierarchyFactories);
     factories.addAll(hierarchyFactories);
 


### PR DESCRIPTION
This edit replaces type parameters to invoke the constructor of a generic class with an empty set (<>), diamond operator and allow inference of type parameters by the context. This edit ensures the use of generic instead of the deprecated raw types.