### PR TITLE
Make "requires java.sql" transitive

### DIFF
--- a/gson/src/main/java/module-info.java
+++ b/gson/src/main/java/module-info.java
@@ -4,5 +4,5 @@ module com.google.gson {
 	exports com.google.gson.reflect;
 	exports com.google.gson.stream;
 
-	requires java.sql;
+	requires transitive java.sql;
 }


### PR DESCRIPTION
Make the "java.sql" dependency transitive in the module-info.java file. It's not transitive, so every module that requires the "gson" module also needs to explicitly require the "java.sql" module. Without requiring it application startups fails with a "java.lang.NoClassDefFoundError: java/sql/Time" exception every time.