### PR TITLE
Remove package private helpers in JsonElement & JsonPrimitive

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonElement.java
+++ b/gson/src/main/java/com/google/gson/JsonElement.java
@@ -154,19 +154,6 @@ public abstract class JsonElement {
   }
 
   /**
-   * convenience method to get this element as a {@link Boolean} value.
-   *
-   * @return get this element as a {@link Boolean} value.
-   * @throws ClassCastException if the element is of not a {@link JsonPrimitive} and is not a valid
-   * boolean value.
-   * @throws IllegalStateException if the element is of the type {@link JsonArray} but contains
-   * more than a single element.
-   */
-  Boolean getAsBooleanWrapper() {
-    throw new UnsupportedOperationException(getClass().getSimpleName());
-  }
-
-  /**
    * convenience method to get this element as a {@link Number}.
    *
    * @return get this element as a {@link Number}.

--- a/gson/src/main/java/com/google/gson/JsonPrimitive.java
+++ b/gson/src/main/java/com/google/gson/JsonPrimitive.java
@@ -92,16 +92,6 @@ public final class JsonPrimitive extends JsonElement {
   }
 
   /**
-   * convenience method to get this element as a {@link Boolean}.
-   *
-   * @return get this element as a {@link Boolean}.
-   */
-  @Override
-  Boolean getAsBooleanWrapper() {
-    return (Boolean) value;
-  }
-
-  /**
    * convenience method to get this element as a boolean value.
    *
    * @return get this element as a primitive boolean value.
@@ -109,7 +99,7 @@ public final class JsonPrimitive extends JsonElement {
   @Override
   public boolean getAsBoolean() {
     if (isBoolean()) {
-      return getAsBooleanWrapper().booleanValue();
+      return ((Boolean) value).booleanValue();
     } else {
       // Check to see if the value as a String is "true" in any case.
       return Boolean.parseBoolean(getAsString());
@@ -155,7 +145,7 @@ public final class JsonPrimitive extends JsonElement {
     if (isNumber()) {
       return getAsNumber().toString();
     } else if (isBoolean()) {
-      return getAsBooleanWrapper().toString();
+      return ((Boolean) value).toString();
     } else {
       return (String) value;
     }

--- a/gson/src/main/java/com/google/gson/JsonPrimitive.java
+++ b/gson/src/main/java/com/google/gson/JsonPrimitive.java
@@ -100,10 +100,9 @@ public final class JsonPrimitive extends JsonElement {
   public boolean getAsBoolean() {
     if (isBoolean()) {
       return ((Boolean) value).booleanValue();
-    } else {
-      // Check to see if the value as a String is "true" in any case.
-      return Boolean.parseBoolean(getAsString());
     }
+	// Check to see if the value as a String is "true" in any case.
+    return Boolean.parseBoolean(getAsString());
   }
 
   /**


### PR DESCRIPTION
-Remove documentation & code for "getAsBooleanWrapper" in JsonElement.
-Remove uses of "getAsBooleanWrapper" in JsonPrimitive.
-Inline "getAsBooleanWrapper" into methods where it was used.

-Not breaking backwards compatibility, because the methods were package private.