### PR TITLE
Allow hierarchical Interfaces to be serialized

### DIFF
--- a/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
@@ -193,7 +193,7 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
   }
 
   public <R> TypeAdapter<R> create(Gson gson, TypeToken<R> type) {
-    if (type.getRawType() != baseType) {
+    if (!baseType.isAssignableFrom(type.getRawType())) {
       return null;
     }
 


### PR DESCRIPTION
If the Shape class from the example above the code would implement an interface named TwoDimensionalObject with the fields x and y and some Shape should be serialized in a class that only knows that its content is a TwoDimensionalObject, this change allows that use case to work. Also, any hierarchical interfaces will work with this improvement.