### PR TITLE
Specify timezone for GregorianCalender in testDateFormatString()

### DIFF
--- a/gson/src/test/java/com/google/gson/internal/bind/util/ISO8601UtilsTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/util/ISO8601UtilsTest.java
@@ -17,7 +17,10 @@ public class ISO8601UtilsTest {
 
     @Test
     public void testDateFormatString() {
-        Date date = new GregorianCalendar(2018, Calendar.JUNE, 25).getTime();
+        GregorianCalendar calendar = new GregorianCalendar(2018, Calendar.JUNE, 25);
+        TimeZone timeZone = TimeZone.getTimeZone("UTC");
+        calendar.setTimeZone(timeZone);
+        Date date = calendar.getTime();
         String dateStr = ISO8601Utils.format(date);
         String expectedDate = "2018-06-25";
         assertEquals(expectedDate, dateStr.substring(0, expectedDate.length()));


### PR DESCRIPTION
The date is formatted using format(Date) which uses UTC-timezone as no other timezone is specified
GregorianCalender instead uses the system-default timezone, which makes this test not pass in all timezones
Therefore the timezone of the calender should be specified before it's used to create a Date-instance using (by default) UTC-timezone