### PR TITLE
Optimize UnsafeReflectionAccessor with MethodHandles

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/reflect/UnsafeReflectionAccessor.java
+++ b/gson/src/main/java/com/google/gson/internal/reflect/UnsafeReflectionAccessor.java
@@ -73,7 +73,13 @@ final class UnsafeReflectionAccessor extends ReflectionAccessor{
 							.findVirtual(unsafeClass, "objectFieldOffset", MethodType.methodType(long.class, Field.class))
 							.bindTo(theUnsafe)
 							.bindTo(AccessibleObject.class.getDeclaredField("override"));
-	} catch (NoSuchMethodException | IllegalAccessException | NoSuchFieldException | SecurityException e) {
+	} catch (NoSuchMethodException e) {
+		return null;
+	} catch (IllegalAccessException e) {
+		return null;
+	} catch (NoSuchFieldException e) {
+		return null;
+	} catch (SecurityException e) {
 		return null;
 	}
   }
@@ -83,7 +89,9 @@ final class UnsafeReflectionAccessor extends ReflectionAccessor{
 		return MethodHandles.publicLookup()
 							.findVirtual(unsafeClass, "putBoolean", MethodType.methodType(void.class, Object.class, long.class, boolean.class))
 							.bindTo(theUnsafe);
-	} catch (NoSuchMethodException | IllegalAccessException e) {
+	} catch (NoSuchMethodException e) {
+		return null;
+	} catch (IllegalAccessException e) {
 		return null;
 	}
   }


### PR DESCRIPTION
Replace reflection invocation with MethodHandles. Avoids boxing, allows better inlining. Afaik all of the MethodHandle methods used in the code are available since java 7. Needs more investigating. Code may need formatting.

Benchmark Code: https://pastebin.com/cqPTUc7i
JMH Output: https://pastebin.com/RcyZ3C05