### PR TITLE
Clean up some deprecations & warnings in tests

### DIFF
--- a/gson/src/test/java/com/google/gson/DefaultDateTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/DefaultDateTypeAdapterTest.java
@@ -167,6 +167,7 @@ public class DefaultDateTypeAdapterTest extends TestCase {
     assertEquals(toLiteral(formatter.format(currentDate)), dateString);
   }
 
+  @SuppressWarnings("unused")
   public void testInvalidDatePattern() throws Exception {
     try {
       new DefaultDateTypeAdapter(Date.class, "I am a bad Date pattern....");

--- a/gson/src/test/java/com/google/gson/FieldAttributesTest.java
+++ b/gson/src/test/java/com/google/gson/FieldAttributesTest.java
@@ -39,6 +39,7 @@ public class FieldAttributesTest extends TestCase {
     fieldAttributes = new FieldAttributes(Foo.class.getField("bar"));
   }
 
+  @SuppressWarnings("unused")
   public void testNullField() throws Exception {
     try {
       new FieldAttributes(null);

--- a/gson/src/test/java/com/google/gson/JsonPrimitiveTest.java
+++ b/gson/src/test/java/com/google/gson/JsonPrimitiveTest.java
@@ -30,6 +30,7 @@ import java.math.BigInteger;
  */
 public class JsonPrimitiveTest extends TestCase {
 
+  @SuppressWarnings("unused")
   public void testNulls() {
     try {
       new JsonPrimitive((Boolean) null);
@@ -113,8 +114,8 @@ public class JsonPrimitiveTest extends TestCase {
     JsonPrimitive json = new JsonPrimitive("1E+7");
 
     assertEquals(new BigDecimal("1E+7"), json.getAsBigDecimal());
-    assertEquals(new Double("1E+7"), json.getAsDouble(), 0.00001);
-    assertEquals(new Float("1E+7"), json.getAsDouble(), 0.00001);
+    assertEquals(1E+7, json.getAsDouble(), 0.00001);
+    assertEquals(1E+7, json.getAsDouble(), 0.00001);
 
     try {
       json.getAsInt();
@@ -123,91 +124,91 @@ public class JsonPrimitiveTest extends TestCase {
   }
 
   public void testByteEqualsShort() {
-    JsonPrimitive p1 = new JsonPrimitive(new Byte((byte)10));
-    JsonPrimitive p2 = new JsonPrimitive(new Short((short)10));
+    JsonPrimitive p1 = new JsonPrimitive(Byte.valueOf((byte)10));
+    JsonPrimitive p2 = new JsonPrimitive(Short.valueOf((short)10));
     assertEquals(p1, p2);
     assertEquals(p1.hashCode(), p2.hashCode());
   }
 
   public void testByteEqualsInteger() {
-    JsonPrimitive p1 = new JsonPrimitive(new Byte((byte)10));
-    JsonPrimitive p2 = new JsonPrimitive(new Integer(10));
+    JsonPrimitive p1 = new JsonPrimitive(Byte.valueOf((byte)10));
+    JsonPrimitive p2 = new JsonPrimitive(Integer.valueOf(10));
     assertEquals(p1, p2);
     assertEquals(p1.hashCode(), p2.hashCode());
   }
 
   public void testByteEqualsLong() {
-    JsonPrimitive p1 = new JsonPrimitive(new Byte((byte)10));
-    JsonPrimitive p2 = new JsonPrimitive(new Long(10L));
+    JsonPrimitive p1 = new JsonPrimitive(Byte.valueOf((byte)10));
+    JsonPrimitive p2 = new JsonPrimitive(Long.valueOf(10L));
     assertEquals(p1, p2);
     assertEquals(p1.hashCode(), p2.hashCode());
   }
 
   public void testByteEqualsBigInteger() {
-    JsonPrimitive p1 = new JsonPrimitive(new Byte((byte)10));
+    JsonPrimitive p1 = new JsonPrimitive(Byte.valueOf((byte)10));
     JsonPrimitive p2 = new JsonPrimitive(new BigInteger("10"));
     assertEquals(p1, p2);
     assertEquals(p1.hashCode(), p2.hashCode());
   }
 
   public void testShortEqualsInteger() {
-    JsonPrimitive p1 = new JsonPrimitive(new Short((short)10));
-    JsonPrimitive p2 = new JsonPrimitive(new Integer(10));
+    JsonPrimitive p1 = new JsonPrimitive(Short.valueOf((short)10));
+    JsonPrimitive p2 = new JsonPrimitive(Integer.valueOf(10));
     assertEquals(p1, p2);
     assertEquals(p1.hashCode(), p2.hashCode());
   }
 
   public void testShortEqualsLong() {
-    JsonPrimitive p1 = new JsonPrimitive(new Short((short)10));
-    JsonPrimitive p2 = new JsonPrimitive(new Long(10));
+    JsonPrimitive p1 = new JsonPrimitive(Short.valueOf((short)10));
+    JsonPrimitive p2 = new JsonPrimitive(Long.valueOf(10));
     assertEquals(p1, p2);
     assertEquals(p1.hashCode(), p2.hashCode());
   }
 
   public void testShortEqualsBigInteger() {
-    JsonPrimitive p1 = new JsonPrimitive(new Short((short)10));
+    JsonPrimitive p1 = new JsonPrimitive(Short.valueOf((short)10));
     JsonPrimitive p2 = new JsonPrimitive(new BigInteger("10"));
     assertEquals(p1, p2);
     assertEquals(p1.hashCode(), p2.hashCode());
   }
 
   public void testIntegerEqualsLong() {
-    JsonPrimitive p1 = new JsonPrimitive(new Integer(10));
-    JsonPrimitive p2 = new JsonPrimitive(new Long(10L));
+    JsonPrimitive p1 = new JsonPrimitive(Integer.valueOf(10));
+    JsonPrimitive p2 = new JsonPrimitive(Long.valueOf(10L));
     assertEquals(p1, p2);
     assertEquals(p1.hashCode(), p2.hashCode());
   }
 
   public void testIntegerEqualsBigInteger() {
-    JsonPrimitive p1 = new JsonPrimitive(new Integer(10));
+    JsonPrimitive p1 = new JsonPrimitive(Integer.valueOf(10));
     JsonPrimitive p2 = new JsonPrimitive(new BigInteger("10"));
     assertEquals(p1, p2);
     assertEquals(p1.hashCode(), p2.hashCode());
   }
 
   public void testLongEqualsBigInteger() {
-    JsonPrimitive p1 = new JsonPrimitive(new Long(10L));
+    JsonPrimitive p1 = new JsonPrimitive(Long.valueOf(10L));
     JsonPrimitive p2 = new JsonPrimitive(new BigInteger("10"));
     assertEquals(p1, p2);
     assertEquals(p1.hashCode(), p2.hashCode());
   }
 
   public void testFloatEqualsDouble() {
-    JsonPrimitive p1 = new JsonPrimitive(new Float(10.25F));
-    JsonPrimitive p2 = new JsonPrimitive(new Double(10.25D));
+    JsonPrimitive p1 = new JsonPrimitive(Float.valueOf(10.25F));
+    JsonPrimitive p2 = new JsonPrimitive(Double.valueOf(10.25D));
     assertEquals(p1, p2);
     assertEquals(p1.hashCode(), p2.hashCode());
   }
 
   public void testFloatEqualsBigDecimal() {
-    JsonPrimitive p1 = new JsonPrimitive(new Float(10.25F));
+    JsonPrimitive p1 = new JsonPrimitive(Float.valueOf(10.25F));
     JsonPrimitive p2 = new JsonPrimitive(new BigDecimal("10.25"));
     assertEquals(p1, p2);
     assertEquals(p1.hashCode(), p2.hashCode());
   }
 
   public void testDoubleEqualsBigDecimal() {
-    JsonPrimitive p1 = new JsonPrimitive(new Double(10.25D));
+    JsonPrimitive p1 = new JsonPrimitive(Double.valueOf(10.25D));
     JsonPrimitive p2 = new JsonPrimitive(new BigDecimal("10.25"));
     assertEquals(p1, p2);
     assertEquals(p1.hashCode(), p2.hashCode());

--- a/gson/src/test/java/com/google/gson/common/MoreAsserts.java
+++ b/gson/src/test/java/com/google/gson/common/MoreAsserts.java
@@ -16,7 +16,7 @@
 
 package com.google.gson.common;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import java.util.Collection;
 
@@ -27,26 +27,6 @@ import java.util.Collection;
  * @author Inderjeet Singh
  */
 public class MoreAsserts {
-
-  public static void assertEquals(int[] expected, int[] target) {
-    if (expected == null) {
-      Assert.assertNull(target);
-    }
-    Assert.assertEquals(expected.length, target.length);
-    for (int i = 0; i < expected.length; ++i) {
-      Assert.assertEquals(expected[i], target[i]);
-    }
-  }
-
-  public static void assertEquals(Integer[] expected, Integer[] target) {
-    if (expected == null) {
-      Assert.assertNull(target);
-    }
-    Assert.assertEquals(expected.length, target.length);
-    for (int i = 0; i < expected.length; ++i) {
-      Assert.assertEquals(expected[i], target[i]);
-    }
-  }
 
   /**
    * Asserts that the specified {@code value} is not present in {@code collection}
@@ -69,5 +49,4 @@ public class MoreAsserts {
     Assert.assertFalse(a.equals(null));
     Assert.assertFalse(a.equals(new Object()));
   }
-
 }

--- a/gson/src/test/java/com/google/gson/functional/ArrayTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ArrayTest.java
@@ -19,12 +19,12 @@ package com.google.gson.functional;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParseException;
-import com.google.gson.common.MoreAsserts;
 import com.google.gson.common.TestTypes.BagOfPrimitives;
 import com.google.gson.common.TestTypes.ClassWithObjects;
 import com.google.gson.reflect.TypeToken;
 
 import junit.framework.TestCase;
+import static org.junit.Assert.assertArrayEquals;
 
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
@@ -53,7 +53,7 @@ public class ArrayTest extends TestCase {
   public void testTopLevelArrayOfIntsDeserialization() {
     int[] expected = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
     int[] actual = gson.fromJson("[1,2,3,4,5,6,7,8,9]", int[].class);
-    MoreAsserts.assertEquals(expected, actual);
+    assertArrayEquals(expected, actual);
   }
 
   public void testInvalidArrayDeserialization() {
@@ -173,8 +173,8 @@ public class ArrayTest extends TestCase {
     Collection<Integer>[] target = gson.fromJson(json, type);
 
     assertEquals(2, target.length);
-    MoreAsserts.assertEquals(new Integer[] { 1, 2 }, target[0].toArray(new Integer[0]));
-    MoreAsserts.assertEquals(new Integer[] { 3, 4 }, target[1].toArray(new Integer[0]));
+    assertArrayEquals(new Integer[] { 1, 2 }, target[0].toArray(new Integer[0]));
+    assertArrayEquals(new Integer[] { 3, 4 }, target[1].toArray(new Integer[0]));
   }
 
   public void testArrayOfPrimitivesAsObjectsSerialization() throws Exception {

--- a/gson/src/test/java/com/google/gson/functional/CollectionTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CollectionTest.java
@@ -42,6 +42,7 @@ import com.google.gson.common.TestTypes.BagOfPrimitives;
 import com.google.gson.reflect.TypeToken;
 
 import junit.framework.TestCase;
+import static org.junit.Assert.assertArrayEquals;
 
 /**
  * Functional tests for Json serialization and deserialization of collections.
@@ -70,7 +71,7 @@ public class CollectionTest extends TestCase {
     Type collectionType = new TypeToken<Collection<Integer>>() { }.getType();
     Collection<Integer> target = gson.fromJson(json, collectionType);
     int[] expected = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-    MoreAsserts.assertEquals(expected, toIntArray(target));
+    assertArrayEquals(expected, toIntArray(target));
   }
 
   public void testTopLevelListOfIntegerCollectionsDeserialization() throws Exception {
@@ -86,7 +87,7 @@ public class CollectionTest extends TestCase {
     }
 
     for (int i = 0; i < 3; i++) {
-      MoreAsserts.assertEquals(expected[i], toIntArray(target.get(i)));
+      assertArrayEquals(expected[i], toIntArray(target.get(i)));
     }
   }
 

--- a/gson/src/test/java/com/google/gson/functional/JsonParserTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonParserTest.java
@@ -123,9 +123,9 @@ public class JsonParserTest extends TestCase {
 
   public void testExtraCommasInArrays() {
     Type type = new TypeToken<List<String>>() {}.getType();
-    assertEquals(list("a", null, "b", null, null), gson.fromJson("[a,,b,,]", type));
-    assertEquals(list(null, null), gson.fromJson("[,]", type));
-    assertEquals(list("a", null), gson.fromJson("[a,]", type));
+    assertEquals(Arrays.asList("a", null, "b", null, null), gson.fromJson("[a,,b,,]", type));
+    assertEquals(Arrays.asList(null, null), gson.fromJson("[,]", type));
+    assertEquals(Arrays.asList("a", null), gson.fromJson("[a,]", type));
   }
 
   public void testExtraCommasInMaps() {
@@ -135,9 +135,5 @@ public class JsonParserTest extends TestCase {
       fail();
     } catch (JsonSyntaxException expected) {
     }
-  }
-
-  private <T> List<T> list(T... elements) {
-    return Arrays.asList(elements);
   }
 }

--- a/gson/src/test/java/com/google/gson/functional/MapAsArrayTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MapAsArrayTypeAdapterTest.java
@@ -59,8 +59,8 @@ public class MapAsArrayTypeAdapterTest extends TestCase {
         .create();
 
     Map<Number, String> original = new LinkedHashMap<Number, String>();
-    original.put(new Double(1.0), "a");
-    original.put(new Float(1.0), "b");
+    original.put(1.0D, "a");
+    original.put(1.0F, "b");
     try {
       gson.toJson(original, new TypeToken<Map<Number, String>>() {}.getType());
       fail(); // we no longer hash keys at serialization time

--- a/gson/src/test/java/com/google/gson/functional/MapTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MapTest.java
@@ -364,7 +364,7 @@ public class MapTest extends TestCase {
     Type typeOfMap = new TypeToken<Map<String, ? extends Long>>() {}.getType();
     Map<String, ? extends Long> map = gson.fromJson("{\"test\":123}", typeOfMap);
     assertEquals(1, map.size());
-    assertEquals(new Long(123L), map.get("test"));
+    assertEquals(Long.valueOf(123L), map.get("test"));
   }
 
 

--- a/gson/src/test/java/com/google/gson/functional/ParameterizedTypesTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ParameterizedTypesTest.java
@@ -121,7 +121,7 @@ public class ParameterizedTypesTest extends TestCase {
         .registerTypeAdapter(ptStringType, new MyParameterizedTypeAdapter<String>())
         .registerTypeAdapter(ptStringType, new MyParameterizedTypeInstanceCreator<String>(""))
         .registerTypeAdapter(ptIntegerType,
-            new MyParameterizedTypeInstanceCreator<Integer>(new Integer(0)))
+            new MyParameterizedTypeInstanceCreator<Integer>(0))
         .create();
 
     MyParameterizedType<Integer> src = new MyParameterizedType<Integer>(10);

--- a/gson/src/test/java/com/google/gson/functional/PrimitiveTest.java
+++ b/gson/src/test/java/com/google/gson/functional/PrimitiveTest.java
@@ -144,12 +144,12 @@ public class PrimitiveTest extends TestCase {
 
   public void testNumberDeserialization() {
     String json = "1";
-    Number expected = new Integer(json);
+    Number expected = Integer.valueOf(json);
     Number actual = gson.fromJson(json, Number.class);
     assertEquals(expected.intValue(), actual.intValue());
 
     json = String.valueOf(Long.MAX_VALUE);
-    expected = new Long(json);
+    expected = Long.valueOf(json);
     actual = gson.fromJson(json, Number.class);
     assertEquals(expected.longValue(), actual.longValue());
 
@@ -164,16 +164,16 @@ public class PrimitiveTest extends TestCase {
   }
 
   public void testPrimitiveDoubleAutoboxedSerialization() {
-    assertEquals("-122.08234335", gson.toJson(-122.08234335));
-    assertEquals("122.08112002", gson.toJson(new Double(122.08112002)));
+    assertEquals("-122.08234335", gson.toJson(-122.08234335D));
+    assertEquals("122.08112002", gson.toJson(122.08112002D));
   }
 
   public void testPrimitiveDoubleAutoboxedDeserialization() {
     double actual = gson.fromJson("-122.08858585", double.class);
-    assertEquals(-122.08858585, actual);
+    assertEquals(-122.08858585D, actual);
 
     actual = gson.fromJson("122.023900008000", Double.class);
-    assertEquals(122.023900008, actual);
+    assertEquals(122.023900008D, actual);
   }
 
   public void testPrimitiveDoubleAutoboxedInASingleElementArraySerialization() {

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
@@ -157,17 +157,17 @@ public final class JsonTreeWriterTest extends TestCase {
     writer.setLenient(false);
     writer.beginArray();
     try {
-      writer.value(new Double(Double.NaN));
+      writer.value(Double.valueOf(Double.NaN));
       fail();
     } catch (IllegalArgumentException expected) {
     }
     try {
-      writer.value(new Double(Double.NEGATIVE_INFINITY));
+      writer.value(Double.valueOf(Double.NEGATIVE_INFINITY));
       fail();
     } catch (IllegalArgumentException expected) {
     }
     try {
-      writer.value(new Double(Double.POSITIVE_INFINITY));
+      writer.value(Double.valueOf(Double.POSITIVE_INFINITY));
       fail();
     } catch (IllegalArgumentException expected) {
     }

--- a/gson/src/test/java/com/google/gson/internal/bind/RecursiveTypesResolveTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/RecursiveTypesResolveTest.java
@@ -34,10 +34,11 @@ import java.lang.ref.WeakReference;
  */
 public class RecursiveTypesResolveTest extends TestCase {
 
+  @SuppressWarnings("unused")
   private static class Foo1<A> {
-    public Foo2<? extends A> foo2;
+	public Foo2<? extends A> foo2;
   }
-
+  @SuppressWarnings("unused")
   private static class Foo2<B> {
     public Foo1<? super B> foo1;
   }
@@ -93,10 +94,12 @@ public class RecursiveTypesResolveTest extends TestCase {
    * Tests for recursion while resolving type variables.
    */
 
+  @SuppressWarnings("unused")
   private static class TestType<X> {
     TestType<? super X> superType;
   }
 
+  @SuppressWarnings("unused")
   private static class TestType2<X, Y> {
     TestType2<? super Y, ? super X> superReversedType;
   }
@@ -111,6 +114,3 @@ public class RecursiveTypesResolveTest extends TestCase {
     assertNotNull(adapter);
   }
 }
-
-
-

--- a/gson/src/test/java/com/google/gson/regression/JsonAdapterNullSafeTest.java
+++ b/gson/src/test/java/com/google/gson/regression/JsonAdapterNullSafeTest.java
@@ -48,14 +48,13 @@ public class JsonAdapterNullSafeTest extends TestCase {
       // because we use it to return a null type adapter on a recursive call.
       private static final ThreadLocal<Boolean> recursiveCall = new ThreadLocal<Boolean>();
 
-      @SuppressWarnings({"unchecked", "rawtypes"})
       @Override public <T> TypeAdapter<T> create(final Gson gson, TypeToken<T> type) {
         if (type.getRawType() != Device.class || recursiveCall.get() != null) {
           recursiveCall.set(null); // clear for subsequent use
           return null;
         }
         recursiveCall.set(Boolean.TRUE);
-        return (TypeAdapter) gson.getDelegateAdapter(this, type);
+        return gson.getDelegateAdapter(this, type);
       }
     }
   }

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderPathTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderPathTest.java
@@ -27,9 +27,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeTrue;
 
+@SuppressWarnings("resource")
 @RunWith(Parameterized.class)
 public class JsonReaderPathTest {
   @Parameterized.Parameters(name = "{0}")

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -189,6 +189,7 @@ public final class JsonReaderTest extends TestCase {
     }
   }
   
+  @SuppressWarnings("unused")
   public void testNulls() {
     try {
       new JsonReader(null);

--- a/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
@@ -198,17 +198,17 @@ public final class JsonWriterTest extends TestCase {
     JsonWriter jsonWriter = new JsonWriter(stringWriter);
     jsonWriter.beginArray();
     try {
-      jsonWriter.value(new Double(Double.NaN));
+      jsonWriter.value(Double.valueOf(Double.NaN));
       fail();
     } catch (IllegalArgumentException expected) {
     }
     try {
-      jsonWriter.value(new Double(Double.NEGATIVE_INFINITY));
+      jsonWriter.value(Double.valueOf(Double.NEGATIVE_INFINITY));
       fail();
     } catch (IllegalArgumentException expected) {
     }
     try {
-      jsonWriter.value(new Double(Double.POSITIVE_INFINITY));
+      jsonWriter.value(Double.valueOf(Double.POSITIVE_INFINITY));
       fail();
     } catch (IllegalArgumentException expected) {
     }


### PR DESCRIPTION
- Add some SuppressWarnings("unused") to some fields & classes that are used in reflection code.
- Replace MoreAsserts.assertEquals with Assert.assertArrayEquals.
- Replace primitive wrapper constructor calls with autoboxing or explicit valueOf calls. (Wrapper class constructors deprecated after j9)
- Fix wrong assert imports in MoreAsserts & JsonReaderPathTest.
- Noticed that one of the test methods are failing when using newer java versions in DefaultDateTypeAdapterTest.java, there's already a pr for that: #1454
- Was thinking about refactoring all the test methods to use the Junit4 @Test annotations instead of using the TestCase class