### PR TITLE
Implement JSOG protocol

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -700,6 +700,7 @@ public final class Gson {
     writer.setHtmlSafe(htmlSafe);
     boolean oldSerializeNulls = writer.getSerializeNulls();
     writer.setSerializeNulls(serializeNulls);
+    GsonLocal.Context oldGsonContext = GsonLocal.Context.start(this);
     try {
       ((TypeAdapter<Object>) adapter).write(writer, src);
     } catch (IOException e) {
@@ -709,6 +710,7 @@ public final class Gson {
       error.initCause(e);
       throw error;
     } finally {
+      GsonLocal.Context.set(oldGsonContext);
       writer.setLenient(oldLenient);
       writer.setHtmlSafe(oldHtmlSafe);
       writer.setSerializeNulls(oldSerializeNulls);
@@ -924,6 +926,7 @@ public final class Gson {
     boolean isEmpty = true;
     boolean oldLenient = reader.isLenient();
     reader.setLenient(true);
+    GsonLocal.Context oldGsonContext = GsonLocal.Context.start(this);
     try {
       reader.peek();
       isEmpty = false;
@@ -950,6 +953,7 @@ public final class Gson {
       error.initCause(e);
       throw error;
     } finally {
+      GsonLocal.Context.set(oldGsonContext);
       reader.setLenient(oldLenient);
     }
   }

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -147,6 +147,7 @@ public final class Gson {
   final LongSerializationPolicy longSerializationPolicy;
   final List<TypeAdapterFactory> builderFactories;
   final List<TypeAdapterFactory> builderHierarchyFactories;
+  final JsogPolicy jsogPolicy;
 
   /**
    * Constructs a Gson object with default configuration. The default configuration has the
@@ -189,7 +190,7 @@ public final class Gson {
         DEFAULT_PRETTY_PRINT, DEFAULT_LENIENT, DEFAULT_SPECIALIZE_FLOAT_VALUES,
         LongSerializationPolicy.DEFAULT, null, DateFormat.DEFAULT, DateFormat.DEFAULT,
         Collections.<TypeAdapterFactory>emptyList(), Collections.<TypeAdapterFactory>emptyList(),
-        Collections.<TypeAdapterFactory>emptyList());
+        Collections.<TypeAdapterFactory>emptyList(), JsogPolicy.DEFAULT);
   }
 
   Gson(Excluder excluder, FieldNamingStrategy fieldNamingStrategy,
@@ -199,7 +200,7 @@ public final class Gson {
       LongSerializationPolicy longSerializationPolicy, String datePattern, int dateStyle,
       int timeStyle, List<TypeAdapterFactory> builderFactories,
       List<TypeAdapterFactory> builderHierarchyFactories,
-      List<TypeAdapterFactory> factoriesToBeAdded) {
+      List<TypeAdapterFactory> factoriesToBeAdded, JsogPolicy jsogPolicy) {
     this.excluder = excluder;
     this.fieldNamingStrategy = fieldNamingStrategy;
     this.instanceCreators = instanceCreators;
@@ -217,6 +218,7 @@ public final class Gson {
     this.timeStyle = timeStyle;
     this.builderFactories = builderFactories;
     this.builderHierarchyFactories = builderHierarchyFactories;
+    this.jsogPolicy = jsogPolicy;
 
     List<TypeAdapterFactory> factories = new ArrayList<TypeAdapterFactory>();
 
@@ -275,7 +277,7 @@ public final class Gson {
     factories.add(jsonAdapterFactory);
     factories.add(TypeAdapters.ENUM_FACTORY);
     factories.add(new ReflectiveTypeAdapterFactory(
-        constructorConstructor, fieldNamingStrategy, excluder, jsonAdapterFactory));
+        constructorConstructor, fieldNamingStrategy, excluder, jsonAdapterFactory, jsogPolicy));
 
     this.factories = Collections.unmodifiableList(factories);
   }
@@ -304,6 +306,19 @@ public final class Gson {
 
   public boolean htmlSafe() {
     return htmlSafe;
+  }
+
+  /**
+   * Gets the JSOG policy applied to this instance.
+   *
+   * <p>This is used to decide on which classes JSOG is enabled, and what prefix
+   * (if any) should be assigned for instance IDs during serialization.</p>
+   *
+   * @return The current {@link JsogPolicy}
+   * @see <a href="https://github.com/jsog/jsog">JSOG</a>
+   */
+  public JsogPolicy getJsogPolicy() {
+    return jsogPolicy;
   }
 
   private TypeAdapter<Number> doubleAdapter(boolean serializeSpecialFloatingPointValues) {

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -94,7 +94,7 @@ public final class GsonBuilder {
   private boolean prettyPrinting = DEFAULT_PRETTY_PRINT;
   private boolean generateNonExecutableJson = DEFAULT_JSON_NON_EXECUTABLE;
   private boolean lenient = DEFAULT_LENIENT;
-
+  private JsogPolicy jsogPolicy = JsogPolicy.DEFAULT;
   /**
    * Creates a GsonBuilder instance that can be used to build Gson with various configuration
    * settings. GsonBuilder follows the builder pattern, and it is typically used by first
@@ -127,6 +127,7 @@ public final class GsonBuilder {
     this.timeStyle = gson.timeStyle;
     this.factories.addAll(gson.builderFactories);
     this.hierarchyFactories.addAll(gson.builderHierarchyFactories);
+    this.jsogPolicy = gson.jsogPolicy;
   }
 
   /**
@@ -477,6 +478,20 @@ public final class GsonBuilder {
   }
 
   /**
+   * Configures Gson to use the specified JSOG policy.
+   *
+   * <p>This is used to decide on which classes JSOG is enabled, and what prefix
+   * (if any) should be assigned for instance IDs during serialization.</p>
+   *
+   * @param jsogPolicy The {@link JsogPolicy} to use
+   * @see <a href="https://github.com/jsog/jsog">JSOG</a>
+   */
+  public GsonBuilder setJsogPolicy(JsogPolicy jsogPolicy) {
+    this.jsogPolicy = jsogPolicy;
+    return this;
+  }
+
+  /**
    * Configures Gson for custom serialization or deserialization. This method combines the
    * registration of an {@link TypeAdapter}, {@link InstanceCreator}, {@link JsonSerializer}, and a
    * {@link JsonDeserializer}. It is best used when a single object {@code typeAdapter} implements
@@ -599,7 +614,7 @@ public final class GsonBuilder {
         generateNonExecutableJson, escapeHtmlChars, prettyPrinting, lenient,
         serializeSpecialFloatingPointValues, longSerializationPolicy,
         datePattern, dateStyle, timeStyle,
-        this.factories, this.hierarchyFactories, factories);
+        this.factories, this.hierarchyFactories, factories, jsogPolicy);
   }
 
   @SuppressWarnings("unchecked")

--- a/gson/src/main/java/com/google/gson/GsonLocal.java
+++ b/gson/src/main/java/com/google/gson/GsonLocal.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2008 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gson;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+/**
+ * This class provides Gson-local variables.  These variables
+ * only exist during the execution of {@link com.google.gson.Gson#toJson},
+ * {@link com.google.gson.Gson#fromJson} and related methods.
+ *
+ * <p>This can be used as a shared storage for working with complex Json entities,
+ * where the stateless architecture of {@link com.google.gson.TypeAdapter} doesn't
+ * provide enough context.</p>
+ *
+ * <p>The API mimics that of {@link ThreadLocal}, except that all methods will throw
+ * {@link IllegalStateException} if not called from within a Gson operation.</p>
+ *
+ * @author Paulo Costa
+ */
+public class GsonLocal<T> {
+    /**
+     * Returns the value in this
+     * gson-local variable.  If the variable has no value for the
+     * current gson operation, it is first initialized to the
+     * value returned by an invocation of the {@link #initialValue} method.
+     *
+     * @return the current value of this gson-local
+     * @throws IllegalStateException if there is no ongoing Gson operation in the current thread
+     */
+    @SuppressWarnings("unchecked")
+    public T get() {
+        Context context = Context.get();
+        T value;
+        if (!context.states.containsKey(this)) {
+            value = initialValue();
+            context.states.put(this, value);
+        } else {
+            value = (T) context.states.get(this);
+        }
+        return value;
+    }
+
+    /**
+     * Sets the current value of this gson-local variable
+     * to the specified value.  Most subclasses will have no need to
+     * override this method, relying solely on the {@link #initialValue}
+     * method to set the values of gson-locals.
+     *
+     * @param value the value to be stored in the current gson-local storage.
+     * @throws IllegalStateException if there is no ongoing Gson operation in the current thread
+     */
+    public void set(T value) {
+        Context.get().states.put(this, value);
+    }
+
+    /**
+     * Removes the current value for this gson-local
+     * variable.  If this gson-local variable is subsequently
+     * {@linkplain #get read}, its value will be
+     * reinitialized by invoking its {@link #initialValue} method,
+     * unless its value is {@linkplain #set set}
+     * in the interim.  This may result in multiple invocations of the
+     * {@code initialValue} method.
+     *
+     * @throws IllegalStateException if there is no ongoing Gson operation in the current thread
+     */
+    public void remove() {
+        Context.get().states.remove(this);
+    }
+
+    /**
+     * Returns the "initial value" for this
+     * gson-local variable.  This method will be invoked the first
+     * time a the variable with the {@link #get}
+     * method from a gson-operation, unless the thread previously invoked the {@link #set}
+     * method, in which case the {@code initialValue} method will not
+     * be invoked for the gson operation.  Normally, this method is invoked at
+     * most once per operation, but it may be invoked again in case of
+     * subsequent invocations of {@link #remove} followed by {@link #get}.
+     *
+     * <p>This implementation simply returns {@code null}; if the
+     * programmer desires gson-local variables to have an initial
+     * value other than {@code null}, {@code GsonLocal} must be
+     * subclassed, and this method overridden.  Typically, an
+     * anonymous inner class will be used.
+     *
+     * @return the initial value for this gson-local
+     */
+    protected T initialValue() {
+        return null;
+    }
+
+    /**
+     * Return the Gson instance that started the current operation
+     * @return The current {@link Gson} instance
+     * @throws IllegalStateException if there is no ongoing Gson operation in the current thread
+     */
+    public static Gson gson() {
+        return Context.get().gson;
+    }
+
+    /**
+     * The Context stores information for all the GsonLocal variables.
+     *
+     * It is thread-local and set during a Gson operation.
+     */
+    /* package */ static class Context {
+        /** Stores each thread's Context */
+        private static ThreadLocal<Context> threadContext = new ThreadLocal<Context>();
+
+        /** Stores the state of each GsonLocal during the current operation */
+        Map<GsonLocal, Object> states = new IdentityHashMap<GsonLocal, Object>();
+
+        /** Gson instance where the current operation is taking place */
+        Gson gson;
+
+        private Context(Gson gson) {
+            this.gson = gson;
+        }
+
+        /**
+         * Creates a new context before a Gson operation.
+         *
+         * @return The previous context for this thread -- Likely null
+         */
+        public static Context start(Gson gson) {
+            Context oldContext = threadContext.get();
+            threadContext.set(new Context(gson));
+            return oldContext;
+        }
+
+        /**
+         * Sets the current context for this thread.
+         *
+         * Used to restore the previous context after a Gson operation is finished.
+         *
+         * @param oldContext The new context, possibly null.
+         */
+        public static void set(Context oldContext) {
+            if (oldContext == null) {
+                threadContext.remove();
+            } else {
+                threadContext.set(oldContext);
+            }
+        }
+
+        /**
+         * Gets the context for the curreny Gson operation.
+         *
+         * @return The context associated with the curreny Gson operation
+         * @throws IllegalStateException if there is no ongoing Gson operation in the current thread
+         */
+        public static Context get() throws IllegalStateException {
+            Context context = threadContext.get();
+            if (context == null) {
+                threadContext.remove();
+                throw new IllegalStateException("Not in a Gson operation");
+            }
+            return context;
+        }
+    }
+}

--- a/gson/src/main/java/com/google/gson/JsogPolicy.java
+++ b/gson/src/main/java/com/google/gson/JsogPolicy.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2008 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson;
+
+import com.google.gson.annotations.JsogEnabled;
+import com.google.gson.internal.bind.JsogRegistry;
+import com.google.gson.reflect.TypeToken;
+
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * The JSOG policy decides on which classes JSOG is enabled, and what prefix
+ * (if any) should be assigned for instance IDs during serialization.
+ *
+ * @see JsogRegistry
+ * @see <a href="https://github.com/jsog/jsog">JSOG</a>
+ * @author Paulo Costa
+ */
+public class JsogPolicy {
+
+  /** A vanilla JsogPolicy instance */
+  public static JsogPolicy DEFAULT = new JsogPolicy();
+
+  /**
+   * Checks whenever Gson should use JSOG on objects of this type
+   *
+   * <p>The default implementation will check for the presence of @{@link JsogEnabled}
+   * annotation.</p>
+   *
+   * @param type Type being checked
+   * @return if JSOG should be enabled for this type
+   * @see #withWhitelist(Type...)
+   * @see #withBlacklist(Type...)
+   */
+  public boolean isJsogEnabled(TypeToken type) {
+    JsogEnabled annotation = (JsogEnabled)type.getRawType().getAnnotation(JsogEnabled.class);
+    if (annotation != null) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * This can be used to assign meaningful JSOG IDs to instances during serialization.
+   *
+   * <p>If it returns null, IDs will be simple sequential numbers, "1", "2", "3", etc.</p>
+   *
+   * <p>Otherwise the id will be generated from the given prefix + sequential number. E.g.:
+   * "Person-1", "Dog-1", "Person-2", "Cat-1", "Person-3".</p>
+   *
+   * <p>Suggested uses are class names (e.g., "Person-1") or existing identifiers (e.g., "JohnSmith-1")</p>
+   *
+   * @param instance
+   * @return A prefix that should be added to the instance's JSOG id
+   * @see #withTypePrefix()
+   */
+  public String getIdPrefix(Object instance) {
+    return null;
+  }
+
+  /**
+   * Creates a new JsogPolicy that enables JSOG for the specified types.
+   *
+   * <p>Other than that, it behaves exactly like this instace.</p>
+   *
+   * @param types Types where JSOG should be enabled
+   * @return a {@link JsogPolicy} with JSOG enabled for the specified types
+   */
+  public JsogPolicy withWhitelist(Type... types) {
+    final Set<Type> typeSet = new HashSet(Arrays.asList(types));
+    return new Wrapper(this) {
+      @Override
+      public boolean isJsogEnabled(TypeToken type) {
+        if (typeSet.contains(type.getType()) || typeSet.contains(type.getRawType())) {
+          return true;
+        }
+        return super.isJsogEnabled(type);
+      }
+    };
+  }
+
+  /**
+   * Creates a new JsogPolicy that disables JSOG for the specified types.
+   *
+   * <p>Other than that, it behaves exactly like this instace.</p>
+   *
+   * @param types Types where JSOG should be disabled
+   * @return a {@link JsogPolicy} with JSOG disabled for the specified types
+   */
+  public JsogPolicy withBlacklist(Type... types) {
+    final Set<Type> typeSet = new HashSet(Arrays.asList(types));
+    return new Wrapper(this) {
+      @Override
+      public boolean isJsogEnabled(TypeToken type) {
+        if (typeSet.contains(type.getType()) || typeSet.contains(type.getRawType())) {
+          return false;
+        }
+        return super.isJsogEnabled(type);
+      }
+    };
+  }
+
+
+  /**
+   * Creates a new JsogPolicy that prefixes IDs with the class name.
+   *
+   * <p>Examples: "Person-1", "Student-1", "Person-2", "OuterClass.Innerclass-1"</p>
+   *
+   * <p>Other than that, it behaves exactly like this instace.</p>
+   *
+   * @return a {@link JsogPolicy} which prefixes JSOG ids with the class name
+   */
+  public JsogPolicy withTypePrefix() {
+    return new Wrapper(this) {
+      @Override
+      public String getIdPrefix(Object instance) {
+        String prefix = instance.getClass().getName();
+        int indexOfLastDot = prefix.lastIndexOf(".");
+        if (indexOfLastDot != -1) {
+          prefix = prefix.substring(indexOfLastDot + 1);
+        }
+        prefix = prefix.replaceAll("\\$", ".");
+        return prefix;
+      }
+    };
+  }
+
+  /**
+   * Creates a new JsogPolicy that enabled GSOG for all data types
+   *
+   * <p>Other than that, it behaves exactly like this instace.</p>
+   *
+   * @return a {@link JsogPolicy} that enables JSOG on all data types
+   */
+  public JsogPolicy withJsogAlwaysEnabled() {
+    return new Wrapper(this) {
+      @Override
+      public boolean isJsogEnabled(TypeToken type) {
+        return true;
+      }
+    };
+  }
+
+  /**
+   * Helper class that allows easily tweaking an existing JsogPolicy by
+   * overriding the target methods
+   */
+  private class Wrapper extends JsogPolicy {
+    private final JsogPolicy wrapped;
+
+    public Wrapper(JsogPolicy wrapped) {
+      this.wrapped = wrapped;
+    }
+
+    @Override
+    public boolean isJsogEnabled(TypeToken type) {
+      return wrapped.isJsogEnabled(type);
+    }
+
+    @Override
+    public String getIdPrefix(Object instance) {
+      return wrapped.getIdPrefix(instance);
+    }
+  }
+}

--- a/gson/src/main/java/com/google/gson/JsogPolicy.java
+++ b/gson/src/main/java/com/google/gson/JsogPolicy.java
@@ -144,7 +144,7 @@ public class JsogPolicy {
   }
 
   /**
-   * Creates a new JsogPolicy that enabled GSOG for all data types
+   * Creates a new JsogPolicy that enabled JSOG for all data types
    *
    * <p>Other than that, it behaves exactly like this instace.</p>
    *

--- a/gson/src/main/java/com/google/gson/annotations/JsogEnabled.java
+++ b/gson/src/main/java/com/google/gson/annotations/JsogEnabled.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson.annotations;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.internal.bind.JsogRegistry;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation that indicates the Gson should use <a href="https://github.com/jsog/jsog">JSOG</a>
+ * to solve circular / redundant references to objects of this class.
+ *
+ *<p>If your type requires a custom {@link TypeAdapter}s, ensure that it uses
+ * {@link JsogRegistry} to support JSOG IDs and references.</p>
+ *
+ * @author Paulo Costa
+ * @see <a href="https://github.com/jsog/jsog">JSOG</a>
+ * @see JsogRegistry
+ * @see com.google.gson.JsogPolicy
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface JsogEnabled {
+}

--- a/gson/src/main/java/com/google/gson/internal/bind/JsogRegistry.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsogRegistry.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2008 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson.internal.bind;
+
+import com.google.gson.GsonLocal;
+import com.google.gson.JsogPolicy;
+
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+/**
+ * This helper class acts as a registry for JSOG instances during serialization and deserialization.
+ *
+ * <p>You should use this in any {@link com.google.gson.TypeAdapter} subclass that supports JSOG</p>
+ *
+ * @see JsogPolicy
+ * @see <a href="https://github.com/jsog/jsog">JSOG</a>
+ * @author Paulo Costa
+ */
+public class JsogRegistry {
+    /** Field name where JSOG instance id is stored */
+    public static final String JSOG_FIELD_ID = "@id";
+
+    /** Field name where JSOG reference id is stored */
+    public static final String JSOG_FIELD_REF = "@ref";
+
+    /**
+     * A {@link GsonLocal} is used to bind a different instance to
+     * each serialization / deserialization
+     */
+    private static GsonLocal<JsogRegistry> currentRegistry = new GsonLocal<JsogRegistry>() {
+        @Override
+        protected JsogRegistry initialValue() {
+            return new JsogRegistry();
+        }
+    };
+
+    /** JSOG policy associated with the current {@link com.google.gson.Gson instance */
+    private JsogPolicy jsogPolicy = GsonLocal.gson().getJsogPolicy();
+    /** Maps ids to instances */
+    private Map<String, Object> idToInstance = new HashMap<String, Object>();
+    /** Mapps instances to ids */
+    private Map<Object, String> instanceToId = new IdentityHashMap<Object, String>();
+    /** The next JSOG id that should be assigned to each prefix */
+    private Map<String, Integer> nextIdByPrefix = new HashMap<String, Integer>();
+
+    /** Cannot get an instance directly, only via {@link #get()} */
+    private JsogRegistry() {}
+
+    /**
+     * Returns the JSOG registry associated with the current serialization / deserialization.
+     */
+    public static JsogRegistry get() {
+        return currentRegistry.get();
+    }
+
+    /**
+     * Returns the JSOG id associated with this instance, or null
+     * if the instance has not been registered
+     */
+    public String geId(Object instance) {
+        return instanceToId.get(instance);
+    }
+
+    /**
+     * Returns the instance associated with the given JSOG id, or null
+     * if the id has not been registered
+     */
+    public Object getInstance(String id) {
+        return idToInstance.get(id);
+    }
+
+    /**
+     * Register an instance with an auto-generated id
+     *
+     * @param instance Instance being registered
+     * @return The JSOG id associated with the instance
+     * @throws IllegalStateException If the object has already been registered
+     * @see JsogPolicy#getIdPrefix(Object)
+     */
+    public String register(Object instance) {
+        String prefix = jsogPolicy.getIdPrefix(instance);
+        if (prefix == null) {
+            prefix = "";
+        } else {
+            prefix += "-";
+        }
+
+        Integer id = nextIdByPrefix.get(prefix);
+        if (id == null) {
+            id = 1;
+        }
+
+        // Ensure automatic IDs don't conflict with manually-registered IDs
+        while (idToInstance.containsKey(prefix + id)) {
+            id++;
+        }
+        String fullId = prefix + id;
+        register(fullId, instance);
+        nextIdByPrefix.put(prefix, id + 1);
+        return fullId;
+    }
+
+    /**
+     * Register an instance with an auto-generated JSOG id
+     *
+     * @param id JSOG id of the instance
+     * @param instance Instance being registered
+     * @throws IllegalStateException If the object or the id have already been registered
+     */
+    public void register(String id, Object instance) {
+        if (id == null) {
+            throw new NullPointerException("null id");
+        }
+        if (instance == null) {
+            throw new NullPointerException("null instance");
+        }
+        if (idToInstance.containsKey(id)) {
+            throw new IllegalStateException("JsogEnabled id already registered: " + id);
+        }
+        if (instanceToId.containsKey(instance)) {
+            throw new IllegalStateException("JsogEnabled instance already registered: " + instance);
+        }
+        idToInstance.put(id, instance);
+        instanceToId.put(instance, id);
+    }
+}

--- a/gson/src/main/java/com/google/gson/internal/bind/JsogRegistry.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsogRegistry.java
@@ -50,11 +50,11 @@ public class JsogRegistry {
         }
     };
 
-    /** JSOG policy associated with the current {@link com.google.gson.Gson instance */
+    /** JSOG policy associated with the current {@link com.google.gson.Gson} instance */
     private JsogPolicy jsogPolicy = GsonLocal.gson().getJsogPolicy();
     /** Maps ids to instances */
     private Map<String, Object> idToInstance = new HashMap<String, Object>();
-    /** Mapps instances to ids */
+    /** Maps instances to ids */
     private Map<Object, String> instanceToId = new IdentityHashMap<Object, String>();
     /** The next JSOG id that should be assigned to each prefix */
     private Map<String, Integer> nextIdByPrefix = new HashMap<String, Integer>();

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -230,7 +230,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
             String jsogId = in.nextString();
             instance = (T) JsogRegistry.get().getInstance(jsogId);
             if (instance == null) {
-              throw new JsonSyntaxException("Unresolved JsogEnabled reference: " + jsogId);
+              throw new JsonSyntaxException("Unresolved JSOG reference: " + jsogId);
             }
           } else {
             BoundField field = boundFields.get(name);

--- a/gson/src/test/java/com/google/gson/GsonTest.java
+++ b/gson/src/test/java/com/google/gson/GsonTest.java
@@ -49,7 +49,7 @@ public final class GsonTest extends TestCase {
         new HashMap<Type, InstanceCreator<?>>(), true, false, true, false,
         true, true, false, LongSerializationPolicy.DEFAULT, null, DateFormat.DEFAULT,
         DateFormat.DEFAULT, new ArrayList<TypeAdapterFactory>(),
-        new ArrayList<TypeAdapterFactory>(), new ArrayList<TypeAdapterFactory>());
+        new ArrayList<TypeAdapterFactory>(), new ArrayList<TypeAdapterFactory>(), JsogPolicy.DEFAULT);
 
     assertEquals(CUSTOM_EXCLUDER, gson.excluder());
     assertEquals(CUSTOM_FIELD_NAMING_STRATEGY, gson.fieldNamingStrategy());
@@ -57,12 +57,14 @@ public final class GsonTest extends TestCase {
     assertEquals(false, gson.htmlSafe());
   }
 
+
+
   public void testClonedTypeAdapterFactoryListsAreIndependent() {
     Gson original = new Gson(CUSTOM_EXCLUDER, CUSTOM_FIELD_NAMING_STRATEGY,
         new HashMap<Type, InstanceCreator<?>>(), true, false, true, false,
         true, true, false, LongSerializationPolicy.DEFAULT, null, DateFormat.DEFAULT,
         DateFormat.DEFAULT, new ArrayList<TypeAdapterFactory>(),
-        new ArrayList<TypeAdapterFactory>(), new ArrayList<TypeAdapterFactory>());
+        new ArrayList<TypeAdapterFactory>(), new ArrayList<TypeAdapterFactory>(), JsogPolicy.DEFAULT);
 
     Gson clone = original.newBuilder()
         .registerTypeAdapter(Object.class, new TestTypeAdapter())

--- a/gson/src/test/java/com/google/gson/JsogTest.java
+++ b/gson/src/test/java/com/google/gson/JsogTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2016 The Gson Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson;
+
+import com.google.gson.annotations.JsogEnabled;
+
+import junit.framework.Assert;
+import junit.framework.TestCase;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Unit tests for JSOG
+ *
+ * This test was partially based on the test for jsog-jackson
+ *
+ * @author Paulo Costa
+ */
+public final class JsogTest extends TestCase {
+  @JsogEnabled
+  public static class Outer {
+    public String foo;
+    public List<Inner> inner;
+  }
+
+  @JsogEnabled
+  public static class Inner {
+    public String bar;
+    public Outer outer;
+  }
+
+
+  /** Expected output */
+  private static final String JSOGIFIED = "{\"@id\":\"1\",\"foo\":\"foo\",\"inner\":[{\"@id\":\"2\",\"bar\":\"bar1\",\"outer\":{\"@ref\":\"1\"}},{\"@id\":\"3\",\"bar\":\"bar2\",\"outer\":{\"@ref\":\"1\"}},{\"@ref\":\"2\"}]}";
+  private static final String JSOGIFIED_WITH_PREFIX = "{\"@id\":\"JsogTest.Outer-1\",\"foo\":\"foo\",\"inner\":[{\"@id\":\"JsogTest.Inner-1\",\"bar\":\"bar1\",\"outer\":{\"@ref\":\"JsogTest.Outer-1\"}},{\"@id\":\"JsogTest.Inner-2\",\"bar\":\"bar2\",\"outer\":{\"@ref\":\"JsogTest.Outer-1\"}},{\"@ref\":\"JsogTest.Inner-1\"}]}";
+
+
+  public void testSerialization() {
+    Outer outer = new Outer();
+    outer.foo = "foo";
+
+    Inner inner1 = new Inner();
+    inner1.bar = "bar1";
+    inner1.outer = outer;
+
+    Inner inner2 = new Inner();
+    inner2.bar = "bar2";
+    inner2.outer = outer;
+
+    outer.inner = Arrays.asList(inner1, inner2, inner1);
+
+    String json = new Gson().toJson(outer);
+    Assert.assertEquals(
+            JSOGIFIED,
+            json
+    );
+  }
+
+  public void testSerializationWithTypePrefix() {
+    Outer outer = new Outer();
+    outer.foo = "foo";
+
+    Inner inner1 = new Inner();
+    inner1.bar = "bar1";
+    inner1.outer = outer;
+
+    Inner inner2 = new Inner();
+    inner2.bar = "bar2";
+    inner2.outer = outer;
+
+    outer.inner = Arrays.asList(inner1, inner2, inner1);
+
+    Gson gson = new GsonBuilder().setJsogPolicy(JsogPolicy.DEFAULT.withTypePrefix()).create();
+    Assert.assertEquals(JSOGIFIED_WITH_PREFIX, gson.toJson(outer)
+    );
+  }
+
+
+  public void testDeserialization() {
+    Outer outer = new Gson().fromJson(JSOGIFIED, Outer.class);
+    assert outer == outer.inner.get(0).outer;
+    assert outer == outer.inner.get(1).outer;
+    assert outer == outer.inner.get(2).outer;
+    assert outer.inner.get(0) == outer.inner.get(2);
+  }
+
+
+  public void testDeserializationWithTypePrefix() {
+    Outer outer = new Gson().fromJson(JSOGIFIED_WITH_PREFIX, Outer.class);
+    assert outer == outer.inner.get(0).outer;
+    assert outer == outer.inner.get(1).outer;
+    assert outer == outer.inner.get(2).outer;
+    assert outer.inner.get(0) == outer.inner.get(2);
+  }
+}


### PR DESCRIPTION
This PR addressed  #137 by adding support for JSOG, a very simple convention that allows complex  object graphs to be represented in JSON without redundancy.

This PR is Split in 2 parts:

## Part 1: GsonLocal

Everything in Gson is stateless -- Overall this is a great design, but JSOG requires a registry of instances read/written to be stored _somewhere_.

This storage should only be valid during a serialization/deserialization operation, and must go away once done.

I implemented it in the `GsonLocal` class, which mimics the design from `ThreadLocal`. The GsonLocal is only valid within a call to `Gson.toJson()` or `Gson.fromJson()` in the current thread.

While I created it with JSOG in mind, the design is general and it is reusable on other complex TypeAdapters -- e.g., on `GraphAdapterBuilder`

## Part 2: Actual JSOG support

- Added `JsogPolicy`, an object linked to the `Gson` that decides in which objects the JSOG protocol should be used and how to assign IDs to them.

- Added `@JsogEnabled` annotation, which tells Gson to enabled JSOG on the class

- Added `JsogRegistry`, an helper class that stores instances and their JSOG ids in a `GsonLocal`. This should be used by any TypeAdapters that wants to support JSOG.
    
- Modified `ReflectiveTypeAdapterFactory` to support JSOG.