### PR TITLE
Add j2objc annotations to fix memory leak in transpiled objective-c 

### DIFF
--- a/gson/build.gradle
+++ b/gson/build.gradle
@@ -9,5 +9,6 @@ targetCompatibility = 1.6
 
 sourceSets.main.java.exclude("**/module-info.java")
 dependencies {
+    compile group: 'com.google.j2objc', name: 'j2objc-annotations', version: '1.1'
     testCompile "junit:junit:4.12"
 }

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -12,6 +12,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.j2objc</groupId>
+      <artifactId>j2objc-annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/gson/src/main/java/com/google/gson/internal/LinkedTreeMap.java
+++ b/gson/src/main/java/com/google/gson/internal/LinkedTreeMap.java
@@ -17,6 +17,9 @@
 
 package com.google.gson.internal;
 
+import com.google.j2objc.annotations.Weak;
+import com.google.j2objc.annotations.WeakOuter;
+
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.util.AbstractMap;
@@ -437,10 +440,13 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
   }
 
   static final class Node<K, V> implements Entry<K, V> {
+    @Weak
     Node<K, V> parent;
     Node<K, V> left;
     Node<K, V> right;
+    @Weak
     Node<K, V> next;
+    @Weak
     Node<K, V> prev;
     final K key;
     V value;
@@ -557,6 +563,7 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
     }
   }
 
+  @WeakOuter
   class EntrySet extends AbstractSet<Entry<K, V>> {
     @Override public int size() {
       return size;
@@ -592,6 +599,7 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
     }
   }
 
+  @WeakOuter
   final class KeySet extends AbstractSet<K> {
     @Override public int size() {
       return size;

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>com.google.j2objc</groupId>
+        <artifactId>j2objc-annotations</artifactId>
+        <version>1.1</version>
+      </dependency>
+      <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.12</version>


### PR DESCRIPTION
The issue has been discussed on j2objc page here, j2objc team recommended to create a PR to be merged into mainstream gson codebase. 
https://github.com/google/j2objc/issues/921

The guava project already has j2objc annotations. 
These annotations will fix memory leak related to LinkedTreeMap when transpiled to objective-c code using j2objc. 

Thanks.