### PR TITLE
Keep `TypeAdapter`s from being stripped

### DIFF
--- a/examples/android-proguard-example/proguard.cfg
+++ b/examples/android-proguard-example/proguard.cfg
@@ -13,8 +13,9 @@
 # Application classes that will be serialized/deserialized over Gson
 -keep class com.google.gson.examples.android.model.** { <fields>; }
 
-# Prevent proguard from stripping interface information from TypeAdapterFactory,
+# Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
 # JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)
+-keep class * implements com.google.gson.TypeAdapter
 -keep class * implements com.google.gson.TypeAdapterFactory
 -keep class * implements com.google.gson.JsonSerializer
 -keep class * implements com.google.gson.JsonDeserializer


### PR DESCRIPTION
`TypeAdapter` implementations used in JsonAdapter annotation sometimes are never instantiated explicitly without reflection, causing R8 to strip their instance methods.