### PR TITLE
Update sample ProGuard config to mark fields instead of all members.

### DIFF
--- a/examples/android-proguard-example/proguard.cfg
+++ b/examples/android-proguard-example/proguard.cfg
@@ -11,7 +11,7 @@
 #-keep class com.google.gson.stream.** { *; }
 
 # Application classes that will be serialized/deserialized over Gson
--keep class com.google.gson.examples.android.model.** { *; }
+-keep class com.google.gson.examples.android.model.** { <fields>; }
 
 # Prevent proguard from stripping interface information from TypeAdapterFactory,
 # JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)


### PR DESCRIPTION
GSON only needs to reflect based on fields:
https://github.com/google/gson/blob/4d942db168c593ba86e46e2b26b026ff2b0d1018/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java#L152

There's no reason to disallow optimizing methods.