### PR TITLE
Use the class Path to represent a path instead of a String.

### DIFF
--- a/metrics/src/main/java/com/google/gson/metrics/ParseBenchmark.java
+++ b/metrics/src/main/java/com/google/gson/metrics/ParseBenchmark.java
@@ -31,6 +31,8 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringWriter;
 import java.lang.reflect.Type;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
@@ -114,9 +116,10 @@ public final class ParseBenchmark extends SimpleBenchmark {
   }
 
   private static String resourceToString(String path) throws Exception {
-    InputStream in = ParseBenchmark.class.getResourceAsStream(path);
+	Path fpath = Paths.get(path.toString());
+	InputStream in = ParseBenchmark.class.getResourceAsStream(path.toString());
     if (in == null) {
-      throw new IllegalArgumentException("No such file: " + path);
+      throw new IllegalArgumentException("No such file: " + path.toString());
     }
 
     Reader reader = new InputStreamReader(in, "UTF-8");

--- a/metrics/src/main/java/com/google/gson/metrics/ParseBenchmark.java
+++ b/metrics/src/main/java/com/google/gson/metrics/ParseBenchmark.java
@@ -117,9 +117,9 @@ public final class ParseBenchmark extends SimpleBenchmark {
 
   private static String resourceToString(String path) throws Exception {
 	Path fpath = Paths.get(path.toString());
-	InputStream in = ParseBenchmark.class.getResourceAsStream(path.toString());
+	InputStream in = ParseBenchmark.class.getResourceAsStream(fpath.toString());
     if (in == null) {
-      throw new IllegalArgumentException("No such file: " + path.toString());
+      throw new IllegalArgumentException("No such file: " + fpath.toString());
     }
 
     Reader reader = new InputStreamReader(in, "UTF-8");


### PR DESCRIPTION
Strings can be used to represent a file system path even though some classes are specifically designed for this task. For instance, java.nio.Path. It is useful to change the type of the variable to Path, since strings can be combined in an undisciplined way, which can lead to invalid paths. Second, different operating systems use different file separators, which can cause bugs.