### PR TITLE
Add static methods to JsonParser

### DIFF
--- a/gson/src/test/java/com/google/gson/JsonObjectTest.java
+++ b/gson/src/test/java/com/google/gson/JsonObjectTest.java
@@ -128,7 +128,7 @@ public class JsonObjectTest extends TestCase {
   }
 
   public void testReadPropertyWithEmptyStringName() {
-    JsonObject jsonObj = new JsonParser().parse("{\"\":true}").getAsJsonObject();
+    JsonObject jsonObj = JsonParser.parseString("{\"\":true}").getAsJsonObject();
     assertEquals(true, jsonObj.get("").getAsBoolean());
   }
 

--- a/gson/src/test/java/com/google/gson/JsonParserTest.java
+++ b/gson/src/test/java/com/google/gson/JsonParserTest.java
@@ -32,23 +32,16 @@ import com.google.gson.stream.JsonReader;
  * @author Inderjeet Singh
  */
 public class JsonParserTest extends TestCase {
-  private JsonParser parser;
-
-  @Override
-  protected void setUp() throws Exception {
-    super.setUp();
-    parser = new JsonParser();
-  }
 
   public void testParseInvalidJson() {
     try {
-      parser.parse("[[]");
+      JsonParser.parseString("[[]");
       fail();
     } catch (JsonSyntaxException expected) { }
   }
 
   public void testParseUnquotedStringArrayFails() {
-    JsonElement element = parser.parse("[a,b,c]");
+    JsonElement element = JsonParser.parseString("[a,b,c]");
     assertEquals("a", element.getAsJsonArray().get(0).getAsString());
     assertEquals("b", element.getAsJsonArray().get(1).getAsString());
     assertEquals("c", element.getAsJsonArray().get(2).getAsString());
@@ -57,38 +50,38 @@ public class JsonParserTest extends TestCase {
 
   public void testParseString() {
     String json = "{a:10,b:'c'}";
-    JsonElement e = parser.parse(json);
+    JsonElement e = JsonParser.parseString(json);
     assertTrue(e.isJsonObject());
     assertEquals(10, e.getAsJsonObject().get("a").getAsInt());
     assertEquals("c", e.getAsJsonObject().get("b").getAsString());
   }
 
   public void testParseEmptyString() {
-    JsonElement e = parser.parse("\"   \"");
+    JsonElement e = JsonParser.parseString("\"   \"");
     assertTrue(e.isJsonPrimitive());
     assertEquals("   ", e.getAsString());
   }
 
   public void testParseEmptyWhitespaceInput() {
-    JsonElement e = parser.parse("     ");
+    JsonElement e = JsonParser.parseString("     ");
     assertTrue(e.isJsonNull());
   }
 
   public void testParseUnquotedSingleWordStringFails() {
-    assertEquals("Test", parser.parse("Test").getAsString());
+    assertEquals("Test", JsonParser.parseString("Test").getAsString());
   }
 
   public void testParseUnquotedMultiWordStringFails() {
     String unquotedSentence = "Test is a test..blah blah";
     try {
-      parser.parse(unquotedSentence);
+      JsonParser.parseString(unquotedSentence);
       fail();
     } catch (JsonSyntaxException expected) { }
   }
 
   public void testParseMixedArray() {
     String json = "[{},13,\"stringValue\"]";
-    JsonElement e = parser.parse(json);
+    JsonElement e = JsonParser.parseString(json);
     assertTrue(e.isJsonArray());
 
     JsonArray  array = e.getAsJsonArray();
@@ -99,7 +92,7 @@ public class JsonParserTest extends TestCase {
 
   public void testParseReader() {
     StringReader reader = new StringReader("{a:10,b:'c'}");
-    JsonElement e = parser.parse(reader);
+    JsonElement e = JsonParser.parseReader(reader);
     assertTrue(e.isJsonObject());
     assertEquals(10, e.getAsJsonObject().get("a").getAsInt());
     assertEquals("c", e.getAsJsonObject().get("b").getAsString());

--- a/gson/src/test/java/com/google/gson/functional/JsonParserTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonParserTest.java
@@ -112,7 +112,7 @@ public class JsonParserTest extends TestCase {
   public void testChangingCustomTreeAndDeserializing() {
     StringReader json =
       new StringReader("{'stringValue':'no message','intValue':10,'longValue':20}");
-    JsonObject obj = (JsonObject) new JsonParser().parse(json);
+    JsonObject obj = (JsonObject) JsonParser.parseReader(json);
     obj.remove("stringValue");
     obj.addProperty("stringValue", "fooBar");
     BagOfPrimitives target = gson.fromJson(obj, BagOfPrimitives.class);

--- a/gson/src/test/java/com/google/gson/functional/MapTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MapTest.java
@@ -608,7 +608,7 @@ public class MapTest extends TestCase {
     String json = "{'2.3':'a'}";
     Map<Double, String> map = new LinkedHashMap<Double, String>();
     map.put(2.3, "a");
-    JsonElement tree = new JsonParser().parse(json);
+    JsonElement tree = JsonParser.parseString(json);
     assertEquals(map, gson.fromJson(tree, new TypeToken<Map<Double, String>>() {}.getType()));
   }
 

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonElementReaderTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonElementReaderTest.java
@@ -26,7 +26,7 @@ import junit.framework.TestCase;
 public final class JsonElementReaderTest extends TestCase {
 
   public void testNumbers() throws IOException {
-    JsonElement element = new JsonParser().parse("[1, 2, 3]");
+    JsonElement element = JsonParser.parseString("[1, 2, 3]");
     JsonTreeReader reader = new JsonTreeReader(element);
     reader.beginArray();
     assertEquals(1, reader.nextInt());
@@ -36,7 +36,7 @@ public final class JsonElementReaderTest extends TestCase {
   }
 
   public void testLenientNansAndInfinities() throws IOException {
-    JsonElement element = new JsonParser().parse("[NaN, -Infinity, Infinity]");
+    JsonElement element = JsonParser.parseString("[NaN, -Infinity, Infinity]");
     JsonTreeReader reader = new JsonTreeReader(element);
     reader.setLenient(true);
     reader.beginArray();
@@ -47,7 +47,7 @@ public final class JsonElementReaderTest extends TestCase {
   }
 
   public void testStrictNansAndInfinities() throws IOException {
-    JsonElement element = new JsonParser().parse("[NaN, -Infinity, Infinity]");
+    JsonElement element = JsonParser.parseString("[NaN, -Infinity, Infinity]");
     JsonTreeReader reader = new JsonTreeReader(element);
     reader.setLenient(false);
     reader.beginArray();
@@ -73,7 +73,7 @@ public final class JsonElementReaderTest extends TestCase {
   }
 
   public void testNumbersFromStrings() throws IOException {
-    JsonElement element = new JsonParser().parse("[\"1\", \"2\", \"3\"]");
+    JsonElement element = JsonParser.parseString("[\"1\", \"2\", \"3\"]");
     JsonTreeReader reader = new JsonTreeReader(element);
     reader.beginArray();
     assertEquals(1, reader.nextInt());
@@ -83,7 +83,7 @@ public final class JsonElementReaderTest extends TestCase {
   }
 
   public void testStringsFromNumbers() throws IOException {
-    JsonElement element = new JsonParser().parse("[1]");
+    JsonElement element = JsonParser.parseString("[1]");
     JsonTreeReader reader = new JsonTreeReader(element);
     reader.beginArray();
     assertEquals("1", reader.nextString());
@@ -91,7 +91,7 @@ public final class JsonElementReaderTest extends TestCase {
   }
 
   public void testBooleans() throws IOException {
-    JsonElement element = new JsonParser().parse("[true, false]");
+    JsonElement element = JsonParser.parseString("[true, false]");
     JsonTreeReader reader = new JsonTreeReader(element);
     reader.beginArray();
     assertEquals(true, reader.nextBoolean());
@@ -100,7 +100,7 @@ public final class JsonElementReaderTest extends TestCase {
   }
 
   public void testNulls() throws IOException {
-    JsonElement element = new JsonParser().parse("[null,null]");
+    JsonElement element = JsonParser.parseString("[null,null]");
     JsonTreeReader reader = new JsonTreeReader(element);
     reader.beginArray();
     reader.nextNull();
@@ -109,7 +109,7 @@ public final class JsonElementReaderTest extends TestCase {
   }
 
   public void testStrings() throws IOException {
-    JsonElement element = new JsonParser().parse("[\"A\",\"B\"]");
+    JsonElement element = JsonParser.parseString("[\"A\",\"B\"]");
     JsonTreeReader reader = new JsonTreeReader(element);
     reader.beginArray();
     assertEquals("A", reader.nextString());
@@ -118,7 +118,7 @@ public final class JsonElementReaderTest extends TestCase {
   }
 
   public void testArray() throws IOException {
-    JsonElement element = new JsonParser().parse("[1, 2, 3]");
+    JsonElement element = JsonParser.parseString("[1, 2, 3]");
     JsonTreeReader reader = new JsonTreeReader(element);
     assertEquals(JsonToken.BEGIN_ARRAY, reader.peek());
     reader.beginArray();
@@ -134,7 +134,7 @@ public final class JsonElementReaderTest extends TestCase {
   }
 
   public void testObject() throws IOException {
-    JsonElement element = new JsonParser().parse("{\"A\": 1, \"B\": 2}");
+    JsonElement element = JsonParser.parseString("{\"A\": 1, \"B\": 2}");
     JsonTreeReader reader = new JsonTreeReader(element);
     assertEquals(JsonToken.BEGIN_OBJECT, reader.peek());
     reader.beginObject();
@@ -152,14 +152,14 @@ public final class JsonElementReaderTest extends TestCase {
   }
 
   public void testEmptyArray() throws IOException {
-    JsonElement element = new JsonParser().parse("[]");
+    JsonElement element = JsonParser.parseString("[]");
     JsonTreeReader reader = new JsonTreeReader(element);
     reader.beginArray();
     reader.endArray();
   }
 
   public void testNestedArrays() throws IOException {
-    JsonElement element = new JsonParser().parse("[[],[[]]]");
+    JsonElement element = JsonParser.parseString("[[],[[]]]");
     JsonTreeReader reader = new JsonTreeReader(element);
     reader.beginArray();
     reader.beginArray();
@@ -172,7 +172,7 @@ public final class JsonElementReaderTest extends TestCase {
   }
 
   public void testNestedObjects() throws IOException {
-    JsonElement element = new JsonParser().parse("{\"A\":{},\"B\":{\"C\":{}}}");
+    JsonElement element = JsonParser.parseString("{\"A\":{},\"B\":{\"C\":{}}}");
     JsonTreeReader reader = new JsonTreeReader(element);
     reader.beginObject();
     assertEquals("A", reader.nextName());
@@ -188,14 +188,14 @@ public final class JsonElementReaderTest extends TestCase {
   }
 
   public void testEmptyObject() throws IOException {
-    JsonElement element = new JsonParser().parse("{}");
+    JsonElement element = JsonParser.parseString("{}");
     JsonTreeReader reader = new JsonTreeReader(element);
     reader.beginObject();
     reader.endObject();
   }
 
   public void testSkipValue() throws IOException {
-    JsonElement element = new JsonParser().parse("[\"A\",{\"B\":[[]]},\"C\",[[]],\"D\",null]");
+    JsonElement element = JsonParser.parseString("[\"A\",{\"B\":[[]]},\"C\",[[]],\"D\",null]");
     JsonTreeReader reader = new JsonTreeReader(element);
     reader.beginArray();
     assertEquals("A", reader.nextString());
@@ -208,7 +208,7 @@ public final class JsonElementReaderTest extends TestCase {
   }
 
   public void testWrongType() throws IOException {
-    JsonElement element = new JsonParser().parse("[[],\"A\"]");
+    JsonElement element = JsonParser.parseString("[[],\"A\"]");
     JsonTreeReader reader = new JsonTreeReader(element);
     reader.beginArray();
     try {
@@ -299,7 +299,7 @@ public final class JsonElementReaderTest extends TestCase {
   }
 
   public void testEarlyClose() throws IOException {
-    JsonElement element = new JsonParser().parse("[1, 2, 3]");
+    JsonElement element = JsonParser.parseString("[1, 2, 3]");
     JsonTreeReader reader = new JsonTreeReader(element);
     reader.beginArray();
     reader.close();


### PR DESCRIPTION
-Add static parser method alternatives to JsonParser.class.
-Mark the default constructor of JsonParser as deprecated.
-Point of this pr is to stop forcing people to create a JsonParser instance per parsing.
-People usually store a JsonParser instance as a global somewhere in their projects, and call the parser methods on that instance. With this pr, all these globals could be removed.
-No deprecations or warnings on parser method calls, single deprecation warning on JsonParser constructor.
-No breaking changes, the old solution works just like before.
-Fixed all tests to use the new static methods.