### PR TITLE
Added Adapter Layering Feature

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -127,7 +127,6 @@ public final class Gson {
   private final Map<TypeToken<?>, TypeAdapter<?>> typeTokenCache = new ConcurrentHashMap<TypeToken<?>, TypeAdapter<?>>();
 
   private final ConstructorConstructor constructorConstructor;
-
   final JsonAdapterAnnotationTypeAdapterFactory jsonAdapterFactory;
 
   final List<TypeAdapterFactory> factories;

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -127,7 +127,8 @@ public final class Gson {
   private final Map<TypeToken<?>, TypeAdapter<?>> typeTokenCache = new ConcurrentHashMap<TypeToken<?>, TypeAdapter<?>>();
 
   private final ConstructorConstructor constructorConstructor;
-  private final JsonAdapterAnnotationTypeAdapterFactory jsonAdapterFactory;
+
+  final JsonAdapterAnnotationTypeAdapterFactory jsonAdapterFactory;
 
   final List<TypeAdapterFactory> factories;
 

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -896,7 +896,7 @@ public final class Gson {
   public <T> T fromJson(Reader json, Type typeOfT) throws JsonIOException, JsonSyntaxException {
     JsonReader jsonReader = newJsonReader(json);
     T object = (T) fromJson(jsonReader, typeOfT);
-    assertFullConsumption(object, jsonReader);
+  //  assertFullConsumption(object, jsonReader);
     return object;
   }
 

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -896,7 +896,9 @@ public final class Gson {
   public <T> T fromJson(Reader json, Type typeOfT) throws JsonIOException, JsonSyntaxException {
     JsonReader jsonReader = newJsonReader(json);
     T object = (T) fromJson(jsonReader, typeOfT);
-  //  assertFullConsumption(object, jsonReader);
+    if (!ReflectiveTypeAdapterFactory.Adapter.class.isAssignableFrom(getAdapter(TypeToken.get(typeOfT)).getClass())) {
+      assertFullConsumption(object, jsonReader);
+    }
     return object;
   }
 

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -535,7 +535,6 @@ public final class GsonBuilder {
          @Override
          public T apply(JsonReader reader) {
            try {
-             reader.mark();
              T returnedObject = (T) typeAdapter.read(reader);
              reader.reset();
              return returnedObject;

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -515,7 +515,14 @@ public final class GsonBuilder {
   }
 
   /**
-   * TODO: Add a meaningful description
+   * Configures Gson for custom serialization and deserialization with Fill-in. Takes the type
+   * adapter, and wraps the result from the {@link TypeAdapter} into a {@link ReflectiveTypeAdapterFactory.Adapter}. Like
+   * {@link #registerTypeAdapter(Type, Object)}, it only applies to the type specified by
+   * the {@code type} parameter.
+   *
+   * @param baseType the type definition for the type adapter being registered
+   * @param objectAdapter This object must implement the {@link TypeAdapter} class
+   * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
    */
   public GsonBuilder registerTypeAdapterWithFillIn(Type baseType, Object objectAdapter) {
    $Gson$Preconditions.checkArgument(objectAdapter instanceof TypeAdapter<?>);
@@ -532,11 +539,9 @@ public final class GsonBuilder {
              T returnedObject = (T) typeAdapter.read(reader);
              reader.reset();
              return returnedObject;
-             //return null;
            } catch (IOException e) {
-             // TODO: wrap this in a reasonable exception
+             throw new JsonIOException("Unable to mark stream: your JVM does not support stream marking.");
              // Another cause for exception was that mark was not supported
-             return null;
            }
          }
        };

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -33,7 +33,6 @@ import com.google.gson.internal.bind.TypeAdapters;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import java.io.IOException;
-import java.lang.reflect.Array;
 import java.lang.reflect.Type;
 import java.sql.Timestamp;
 import java.text.DateFormat;

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -33,6 +33,7 @@ import com.google.gson.internal.bind.TypeAdapters;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import java.io.IOException;
+import java.lang.reflect.Array;
 import java.lang.reflect.Type;
 import java.sql.Timestamp;
 import java.text.DateFormat;
@@ -545,11 +546,11 @@ public final class GsonBuilder {
          }
        };
        ConstructorConstructor constructorConstructor = new ConstructorConstructor(type, function);
+       List<Type> typeList = new ArrayList<Type>();
+       typeList.add(baseType);
        ReflectiveTypeAdapterFactory reflectiveTypeAdapterFactory =
            new ReflectiveTypeAdapterFactory(constructorConstructor, gson.fieldNamingStrategy,
-               gson.excluder, gson.jsonAdapterFactory, new ArrayList<Type>() {{
-             add(baseType);
-           }});
+               gson.excluder, gson.jsonAdapterFactory, typeList);
        return reflectiveTypeAdapterFactory.create(gson, type);
      }
    });

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -547,7 +547,7 @@ public final class GsonBuilder {
        ConstructorConstructor constructorConstructor = new ConstructorConstructor(type, function);
        ReflectiveTypeAdapterFactory reflectiveTypeAdapterFactory =
            new ReflectiveTypeAdapterFactory(constructorConstructor, gson.fieldNamingStrategy,
-               gson.excluder, gson.jsonAdapterFactory, new ArrayList<>() {{
+               gson.excluder, gson.jsonAdapterFactory, new ArrayList<Type>() {{
              add(baseType);
            }});
        return reflectiveTypeAdapterFactory.create(gson, type);

--- a/gson/src/main/java/com/google/gson/InstanceCreator.java
+++ b/gson/src/main/java/com/google/gson/InstanceCreator.java
@@ -100,7 +100,6 @@ public interface InstanceCreator<T> {
    * @return
    */
   default T createInstance(Type type, JsonReader in) {
-    createInstance(type);
-    return null;
+    return createInstance(type);
   }
 }

--- a/gson/src/main/java/com/google/gson/InstanceCreator.java
+++ b/gson/src/main/java/com/google/gson/InstanceCreator.java
@@ -16,6 +16,8 @@
 
 package com.google.gson;
 
+import com.google.gson.stream.JsonReader;
+import java.io.Reader;
 import java.lang.reflect.Type;
 
 /**
@@ -89,4 +91,16 @@ public interface InstanceCreator<T> {
    * @return a default object instance of type T.
    */
   public T createInstance(Type type);
+
+  /**
+   * If not defined, defaults to returning CreateInstance. Otherwise, this is designed to be
+   * used with layered TypeAdapters.
+   * @param type
+   * @param in
+   * @return
+   */
+  default T createInstance(Type type, JsonReader in) {
+    createInstance(type);
+    return null;
+  }
 }

--- a/gson/src/main/java/com/google/gson/InstanceCreator.java
+++ b/gson/src/main/java/com/google/gson/InstanceCreator.java
@@ -17,7 +17,6 @@
 package com.google.gson;
 
 import com.google.gson.stream.JsonReader;
-import java.io.Reader;
 import java.lang.reflect.Type;
 
 /**
@@ -93,11 +92,11 @@ public interface InstanceCreator<T> {
   public T createInstance(Type type);
 
   /**
-   * If not defined, defaults to returning CreateInstance. Otherwise, this is designed to be
-   * used with layered TypeAdapters.
-   * @param type
-   * @param in
-   * @return
+   * If not defined, defaults to returning the result of {@link #createInstance}. This method is
+   * designed to help with creating Adapters with Fill-In. See {@link GsonBuilder#registerTypeAdapterFactory}.
+   * @param type the parameterized T represented as a {@link Type}.
+   * @param in the JsonReader from which to create the instance.
+   * @return a default object instance of type T.
    */
   default T createInstance(Type type, JsonReader in) {
     return createInstance(type);

--- a/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
+++ b/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
@@ -57,6 +57,11 @@ public final class ConstructorConstructor {
     this.instanceCreators = instanceCreators;
   }
 
+  /** Constructor for the Fill-In mechanic implemented with {@link com.google.gson.GsonBuilder#registerTypeAdapterWithFillIn}.
+   * @param typeToken represents the type of the object to be returned.
+   * @param objectCreator function that returns the object that is to be contstructed.
+   * @param <T> returns an instance of T that is returned by the {@code objectCreator}.
+   */
   public <T> ConstructorConstructor(TypeToken<T> typeToken, Function<JsonReader, T> objectCreator) {
     InstanceCreator<?> instanceCreator = new InstanceCreator<T>() {
       @Override

--- a/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
+++ b/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
@@ -75,9 +75,9 @@ public final class ConstructorConstructor {
       }
     };
     // Using HashMap for a concrete implementation of the Map Abstract class
-    this.instanceCreators = new HashMap<Type, InstanceCreator<?>>() {{
-      put(typeToken.getType(), instanceCreator);
-    }};
+    Map<Type, InstanceCreator<?>> instanceCreatorMap = new HashMap<Type, InstanceCreator<?>>();
+    instanceCreatorMap.put(typeToken.getType(), instanceCreator);
+    this.instanceCreators = instanceCreatorMap;
   }
 
 

--- a/gson/src/main/java/com/google/gson/internal/ObjectConstructor.java
+++ b/gson/src/main/java/com/google/gson/internal/ObjectConstructor.java
@@ -16,8 +16,8 @@
 
 package com.google.gson.internal;
 
+import com.google.gson.GsonBuilder;
 import com.google.gson.stream.JsonReader;
-import java.io.Reader;
 
 /**
  * Defines a generic object construction factory.  The purpose of this class
@@ -34,11 +34,10 @@ public interface ObjectConstructor<T> {
    */
   public T construct();
 
-  /**
-   * If defining an object constructor that returns a new instance, override this method. Otherwise
-   * it will just call the default construct method.
-   * @param in
-   * @return
+  /** If not defined, returns the result of the {@link #construct} method. This method is designed
+   * to create an object of class T to suport the Fill-In mechanic {@link GsonBuilder#registerTypeAdapterFactory}.
+   * @param in is the JsonReader from which the object should be constructed.
+   * @return returns the object of class T that was constructed based on the {@code in} stream.
    */
   default T construct(JsonReader in) {
     return construct();

--- a/gson/src/main/java/com/google/gson/internal/ObjectConstructor.java
+++ b/gson/src/main/java/com/google/gson/internal/ObjectConstructor.java
@@ -16,6 +16,9 @@
 
 package com.google.gson.internal;
 
+import com.google.gson.stream.JsonReader;
+import java.io.Reader;
+
 /**
  * Defines a generic object construction factory.  The purpose of this class
  * is to construct a default instance of a class that can be used for object
@@ -30,4 +33,15 @@ public interface ObjectConstructor<T> {
    * Returns a new instance.
    */
   public T construct();
+
+  /**
+   * If defining an object constructor that returns a new instance, override this method. Otherwise
+   * it will just call the default construct method.
+   * @param in
+   * @return
+   */
+  default T construct(JsonReader in) {
+    construct();
+    return null;
+  }
 }

--- a/gson/src/main/java/com/google/gson/internal/ObjectConstructor.java
+++ b/gson/src/main/java/com/google/gson/internal/ObjectConstructor.java
@@ -41,7 +41,6 @@ public interface ObjectConstructor<T> {
    * @return
    */
   default T construct(JsonReader in) {
-    construct();
-    return null;
+    return construct();
   }
 }

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -209,7 +209,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
         return null;
       }
 
-      T instance = constructor.construct();
+      T instance = constructor.construct(in);
 
       try {
         in.beginObject();

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -51,6 +51,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
   private final Excluder excluder;
   private final JsonAdapterAnnotationTypeAdapterFactory jsonAdapterFactory;
   private final ReflectionAccessor accessor = ReflectionAccessor.getInstance();
+  // Helps with restricting the Adapter only to certain types for the Fill-In mechanic.
   private final List<Type> typeIncluder;
 
   public ReflectiveTypeAdapterFactory(ConstructorConstructor constructorConstructor,

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -299,6 +299,11 @@ public class JsonReader implements Closeable {
       throw new NullPointerException("in == null");
     }
     this.in = in;
+    try {
+      in.mark(Integer.MAX_VALUE);
+    } catch (Exception e) {
+      // Do nothing
+    }
   }
 
   /**
@@ -1500,40 +1505,22 @@ public class JsonReader implements Closeable {
   }
 
 
-  /** Marks the {@code JsonReader} and stores all current parameters for reinstatement. This can be used
-   * to read the same {@code JsonReader} twice. Reinstatement can be done with {@link #reset}.
-   *
-   * @throws IOException
-   */
-  public void mark() throws IOException {
-    in.mark(Integer.MAX_VALUE);
-
-    markPeeked = peeked;
-
-    markPos = pos;
-    markLineNumber = lineNumber;
-    markLineStart = lineStart;
-
-    markStack = stack;
-    markStackSize = stackSize;
-  }
-
-  /** Resets the {@code JsonReader} to the previously marked location. To be used to restore the
-   * previous mark set by the {@link #mark} method.
+  /** Resets the {@code JsonReader} to the beginning of the stream. To be used to restore the
+   * previous mark at the beginning of the stream.
    *
    * @throws IOException
    */
   public void reset() throws IOException {
     in.reset();
 
-    peeked = markPeeked;
+    peeked = 0;
 
-    pos = markPos;
-    lineNumber = markLineNumber;
-    lineStart = markLineStart;
+    pos = 0;
+    lineNumber = 0;
+    lineStart = 0;
 
-    stack = markStack;
-    stackSize = markStackSize;
+    stack = new int[32];
+    stackSize = 1;
 
     fillBuffer(limit);
   }

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -242,6 +242,14 @@ public class JsonReader implements Closeable {
   private int lineNumber = 0;
   private int lineStart = 0;
 
+  private int markPeeked = 0;
+  private int markPos = 0;
+  private int markLineNumber = 0;
+  private int markLineStart = 0;
+
+  private int[] markStack = new int[0];
+  private int markStackSize = 0;
+
   int peeked = PEEKED_NONE;
 
   /**
@@ -1489,6 +1497,37 @@ public class JsonReader implements Closeable {
       }
     }
     return result.toString();
+  }
+
+
+  public void mark() throws IOException {
+    in.mark(Integer.MAX_VALUE);
+
+    markPeeked = peeked;
+
+    markPos = pos;
+    markLineNumber = lineNumber;
+    markLineStart = lineStart;
+
+    markStack = stack;
+    markStackSize = stackSize;
+  }
+
+  public void reset() throws IOException {
+    in.reset();
+
+    peeked = 0;
+
+    pos = 0;
+    lineNumber = 0;
+    lineStart = 0;
+
+    stack = new int[32];
+    stackSize = 1;
+
+    fillBuffer(limit);
+
+    System.out.println(peek());
   }
 
   /**

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -1526,8 +1526,6 @@ public class JsonReader implements Closeable {
     stackSize = 1;
 
     fillBuffer(limit);
-
-    System.out.println(peek());
   }
 
   /**

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -242,14 +242,6 @@ public class JsonReader implements Closeable {
   private int lineNumber = 0;
   private int lineStart = 0;
 
-  private int markPeeked = 0;
-  private int markPos = 0;
-  private int markLineNumber = 0;
-  private int markLineStart = 0;
-
-  private int[] markStack = new int[0];
-  private int markStackSize = 0;
-
   int peeked = PEEKED_NONE;
 
   /**

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -1500,6 +1500,11 @@ public class JsonReader implements Closeable {
   }
 
 
+  /** Marks the {@code JsonReader} and stores all current parameters for reinstatement. This can be used
+   * to read the same {@code JsonReader} twice. Reinstatement can be done with {@link #reset}.
+   *
+   * @throws IOException
+   */
   public void mark() throws IOException {
     in.mark(Integer.MAX_VALUE);
 
@@ -1513,17 +1518,22 @@ public class JsonReader implements Closeable {
     markStackSize = stackSize;
   }
 
+  /** Resets the {@code JsonReader} to the previously marked location. To be used to restore the
+   * previous mark set by the {@link #mark} method.
+   *
+   * @throws IOException
+   */
   public void reset() throws IOException {
     in.reset();
 
-    peeked = 0;
+    peeked = markPeeked;
 
-    pos = 0;
-    lineNumber = 0;
-    lineStart = 0;
+    pos = markPos;
+    lineNumber = markLineNumber;
+    lineStart = markLineStart;
 
-    stack = new int[32];
-    stackSize = 1;
+    stack = markStack;
+    stackSize = markStackSize;
 
     fillBuffer(limit);
   }

--- a/gson/src/test/java/com/google/gson/common/TestTypes.java
+++ b/gson/src/test/java/com/google/gson/common/TestTypes.java
@@ -16,9 +16,6 @@
 
 package com.google.gson.common;
 
-import java.lang.reflect.Type;
-import java.util.Collection;
-
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
@@ -27,7 +24,11 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
+import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Date;
 
 /**
  * Types used for testing JSON serialization and deserialization
@@ -36,8 +37,9 @@ import com.google.gson.annotations.SerializedName;
  * @author Joel Leitch
  */
 public class TestTypes {
-  
+
   public static class Base {
+
     public static final String BASE_NAME = Base.class.getSimpleName();
     public static final String BASE_FIELD_KEY = "baseName";
     public static final String SERIALIZER_KEY = "serializerName";
@@ -46,37 +48,46 @@ public class TestTypes {
   }
 
   public static class Sub extends Base {
+
     public static final String SUB_NAME = Sub.class.getSimpleName();
     public static final String SUB_FIELD_KEY = "subName";
     public final String subName = SUB_NAME;
   }
 
   public static class ClassWithBaseField {
+
     public static final String FIELD_KEY = "base";
     public final Base base;
+
     public ClassWithBaseField(Base base) {
       this.base = base;
     }
   }
 
   public static class ClassWithBaseArrayField {
+
     public static final String FIELD_KEY = "base";
     public final Base[] base;
+
     public ClassWithBaseArrayField(Base[] base) {
       this.base = base;
     }
   }
 
   public static class ClassWithBaseCollectionField {
+
     public static final String FIELD_KEY = "base";
     public final Collection<Base> base;
+
     public ClassWithBaseCollectionField(Collection<Base> base) {
       this.base = base;
     }
   }
 
   public static class BaseSerializer implements JsonSerializer<Base> {
-    public static final String NAME = BaseSerializer.class.getSimpleName(); 
+
+    public static final String NAME = BaseSerializer.class.getSimpleName();
+
     @Override
     public JsonElement serialize(Base src, Type typeOfSrc, JsonSerializationContext context) {
       JsonObject obj = new JsonObject();
@@ -84,17 +95,21 @@ public class TestTypes {
       return obj;
     }
   }
+
   public static class SubSerializer implements JsonSerializer<Sub> {
-    public static final String NAME = SubSerializer.class.getSimpleName(); 
+
+    public static final String NAME = SubSerializer.class.getSimpleName();
+
     @Override
     public JsonElement serialize(Sub src, Type typeOfSrc, JsonSerializationContext context) {
       JsonObject obj = new JsonObject();
       obj.addProperty(Base.SERIALIZER_KEY, NAME);
       return obj;
-    }    
+    }
   }
 
   public static class StringWrapper {
+
     public final String someConstantStringInstanceField;
 
     public StringWrapper(String value) {
@@ -103,6 +118,7 @@ public class TestTypes {
   }
 
   public static class BagOfPrimitives {
+
     public static final long DEFAULT_VALUE = 0;
     public long longValue;
     public int intValue;
@@ -148,24 +164,32 @@ public class TestTypes {
 
     @Override
     public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
         return true;
-      if (obj == null)
+      }
+      if (obj == null) {
         return false;
-      if (getClass() != obj.getClass())
+      }
+      if (getClass() != obj.getClass()) {
         return false;
+      }
       BagOfPrimitives other = (BagOfPrimitives) obj;
-      if (booleanValue != other.booleanValue)
+      if (booleanValue != other.booleanValue) {
         return false;
-      if (intValue != other.intValue)
+      }
+      if (intValue != other.intValue) {
         return false;
-      if (longValue != other.longValue)
+      }
+      if (longValue != other.longValue) {
         return false;
+      }
       if (stringValue == null) {
-        if (other.stringValue != null)
+        if (other.stringValue != null) {
           return false;
-      } else if (!stringValue.equals(other.stringValue))
+        }
+      } else if (!stringValue.equals(other.stringValue)) {
         return false;
+      }
       return true;
     }
 
@@ -177,6 +201,7 @@ public class TestTypes {
   }
 
   public static class BagOfPrimitiveWrappers {
+
     private final Long longValue;
     private final Integer intValue;
     private final Boolean booleanValue;
@@ -199,6 +224,7 @@ public class TestTypes {
   }
 
   public static class PrimitiveArray {
+
     private final long[] longArray;
 
     public PrimitiveArray() {
@@ -229,6 +255,7 @@ public class TestTypes {
   }
 
   public static class ClassWithNoFields {
+
     // Nothing here..
     @Override
     public boolean equals(Object other) {
@@ -237,6 +264,7 @@ public class TestTypes {
   }
 
   public static class Nested {
+
     private final BagOfPrimitives primitive1;
     private final BagOfPrimitives primitive2;
 
@@ -271,16 +299,17 @@ public class TestTypes {
   }
 
   public static class ClassWithTransientFields<T> {
-    public transient T transientT; 
+
     public final transient long transientLongValue;
     private final long[] longValue;
+    public transient T transientT;
 
     public ClassWithTransientFields() {
       this(0L);
     }
 
     public ClassWithTransientFields(long value) {
-      longValue = new long[] { value };
+      longValue = new long[]{value};
       transientLongValue = value + 1;
     }
 
@@ -294,6 +323,7 @@ public class TestTypes {
   }
 
   public static class ClassWithCustomTypeConverter {
+
     private final BagOfPrimitives bag;
     private final int value;
 
@@ -324,13 +354,16 @@ public class TestTypes {
   }
 
   public static class ArrayOfObjects {
+
     private final BagOfPrimitives[] elements;
+
     public ArrayOfObjects() {
       elements = new BagOfPrimitives[3];
       for (int i = 0; i < elements.length; ++i) {
-        elements[i] = new BagOfPrimitives(i, i+2, false, "i"+i);
+        elements[i] = new BagOfPrimitives(i, i + 2, false, "i" + i);
       }
     }
+
     public String getExpectedJson() {
       StringBuilder sb = new StringBuilder("{\"elements\":[");
       boolean first = true;
@@ -348,6 +381,7 @@ public class TestTypes {
   }
 
   public static class ClassOverridingEquals {
+
     public ClassOverridingEquals ref;
 
     public String getExpectedJson() {
@@ -356,6 +390,7 @@ public class TestTypes {
       }
       return "{\"ref\":" + ref.getExpectedJson() + "}";
     }
+
     @Override
     public boolean equals(Object obj) {
       return true;
@@ -368,7 +403,9 @@ public class TestTypes {
   }
 
   public static class ClassWithArray {
+
     public final Object[] array;
+
     public ClassWithArray() {
       array = null;
     }
@@ -379,22 +416,29 @@ public class TestTypes {
   }
 
   public static class ClassWithObjects {
+
     public final BagOfPrimitives bag;
+
     public ClassWithObjects() {
       this(new BagOfPrimitives());
     }
+
     public ClassWithObjects(BagOfPrimitives bag) {
       this.bag = bag;
     }
   }
 
   public static class ClassWithSerializedNameFields {
-    @SerializedName("fooBar") public final int f;
-    @SerializedName("Another Foo") public final int g;
+
+    @SerializedName("fooBar")
+    public final int f;
+    @SerializedName("Another Foo")
+    public final int g;
 
     public ClassWithSerializedNameFields() {
       this(1, 4);
     }
+
     public ClassWithSerializedNameFields(int f, int g) {
       this.f = f;
       this.g = g;
@@ -407,15 +451,128 @@ public class TestTypes {
 
   public static class CrazyLongTypeAdapter
       implements JsonSerializer<Long>, JsonDeserializer<Long> {
+
     public static final long DIFFERENCE = 5L;
+
     @Override
     public JsonElement serialize(Long src, Type typeOfSrc, JsonSerializationContext context) {
       return new JsonPrimitive(src + DIFFERENCE);
     }
+
     @Override
     public Long deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
         throws JsonParseException {
       return json.getAsLong() - DIFFERENCE;
+    }
+  }
+
+  public static class LayeredInsideClass {
+
+    @Expose
+    private String hello;
+    @Expose
+    private Integer hello2;
+
+    public String getHello() {
+      return hello;
+    }
+
+    public void setHello(String hello) {
+      this.hello = hello;
+    }
+
+    public Integer getHello2() {
+      return hello2;
+    }
+
+    public void setHello2(Integer hello2) {
+      this.hello2 = hello2;
+    }
+  }
+
+  public static class LayeredOutsideClass {
+
+    private String field1;
+    private Integer field2;
+    private LayeredInsideClass insideClass;
+
+    public String getField1() {
+      return field1;
+    }
+
+    public Integer getField2() {
+      return field2;
+    }
+
+    public LayeredInsideClass getInsideClass() {
+      return insideClass;
+    }
+
+    public void setInsideClass(LayeredInsideClass insideClass) {
+      this.insideClass = insideClass;
+    }
+  }
+
+  // Some fields overlap with insideClass class.
+  public static class LayeredConflictOutsideClass {
+
+    private LayeredInsideClass insideClass;
+    private String hello;
+    private int hello2;
+
+    public LayeredInsideClass getInsideClass() {
+      return insideClass;
+    }
+
+    public void setInsideClass(LayeredInsideClass insideClass) {
+      this.insideClass = insideClass;
+    }
+
+    public String getHello() {
+      return hello;
+    }
+
+    public void setHello(String hello) {
+      this.hello = hello;
+    }
+
+    public int getHello2() {
+      return hello2;
+    }
+
+    public void setHello2(int hello2) {
+      this.hello2 = hello2;
+    }
+  }
+
+  public static class LayeredTypeConflictOutsideClass {
+
+    private LayeredInsideClass insideClass;
+    private String hello;
+    private Date hello2;
+
+    public LayeredInsideClass getInsideClass() {
+      return insideClass;
+    }
+
+    public void setInsideClass(LayeredInsideClass insideClass) {
+      this.insideClass = insideClass;
+    }
+
+    public String getHello() {
+      return hello;
+    }
+
+    public void setHello(String hello) {
+      this.hello = hello;
+    }
+
+    public Date getHello2() {
+      return hello2;
+    }
+
+    public void setHello2(Date hello2) {
+      this.hello2 = hello2;
     }
   }
 }

--- a/gson/src/test/java/com/google/gson/common/TestTypes.java
+++ b/gson/src/test/java/com/google/gson/common/TestTypes.java
@@ -575,4 +575,48 @@ public class TestTypes {
       this.hello2 = hello2;
     }
   }
+
+  public static class LayeredFieldNamingClass {
+
+    // corresponds to first_string
+    private String firstString;
+    // corresponds to second_integer
+    private Integer secondInteger;
+    // corresponds to third_date
+    private Date thirdDate;
+    // corresponds to weirdlyNamedDateObjectThing
+    private String weirdly_named_date;
+
+    public String getFirstString() {
+      return firstString;
+    }
+
+    public void setFirstString(String firstString) {
+      this.firstString = firstString;
+    }
+
+    public Integer getSecondInteger() {
+      return secondInteger;
+    }
+
+    public void setSecondInteger(Integer secondInteger) {
+      this.secondInteger = secondInteger;
+    }
+
+    public Date getThirdDate() {
+      return thirdDate;
+    }
+
+    public void setThirdDate(Date thirdDate) {
+      this.thirdDate = thirdDate;
+    }
+
+    public String getWeirdly_named_date() {
+      return weirdly_named_date;
+    }
+
+    public void setWeirdly_named_date(String weirdly_named_date) {
+      this.weirdly_named_date = weirdly_named_date;
+    }
+  }
 }

--- a/gson/src/test/java/com/google/gson/common/TestTypes.java
+++ b/gson/src/test/java/com/google/gson/common/TestTypes.java
@@ -611,11 +611,11 @@ public class TestTypes {
       this.thirdDate = thirdDate;
     }
 
-    public String getWeirdly_named_date() {
+    public String getWeirdlyNamedDate() {
       return weirdly_named_date;
     }
 
-    public void setWeirdly_named_date(String weirdly_named_date) {
+    public void setWeirdlyNamedDate(String weirdly_named_date) {
       this.weirdly_named_date = weirdly_named_date;
     }
   }

--- a/gson/src/test/java/com/google/gson/internal/bind/LayeredAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/LayeredAdapterTest.java
@@ -2,87 +2,111 @@ package com.google.gson.internal.bind;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
 import com.google.gson.TypeAdapter;
+import com.google.gson.common.TestTypes.LayeredConflictOutsideClass;
+import com.google.gson.common.TestTypes.LayeredInsideClass;
+import com.google.gson.common.TestTypes.LayeredOutsideClass;
+import com.google.gson.common.TestTypes.LayeredTypeConflictOutsideClass;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
+import java.text.ParseException;
 import junit.framework.TestCase;
 import org.junit.Assert;
+import org.junit.Test;
 
 public class LayeredAdapterTest extends TestCase {
 
-  private Gson gson;
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+  }
 
-  public class Inside {
-    private String hello;
-    private Integer hello2;
+  @Test
+  public void testBasicLayering() {
+    Gson gson = new GsonBuilder()
+        .registerTypeAdapterWithFillIn(LayeredOutsideClass.class, new OutsideAdapter())
+        .create();
+    String basicString = "{ \"field1\": \"sample\", \"field2\": 5, \"hello\": \"hi there\", \"hello2\": 6}";
+    LayeredOutsideClass outside = gson.fromJson(basicString, LayeredOutsideClass.class);
 
-    public String getHello() {
-      return hello;
-    }
+    Assert.assertEquals("sample", outside.getField1());
+    Assert.assertEquals(Integer.valueOf(5), outside.getField2());
+    Assert.assertEquals("hi there", outside.getInsideClass().getHello());
+    Assert.assertEquals(Integer.valueOf(6), outside.getInsideClass().getHello2());
+  }
 
-    public void setHello(String hello) {
-      this.hello = hello;
-    }
+  @Test
+  public void testConflictingNames() {
+    Gson gson = new GsonBuilder()
+        .registerTypeAdapterWithFillIn(LayeredConflictOutsideClass.class,
+            new ConflictOutsideAdapter())
+        .create();
+    String conflictString = "{ \"hello\": \"sample\", \"hello2\": 89}";
 
-    public Integer getHello2() {
-      return hello2;
-    }
+    LayeredConflictOutsideClass outside = gson
+        .fromJson(conflictString, LayeredConflictOutsideClass.class);
+    Assert.assertEquals("sample", outside.getInsideClass().getHello());
+    Assert.assertEquals(Integer.valueOf(89), outside.getInsideClass().getHello2());
+    Assert.assertEquals("sample", outside.getHello());
+    Assert.assertEquals(89, outside.getHello2());
+  }
 
-    public void setHello2(Integer hello2) {
-      this.hello2 = hello2;
+  @Test
+  public void testConflictingTypes() {
+    Gson gson = new GsonBuilder()
+        .registerTypeAdapterWithFillIn(LayeredTypeConflictOutsideClass.class,
+            new TypeConflictOutsideAdapter())
+        .create();
+    String conflictString = "{ \"hello\": \"sample\", \"hello2\": 89}";
+
+    try {
+      LayeredTypeConflictOutsideClass outside = gson
+          .fromJson(conflictString, LayeredTypeConflictOutsideClass.class);
+      fail();
+    } catch (JsonSyntaxException e) {
+      Assert.assertEquals(ParseException.class, e.getCause().getClass());
+      Assert.assertEquals(NumberFormatException.class, e.getCause().getCause().getClass());
     }
   }
 
-  public class Outside {
-    private String field1;
-    private Integer field2;
-    private Inside insideClass;
+  @Test
+  public void testConflictingTypesWithExposeAnnotation() {
+    Gson gson = new GsonBuilder()
+        .registerTypeAdapterWithFillIn(LayeredTypeConflictOutsideClass.class,
+            new TypeConflictOutsideAdapter())
+        .excludeFieldsWithoutExposeAnnotation()
+        .create();
+    String conflictString = "{ \"hello\": \"sample\", \"hello2\": 89}";
 
-    public String getField1() {
-      return field1;
-    }
-
-    public void setField1(String field1) {
-      this.field1 = field1;
-    }
-
-    public Integer getField2() {
-      return field2;
-    }
-
-    public void setField2(Integer field2) {
-      this.field2 = field2;
-    }
-
-    public Inside getInsideClass() {
-      return insideClass;
-    }
-
-    public void setInsideClass(Inside insideClass) {
-      this.insideClass = insideClass;
-    }
+    LayeredTypeConflictOutsideClass outside = gson
+        .fromJson(conflictString, LayeredTypeConflictOutsideClass.class);
+    Assert.assertEquals("sample", outside.getInsideClass().getHello());
+    Assert.assertEquals(Integer.valueOf(89), outside.getInsideClass().getHello2());
+    Assert.assertNull(outside.getHello());
+    Assert.assertNull(outside.getHello2());
   }
 
-  public class OutsideAdapter extends TypeAdapter<Outside> {
+  public class OutsideAdapter extends TypeAdapter<LayeredOutsideClass> {
 
     @Override
-    public void write(JsonWriter out, Outside value) throws IOException {
+    public void write(JsonWriter out, LayeredOutsideClass value) throws IOException {
       // we don't care about this method. Write will happen the normal way that writes happen.
     }
 
     @Override
-    public Outside read(JsonReader in) throws IOException {
-      if (in.peek()== JsonToken.NULL) {
+    public LayeredOutsideClass read(JsonReader in) throws IOException {
+      if (in.peek() == JsonToken.NULL) {
         in.nextNull();
         return null;
       }
 
       in.beginObject();
 
-      Inside inside = new Inside();
-      Outside outside = new Outside();
+      LayeredInsideClass inside = new LayeredInsideClass();
+      LayeredOutsideClass outside = new LayeredOutsideClass();
 
       while (in.hasNext()) {
         String name = in.nextName();
@@ -101,21 +125,75 @@ public class LayeredAdapterTest extends TestCase {
     }
   }
 
-  @Override
-  public void setUp() throws Exception {
-    super.setUp();
-    gson = new GsonBuilder()
-        .registerTypeAdapterWithFillIn(Outside.class, new OutsideAdapter())
-        .create();
+  public class ConflictOutsideAdapter extends TypeAdapter<LayeredConflictOutsideClass> {
+
+    @Override
+    public void write(JsonWriter out, LayeredConflictOutsideClass value) throws IOException {
+      // we don't care about this method. Write will happen the normal way that writes happen.
+    }
+
+    @Override
+    public LayeredConflictOutsideClass read(JsonReader in) throws IOException {
+      if (in.peek() == JsonToken.NULL) {
+        in.nextNull();
+        return null;
+      }
+
+      in.beginObject();
+
+      LayeredInsideClass inside = new LayeredInsideClass();
+      LayeredConflictOutsideClass outside = new LayeredConflictOutsideClass();
+
+      while (in.hasNext()) {
+        String name = in.nextName();
+        if (name.equals("hello")) {
+          inside.setHello(in.nextString());
+        } else if (name.equals("hello2")) {
+          inside.setHello2(in.nextInt());
+        } else {
+          in.skipValue();
+        }
+      }
+      in.endObject();
+
+      outside.setInsideClass(inside);
+      return outside;
+    }
   }
 
-  public void testBasicLayering() {
-    String basicString = "{ \"field1\": \"sample\", \"field2\": 5, \"hello\": \"hi there\", \"hello2\": 6}";
-    Outside outside = gson.fromJson(basicString, Outside.class);
+  public class TypeConflictOutsideAdapter extends TypeAdapter<LayeredTypeConflictOutsideClass> {
 
-    Assert.assertEquals("sample", outside.getField1());
-    Assert.assertEquals(Integer.valueOf(5), outside.getField2());
-    Assert.assertEquals("hi there", outside.getInsideClass().getHello());
-    Assert.assertEquals(Integer.valueOf(6), outside.getInsideClass().getHello2());
+    @Override
+    public void write(JsonWriter out, LayeredTypeConflictOutsideClass value) throws IOException {
+      // we don't care about this method. Write will happen the normal way that writes happen.
+    }
+
+    @Override
+    public LayeredTypeConflictOutsideClass read(JsonReader in) throws IOException {
+      if (in.peek() == JsonToken.NULL) {
+        in.nextNull();
+        return null;
+      }
+
+      in.beginObject();
+
+      LayeredInsideClass inside = new LayeredInsideClass();
+      LayeredTypeConflictOutsideClass outside = new LayeredTypeConflictOutsideClass();
+
+      while (in.hasNext()) {
+        String name = in.nextName();
+        if (name.equals("hello")) {
+          inside.setHello(in.nextString());
+        } else if (name.equals("hello2")) {
+          inside.setHello2(in.nextInt());
+        } else {
+          in.skipValue();
+        }
+      }
+      in.endObject();
+
+      outside.setInsideClass(inside);
+      return outside;
+    }
   }
 }

--- a/gson/src/test/java/com/google/gson/internal/bind/LayeredAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/LayeredAdapterTest.java
@@ -1,0 +1,121 @@
+package com.google.gson.internal.bind;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+public class LayeredAdapterTest extends TestCase {
+
+  private Gson gson;
+
+  public class Inside {
+    private String hello;
+    private Integer hello2;
+
+    public String getHello() {
+      return hello;
+    }
+
+    public void setHello(String hello) {
+      this.hello = hello;
+    }
+
+    public Integer getHello2() {
+      return hello2;
+    }
+
+    public void setHello2(Integer hello2) {
+      this.hello2 = hello2;
+    }
+  }
+
+  public class Outside {
+    private String field1;
+    private Integer field2;
+    private Inside insideClass;
+
+    public String getField1() {
+      return field1;
+    }
+
+    public void setField1(String field1) {
+      this.field1 = field1;
+    }
+
+    public Integer getField2() {
+      return field2;
+    }
+
+    public void setField2(Integer field2) {
+      this.field2 = field2;
+    }
+
+    public Inside getInsideClass() {
+      return insideClass;
+    }
+
+    public void setInsideClass(Inside insideClass) {
+      this.insideClass = insideClass;
+    }
+  }
+
+  public class OutsideAdapter extends TypeAdapter<Outside> {
+
+    @Override
+    public void write(JsonWriter out, Outside value) throws IOException {
+      // we don't care about this method. Write will happen the normal way that writes happen.
+    }
+
+    @Override
+    public Outside read(JsonReader in) throws IOException {
+      if (in.peek()== JsonToken.NULL) {
+        in.nextNull();
+        return null;
+      }
+
+      in.beginObject();
+
+      Inside inside = new Inside();
+      Outside outside = new Outside();
+
+      while (in.hasNext()) {
+        String name = in.nextName();
+        if (name.equals("hello")) {
+          inside.setHello(in.nextString());
+        } else if (name.equals("hello2")) {
+          inside.setHello2(in.nextInt());
+        } else {
+          in.skipValue();
+        }
+      }
+      in.endObject();
+
+      outside.setInsideClass(inside);
+      return outside;
+    }
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    gson = new GsonBuilder()
+        .registerTypeAdapterWithFillIn(Outside.class, new OutsideAdapter())
+        .create();
+  }
+
+  public void testBasicLayering() {
+    String basicString = "{ \"field1\": \"sample\", \"field2\": 5, \"hello\": \"hi there\", \"hello2\": 6}";
+    Outside outside = gson.fromJson(basicString, Outside.class);
+
+    Assert.assertEquals("sample", outside.getField1());
+    Assert.assertEquals(Integer.valueOf(5), outside.getField2());
+    Assert.assertEquals("hi there", outside.getInsideClass().getHello());
+    Assert.assertEquals(Integer.valueOf(6), outside.getInsideClass().getHello2());
+  }
+}

--- a/gson/src/test/java/com/google/gson/internal/bind/LayeredAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/LayeredAdapterTest.java
@@ -65,8 +65,8 @@ public class LayeredAdapterTest extends TestCase {
     String conflictString = "{ \"hello\": \"sample\", \"hello2\": 89}";
 
     try {
-      LayeredTypeConflictOutsideClass outside = gson
-          .fromJson(conflictString, LayeredTypeConflictOutsideClass.class);
+      // Just check that there is an error thrown when this method is called
+      gson.fromJson(conflictString, LayeredTypeConflictOutsideClass.class);
       fail();
     } catch (JsonSyntaxException e) {
       Assert.assertEquals(ParseException.class, e.getCause().getClass());
@@ -105,7 +105,7 @@ public class LayeredAdapterTest extends TestCase {
 
     LayeredFieldNamingClass fieldNamingClass = gson.fromJson(json, LayeredFieldNamingClass.class);
     Assert.assertEquals(fieldNamingClass.getFirstString(), "sample");
-    Assert.assertEquals(fieldNamingClass.getWeirdly_named_date(), "sample_text");
+    Assert.assertEquals(fieldNamingClass.getWeirdlyNamedDate(), "sample_text");
   }
 
   public class OutsideAdapter extends TypeAdapter<LayeredOutsideClass> {
@@ -201,9 +201,9 @@ public class LayeredAdapterTest extends TestCase {
 
       while (in.hasNext()) {
         String name = in.nextName();
-        if (name.equals("hello")) {
+        if ("hello".equals(name)) {
           inside.setHello(in.nextString());
-        } else if (name.equals("hello2")) {
+        } else if ("hello2".equals(name)) {
           inside.setHello2(in.nextInt());
         } else {
           in.skipValue();
@@ -236,8 +236,8 @@ public class LayeredAdapterTest extends TestCase {
       String name = "";
       while (in.hasNext()) {
         name = in.nextName();
-        if (name.equals("weirdlyNameDateObjectThing")) {
-          fieldNamingClass.setWeirdly_named_date(in.nextString());
+        if ("weirdlyNameDateObjectThing".equals(name)) {
+          fieldNamingClass.setWeirdlyNamedDate(in.nextString());
         } else {
           in.skipValue();
         }

--- a/gson/src/test/java/com/google/gson/internal/bind/LayeredAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/LayeredAdapterTest.java
@@ -129,9 +129,9 @@ public class LayeredAdapterTest extends TestCase {
 
       while (in.hasNext()) {
         String name = in.nextName();
-        if (name.equals("hello")) {
+        if ("hello".equals(name)) {
           inside.setHello(in.nextString());
-        } else if (name.equals("hello2")) {
+        } else if ("hello2".equals(name)) {
           inside.setHello2(in.nextInt());
         } else {
           in.skipValue();
@@ -165,9 +165,9 @@ public class LayeredAdapterTest extends TestCase {
 
       while (in.hasNext()) {
         String name = in.nextName();
-        if (name.equals("hello")) {
+        if ("hello".equals(name)) {
           inside.setHello(in.nextString());
-        } else if (name.equals("hello2")) {
+        } else if ("hello2".equals(name)) {
           inside.setHello2(in.nextInt());
         } else {
           in.skipValue();

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -22,6 +22,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.util.Arrays;
 import junit.framework.TestCase;
+import org.junit.Assert;
 
 import static com.google.gson.stream.JsonToken.BEGIN_ARRAY;
 import static com.google.gson.stream.JsonToken.BEGIN_OBJECT;
@@ -1783,5 +1784,19 @@ public final class JsonReaderTest extends TestCase {
       @Override public void close() throws IOException {
       }
     }; */
+  }
+
+  public void testReset() throws IOException {
+    String input = "{\"field1\": \"sample\", \"field2\": 5}";
+    JsonReader reader = new JsonReader(reader(input));
+
+    reader.beginObject();
+    Assert.assertEquals("field1", reader.nextName());
+    Assert.assertEquals("sample", reader.nextString());
+    reader.reset();
+    Assert.assertEquals(JsonToken.BEGIN_OBJECT, reader.peek());
+    reader.beginObject();
+    Assert.assertEquals("field1", reader.nextName());
+    Assert.assertEquals("sample", reader.nextString());
   }
 }

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -1794,7 +1794,7 @@ public final class JsonReaderTest extends TestCase {
     Assert.assertEquals("field1", reader.nextName());
     Assert.assertEquals("sample", reader.nextString());
     reader.reset();
-    Assert.assertEquals(JsonToken.BEGIN_OBJECT, reader.peek());
+    Assert.assertEquals(BEGIN_OBJECT, reader.peek());
     reader.beginObject();
     Assert.assertEquals("field1", reader.nextName());
     Assert.assertEquals("sample", reader.nextString());


### PR DESCRIPTION
**Why this is useful:** Suppose you have a class with a lot of fields. Most of them can be easily interpreted by the Gson reader, possibly with a field naming strategy. But some have such weird names that the field naming strategy might not necessarily properly match them to the target properties. Especially if the JSON comes from a third party (like an API), the best course of action as of today is to create your own `TypeAdapter` and manually map *all* of the fields, including the ones that GSON could map on it's own. This is why I added the "Fill-In" feature. The `registerTypeAdapterWithFillIn` method allows you to manually define only the fields that Gson can not map properly, while not having to map trivial mappings.

**Implementation Details:** The way to register a custom adapter with Fill-in is through the `GsonBuilder#registerTypeAdapterWithFillIn` method. This method wraps the adapter into a constructor object that is then passed to an instance of the `ReflectiveTypeAdapterFactory.Adapter` class. In other words, when the `read` method is called on a `ReflectiveTypeAdapterFactory.Adapter` instance, the `ObjectContstructor` object calls the custom adapter and generates an instance of the target class whose fields are written to or overwritten (see the Conditions section).

When calling the `create` method on the `ReflectiveTypeAdapterFactory` responsible for producing a fill-in adapter, it will only return the adapter when the target type is or is a subclass of the desired target class. This is unlike the usual `ReflectiveTypeAdapterFactory` instances which serve to create a catch-all type adapter for non-standard classes.

In order to support the construction of instances while reading from the input `JsonReader`, the `InstanceCreator` and `ObjectConstructor` have methods that accept a `JsonReader` object. If not overridden by the implementation, they default to the normal `construct` method (for backwards compatibility). 

I wrote some tests in the `test/.../gson/internal/bind/LayeredAdapterTest.java` class to demonstrate and test some common use cases that I thought of for this feature.

**Notes:** 
* The outside adapter field will overwrite any field values previously written to in the instance returned by the user-defined Adapter. To avoid this, add the `@Expose` annotation to the fields that you want to be protected from overwriting. 
* Due to the use of `default` methods in interfaces, this only supports java versions of 8+, and **will fail the travis-ci check**. I would really appreciate if someone pointed out a way to achieve the same thing in a backwards-compatible way without relying on Java 8 features. Also, if there is going to be a multi-release jar as suggested in #1469, this can go in the java 8+ jar.