### PR TITLE
JsonPrimitive: considers integral LazilyParsedNumber as integral when evaluating hashCode

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonPrimitive.java
+++ b/gson/src/main/java/com/google/gson/JsonPrimitive.java
@@ -288,7 +288,16 @@ public final class JsonPrimitive extends JsonElement {
     if (primitive.value instanceof Number) {
       Number number = (Number) primitive.value;
       return number instanceof BigInteger || number instanceof Long || number instanceof Integer
-          || number instanceof Short || number instanceof Byte;
+          || number instanceof Short || number instanceof Byte || isIntegralLazilyParsedNumber(number);
+    }
+    return false;
+  }
+
+  /** @return true if the specified number is of type LazilyParsedNumber and has an integral value */
+  private static boolean isIntegralLazilyParsedNumber(Number number) {
+    if (number instanceof LazilyParsedNumber) {
+      double value = number.doubleValue();
+      return value == Math.rint(value);
     }
     return false;
   }

--- a/gson/src/test/java/com/google/gson/JsonPrimitiveTest.java
+++ b/gson/src/test/java/com/google/gson/JsonPrimitiveTest.java
@@ -17,6 +17,7 @@
 package com.google.gson;
 
 import com.google.gson.common.MoreAsserts;
+import com.google.gson.internal.LazilyParsedNumber;
 
 import junit.framework.TestCase;
 
@@ -262,6 +263,15 @@ public class JsonPrimitiveTest extends TestCase {
     assertFalse(new JsonPrimitive("true").equals(new JsonPrimitive(true)));
     assertFalse(new JsonPrimitive("0").equals(new JsonPrimitive(0)));
     assertFalse(new JsonPrimitive("NaN").equals(new JsonPrimitive(Float.NaN)));
+  }
+
+  public void testLazilyParsedNumbers() {
+    MoreAsserts.assertEqualsAndHashCode(
+        new JsonPrimitive(26),
+        new JsonPrimitive(new LazilyParsedNumber("26")));
+    MoreAsserts.assertEqualsAndHashCode(
+        new JsonPrimitive(0.26),
+        new JsonPrimitive(new LazilyParsedNumber("0.26")));
   }
 
   public void testDeepCopy() {


### PR DESCRIPTION
This fixes the bug described in https://github.com/google/gson/issues/992 where two JsonPrimitives could equal each other but have different hashCodes.