### PR TITLE
Arraycopy optimization

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
@@ -25,7 +25,9 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import java.io.IOException;
 import java.io.Reader;
-import java.util.*;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Arrays;
 
 /**
  * This reader walks the elements of a JsonElement as if it was coming from a

--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
@@ -25,8 +25,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import java.io.IOException;
 import java.io.Reader;
-import java.util.Iterator;
-import java.util.Map;
+import java.util.*;
 
 /**
  * This reader walks the elements of a JsonElement as if it was coming from a
@@ -282,15 +281,11 @@ public final class JsonTreeReader extends JsonReader {
 
   private void push(Object newTop) {
     if (stackSize == stack.length) {
-      Object[] newStack = new Object[stackSize * 2];
-      int[] newPathIndices = new int[stackSize * 2];
-      String[] newPathNames = new String[stackSize * 2];
-      System.arraycopy(stack, 0, newStack, 0, stackSize);
-      System.arraycopy(pathIndices, 0, newPathIndices, 0, stackSize);
-      System.arraycopy(pathNames, 0, newPathNames, 0, stackSize);
-      stack = newStack;
-      pathIndices = newPathIndices;
-      pathNames = newPathNames;
+      int newLength = stackSize * 2;
+      
+      stack = Arrays.copyOf(stack, newLength);
+	  pathIndices = Arrays.copyOf(pathIndices, newLength);
+	  pathNames = Arrays.copyOf(pathNames, newLength);
     }
     stack[stackSize++] = newTop;
   }

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -22,6 +22,7 @@ import java.io.Closeable;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.Reader;
+import java.util.*;
 
 /**
  * Reads a JSON (<a href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>)
@@ -1262,15 +1263,11 @@ public class JsonReader implements Closeable {
 
   private void push(int newTop) {
     if (stackSize == stack.length) {
-      int[] newStack = new int[stackSize * 2];
-      int[] newPathIndices = new int[stackSize * 2];
-      String[] newPathNames = new String[stackSize * 2];
-      System.arraycopy(stack, 0, newStack, 0, stackSize);
-      System.arraycopy(pathIndices, 0, newPathIndices, 0, stackSize);
-      System.arraycopy(pathNames, 0, newPathNames, 0, stackSize);
-      stack = newStack;
-      pathIndices = newPathIndices;
-      pathNames = newPathNames;
+      int newLength = stackSize * 2;
+      
+      stack = Arrays.copyOf(stack, newLength);
+  	  pathIndices = Arrays.copyOf(pathIndices, newLength);
+  	  pathNames = Arrays.copyOf(pathNames, newLength);
     }
     stack[stackSize++] = newTop;
   }

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -22,7 +22,7 @@ import java.io.Closeable;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.Reader;
-import java.util.*;
+import java.util.Arrays;
 
 /**
  * Reads a JSON (<a href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>)

--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -20,6 +20,7 @@ import java.io.Closeable;
 import java.io.Flushable;
 import java.io.IOException;
 import java.io.Writer;
+import java.util.*;
 
 import static com.google.gson.stream.JsonScope.DANGLING_NAME;
 import static com.google.gson.stream.JsonScope.EMPTY_ARRAY;
@@ -352,9 +353,7 @@ public class JsonWriter implements Closeable, Flushable {
 
   private void push(int newTop) {
     if (stackSize == stack.length) {
-      int[] newStack = new int[stackSize * 2];
-      System.arraycopy(stack, 0, newStack, 0, stackSize);
-      stack = newStack;
+      stack = Arrays.copyOf(stack, stackSize * 2);
     }
     stack[stackSize++] = newTop;
   }

--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -20,7 +20,7 @@ import java.io.Closeable;
 import java.io.Flushable;
 import java.io.IOException;
 import java.io.Writer;
-import java.util.*;
+import java.util.Arrays;
 
 import static com.google.gson.stream.JsonScope.DANGLING_NAME;
 import static com.google.gson.stream.JsonScope.EMPTY_ARRAY;


### PR DESCRIPTION
Optimize array copies inside JsonTreeReader, JsonReader and JsonWriter. Faster & nicer.

Benchmark code: https://pastebin.com/80ztCuVx
Benchmark run: https://pastebin.com/RwfGAmnh