### PR TITLE
Primitives refactor

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/Primitives.java
+++ b/gson/src/main/java/com/google/gson/internal/Primitives.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.google.gson.internal;
 
 import java.lang.reflect.Type;

--- a/gson/src/main/java/com/google/gson/internal/Primitives.java
+++ b/gson/src/main/java/com/google/gson/internal/Primitives.java
@@ -13,14 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.gson.internal;
 
-
 import java.lang.reflect.Type;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Contains static utility methods pertaining to primitive types and their
@@ -29,47 +24,34 @@ import java.util.Map;
  * @author Kevin Bourrillion
  */
 public final class Primitives {
-  private Primitives() {
-    throw new UnsupportedOperationException();
+  private Primitives() {}
+
+  private static final Class<?>[] classes = {int.class,     float.class, byte.class, 
+		  									 double.class,  long.class,  char.class, 
+		  									 boolean.class, short.class, void.class,
+		  									 Integer.class, Float.class, Byte.class,
+		  									 Double.class,  Long.class,  Character.class,
+		  									 Boolean.class, Short.class, Void.class};
+
+  //Finds the index of a type, begin is 0 for primitive lookup, 9 for wrapper lookup
+  //Returns -1 if the type is not a wrapper/primitve class
+  private static int indexOf(Type type, int begin) {
+	$Gson$Preconditions.checkNotNull(type);
+	Class<?>[] array = classes;
+	
+	for(int k = begin, end = begin + 9; k < end; ++k) {
+	  if(array[k] == type) {
+		  return k;
+	  }
+	}
+	return -1;
   }
-
-  /** A map from primitive types to their corresponding wrapper types. */
-  private static final Map<Class<?>, Class<?>> PRIMITIVE_TO_WRAPPER_TYPE;
-
-  /** A map from wrapper types to their corresponding primitive types. */
-  private static final Map<Class<?>, Class<?>> WRAPPER_TO_PRIMITIVE_TYPE;
-
-  // Sad that we can't use a BiMap. :(
-
-  static {
-    Map<Class<?>, Class<?>> primToWrap = new HashMap<Class<?>, Class<?>>(16);
-    Map<Class<?>, Class<?>> wrapToPrim = new HashMap<Class<?>, Class<?>>(16);
-
-    add(primToWrap, wrapToPrim, boolean.class, Boolean.class);
-    add(primToWrap, wrapToPrim, byte.class, Byte.class);
-    add(primToWrap, wrapToPrim, char.class, Character.class);
-    add(primToWrap, wrapToPrim, double.class, Double.class);
-    add(primToWrap, wrapToPrim, float.class, Float.class);
-    add(primToWrap, wrapToPrim, int.class, Integer.class);
-    add(primToWrap, wrapToPrim, long.class, Long.class);
-    add(primToWrap, wrapToPrim, short.class, Short.class);
-    add(primToWrap, wrapToPrim, void.class, Void.class);
-
-    PRIMITIVE_TO_WRAPPER_TYPE = Collections.unmodifiableMap(primToWrap);
-    WRAPPER_TO_PRIMITIVE_TYPE = Collections.unmodifiableMap(wrapToPrim);
-  }
-
-  private static void add(Map<Class<?>, Class<?>> forward,
-      Map<Class<?>, Class<?>> backward, Class<?> key, Class<?> value) {
-    forward.put(key, value);
-    backward.put(value, key);
-  }
-
+  
   /**
    * Returns true if this type is a primitive.
    */
   public static boolean isPrimitive(Type type) {
-    return PRIMITIVE_TO_WRAPPER_TYPE.containsKey(type);
+    return indexOf(type, 0) != -1;
   }
 
   /**
@@ -79,8 +61,7 @@ public final class Primitives {
    * @see Class#isPrimitive
    */
   public static boolean isWrapperType(Type type) {
-    return WRAPPER_TO_PRIMITIVE_TYPE.containsKey(
-        $Gson$Preconditions.checkNotNull(type));
+	return indexOf(type, 9) != -1;
   }
 
   /**
@@ -92,12 +73,12 @@ public final class Primitives {
    *     wrap(String.class) == String.class
    * </pre>
    */
+  @SuppressWarnings("unchecked")
   public static <T> Class<T> wrap(Class<T> type) {
+	int index = indexOf(type, 0);
+	
     // cast is safe: long.class and Long.class are both of type Class<Long>
-    @SuppressWarnings("unchecked")
-    Class<T> wrapped = (Class<T>) PRIMITIVE_TO_WRAPPER_TYPE.get(
-        $Gson$Preconditions.checkNotNull(type));
-    return (wrapped == null) ? type : wrapped;
+	return index == -1 ? type : (Class<T>) classes[index + 9];
   }
 
   /**
@@ -109,11 +90,11 @@ public final class Primitives {
    *     unwrap(String.class) == String.class
    * </pre>
    */
+  @SuppressWarnings("unchecked")
   public static <T> Class<T> unwrap(Class<T> type) {
-    // cast is safe: long.class and Long.class are both of type Class<Long>
-    @SuppressWarnings("unchecked")
-    Class<T> unwrapped = (Class<T>) WRAPPER_TO_PRIMITIVE_TYPE.get(
-        $Gson$Preconditions.checkNotNull(type));
-    return (unwrapped == null) ? type : unwrapped;
+	int index = indexOf(type, 9);
+	
+	// cast is safe: long.class and Long.class are both of type Class<Long>
+	return index == -1 ? type : (Class<T>) classes[index - 9];
   }
 }

--- a/gson/src/main/java/com/google/gson/internal/Primitives.java
+++ b/gson/src/main/java/com/google/gson/internal/Primitives.java
@@ -27,32 +27,11 @@ import java.lang.reflect.Type;
 public final class Primitives {
   private Primitives() {}
 
-  private static final Class<?>[] classes = {int.class,     float.class, byte.class, 
-		  									 double.class,  long.class,  char.class, 
-		  									 boolean.class, short.class, void.class,
-		  									 Integer.class, Float.class, Byte.class,
-		  									 Double.class,  Long.class,  Character.class,
-		  									 Boolean.class, Short.class, Void.class};
-
-  //Finds the index of a type, begin is 0 for primitive lookup, 9 for wrapper lookup
-  //Returns -1 if the type is not a wrapper/primitve class
-  private static int indexOf(Type type, int begin) {
-	$Gson$Preconditions.checkNotNull(type);
-	Class<?>[] array = classes;
-	
-	for(int k = begin, end = begin + 9; k < end; ++k) {
-	  if(array[k] == type) {
-		  return k;
-	  }
-	}
-	return -1;
-  }
-  
   /**
    * Returns true if this type is a primitive.
    */
   public static boolean isPrimitive(Type type) {
-    return indexOf(type, 0) != -1;
+	return type instanceof Class<?> && ((Class<?>)type).isPrimitive();
   }
 
   /**
@@ -62,7 +41,9 @@ public final class Primitives {
    * @see Class#isPrimitive
    */
   public static boolean isWrapperType(Type type) {
-	return indexOf(type, 9) != -1;
+	return type == Integer.class || type == Float.class || type == Byte.class || 
+		   type == Double.class  || type == Long.class  || type == Character.class ||
+		   type == Boolean.class || type == Short.class || type == Void.class;
   }
 
   /**
@@ -76,10 +57,35 @@ public final class Primitives {
    */
   @SuppressWarnings("unchecked")
   public static <T> Class<T> wrap(Class<T> type) {
-	int index = indexOf(type, 0);
+	if(type == int.class) {
+		return (Class<T>) Integer.class;
+	}
+	if(type == float.class) {
+		return (Class<T>) Float.class;
+	}
+	if(type == byte.class) {
+		return (Class<T>) Byte.class;
+	}
+	if(type == double.class) {
+		return (Class<T>) Double.class;
+	}
+	if(type == long.class) {
+		return (Class<T>) Long.class;
+	}
+	if(type == char.class) {
+		return (Class<T>) Character.class;
+	}
+	if(type == boolean.class) {
+		return (Class<T>) Boolean.class;
+	}
+	if(type == short.class) {
+		return (Class<T>) Short.class;
+	}
+	if(type == void.class) {
+		return (Class<T>) Void.class;
+	}
 	
-    // cast is safe: long.class and Long.class are both of type Class<Long>
-	return index == -1 ? type : (Class<T>) classes[index + 9];
+	return type;
   }
 
   /**
@@ -93,9 +99,34 @@ public final class Primitives {
    */
   @SuppressWarnings("unchecked")
   public static <T> Class<T> unwrap(Class<T> type) {
-	int index = indexOf(type, 9);
-	
-	// cast is safe: long.class and Long.class are both of type Class<Long>
-	return index == -1 ? type : (Class<T>) classes[index - 9];
+	if(type == Integer.class) {
+		return (Class<T>) int.class;
+	}
+	if(type == Float.class) {
+		return (Class<T>) float.class;
+	}
+	if(type == Byte.class) {
+		return (Class<T>) byte.class;
+	}
+	if(type == Double.class) {
+		return (Class<T>) double.class;
+	}
+	if(type == Long.class) {
+		return (Class<T>) long.class;
+	}
+	if(type == Character.class) {
+		return (Class<T>) char.class;
+	}
+	if(type == Boolean.class) {
+		return (Class<T>) boolean.class;
+	}
+	if(type == Short.class) {
+		return (Class<T>) short.class;
+	}
+	if(type == Void.class) {
+		return (Class<T>) void.class;
+	}
+		
+	return type;
   }
 }


### PR DESCRIPTION
Refactor & Clean up the Primitives class to use array lookup instead of HashMap lookup. There's no need to use a HashMap for 9 elements.
Benchmark code: https://pastebin.com/cG8w2pyy
Benchmark output: https://pastebin.com/dCKfacCy