### PR TITLE
Fixing issue #1592

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeWriter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeWriter.java
@@ -130,6 +130,9 @@ public final class JsonTreeWriter extends JsonWriter {
   }
 
   @Override public JsonWriter name(String name) throws IOException {
+    if (name == null) {
+      throw new NullPointerException("name == null");
+    }
     if (stack.isEmpty() || pendingName != null) {
       throw new IllegalStateException();
     }


### PR DESCRIPTION
Condensed #1620. 

As cqjason describes in [issue #1592](https://github.com/google/gson/issues/1592), the behavior of `JsonTreeWriter.name()` is inconsistent with the method it overrides in its parent JsonWriter. When calling `JsonWriter.name(null)`, a NullPointerException is thrown, while calling `JsonTreeWriter.name(null)` does not throw an exception, leading to a potentially misleading IllegalStateException when calling `JsonTreeWriter.value()` later in execution.

To resolve this, I just copied the null check from lines 385-387 of [JsonWriter](https://github.com/google/gson/blob/master/gson/src/main/java/com/google/gson/stream/JsonWriter.java).