### PR TITLE
Created protected method JsonReader.promoteNameToValue to enable JsonReader subclassing

### DIFF
--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -1590,27 +1590,27 @@ public class JsonReader implements Closeable {
     pos += NON_EXECUTE_PREFIX.length;
   }
 
+  protected void promoteNameToValue() throws IOException {
+    int p = this.peeked;
+    if (p == PEEKED_NONE) {
+      p = this.doPeek();
+    }
+    if (p == PEEKED_DOUBLE_QUOTED_NAME) {
+      this.peeked = PEEKED_DOUBLE_QUOTED;
+    } else if (p == PEEKED_SINGLE_QUOTED_NAME) {
+      this.peeked = PEEKED_SINGLE_QUOTED;
+    } else if (p == PEEKED_UNQUOTED_NAME) {
+      this.peeked = PEEKED_UNQUOTED;
+    } else {
+      throw new IllegalStateException(
+        "Expected a name but was " + this.peek() + this.locationString());
+    }
+  }
+
   static {
     JsonReaderInternalAccess.INSTANCE = new JsonReaderInternalAccess() {
       @Override public void promoteNameToValue(JsonReader reader) throws IOException {
-        if (reader instanceof JsonTreeReader) {
-          ((JsonTreeReader)reader).promoteNameToValue();
-          return;
-        }
-        int p = reader.peeked;
-        if (p == PEEKED_NONE) {
-          p = reader.doPeek();
-        }
-        if (p == PEEKED_DOUBLE_QUOTED_NAME) {
-          reader.peeked = PEEKED_DOUBLE_QUOTED;
-        } else if (p == PEEKED_SINGLE_QUOTED_NAME) {
-          reader.peeked = PEEKED_SINGLE_QUOTED;
-        } else if (p == PEEKED_UNQUOTED_NAME) {
-          reader.peeked = PEEKED_UNQUOTED;
-        } else {
-          throw new IllegalStateException(
-              "Expected a name but was " + reader.peek() + reader.locationString());
-        }
+        reader.promoteNameToValue();
       }
     };
   }


### PR DESCRIPTION
Solution for #1453 : Extending JsonReader

Context:   I want to subclass JsonReader so that my custom JsonReader reads a certain field of the object as the first property.  If that property is not the first in the original JsonReader, my custom JsonReader will cache the tokens of the original JsonReader until the specific property is read.  Afterwards my custom JsonReader just delegates to the underlying JsonReader. 
