### PR TITLE
SerializedName annotation workaround for obfuscated enums by ProGuard

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -776,9 +776,13 @@ public final class TypeAdapters {
 
     public EnumTypeAdapter(Class<T> classOfT) {
       try {
-        for (T constant : classOfT.getEnumConstants()) {
+        for (java.lang.reflect.Field field : classOfT.getDeclaredFields()) {
+          if (!field.isEnumConstant()) {
+            continue;
+          }
+          T constant = (T)(field.get(null));
           String name = constant.name();
-          SerializedName annotation = classOfT.getField(name).getAnnotation(SerializedName.class);
+          SerializedName annotation = field.getAnnotation(SerializedName.class);
           if (annotation != null) {
             name = annotation.value();
             for (String alternate : annotation.alternate()) {
@@ -788,7 +792,7 @@ public final class TypeAdapters {
           nameToConstant.put(name, constant);
           constantToName.put(constant, name);
         }
-      } catch (NoSuchFieldException e) {
+      } catch (IllegalAccessException e) {
         throw new AssertionError(e);
       }
     }


### PR DESCRIPTION
SerializedName annotation cannot be applied on enums when obfuscated by
proguard.
Because EnumTypeAdapter cannot find obfuscated enum constant field
with its name.
So, EnumTypeAdapter should load annotation from DeclaredFields, not EnumConstants