### PR TITLE
JsonReader nextFloat support

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
@@ -220,7 +220,24 @@ public final class JsonTreeReader extends JsonReader {
     }
     return result;
   }
-
+    
+  @Override public float nextFloat() throws IOException {
+    JsonToken token = peek();
+    if (token != JsonToken.NUMBER && token != JsonToken.STRING) {
+      throw new IllegalStateException(
+          "Expected " + JsonToken.NUMBER + " but was " + token + locationString());
+    }
+    float result = ((JsonPrimitive) peekStack()).getAsFloat();
+    if (!isLenient() && (Float.isNaN(result) || Float.isInfinite(result))) {
+      throw new NumberFormatException("JSON forbids NaN and infinities: " + result);
+    }
+    popStack();
+    if (stackSize > 0) {
+      pathIndices[stackSize - 1]++;
+    }
+    return result;
+  }
+  
   @Override public long nextLong() throws IOException {
     JsonToken token = peek();
     if (token != JsonToken.NUMBER && token != JsonToken.STRING) {

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -925,7 +925,7 @@ public class JsonReader implements Closeable {
    *
    * @throws IllegalStateException if the next token is not a literal value.
    * @throws NumberFormatException if the next literal value cannot be parsed
-   *     as a double, or is non-finite.
+   *     as a float, or is non-finite.
    */
   public float nextFloat() throws IOException {
     int p = peeked;

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonElementReaderTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonElementReaderTest.java
@@ -85,9 +85,6 @@ public final class JsonElementReaderTest extends TestCase {
   }
   
   public void testStrictNansAndInfinitiesFloat() throws IOException {
-      System.out.println("Float.NaN = " + Float.NaN);
-      System.out.println("Float.NEGATIVE_INFINITY = " + Float.NEGATIVE_INFINITY);
-      System.out.println("Float.POSITIVE_INFINITY = " + Float.POSITIVE_INFINITY);
     JsonElement element = JsonParser.parseString("[NaN, -Infinity, Infinity]");
     JsonTreeReader reader = new JsonTreeReader(element);
     reader.setLenient(false);

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonElementReaderTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonElementReaderTest.java
@@ -26,12 +26,13 @@ import junit.framework.TestCase;
 public final class JsonElementReaderTest extends TestCase {
 
   public void testNumbers() throws IOException {
-    JsonElement element = JsonParser.parseString("[1, 2, 3]");
+    JsonElement element = JsonParser.parseString("[1, 2, 3, 4]");
     JsonTreeReader reader = new JsonTreeReader(element);
     reader.beginArray();
     assertEquals(1, reader.nextInt());
     assertEquals(2L, reader.nextLong());
     assertEquals(3.0, reader.nextDouble());
+    assertEquals(4.0f, reader.nextFloat());
     reader.endArray();
   }
 
@@ -43,6 +44,17 @@ public final class JsonElementReaderTest extends TestCase {
     assertTrue(Double.isNaN(reader.nextDouble()));
     assertEquals(Double.NEGATIVE_INFINITY, reader.nextDouble());
     assertEquals(Double.POSITIVE_INFINITY, reader.nextDouble());
+    reader.endArray();
+  }
+  
+  public void testLenientNansAndInfinitiesFloat() throws IOException {
+    JsonElement element = JsonParser.parseString("[NaN, -Infinity, Infinity]");
+    JsonTreeReader reader = new JsonTreeReader(element);
+    reader.setLenient(true);
+    reader.beginArray();
+    assertTrue(Float.isNaN(reader.nextFloat()));
+    assertEquals(Float.NEGATIVE_INFINITY, reader.nextFloat());
+    assertEquals(Float.POSITIVE_INFINITY, reader.nextFloat());
     reader.endArray();
   }
 
@@ -71,14 +83,44 @@ public final class JsonElementReaderTest extends TestCase {
     assertEquals("Infinity", reader.nextString());
     reader.endArray();
   }
+  
+  public void testStrictNansAndInfinitiesFloat() throws IOException {
+      System.out.println("Float.NaN = " + Float.NaN);
+      System.out.println("Float.NEGATIVE_INFINITY = " + Float.NEGATIVE_INFINITY);
+      System.out.println("Float.POSITIVE_INFINITY = " + Float.POSITIVE_INFINITY);
+    JsonElement element = JsonParser.parseString("[NaN, -Infinity, Infinity]");
+    JsonTreeReader reader = new JsonTreeReader(element);
+    reader.setLenient(false);
+    reader.beginArray();
+    try {
+      reader.nextFloat();
+      fail();
+    } catch (NumberFormatException e) {
+    }
+    assertEquals("NaN", reader.nextString());
+    try {
+      reader.nextFloat();
+      fail();
+    } catch (NumberFormatException e) {
+    }
+    assertEquals("-Infinity", reader.nextString());
+    try {
+      reader.nextFloat();
+      fail();
+    } catch (NumberFormatException e) {
+    }
+    assertEquals("Infinity", reader.nextString());
+    reader.endArray();
+  }
 
   public void testNumbersFromStrings() throws IOException {
-    JsonElement element = JsonParser.parseString("[\"1\", \"2\", \"3\"]");
+    JsonElement element = JsonParser.parseString("[\"1\", \"2\", \"3\", \"4\"]");
     JsonTreeReader reader = new JsonTreeReader(element);
     reader.beginArray();
     assertEquals(1, reader.nextInt());
     assertEquals(2L, reader.nextLong());
     assertEquals(3.0, reader.nextDouble());
+    assertEquals(4.0f, reader.nextFloat());
     reader.endArray();
   }
 
@@ -242,6 +284,11 @@ public final class JsonElementReaderTest extends TestCase {
     } catch (IllegalStateException expected) {
     }
     try {
+      reader.nextFloat();
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+    try {
       reader.nextName();
       fail();
     } catch (IllegalStateException expected) {
@@ -286,6 +333,11 @@ public final class JsonElementReaderTest extends TestCase {
     }
     try {
       reader.nextDouble();
+      fail();
+    } catch (NumberFormatException expected) {
+    }
+    try {
+      reader.nextFloat();
       fail();
     } catch (NumberFormatException expected) {
     }

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -332,7 +332,6 @@ public final class JsonReaderTest extends TestCase {
         + "-0.5,"
         + "3.141592653589793,"
         + "2.718281828459045]";
-      System.out.println("json = " + json);
     JsonReader reader = new JsonReader(reader(json));
     reader.beginArray();
     assertEquals(-0.0F, reader.nextFloat());

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -290,11 +290,12 @@ public final class JsonReaderTest extends TestCase {
   }
 
   public void testIntegersWithFractionalPartSpecified() throws IOException {
-    JsonReader reader = new JsonReader(reader("[1.0,1.0,1.0]"));
+    JsonReader reader = new JsonReader(reader("[1.0,1.0,1.0,1.0]"));
     reader.beginArray();
     assertEquals(1.0, reader.nextDouble());
     assertEquals(1, reader.nextInt());
     assertEquals(1L, reader.nextLong());
+    assertEquals(1F, reader.nextFloat());
   }
 
   public void testDoubles() throws IOException {
@@ -321,6 +322,30 @@ public final class JsonReaderTest extends TestCase {
     reader.endArray();
     assertEquals(JsonToken.END_DOCUMENT, reader.peek());
   }
+  
+  public void testFloats() throws IOException {
+    String json = "[-0.0,"
+        + "1.0,"
+        + "3.4028235E38,"
+        + "1.4E-45,"
+        + "0.0,"
+        + "-0.5,"
+        + "3.141592653589793,"
+        + "2.718281828459045]";
+      System.out.println("json = " + json);
+    JsonReader reader = new JsonReader(reader(json));
+    reader.beginArray();
+    assertEquals(-0.0F, reader.nextFloat());
+    assertEquals(1.0F, reader.nextFloat());
+    assertEquals(3.4028235E38F, reader.nextFloat());
+    assertEquals(1.4E-45F, reader.nextFloat());
+    assertEquals(0.0F, reader.nextFloat());
+    assertEquals(-0.5F, reader.nextFloat());
+    assertEquals(3.141592653589793F, reader.nextFloat());
+    assertEquals(2.718281828459045F, reader.nextFloat());
+    reader.endArray();
+    assertEquals(JsonToken.END_DOCUMENT, reader.peek());
+  }
 
   public void testStrictNonFiniteDoubles() throws IOException {
     String json = "[NaN]";
@@ -328,6 +353,17 @@ public final class JsonReaderTest extends TestCase {
     reader.beginArray();
     try {
       reader.nextDouble();
+      fail();
+    } catch (MalformedJsonException expected) {
+    }
+  }
+  
+  public void testStrictNonFiniteFloats() throws IOException {
+    String json = "[NaN]";
+    JsonReader reader = new JsonReader(reader(json));
+    reader.beginArray();
+    try {
+      reader.nextFloat();
       fail();
     } catch (MalformedJsonException expected) {
     }
@@ -343,6 +379,17 @@ public final class JsonReaderTest extends TestCase {
     } catch (MalformedJsonException expected) {
     }
   }
+  
+  public void testStrictQuotedNonFiniteFloats() throws IOException {
+    String json = "[\"NaN\"]";
+    JsonReader reader = new JsonReader(reader(json));
+    reader.beginArray();
+    try {
+      reader.nextFloat();
+      fail();
+    } catch (MalformedJsonException expected) {
+    }
+  }
 
   public void testLenientNonFiniteDoubles() throws IOException {
     String json = "[NaN, -Infinity, Infinity]";
@@ -354,6 +401,17 @@ public final class JsonReaderTest extends TestCase {
     assertEquals(Double.POSITIVE_INFINITY, reader.nextDouble());
     reader.endArray();
   }
+  
+  public void testLenientNonFiniteFloats() throws IOException {
+    String json = "[NaN, -Infinity, Infinity]";
+    JsonReader reader = new JsonReader(reader(json));
+    reader.setLenient(true);
+    reader.beginArray();
+    assertTrue(Float.isNaN(reader.nextFloat()));
+    assertEquals(Float.NEGATIVE_INFINITY, reader.nextFloat());
+    assertEquals(Float.POSITIVE_INFINITY, reader.nextFloat());
+    reader.endArray();
+  }
 
   public void testLenientQuotedNonFiniteDoubles() throws IOException {
     String json = "[\"NaN\", \"-Infinity\", \"Infinity\"]";
@@ -363,6 +421,17 @@ public final class JsonReaderTest extends TestCase {
     assertTrue(Double.isNaN(reader.nextDouble()));
     assertEquals(Double.NEGATIVE_INFINITY, reader.nextDouble());
     assertEquals(Double.POSITIVE_INFINITY, reader.nextDouble());
+    reader.endArray();
+  }
+  
+  public void testLenientQuotedNonFiniteFloats() throws IOException {
+    String json = "[\"NaN\", \"-Infinity\", \"Infinity\"]";
+    JsonReader reader = new JsonReader(reader(json));
+    reader.setLenient(true);
+    reader.beginArray();
+    assertTrue(Float.isNaN(reader.nextFloat()));
+    assertEquals(Float.NEGATIVE_INFINITY, reader.nextFloat());
+    assertEquals(Float.POSITIVE_INFINITY, reader.nextFloat());
     reader.endArray();
   }
 


### PR DESCRIPTION
in order to slightly optimize the performance of GSON JsonReader, I have added nextFloat function to skip converting into a double