### PR TITLE
Update RuntimeTypeAdapterFactory.java

### DIFF
--- a/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
@@ -193,7 +193,7 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
   }
 
   public <R> TypeAdapter<R> create(Gson gson, TypeToken<R> type) {
-    if (!baseType.isAssignableFrom(type.getRawType()))
+    if (!baseType.isAssignableFrom(type.getRawType())){
       return null;
     }
 

--- a/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
@@ -193,7 +193,7 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
   }
 
   public <R> TypeAdapter<R> create(Gson gson, TypeToken<R> type) {
-    if (type.getRawType() != baseType) {
+    if (!baseType.isAssignableFrom(type.getRawType()))
       return null;
     }
 


### PR DESCRIPTION
	public class JsonSerializableTest {
	    protected static transient RuntimeTypeAdapterFactory<JsonSerializable> adapterFactory =
	            RuntimeTypeAdapterFactory.of(JsonSerializable.class,"clazz",true)
	            .registerSubtype(A.class,A.class.getName())
	            .registerSubtype(B.class,B.class.getName())
	            .registerSubtype(C.class,C.class.getName());
	    protected static transient Gson gson = new GsonBuilder().registerTypeAdapterFactory(adapterFactory).create();
	    protected static transient Type typeToken = new TypeToken<JsonSerializable>() {}.getType();
	    @Test
	    public void fromJson(){

	        C c = new C();
	        LogbackReporter.log(gson.toJson(c));
	        c = gson.fromJson(gson.toJson(c),typeToken);
	        LogbackReporter.log(gson.toJson(c));

	        A a = new B();
	        LogbackReporter.log(gson.toJson(a));
	        a = gson.fromJson(gson.toJson(a),typeToken);
	        LogbackReporter.log(gson.toJson(a));


	    }

	    private class A extends JsonSerializable{
	    }

	    private class B extends A{
	        int b_1 =1 ;
	    }

	    private class C extends JsonSerializable{
	        public A a1 = new B();
	        public A a2 = new B();
	    }
}

wrong answer