### PR TITLE
Refactor CostructorConstructor to be stateless

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -35,7 +35,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongArray;
 
-import com.google.gson.internal.ConstructorConstructor;
 import com.google.gson.internal.Excluder;
 import com.google.gson.internal.GsonBuildConfig;
 import com.google.gson.internal.Primitives;
@@ -126,7 +125,6 @@ public final class Gson {
 
   private final Map<TypeToken<?>, TypeAdapter<?>> typeTokenCache = new ConcurrentHashMap<TypeToken<?>, TypeAdapter<?>>();
 
-  private final ConstructorConstructor constructorConstructor;
   private final JsonAdapterAnnotationTypeAdapterFactory jsonAdapterFactory;
 
   final List<TypeAdapterFactory> factories;
@@ -203,7 +201,6 @@ public final class Gson {
     this.excluder = excluder;
     this.fieldNamingStrategy = fieldNamingStrategy;
     this.instanceCreators = instanceCreators;
-    this.constructorConstructor = new ConstructorConstructor(instanceCreators);
     this.serializeNulls = serializeNulls;
     this.complexMapKeySerialization = complexMapKeySerialization;
     this.generateNonExecutableJson = generateNonExecutableGson;
@@ -269,13 +266,13 @@ public final class Gson {
     factories.add(TypeAdapters.CLASS_FACTORY);
 
     // type adapters for composite and user-defined types
-    factories.add(new CollectionTypeAdapterFactory(constructorConstructor));
-    factories.add(new MapTypeAdapterFactory(constructorConstructor, complexMapKeySerialization));
-    this.jsonAdapterFactory = new JsonAdapterAnnotationTypeAdapterFactory(constructorConstructor);
+    factories.add(new CollectionTypeAdapterFactory(instanceCreators));
+    factories.add(new MapTypeAdapterFactory(instanceCreators, complexMapKeySerialization));
+    this.jsonAdapterFactory = new JsonAdapterAnnotationTypeAdapterFactory(instanceCreators);
     factories.add(jsonAdapterFactory);
     factories.add(TypeAdapters.ENUM_FACTORY);
     factories.add(new ReflectiveTypeAdapterFactory(
-        constructorConstructor, fieldNamingStrategy, excluder, jsonAdapterFactory));
+        instanceCreators, fieldNamingStrategy, excluder, jsonAdapterFactory));
 
     this.factories = Collections.unmodifiableList(factories);
   }
@@ -1033,7 +1030,7 @@ public final class Gson {
     return new StringBuilder("{serializeNulls:")
         .append(serializeNulls)
         .append(",factories:").append(factories)
-        .append(",instanceCreators:").append(constructorConstructor)
+        .append(",instanceCreators:").append(instanceCreators)
         .append("}")
         .toString();
   }

--- a/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
+++ b/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
@@ -47,14 +47,8 @@ import com.google.gson.reflect.TypeToken;
  * Returns a function that can construct an instance of a requested type.
  */
 public final class ConstructorConstructor {
-  private final Map<Type, InstanceCreator<?>> instanceCreators;
-  private final ReflectionAccessor accessor = ReflectionAccessor.getInstance();
 
-  public ConstructorConstructor(Map<Type, InstanceCreator<?>> instanceCreators) {
-    this.instanceCreators = instanceCreators;
-  }
-
-  public <T> ObjectConstructor<T> get(TypeToken<T> typeToken) {
+  public static <T> ObjectConstructor<T> get(TypeToken<T> typeToken, Map<Type, InstanceCreator<?>> instanceCreators) {
     final Type type = typeToken.getType();
     final Class<? super T> rawType = typeToken.getRawType();
 
@@ -96,11 +90,11 @@ public final class ConstructorConstructor {
     return newUnsafeAllocator(type, rawType);
   }
 
-  private <T> ObjectConstructor<T> newDefaultConstructor(Class<? super T> rawType) {
+  private static <T> ObjectConstructor<T> newDefaultConstructor(Class<? super T> rawType) {
     try {
       final Constructor<? super T> constructor = rawType.getDeclaredConstructor();
       if (!constructor.isAccessible()) {
-        accessor.makeAccessible(constructor);
+        ReflectionAccessor.getInstance().makeAccessible(constructor);
       }
       return new ObjectConstructor<T>() {
         @SuppressWarnings("unchecked") // T is the same raw type as is requested
@@ -131,7 +125,7 @@ public final class ConstructorConstructor {
    * subtypes.
    */
   @SuppressWarnings("unchecked") // use runtime checks to guarantee that 'T' is what it is
-  private <T> ObjectConstructor<T> newDefaultImplementationConstructor(
+  private static <T> ObjectConstructor<T> newDefaultImplementationConstructor(
       final Type type, Class<? super T> rawType) {
     if (Collection.class.isAssignableFrom(rawType)) {
       if (SortedSet.class.isAssignableFrom(rawType)) {
@@ -215,7 +209,7 @@ public final class ConstructorConstructor {
     return null;
   }
 
-  private <T> ObjectConstructor<T> newUnsafeAllocator(
+  private static <T> ObjectConstructor<T> newUnsafeAllocator(
       final Type type, final Class<? super T> rawType) {
     return new ObjectConstructor<T>() {
       private final UnsafeAllocator unsafeAllocator = UnsafeAllocator.create();
@@ -230,9 +224,5 @@ public final class ConstructorConstructor {
         }
       }
     };
-  }
-
-  @Override public String toString() {
-    return instanceCreators.toString();
   }
 }

--- a/gson/src/main/java/com/google/gson/internal/bind/CollectionTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/CollectionTypeAdapterFactory.java
@@ -17,6 +17,7 @@
 package com.google.gson.internal.bind;
 
 import com.google.gson.Gson;
+import com.google.gson.InstanceCreator;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
 import com.google.gson.internal.$Gson$Types;
@@ -29,15 +30,16 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * Adapt a homogeneous collection of objects.
  */
 public final class CollectionTypeAdapterFactory implements TypeAdapterFactory {
-  private final ConstructorConstructor constructorConstructor;
+  private final Map<Type, InstanceCreator<?>> instanceCreators;
 
-  public CollectionTypeAdapterFactory(ConstructorConstructor constructorConstructor) {
-    this.constructorConstructor = constructorConstructor;
+  public CollectionTypeAdapterFactory(Map<Type, InstanceCreator<?>> instanceCreators) {
+    this.instanceCreators = instanceCreators;
   }
 
   @Override
@@ -51,7 +53,7 @@ public final class CollectionTypeAdapterFactory implements TypeAdapterFactory {
 
     Type elementType = $Gson$Types.getCollectionElementType(type, rawType);
     TypeAdapter<?> elementTypeAdapter = gson.getAdapter(TypeToken.get(elementType));
-    ObjectConstructor<T> constructor = constructorConstructor.get(typeToken);
+    ObjectConstructor<T> constructor = ConstructorConstructor.get(typeToken, instanceCreators);
 
     @SuppressWarnings({"unchecked", "rawtypes"}) // create() doesn't define a type parameter
     TypeAdapter<T> result = new Adapter(gson, elementType, elementTypeAdapter, constructor);

--- a/gson/src/main/java/com/google/gson/internal/bind/JsonAdapterAnnotationTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonAdapterAnnotationTypeAdapterFactory.java
@@ -17,6 +17,7 @@
 package com.google.gson.internal.bind;
 
 import com.google.gson.Gson;
+import com.google.gson.InstanceCreator;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonSerializer;
 import com.google.gson.TypeAdapter;
@@ -24,6 +25,8 @@ import com.google.gson.TypeAdapterFactory;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.internal.ConstructorConstructor;
 import com.google.gson.reflect.TypeToken;
+import java.lang.reflect.Type;
+import java.util.Map;
 
 /**
  * Given a type T, looks for the annotation {@link JsonAdapter} and uses an instance of the
@@ -32,10 +35,10 @@ import com.google.gson.reflect.TypeToken;
  * @since 2.3
  */
 public final class JsonAdapterAnnotationTypeAdapterFactory implements TypeAdapterFactory {
-  private final ConstructorConstructor constructorConstructor;
+  private final Map<Type, InstanceCreator<?>> instanceCreators;
 
-  public JsonAdapterAnnotationTypeAdapterFactory(ConstructorConstructor constructorConstructor) {
-    this.constructorConstructor = constructorConstructor;
+  public JsonAdapterAnnotationTypeAdapterFactory(Map<Type, InstanceCreator<?>> instanceCreators) {
+    this.instanceCreators = instanceCreators;
   }
 
   @SuppressWarnings("unchecked")
@@ -46,13 +49,12 @@ public final class JsonAdapterAnnotationTypeAdapterFactory implements TypeAdapte
     if (annotation == null) {
       return null;
     }
-    return (TypeAdapter<T>) getTypeAdapter(constructorConstructor, gson, targetType, annotation);
+    return (TypeAdapter<T>) getTypeAdapter(gson, targetType, annotation);
   }
 
   @SuppressWarnings({ "unchecked", "rawtypes" }) // Casts guarded by conditionals.
-  TypeAdapter<?> getTypeAdapter(ConstructorConstructor constructorConstructor, Gson gson,
-      TypeToken<?> type, JsonAdapter annotation) {
-    Object instance = constructorConstructor.get(TypeToken.get(annotation.value())).construct();
+  TypeAdapter<?> getTypeAdapter(Gson gson, TypeToken<?> type, JsonAdapter annotation) {
+    Object instance = ConstructorConstructor.get(TypeToken.get(annotation.value()), instanceCreators).construct();
 
     TypeAdapter<?> typeAdapter;
     if (instance instanceof TypeAdapter) {

--- a/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
@@ -17,6 +17,7 @@
 package com.google.gson.internal.bind;
 
 import com.google.gson.Gson;
+import com.google.gson.InstanceCreator;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSyntaxException;
@@ -103,12 +104,12 @@ import java.util.Map;
  * is registered.
  */
 public final class MapTypeAdapterFactory implements TypeAdapterFactory {
-  private final ConstructorConstructor constructorConstructor;
+  private final Map<Type, InstanceCreator<?>> instanceCreators;
   final boolean complexMapKeySerialization;
 
-  public MapTypeAdapterFactory(ConstructorConstructor constructorConstructor,
+  public MapTypeAdapterFactory(Map<Type, InstanceCreator<?>> instanceCreators,
       boolean complexMapKeySerialization) {
-    this.constructorConstructor = constructorConstructor;
+    this.instanceCreators = instanceCreators;
     this.complexMapKeySerialization = complexMapKeySerialization;
   }
 
@@ -124,7 +125,7 @@ public final class MapTypeAdapterFactory implements TypeAdapterFactory {
     Type[] keyAndValueTypes = $Gson$Types.getMapKeyAndValueTypes(type, rawTypeOfSrc);
     TypeAdapter<?> keyAdapter = getKeyAdapter(gson, keyAndValueTypes[0]);
     TypeAdapter<?> valueAdapter = gson.getAdapter(TypeToken.get(keyAndValueTypes[1]));
-    ObjectConstructor<T> constructor = constructorConstructor.get(typeToken);
+    ObjectConstructor<T> constructor = ConstructorConstructor.get(typeToken, instanceCreators);
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     // we don't define a type parameter for the key or value types


### PR DESCRIPTION
- Remove ConstructorConstructor.java constructor, make all methods static
- Remove CostructorConstructor field from gson, pass the instanceCreator map to adapters
- Remove ReflectionAccessor fields, no need to store them in fields, avoids loading some classes when not used(Reflection classes)