### PR TITLE
Added ability to serialize down Anon and Local classes

### DIFF
--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -287,6 +287,16 @@ public final class GsonBuilder {
   }
 
   /**
+   * Configures Gson to include local and/or anonymous classes for serialization
+   * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
+   * @since 2.1
+   */
+  public GsonBuilder enableLocalOrAnonClassSerialization(){
+    excluder = excluder.enableAnonOrLocalClassSerialization();
+    return this;
+  }
+
+  /**
    * Configures Gson to apply a specific serialization policy for {@code Long} and {@code long}
    * objects.
    *

--- a/gson/src/main/java/com/google/gson/internal/Excluder.java
+++ b/gson/src/main/java/com/google/gson/internal/Excluder.java
@@ -54,6 +54,7 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
   private double version = IGNORE_VERSIONS;
   private int modifiers = Modifier.TRANSIENT | Modifier.STATIC;
   private boolean serializeInnerClasses = true;
+  private boolean serializeAnonOrLocalClasses = false;
   private boolean requireExpose;
   private List<ExclusionStrategy> serializationStrategies = Collections.emptyList();
   private List<ExclusionStrategy> deserializationStrategies = Collections.emptyList();
@@ -84,6 +85,12 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
   public Excluder disableInnerClassSerialization() {
     Excluder result = clone();
     result.serializeInnerClasses = false;
+    return result;
+  }
+
+  public Excluder enableAnonOrLocalClassSerialization(){
+    Excluder result = clone();
+    result.serializeAnonOrLocalClasses = true;
     return result;
   }
 
@@ -173,7 +180,7 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
       return true;
     }
 
-    if (isAnonymousOrLocal(field.getType())) {
+    if (!serializeAnonOrLocalClasses && isAnonymousOrLocal(field.getType())) {
       return true;
     }
 
@@ -199,7 +206,7 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
           return true;
       }
 
-      if (isAnonymousOrLocal(clazz)) {
+      if (!serializeAnonOrLocalClasses && isAnonymousOrLocal(clazz)) {
           return true;
       }
 


### PR DESCRIPTION
I placed a flag in GsonBuilder that allows the Excluder to serialize Anon and Local classes down during the serialization to JSON. By default, the flag is false, and therefore won't break any existing usages of the Excluder.