### PR TITLE
Fix OSGi metadata generation to work on JavaSE < 9

### DIFF
--- a/gson/bnd.bnd
+++ b/gson/bnd.bnd
@@ -4,6 +4,7 @@ Bundle-Description: ${project.description}
 Bundle-Vendor: Google Gson Project
 Bundle-ContactAddress: ${project.parent.url}
 Bundle-RequiredExecutionEnvironment: J2SE-1.5, JavaSE-1.6, JavaSE-1.7, JavaSE-1.8
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.5))"
 
 -removeheaders: Private-Package
 

--- a/gson/bnd.bnd
+++ b/gson/bnd.bnd
@@ -3,8 +3,8 @@ Bundle-Name: ${project.name}
 Bundle-Description: ${project.description}
 Bundle-Vendor: Google Gson Project
 Bundle-ContactAddress: ${project.parent.url}
-Bundle-RequiredExecutionEnvironment: J2SE-1.5, JavaSE-1.6, JavaSE-1.7, JavaSE-1.8
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.5))"
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6, JavaSE-1.7, JavaSE-1.8
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.6))"
 
 -removeheaders: Private-Package
 

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -53,10 +53,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>templating-maven-plugin</artifactId>
         <version>1.0.0</version>


### PR DESCRIPTION
Fixes #1601 #1602

  - explicitly specifies `Require-Capability: osgi.ee` for 1.6 or greater to disable `bnd`'s autogeneration which is deceived by the `module-info.class` file
  - drop the JavaSE 1.5 reference since it hasn't been true for years (#790)
  - remove the unused `org.apache.felix:maven-bundle-plugin` plugin reference

Here are the differences in the resulting manifests:
```diff
--- gson-manifest-2.8.6	2019-10-31 12:24:51.000000000 -0400
+++ gson-manifest-2.8.7-SNAPSHOT	2019-10-31 11:49:39.000000000 -0400
@@ -1,23 +1,22 @@
 Manifest-Version: 1.0
 Archiver-Version: Plexus Archiver
-Created-By: 11.0.4 (Oracle Corporation)
-Built-By: inder
+Created-By: 11.0.4 (AdoptOpenJDK)
+Built-By: bsd
 Build-Jdk: 11.0.4
-Bnd-LastModified: 1570215293550
+Bnd-LastModified: 1572539070059
 Bundle-ContactAddress: https://github.com/google/gson
 Bundle-Description: Gson JSON library
 Bundle-ManifestVersion: 2
 Bundle-Name: Gson
-Bundle-RequiredExecutionEnvironment: J2SE-1.5, JavaSE-1.6, JavaSE-1.7, J
- avaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6, JavaSE-1.7, JavaSE-1.8
 Bundle-SymbolicName: com.google.gson
 Bundle-Vendor: Google Gson Project
-Bundle-Version: 2.8.6
+Bundle-Version: 2.8.7.201910311624
 Export-Package: com.google.gson;uses:="com.google.gson.reflect,com.googl
- e.gson.stream";version="2.8.6",com.google.gson.annotations;version="2.8
- .6",com.google.gson.reflect;version="2.8.6",com.google.gson.stream;vers
- ion="2.8.6"
+ e.gson.stream";version="2.8.7",com.google.gson.annotations;version="2.8
+ .7",com.google.gson.reflect;version="2.8.7",com.google.gson.stream;vers
+ ion="2.8.7"
 Import-Package: com.google.gson.annotations
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=9.0))"
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.6))"
 Tool: Bnd-4.0.0.201805111645
 
```