### PR TITLE
Enable default inclusion of type information and use this information...

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -110,6 +110,7 @@ public final class Gson {
   static final boolean DEFAULT_SERIALIZE_NULLS = false;
   static final boolean DEFAULT_COMPLEX_MAP_KEYS = false;
   static final boolean DEFAULT_SPECIALIZE_FLOAT_VALUES = false;
+  static final boolean DEFAULT_TYPING = false;
 
   private static final TypeToken<?> NULL_KEY_SURROGATE = TypeToken.get(Object.class);
   private static final String JSON_NON_EXECUTABLE_PREFIX = ")]}'\n";
@@ -140,6 +141,7 @@ public final class Gson {
   final boolean htmlSafe;
   final boolean prettyPrinting;
   final boolean lenient;
+  final boolean defaultTyping;
   final boolean serializeSpecialFloatingPointValues;
   final String datePattern;
   final int dateStyle;
@@ -186,7 +188,7 @@ public final class Gson {
     this(Excluder.DEFAULT, FieldNamingPolicy.IDENTITY,
         Collections.<Type, InstanceCreator<?>>emptyMap(), DEFAULT_SERIALIZE_NULLS,
         DEFAULT_COMPLEX_MAP_KEYS, DEFAULT_JSON_NON_EXECUTABLE, DEFAULT_ESCAPE_HTML,
-        DEFAULT_PRETTY_PRINT, DEFAULT_LENIENT, DEFAULT_SPECIALIZE_FLOAT_VALUES,
+        DEFAULT_PRETTY_PRINT, DEFAULT_LENIENT, DEFAULT_TYPING, DEFAULT_SPECIALIZE_FLOAT_VALUES,
         LongSerializationPolicy.DEFAULT, null, DateFormat.DEFAULT, DateFormat.DEFAULT,
         Collections.<TypeAdapterFactory>emptyList(), Collections.<TypeAdapterFactory>emptyList(),
         Collections.<TypeAdapterFactory>emptyList());
@@ -195,7 +197,7 @@ public final class Gson {
   Gson(Excluder excluder, FieldNamingStrategy fieldNamingStrategy,
       Map<Type, InstanceCreator<?>> instanceCreators, boolean serializeNulls,
       boolean complexMapKeySerialization, boolean generateNonExecutableGson, boolean htmlSafe,
-      boolean prettyPrinting, boolean lenient, boolean serializeSpecialFloatingPointValues,
+      boolean prettyPrinting, boolean lenient, boolean defaultTyping, boolean serializeSpecialFloatingPointValues,
       LongSerializationPolicy longSerializationPolicy, String datePattern, int dateStyle,
       int timeStyle, List<TypeAdapterFactory> builderFactories,
       List<TypeAdapterFactory> builderHierarchyFactories,
@@ -210,6 +212,7 @@ public final class Gson {
     this.htmlSafe = htmlSafe;
     this.prettyPrinting = prettyPrinting;
     this.lenient = lenient;
+    this.defaultTyping = defaultTyping;
     this.serializeSpecialFloatingPointValues = serializeSpecialFloatingPointValues;
     this.longSerializationPolicy = longSerializationPolicy;
     this.datePattern = datePattern;
@@ -275,7 +278,7 @@ public final class Gson {
     factories.add(jsonAdapterFactory);
     factories.add(TypeAdapters.ENUM_FACTORY);
     factories.add(new ReflectiveTypeAdapterFactory(
-        constructorConstructor, fieldNamingStrategy, excluder, jsonAdapterFactory));
+        constructorConstructor, fieldNamingStrategy, excluder, jsonAdapterFactory, this.defaultTyping));
 
     this.factories = Collections.unmodifiableList(factories);
   }

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -40,6 +40,7 @@ import static com.google.gson.Gson.DEFAULT_LENIENT;
 import static com.google.gson.Gson.DEFAULT_PRETTY_PRINT;
 import static com.google.gson.Gson.DEFAULT_SERIALIZE_NULLS;
 import static com.google.gson.Gson.DEFAULT_SPECIALIZE_FLOAT_VALUES;
+import static com.google.gson.Gson.DEFAULT_TYPING;
 
 /**
  * <p>Use this builder to construct a {@link Gson} instance when you need to set configuration
@@ -94,6 +95,7 @@ public final class GsonBuilder {
   private boolean prettyPrinting = DEFAULT_PRETTY_PRINT;
   private boolean generateNonExecutableJson = DEFAULT_JSON_NON_EXECUTABLE;
   private boolean lenient = DEFAULT_LENIENT;
+  private boolean defaultTyping = DEFAULT_TYPING;
 
   /**
    * Creates a GsonBuilder instance that can be used to build Gson with various configuration
@@ -401,6 +403,18 @@ public final class GsonBuilder {
   }
 
   /**
+   * Enable default inclusion of type information and use this information during deserialization.
+   * Every complex type will be serialized/deserialized using two additional JSON fields - _type and _properties.
+   *
+   * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
+   */
+
+  public GsonBuilder enableDefaultTyping() {
+    defaultTyping = true;
+    return this;
+  }
+
+  /**
    * By default, Gson escapes HTML characters such as &lt; &gt; etc. Use this option to configure
    * Gson to pass-through HTML characters as is.
    *
@@ -596,7 +610,7 @@ public final class GsonBuilder {
 
     return new Gson(excluder, fieldNamingPolicy, instanceCreators,
         serializeNulls, complexMapKeySerialization,
-        generateNonExecutableJson, escapeHtmlChars, prettyPrinting, lenient,
+        generateNonExecutableJson, escapeHtmlChars, prettyPrinting, lenient, defaultTyping,
         serializeSpecialFloatingPointValues, longSerializationPolicy,
         datePattern, dateStyle, timeStyle,
         this.factories, this.hierarchyFactories, factories);

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -404,7 +404,11 @@ public final class GsonBuilder {
 
   /**
    * Enable default inclusion of type information and use this information during deserialization.
-   * Every complex type will be serialized/deserialized using two additional JSON fields - _type and _properties.
+   * Every complex type will be serialized/deserialized using two additional JSON fields:
+   * <ul>
+   *   <li>{@code _type}: The class name of the type as JSON string, e.g. {@code "my.CustomClass$Nested"}</li>
+   *   <li>{@code _properties}: The properties of the serialized instance in a JSON object.</li>
+   * </ul>
    *
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
    */

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -228,7 +228,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
         in.beginObject();
         while (in.hasNext()) {
           String name = in.nextName();
-          if (this.defaultTyping && TYPE_FIELD_NAME.equals(name)) {
+          if (defaultTyping && TYPE_FIELD_NAME.equals(name)) {
             String className = in.nextString();
             if (PROPERTIES_FIELD_NAME.equals(in.nextName())) {
               try {

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -295,8 +295,6 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
         out.endObject();
       }
       out.endObject();
-
     }
-
   }
 }

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -230,10 +230,6 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
           String name = in.nextName();
           if (this.defaultTyping && TYPE_FIELD_NAME.equals(name)) {
             String className = in.nextString();
-
-            if(isObjectClass(className)) {
-              throw new JsonParseException("Because of security reasons you can not parse java.lang.Object");
-            }
             if (PROPERTIES_FIELD_NAME.equals(in.nextName())) {
               try {
                 Class<?> clazz = Class.forName(className, false, this.getClass().getClassLoader());
@@ -270,10 +266,6 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
 
       in.endObject();
       return (T) instance;
-    }
-
-    private boolean isObjectClass(String className) {
-      return JAVA_LANG_OBJECT.equals(className);
     }
 
     @Override public void write(JsonWriter out, T value) throws IOException {

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -49,7 +49,6 @@ import java.util.Map;
 public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
   private static final String TYPE_FIELD_NAME = "_type";
   private static final String PROPERTIES_FIELD_NAME = "_properties";
-  private static final String JAVA_LANG_OBJECT = "java.lang.Object";
   private final ConstructorConstructor constructorConstructor;
   private final FieldNamingStrategy fieldNamingPolicy;
   private final Excluder excluder;

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -47,8 +47,8 @@ import java.util.Map;
  * Type adapter that reflects over the fields and methods of a class.
  */
 public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
-  public static final String TYPE_FIELD_NAME = "_type";
-  public static final String PROPERTIES_FIELD_NAME = "_properties";
+  private static final String TYPE_FIELD_NAME = "_type";
+  private static final String PROPERTIES_FIELD_NAME = "_properties";
   private static final String JAVA_LANG_OBJECT = "java.lang.Object";
   private final ConstructorConstructor constructorConstructor;
   private final FieldNamingStrategy fieldNamingPolicy;

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -18,6 +18,7 @@ package com.google.gson.internal.bind;
 
 import com.google.gson.FieldNamingStrategy;
 import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
@@ -46,19 +47,24 @@ import java.util.Map;
  * Type adapter that reflects over the fields and methods of a class.
  */
 public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
+  public static final String TYPE_FIELD_NAME = "_type";
+  public static final String PROPERTIES_FIELD_NAME = "_properties";
   private final ConstructorConstructor constructorConstructor;
   private final FieldNamingStrategy fieldNamingPolicy;
   private final Excluder excluder;
   private final JsonAdapterAnnotationTypeAdapterFactory jsonAdapterFactory;
   private final ReflectionAccessor accessor = ReflectionAccessor.getInstance();
+  private final boolean defaultTyping;
 
   public ReflectiveTypeAdapterFactory(ConstructorConstructor constructorConstructor,
       FieldNamingStrategy fieldNamingPolicy, Excluder excluder,
-      JsonAdapterAnnotationTypeAdapterFactory jsonAdapterFactory) {
+      JsonAdapterAnnotationTypeAdapterFactory jsonAdapterFactory,
+      boolean defaultTyping) {
     this.constructorConstructor = constructorConstructor;
     this.fieldNamingPolicy = fieldNamingPolicy;
     this.excluder = excluder;
     this.jsonAdapterFactory = jsonAdapterFactory;
+    this.defaultTyping = defaultTyping;
   }
 
   public boolean excludeField(Field f, boolean serialize) {
@@ -99,7 +105,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
     }
 
     ObjectConstructor<T> constructor = constructorConstructor.get(type);
-    return new Adapter<T>(constructor, getBoundFields(gson, type, raw));
+    return new Adapter<T>(constructor, getBoundFields(gson, type, raw), this.defaultTyping, gson);
   }
 
   private ReflectiveTypeAdapterFactory.BoundField createBoundField(
@@ -197,10 +203,16 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
   public static final class Adapter<T> extends TypeAdapter<T> {
     private final ObjectConstructor<T> constructor;
     private final Map<String, BoundField> boundFields;
+    private final boolean defaultTyping;
+    private final Gson context;
 
-    Adapter(ObjectConstructor<T> constructor, Map<String, BoundField> boundFields) {
+    Adapter(ObjectConstructor<T> constructor, Map<String, BoundField> boundFields, boolean defaultTyping,
+            Gson context) {
       this.constructor = constructor;
       this.boundFields = boundFields;
+      this.defaultTyping = defaultTyping;
+      this.context = context;
+
     }
 
     @Override public T read(JsonReader in) throws IOException {
@@ -215,6 +227,26 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
         in.beginObject();
         while (in.hasNext()) {
           String name = in.nextName();
+
+          if (this.defaultTyping && TYPE_FIELD_NAME.equals(name)) {
+            String className = in.nextString();
+            if (PROPERTIES_FIELD_NAME.equals(in.nextName())) {
+              try {
+                Class<?> clazz = Class.forName(className);
+                if (!instance.getClass().equals(clazz) && instance.getClass().isAssignableFrom(clazz)) {
+                  return (T) context.getAdapter(clazz).read(in);
+                } else {
+                  in.beginObject();
+                  continue;
+                }
+              } catch (ClassNotFoundException e) {
+                throw new RuntimeException("Could not find class " + className);
+              }
+            } else {
+              throw new JsonParseException("Could not find _properties field at " + in.toString());
+            }
+          }
+
           BoundField field = boundFields.get(name);
           if (field == null || !field.deserialized) {
             in.skipValue();
@@ -227,8 +259,13 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
       } catch (IllegalAccessException e) {
         throw new AssertionError(e);
       }
+
+      if (defaultTyping) {
+        in.endObject();
+      }
+
       in.endObject();
-      return instance;
+      return (T) instance;
     }
 
     @Override public void write(JsonWriter out, T value) throws IOException {
@@ -238,6 +275,12 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
       }
 
       out.beginObject();
+      if(defaultTyping) {
+        out.name(TYPE_FIELD_NAME);
+        out.value(value.getClass().getName());
+        out.name(PROPERTIES_FIELD_NAME);
+        out.beginObject();
+      }
       try {
         for (BoundField boundField : boundFields.values()) {
           if (boundField.writeField(value)) {
@@ -248,7 +291,12 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
       } catch (IllegalAccessException e) {
         throw new AssertionError(e);
       }
+      if (defaultTyping) {
+        out.endObject();
+      }
       out.endObject();
+
     }
+
   }
 }

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -275,7 +275,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
       }
 
       out.beginObject();
-      if(defaultTyping) {
+      if (defaultTyping) {
         out.name(TYPE_FIELD_NAME);
         out.value(value.getClass().getName());
         out.name(PROPERTIES_FIELD_NAME);

--- a/gson/src/test/java/com/google/gson/GsonTest.java
+++ b/gson/src/test/java/com/google/gson/GsonTest.java
@@ -47,7 +47,7 @@ public final class GsonTest extends TestCase {
   public void testOverridesDefaultExcluder() {
     Gson gson = new Gson(CUSTOM_EXCLUDER, CUSTOM_FIELD_NAMING_STRATEGY,
         new HashMap<Type, InstanceCreator<?>>(), true, false, true, false,
-        true, true, false, LongSerializationPolicy.DEFAULT, null, DateFormat.DEFAULT,
+        true, true, false, false, LongSerializationPolicy.DEFAULT, null, DateFormat.DEFAULT,
         DateFormat.DEFAULT, new ArrayList<TypeAdapterFactory>(),
         new ArrayList<TypeAdapterFactory>(), new ArrayList<TypeAdapterFactory>());
 
@@ -60,7 +60,7 @@ public final class GsonTest extends TestCase {
   public void testClonedTypeAdapterFactoryListsAreIndependent() {
     Gson original = new Gson(CUSTOM_EXCLUDER, CUSTOM_FIELD_NAMING_STRATEGY,
         new HashMap<Type, InstanceCreator<?>>(), true, false, true, false,
-        true, true, false, LongSerializationPolicy.DEFAULT, null, DateFormat.DEFAULT,
+        true, true,false, false, LongSerializationPolicy.DEFAULT, null, DateFormat.DEFAULT,
         DateFormat.DEFAULT, new ArrayList<TypeAdapterFactory>(),
         new ArrayList<TypeAdapterFactory>(), new ArrayList<TypeAdapterFactory>());
 

--- a/gson/src/test/java/com/google/gson/GsonTest.java
+++ b/gson/src/test/java/com/google/gson/GsonTest.java
@@ -60,7 +60,7 @@ public final class GsonTest extends TestCase {
   public void testClonedTypeAdapterFactoryListsAreIndependent() {
     Gson original = new Gson(CUSTOM_EXCLUDER, CUSTOM_FIELD_NAMING_STRATEGY,
         new HashMap<Type, InstanceCreator<?>>(), true, false, true, false,
-        true, true,false, false, LongSerializationPolicy.DEFAULT, null, DateFormat.DEFAULT,
+        true, true, false, false, LongSerializationPolicy.DEFAULT, null, DateFormat.DEFAULT,
         DateFormat.DEFAULT, new ArrayList<TypeAdapterFactory>(),
         new ArrayList<TypeAdapterFactory>(), new ArrayList<TypeAdapterFactory>());
 

--- a/gson/src/test/java/com/google/gson/common/TestTypes.java
+++ b/gson/src/test/java/com/google/gson/common/TestTypes.java
@@ -268,6 +268,24 @@ public class TestTypes {
         sb.append("\"primitive2\":").append(primitive2.getExpectedJson());
       }
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      Nested nested = (Nested) o;
+
+      if (primitive1 != null ? !primitive1.equals(nested.primitive1) : nested.primitive1 != null) return false;
+      return primitive2 != null ? primitive2.equals(nested.primitive2) : nested.primitive2 == null;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = primitive1 != null ? primitive1.hashCode() : 0;
+      result = 31 * result + (primitive2 != null ? primitive2.hashCode() : 0);
+      return result;
+    }
   }
 
   public static class ClassWithTransientFields<T> {

--- a/gson/src/test/java/com/google/gson/functional/DefaultTypingTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DefaultTypingTest.java
@@ -17,6 +17,7 @@ package com.google.gson.functional;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
 import com.google.gson.common.TestTypes.Nested;
 import junit.framework.TestCase;
 
@@ -46,11 +47,21 @@ public class DefaultTypingTest extends TestCase  {
     public void testDefaultTypingDeserialization() {
         ComplexTestType result = gson.fromJson(getJson(), ComplexTestType.class);
         assertEquals(this.testOverThisClass, result);
-        //Explicite check type of some subtypes
+        //Explicit check type of some subtypes
         assertTrue(result.listWithSubTypes.get(0) instanceof SubTypeOfNested);
         assertTrue(result.listWithSubTypes.get(1) instanceof Nested);
         assertTrue(result.subTypeOfNested instanceof SubTypeOfNested);
         assertTrue(result.subTypeOfNestedWithGenericObject.object instanceof SubTypeOfNested);
+    }
+
+    public void testThrowingExceptionWhenDeserializingGenericObject() {
+        try {
+            gson.fromJson(getJsonWithObject(), ComplexTestType.class);
+            fail();
+        } catch (JsonParseException excepted) {
+
+        }
+
     }
 
     private static class ComplexTestType {
@@ -141,5 +152,9 @@ public class DefaultTypingTest extends TestCase  {
 
     private String getJson() {
         return "{\"_type\":\"com.google.gson.functional.DefaultTypingTest$ComplexTestType\",\"_properties\":{\"listWithSubTypes\":[{\"_type\":\"com.google.gson.functional.DefaultTypingTest$SubTypeOfNested\",\"_properties\":{\"value\":5,\"primitive1\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":1,\"intValue\":1,\"booleanValue\":true,\"stringValue\":\"String1\"}},\"primitive2\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":2,\"intValue\":2,\"booleanValue\":true,\"stringValue\":\"String2\"}}}},{\"_type\":\"com.google.gson.common.TestTypes$Nested\",\"_properties\":{\"primitive1\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":1,\"intValue\":1,\"booleanValue\":true,\"stringValue\":\"String1\"}},\"primitive2\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":2,\"intValue\":2,\"booleanValue\":true,\"stringValue\":\"String2\"}}}}],\"subTypeOfNestedWithGenericObject\":{\"_type\":\"com.google.gson.functional.DefaultTypingTest$SubTypeOfNestedWithGenericObject\",\"_properties\":{\"object\":{\"_type\":\"com.google.gson.functional.DefaultTypingTest$SubTypeOfNested\",\"_properties\":{\"value\":5,\"primitive1\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":3,\"intValue\":3,\"booleanValue\":true,\"stringValue\":\"String3\"}},\"primitive2\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":4,\"intValue\":4,\"booleanValue\":true,\"stringValue\":\"String4\"}}}},\"primitive1\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":1,\"intValue\":1,\"booleanValue\":true,\"stringValue\":\"String1\"}},\"primitive2\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":2,\"intValue\":2,\"booleanValue\":true,\"stringValue\":\"String2\"}}}},\"nested\":{\"_type\":\"com.google.gson.common.TestTypes$Nested\",\"_properties\":{\"primitive1\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":3,\"intValue\":3,\"booleanValue\":true,\"stringValue\":\"String3\"}},\"primitive2\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":4,\"intValue\":4,\"booleanValue\":true,\"stringValue\":\"String4\"}}}},\"subTypeOfNested\":{\"_type\":\"com.google.gson.functional.DefaultTypingTest$SubTypeOfNested\",\"_properties\":{\"value\":5,\"primitive1\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":3,\"intValue\":3,\"booleanValue\":true,\"stringValue\":\"String3\"}},\"primitive2\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":4,\"intValue\":4,\"booleanValue\":true,\"stringValue\":\"String4\"}}}},\"primitive\":3,\"bigDecimal\":1.11}}";
+    }
+
+    private String getJsonWithObject() {
+        return "{\"_type\":\"java.lang.Object\",\"_properties\":{}}";
     }
 }

--- a/gson/src/test/java/com/google/gson/functional/DefaultTypingTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DefaultTypingTest.java
@@ -54,7 +54,7 @@ public class DefaultTypingTest extends TestCase  {
     }
 
     private static class ComplexTestType {
-        List<Nested> listWithSubTypes = new ArrayList<>();
+        List<Nested> listWithSubTypes = new ArrayList<Nested>();
         SubTypeOfNestedWithGenericObject<Nested> subTypeOfNestedWithGenericObject;
         Nested nested;
         Nested subTypeOfNested;

--- a/gson/src/test/java/com/google/gson/functional/DefaultTypingTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DefaultTypingTest.java
@@ -13,35 +13,39 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.gson.functional;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.common.TestTypes.Nested;
 import junit.framework.TestCase;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.google.gson.common.TestTypes.*;
+import static com.google.gson.common.TestTypes.BagOfPrimitives;
+
 
 public class DefaultTypingTest extends TestCase  {
     private Gson gson;
+    private ComplexTestType testOverThisClass;
 
     @Override
     protected void setUp() throws Exception {
         super.setUp();
         gson = new GsonBuilder().enableDefaultTyping().create();
+        this.testOverThisClass = prepareComplexType();
     }
 
     public void testDefaultTypingSerialization() {
-        String result = gson.toJson(new ComplexTestType());
+        String result = gson.toJson(testOverThisClass);
         assertEquals(getJson(), result);
     }
 
     public void testDefaultTypingDeserialization() {
         ComplexTestType result = gson.fromJson(getJson(), ComplexTestType.class);
-        assertEquals(new ComplexTestType(), result);
+        assertEquals(this.testOverThisClass, result);
         //Explicite check type of some subtypes
         assertTrue(result.listWithSubTypes.get(0) instanceof SubTypeOfNested);
         assertTrue(result.listWithSubTypes.get(1) instanceof Nested);
@@ -50,23 +54,13 @@ public class DefaultTypingTest extends TestCase  {
     }
 
     private static class ComplexTestType {
-        List<Nested> listWithSubTypes = new ArrayList<Nested>();
+        List<Nested> listWithSubTypes = new ArrayList<>();
         SubTypeOfNestedWithGenericObject<Nested> subTypeOfNestedWithGenericObject;
         Nested nested;
         Nested subTypeOfNested;
-        int primitive = 3;
-        BigDecimal bigDecimal = BigDecimal.valueOf(1.11);
-
+        int primitive;
+        BigDecimal bigDecimal;
         public ComplexTestType() {
-            BagOfPrimitives bagOfPrimitives1 = new BagOfPrimitives(1L, 1, true, "String1");
-            BagOfPrimitives bagOfPrimitives2 = new BagOfPrimitives(2L, 2, true, "String2");
-            BagOfPrimitives bagOfPrimitives3 = new BagOfPrimitives(3L, 3, true, "String3");
-            BagOfPrimitives bagOfPrimitives4 = new BagOfPrimitives(4L, 4, true, "String4");
-            this.listWithSubTypes.add(new SubTypeOfNested(bagOfPrimitives1, bagOfPrimitives2));
-            this.listWithSubTypes.add(new Nested(bagOfPrimitives1, bagOfPrimitives2));
-            this.nested = new Nested(bagOfPrimitives3, bagOfPrimitives4);
-            this.subTypeOfNested = new SubTypeOfNested(bagOfPrimitives3, bagOfPrimitives4);
-            this.subTypeOfNestedWithGenericObject = new SubTypeOfNestedWithGenericObject<Nested>(bagOfPrimitives1, bagOfPrimitives2, new SubTypeOfNested(bagOfPrimitives3, bagOfPrimitives4));
         }
 
         @Override
@@ -88,6 +82,23 @@ public class DefaultTypingTest extends TestCase  {
         }
 
     }
+
+    private ComplexTestType prepareComplexType() {
+        ComplexTestType complexType = new ComplexTestType();
+        complexType.bigDecimal = BigDecimal.valueOf(1.11);
+        complexType.primitive = 3;
+        BagOfPrimitives bagOfPrimitives1 = new BagOfPrimitives(1L, 1, true, "String1");
+        BagOfPrimitives bagOfPrimitives2 = new BagOfPrimitives(2L, 2, true, "String2");
+        BagOfPrimitives bagOfPrimitives3 = new BagOfPrimitives(3L, 3, true, "String3");
+        BagOfPrimitives bagOfPrimitives4 = new BagOfPrimitives(4L, 4, true, "String4");
+        complexType.listWithSubTypes.add(new SubTypeOfNested(bagOfPrimitives1, bagOfPrimitives2));
+        complexType.listWithSubTypes.add(new Nested(bagOfPrimitives1, bagOfPrimitives2));
+        complexType.nested = new Nested(bagOfPrimitives3, bagOfPrimitives4);
+        complexType.subTypeOfNested = new SubTypeOfNested(bagOfPrimitives3, bagOfPrimitives4);
+        complexType.subTypeOfNestedWithGenericObject = new SubTypeOfNestedWithGenericObject<Nested>(bagOfPrimitives1, bagOfPrimitives2, new SubTypeOfNested(bagOfPrimitives3, bagOfPrimitives4));
+        return complexType;
+    }
+
 
     private static class SubTypeOfNested extends Nested {
         private final long value = 5;

--- a/gson/src/test/java/com/google/gson/functional/DefaultTypingTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DefaultTypingTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson.functional;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import junit.framework.TestCase;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.gson.common.TestTypes.*;
+
+public class DefaultTypingTest extends TestCase  {
+    private Gson gson;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        gson = new GsonBuilder().enableDefaultTyping().create();
+    }
+
+    public void testDefaultTypingSerialization() {
+        String result = gson.toJson(new ComplexTestType());
+        assertEquals(getJson(), result);
+    }
+
+    public void testDefaultTypingDeserialization() {
+        ComplexTestType result = gson.fromJson(getJson(), ComplexTestType.class);
+        assertEquals(new ComplexTestType(), result);
+        //Explicite check type of some subtypes
+        assertTrue(result.listWithSubTypes.get(0) instanceof SubTypeOfNested);
+        assertTrue(result.listWithSubTypes.get(1) instanceof Nested);
+        assertTrue(result.subTypeOfNested instanceof SubTypeOfNested);
+        assertTrue(result.subTypeOfNestedWithGenericObject.object instanceof SubTypeOfNested);
+    }
+
+    private static class ComplexTestType {
+        List<Nested> listWithSubTypes = new ArrayList<Nested>();
+        SubTypeOfNestedWithGenericObject<Nested> subTypeOfNestedWithGenericObject;
+        Nested nested;
+        Nested subTypeOfNested;
+        int primitive = 3;
+        BigDecimal bigDecimal = BigDecimal.valueOf(1.11);
+
+        public ComplexTestType() {
+            BagOfPrimitives bagOfPrimitives1 = new BagOfPrimitives(1L, 1, true, "String1");
+            BagOfPrimitives bagOfPrimitives2 = new BagOfPrimitives(2L, 2, true, "String2");
+            BagOfPrimitives bagOfPrimitives3 = new BagOfPrimitives(3L, 3, true, "String3");
+            BagOfPrimitives bagOfPrimitives4 = new BagOfPrimitives(4L, 4, true, "String4");
+            this.listWithSubTypes.add(new SubTypeOfNested(bagOfPrimitives1, bagOfPrimitives2));
+            this.listWithSubTypes.add(new Nested(bagOfPrimitives1, bagOfPrimitives2));
+            this.nested = new Nested(bagOfPrimitives3, bagOfPrimitives4);
+            this.subTypeOfNested = new SubTypeOfNested(bagOfPrimitives3, bagOfPrimitives4);
+            this.subTypeOfNestedWithGenericObject = new SubTypeOfNestedWithGenericObject<Nested>(bagOfPrimitives1, bagOfPrimitives2, new SubTypeOfNested(bagOfPrimitives3, bagOfPrimitives4));
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            ComplexTestType that = (ComplexTestType) o;
+
+            if (primitive != that.primitive) return false;
+            if (listWithSubTypes != null ? !listWithSubTypes.equals(that.listWithSubTypes) : that.listWithSubTypes != null)
+                return false;
+            if (subTypeOfNestedWithGenericObject != null ? !subTypeOfNestedWithGenericObject.equals(that.subTypeOfNestedWithGenericObject) : that.subTypeOfNestedWithGenericObject != null)
+                return false;
+            if (nested != null ? !nested.equals(that.nested) : that.nested != null) return false;
+            if (subTypeOfNested != null ? !subTypeOfNested.equals(that.subTypeOfNested) : that.subTypeOfNested != null)
+                return false;
+            return bigDecimal != null ? bigDecimal.equals(that.bigDecimal) : that.bigDecimal == null;
+        }
+
+    }
+
+    private static class SubTypeOfNested extends Nested {
+        private final long value = 5;
+
+        public SubTypeOfNested(BagOfPrimitives primitive1, BagOfPrimitives primitive2) {
+            super(primitive1, primitive2);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof SubTypeOfNested)) return false;
+            if (!super.equals(o)) return false;
+
+            SubTypeOfNested that = (SubTypeOfNested) o;
+
+            return value == that.value;
+        }
+    }
+
+    private static class SubTypeOfNestedWithGenericObject<T> extends Nested {
+        private T object;
+
+        public SubTypeOfNestedWithGenericObject(BagOfPrimitives primitive1, BagOfPrimitives primitive2, T object) {
+            super(primitive1, primitive2);
+            this.object = object;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof SubTypeOfNestedWithGenericObject)) return false;
+            if (!super.equals(o)) return false;
+
+            SubTypeOfNestedWithGenericObject<?> that = (SubTypeOfNestedWithGenericObject<?>) o;
+
+            return object != null ? object.equals(that.object) : that.object == null;
+        }
+    }
+
+    private String getJson() {
+        return "{\"_type\":\"com.google.gson.functional.DefaultTypingTest$ComplexTestType\",\"_properties\":{\"listWithSubTypes\":[{\"_type\":\"com.google.gson.functional.DefaultTypingTest$SubTypeOfNested\",\"_properties\":{\"value\":5,\"primitive1\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":1,\"intValue\":1,\"booleanValue\":true,\"stringValue\":\"String1\"}},\"primitive2\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":2,\"intValue\":2,\"booleanValue\":true,\"stringValue\":\"String2\"}}}},{\"_type\":\"com.google.gson.common.TestTypes$Nested\",\"_properties\":{\"primitive1\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":1,\"intValue\":1,\"booleanValue\":true,\"stringValue\":\"String1\"}},\"primitive2\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":2,\"intValue\":2,\"booleanValue\":true,\"stringValue\":\"String2\"}}}}],\"subTypeOfNestedWithGenericObject\":{\"_type\":\"com.google.gson.functional.DefaultTypingTest$SubTypeOfNestedWithGenericObject\",\"_properties\":{\"object\":{\"_type\":\"com.google.gson.functional.DefaultTypingTest$SubTypeOfNested\",\"_properties\":{\"value\":5,\"primitive1\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":3,\"intValue\":3,\"booleanValue\":true,\"stringValue\":\"String3\"}},\"primitive2\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":4,\"intValue\":4,\"booleanValue\":true,\"stringValue\":\"String4\"}}}},\"primitive1\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":1,\"intValue\":1,\"booleanValue\":true,\"stringValue\":\"String1\"}},\"primitive2\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":2,\"intValue\":2,\"booleanValue\":true,\"stringValue\":\"String2\"}}}},\"nested\":{\"_type\":\"com.google.gson.common.TestTypes$Nested\",\"_properties\":{\"primitive1\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":3,\"intValue\":3,\"booleanValue\":true,\"stringValue\":\"String3\"}},\"primitive2\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":4,\"intValue\":4,\"booleanValue\":true,\"stringValue\":\"String4\"}}}},\"subTypeOfNested\":{\"_type\":\"com.google.gson.functional.DefaultTypingTest$SubTypeOfNested\",\"_properties\":{\"value\":5,\"primitive1\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":3,\"intValue\":3,\"booleanValue\":true,\"stringValue\":\"String3\"}},\"primitive2\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":4,\"intValue\":4,\"booleanValue\":true,\"stringValue\":\"String4\"}}}},\"primitive\":3,\"bigDecimal\":1.11}}";
+    }
+}

--- a/gson/src/test/java/com/google/gson/functional/DefaultTypingTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DefaultTypingTest.java
@@ -54,16 +54,6 @@ public class DefaultTypingTest extends TestCase  {
         assertTrue(result.subTypeOfNestedWithGenericObject.object instanceof SubTypeOfNested);
     }
 
-    public void testThrowingExceptionWhenDeserializingGenericObject() {
-        try {
-            gson.fromJson(getJsonWithObject(), ComplexTestType.class);
-            fail();
-        } catch (JsonParseException excepted) {
-
-        }
-
-    }
-
     private static class ComplexTestType {
         List<Nested> listWithSubTypes = new ArrayList<Nested>();
         SubTypeOfNestedWithGenericObject<Nested> subTypeOfNestedWithGenericObject;
@@ -152,9 +142,5 @@ public class DefaultTypingTest extends TestCase  {
 
     private String getJson() {
         return "{\"_type\":\"com.google.gson.functional.DefaultTypingTest$ComplexTestType\",\"_properties\":{\"listWithSubTypes\":[{\"_type\":\"com.google.gson.functional.DefaultTypingTest$SubTypeOfNested\",\"_properties\":{\"value\":5,\"primitive1\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":1,\"intValue\":1,\"booleanValue\":true,\"stringValue\":\"String1\"}},\"primitive2\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":2,\"intValue\":2,\"booleanValue\":true,\"stringValue\":\"String2\"}}}},{\"_type\":\"com.google.gson.common.TestTypes$Nested\",\"_properties\":{\"primitive1\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":1,\"intValue\":1,\"booleanValue\":true,\"stringValue\":\"String1\"}},\"primitive2\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":2,\"intValue\":2,\"booleanValue\":true,\"stringValue\":\"String2\"}}}}],\"subTypeOfNestedWithGenericObject\":{\"_type\":\"com.google.gson.functional.DefaultTypingTest$SubTypeOfNestedWithGenericObject\",\"_properties\":{\"object\":{\"_type\":\"com.google.gson.functional.DefaultTypingTest$SubTypeOfNested\",\"_properties\":{\"value\":5,\"primitive1\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":3,\"intValue\":3,\"booleanValue\":true,\"stringValue\":\"String3\"}},\"primitive2\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":4,\"intValue\":4,\"booleanValue\":true,\"stringValue\":\"String4\"}}}},\"primitive1\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":1,\"intValue\":1,\"booleanValue\":true,\"stringValue\":\"String1\"}},\"primitive2\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":2,\"intValue\":2,\"booleanValue\":true,\"stringValue\":\"String2\"}}}},\"nested\":{\"_type\":\"com.google.gson.common.TestTypes$Nested\",\"_properties\":{\"primitive1\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":3,\"intValue\":3,\"booleanValue\":true,\"stringValue\":\"String3\"}},\"primitive2\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":4,\"intValue\":4,\"booleanValue\":true,\"stringValue\":\"String4\"}}}},\"subTypeOfNested\":{\"_type\":\"com.google.gson.functional.DefaultTypingTest$SubTypeOfNested\",\"_properties\":{\"value\":5,\"primitive1\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":3,\"intValue\":3,\"booleanValue\":true,\"stringValue\":\"String3\"}},\"primitive2\":{\"_type\":\"com.google.gson.common.TestTypes$BagOfPrimitives\",\"_properties\":{\"longValue\":4,\"intValue\":4,\"booleanValue\":true,\"stringValue\":\"String4\"}}}},\"primitive\":3,\"bigDecimal\":1.11}}";
-    }
-
-    private String getJsonWithObject() {
-        return "{\"_type\":\"java.lang.Object\",\"_properties\":{}}";
     }
 }


### PR DESCRIPTION
… during deserialization.

Motivation: 
* It fixes some issues with deserialization of polymorphic types. Without it proper deserialization required from user writing specific Adapters. 
* I've tried to achive generic solution similar to Jackson [enableDefaultTyping()](https://fasterxml.github.io/jackson-databind/javadoc/2.5/com/fasterxml/jackson/databind/ObjectMapper.html#enableDefaultTyping())

It is turned on with GsonBuilder.enableDefaultTyping() method. 

Basically when enabled it changes represantion of user defined types (serialized/deserialized with ReflectiveTypeAdapterFactory) in JSON from:

```
{
 prop1: value1,
 prop2: value2
}
```

...to:

```
{
  _type: "name.of.UserClass",
  _properties: {
    prop1: value1,
    prop2: value2
  }
}
```

For ex., when we're running DefaultTypingTest with this option enabled we will get:

![image](https://user-images.githubusercontent.com/1839663/73674991-f3b36f00-46b1-11ea-9db1-f166fc6a6c6b.png)

Without it by default we will lost all data from/about subtypes:

![image](https://user-images.githubusercontent.com/1839663/73677755-3592e400-46b7-11ea-90fb-ec0853b8660a.png)

### **Related issue:**
#1024 