### PR TITLE
Cleanup code & documentation for exceptions

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonIOException.java
+++ b/gson/src/main/java/com/google/gson/JsonIOException.java
@@ -23,7 +23,7 @@ package com.google.gson;
  */
 public final class JsonIOException extends JsonParseException {
 
-  private static final long serialVersionUID = 1818297422735748149L;
+  private static final long serialVersionUID = 1L;
 
   /**
    * Creates exception with the specified message. If you are wrapping another exception, consider
@@ -31,7 +31,7 @@ public final class JsonIOException extends JsonParseException {
    *
    * @param msg error message describing a possible cause of this exception.
    */
-  public JsonIOException(final String msg) {
+  public JsonIOException(String msg) {
     super(msg);
   }
 
@@ -41,7 +41,7 @@ public final class JsonIOException extends JsonParseException {
    * @param msg   error message describing what happened.
    * @param cause root exception that caused this exception to be thrown.
    */
-  public JsonIOException(final String msg, final Throwable cause) {
+  public JsonIOException(String msg, Throwable cause) {
     super(msg, cause);
   }
 
@@ -51,7 +51,7 @@ public final class JsonIOException extends JsonParseException {
    *
    * @param cause root exception that caused this exception to be thrown.
    */
-  public JsonIOException(final Throwable cause) {
+  public JsonIOException(Throwable cause) {
     super(cause);
   }
 }

--- a/gson/src/main/java/com/google/gson/JsonIOException.java
+++ b/gson/src/main/java/com/google/gson/JsonIOException.java
@@ -16,30 +16,42 @@
 package com.google.gson;
 
 /**
- * This exception is raised when Gson was unable to read an input stream
- * or write to one.
- * 
+ * This exception is raised when Gson was unable to read an input stream or write to one.
+ *
  * @author Inderjeet Singh
  * @author Joel Leitch
  */
 public final class JsonIOException extends JsonParseException {
-  private static final long serialVersionUID = 1L;
 
-  public JsonIOException(String msg) {
+  private static final long serialVersionUID = 1818297422735748149L;
+
+  /**
+   * Creates exception with the specified message. If you are wrapping another exception, consider
+   * using {@link #JsonIOException(String, Throwable)} instead.
+   *
+   * @param msg error message describing a possible cause of this exception.
+   */
+  public JsonIOException(final String msg) {
     super(msg);
   }
 
-  public JsonIOException(String msg, Throwable cause) {
+  /**
+   * Creates exception with the specified message and cause.
+   *
+   * @param msg   error message describing what happened.
+   * @param cause root exception that caused this exception to be thrown.
+   */
+  public JsonIOException(final String msg, final Throwable cause) {
     super(msg, cause);
   }
 
   /**
-   * Creates exception with the specified cause. Consider using
-   * {@link #JsonIOException(String, Throwable)} instead if you can describe what happened.
+   * Creates exception with the specified cause. Consider using {@link #JsonIOException(String,
+   * Throwable)} instead if you can describe what happened.
    *
    * @param cause root exception that caused this exception to be thrown.
    */
-  public JsonIOException(Throwable cause) {
+  public JsonIOException(final Throwable cause) {
     super(cause);
   }
 }

--- a/gson/src/main/java/com/google/gson/JsonParseException.java
+++ b/gson/src/main/java/com/google/gson/JsonParseException.java
@@ -17,9 +17,9 @@
 package com.google.gson;
 
 /**
- * This exception is raised if there is a serious issue that occurs during parsing of a Json
- * string. One of the main usages for this class is for the Gson infrastructure. If the incoming
- * Json is bad/malicious, an instance of this exception is raised.
+ * This exception is raised if there is a serious issue that occurs during parsing of a Json string.
+ * One of the main usages for this class is for the Gson infrastructure. If the incoming Json is
+ * bad/malicious, an instance of this exception is raised.
  *
  * <p>This exception is a {@link RuntimeException} because it is exposed to the client. Using a
  * {@link RuntimeException} avoids bad coding practices on the client side where they catch the
@@ -30,7 +30,8 @@ package com.google.gson;
  * @author Joel Leitch
  */
 public class JsonParseException extends RuntimeException {
-  static final long serialVersionUID = -4086729973971783390L;
+
+  private static final long serialVersionUID = -4086729973971783390L;
 
   /**
    * Creates exception with the specified message. If you are wrapping another exception, consider
@@ -38,27 +39,27 @@ public class JsonParseException extends RuntimeException {
    *
    * @param msg error message describing a possible cause of this exception.
    */
-  public JsonParseException(String msg) {
+  public JsonParseException(final String msg) {
     super(msg);
   }
 
   /**
    * Creates exception with the specified message and cause.
    *
-   * @param msg error message describing what happened.
+   * @param msg   error message describing what happened.
    * @param cause root exception that caused this exception to be thrown.
    */
-  public JsonParseException(String msg, Throwable cause) {
+  public JsonParseException(final String msg, final Throwable cause) {
     super(msg, cause);
   }
 
   /**
-   * Creates exception with the specified cause. Consider using
-   * {@link #JsonParseException(String, Throwable)} instead if you can describe what happened.
+   * Creates exception with the specified cause. Consider using {@link #JsonParseException(String,
+   * Throwable)} instead if you can describe what happened.
    *
    * @param cause root exception that caused this exception to be thrown.
    */
-  public JsonParseException(Throwable cause) {
+  public JsonParseException(final Throwable cause) {
     super(cause);
   }
 }

--- a/gson/src/main/java/com/google/gson/JsonParseException.java
+++ b/gson/src/main/java/com/google/gson/JsonParseException.java
@@ -39,7 +39,7 @@ public class JsonParseException extends RuntimeException {
    *
    * @param msg error message describing a possible cause of this exception.
    */
-  public JsonParseException(final String msg) {
+  public JsonParseException(String msg) {
     super(msg);
   }
 
@@ -49,7 +49,7 @@ public class JsonParseException extends RuntimeException {
    * @param msg   error message describing what happened.
    * @param cause root exception that caused this exception to be thrown.
    */
-  public JsonParseException(final String msg, final Throwable cause) {
+  public JsonParseException(String msg, Throwable cause) {
     super(msg, cause);
   }
 
@@ -59,7 +59,7 @@ public class JsonParseException extends RuntimeException {
    *
    * @param cause root exception that caused this exception to be thrown.
    */
-  public JsonParseException(final Throwable cause) {
+  public JsonParseException(Throwable cause) {
     super(cause);
   }
 }

--- a/gson/src/main/java/com/google/gson/JsonSyntaxException.java
+++ b/gson/src/main/java/com/google/gson/JsonSyntaxException.java
@@ -16,32 +16,42 @@
 package com.google.gson;
 
 /**
- * This exception is raised when Gson attempts to read (or write) a malformed
- * JSON element.
+ * This exception is raised when Gson attempts to read (or write) a malformed JSON element.
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
  */
 public final class JsonSyntaxException extends JsonParseException {
 
-  private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = -5720608064000865903L;
 
-  public JsonSyntaxException(String msg) {
+  /**
+   * Creates exception with the specified message. If you are wrapping another exception, consider
+   * using {@link #JsonSyntaxException(String, Throwable)} instead.
+   *
+   * @param msg error message describing a possible cause of this exception.
+   */
+  public JsonSyntaxException(final String msg) {
     super(msg);
   }
 
-  public JsonSyntaxException(String msg, Throwable cause) {
+  /**
+   * Creates exception with the specified message and cause.
+   *
+   * @param msg   error message describing what happened.
+   * @param cause root exception that caused this exception to be thrown.
+   */
+  public JsonSyntaxException(final String msg, final Throwable cause) {
     super(msg, cause);
   }
 
   /**
-   * Creates exception with the specified cause. Consider using
-   * {@link #JsonSyntaxException(String, Throwable)} instead if you can
-   * describe what actually happened.
+   * Creates exception with the specified cause. Consider using {@link #JsonSyntaxException(String,
+   * Throwable)} instead if you can describe what happened.
    *
    * @param cause root exception that caused this exception to be thrown.
    */
-  public JsonSyntaxException(Throwable cause) {
+  public JsonSyntaxException(final Throwable cause) {
     super(cause);
   }
 }

--- a/gson/src/main/java/com/google/gson/JsonSyntaxException.java
+++ b/gson/src/main/java/com/google/gson/JsonSyntaxException.java
@@ -23,7 +23,7 @@ package com.google.gson;
  */
 public final class JsonSyntaxException extends JsonParseException {
 
-  private static final long serialVersionUID = -5720608064000865903L;
+  private static final long serialVersionUID = 1L;
 
   /**
    * Creates exception with the specified message. If you are wrapping another exception, consider
@@ -31,7 +31,7 @@ public final class JsonSyntaxException extends JsonParseException {
    *
    * @param msg error message describing a possible cause of this exception.
    */
-  public JsonSyntaxException(final String msg) {
+  public JsonSyntaxException(String msg) {
     super(msg);
   }
 
@@ -41,7 +41,7 @@ public final class JsonSyntaxException extends JsonParseException {
    * @param msg   error message describing what happened.
    * @param cause root exception that caused this exception to be thrown.
    */
-  public JsonSyntaxException(final String msg, final Throwable cause) {
+  public JsonSyntaxException(String msg, Throwable cause) {
     super(msg, cause);
   }
 
@@ -51,7 +51,7 @@ public final class JsonSyntaxException extends JsonParseException {
    *
    * @param cause root exception that caused this exception to be thrown.
    */
-  public JsonSyntaxException(final Throwable cause) {
+  public JsonSyntaxException(Throwable cause) {
     super(cause);
   }
 }

--- a/gson/src/main/java/com/google/gson/stream/MalformedJsonException.java
+++ b/gson/src/main/java/com/google/gson/stream/MalformedJsonException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,26 +19,48 @@ package com.google.gson.stream;
 import java.io.IOException;
 
 /**
- * Thrown when a reader encounters malformed JSON. Some syntax errors can be
- * ignored by calling {@link JsonReader#setLenient(boolean)}.
+ * Thrown when a reader encounters malformed JSON. Some syntax errors can be ignored by calling
+ * {@link JsonReader#setLenient(boolean)}.
+ *
+ * @author Inderjeet Singh
+ * @author Joel Leitch
  */
 public final class MalformedJsonException extends IOException {
-  private static final long serialVersionUID = 1L;
 
-  public MalformedJsonException(String msg) {
+  private static final long serialVersionUID = -4087810063524778887L;
+
+  /**
+   * Creates exception with the specified message. If you are wrapping another exception, consider
+   * using {@link #MalformedJsonException(String, Throwable)} instead.
+   *
+   * @param msg error message describing a possible cause of this exception.
+   */
+  public MalformedJsonException(final String msg) {
     super(msg);
   }
 
-  public MalformedJsonException(String msg, Throwable throwable) {
+  /**
+   * Creates exception with the specified message and cause.
+   *
+   * @param msg   error message describing what happened.
+   * @param cause root exception that caused this exception to be thrown.
+   */
+  public MalformedJsonException(final String msg, final Throwable cause) {
     super(msg);
     // Using initCause() instead of calling super() because Java 1.5 didn't retrofit IOException
     // with a constructor with Throwable. This was done in Java 1.6
-    initCause(throwable);
+    initCause(cause);
   }
 
-  public MalformedJsonException(Throwable throwable) {
+  /**
+   * Creates exception with the specified cause. Consider using {@link
+   * #MalformedJsonException(String, Throwable)} instead if you can describe what happened.
+   *
+   * @param cause root exception that caused this exception to be thrown.
+   */
+  public MalformedJsonException(final Throwable cause) {
     // Using initCause() instead of calling super() because Java 1.5 didn't retrofit IOException
     // with a constructor with Throwable. This was done in Java 1.6
-    initCause(throwable);
+    initCause(cause);
   }
 }

--- a/gson/src/main/java/com/google/gson/stream/MalformedJsonException.java
+++ b/gson/src/main/java/com/google/gson/stream/MalformedJsonException.java
@@ -21,13 +21,10 @@ import java.io.IOException;
 /**
  * Thrown when a reader encounters malformed JSON. Some syntax errors can be ignored by calling
  * {@link JsonReader#setLenient(boolean)}.
- *
- * @author Inderjeet Singh
- * @author Joel Leitch
  */
 public final class MalformedJsonException extends IOException {
 
-  private static final long serialVersionUID = -4087810063524778887L;
+  private static final long serialVersionUID = 1L;
 
   /**
    * Creates exception with the specified message. If you are wrapping another exception, consider
@@ -35,7 +32,7 @@ public final class MalformedJsonException extends IOException {
    *
    * @param msg error message describing a possible cause of this exception.
    */
-  public MalformedJsonException(final String msg) {
+  public MalformedJsonException(String msg) {
     super(msg);
   }
 
@@ -45,11 +42,8 @@ public final class MalformedJsonException extends IOException {
    * @param msg   error message describing what happened.
    * @param cause root exception that caused this exception to be thrown.
    */
-  public MalformedJsonException(final String msg, final Throwable cause) {
-    super(msg);
-    // Using initCause() instead of calling super() because Java 1.5 didn't retrofit IOException
-    // with a constructor with Throwable. This was done in Java 1.6
-    initCause(cause);
+  public MalformedJsonException(String msg, Throwable cause) {
+    super(msg, cause);
   }
 
   /**
@@ -58,9 +52,7 @@ public final class MalformedJsonException extends IOException {
    *
    * @param cause root exception that caused this exception to be thrown.
    */
-  public MalformedJsonException(final Throwable cause) {
-    // Using initCause() instead of calling super() because Java 1.5 didn't retrofit IOException
-    // with a constructor with Throwable. This was done in Java 1.6
-    initCause(cause);
+  public MalformedJsonException(Throwable cause) {
+    super(cause);
   }
 }


### PR DESCRIPTION
**Add a private generated serialVersionUID**
[According to the java documentation](https://docs.oracle.com/en/java/javase/13/docs/api/java.base/java/io/Serializable.html) different serializable classes should use unique `serialVersionUID`:
> The serialization runtime associates with each serializable class a version number, called a serialVersionUID, which is used during deserialization to verify that the sender and receiver of a serialized object have loaded classes for that object that are compatible with respect to serialization. If the receiver has loaded a class for the object that has a different serialVersionUID than that of the corresponding sender's class, then deserialization will result in an InvalidClassException.

These should also be private if possible:
> It is also strongly advised that explicit serialVersionUID declarations use the private modifier where possible, since such declarations apply only to the immediately declaring class--serialVersionUID fields are not useful as inherited members.

**Parameters of exceptions can be final**
As these parameters are immutable, they should be marked as final

**Add author-tags if missing**
All files should have the `@author`-tag, therefore it has been added to `MalformedJsonException.java`

**Consistent naming for throwable**
The naming of the throwable in exceptions has been unified to be always `cause`

**Add documentation to all methods**
All methods and constructors in exception-classes have received a unified javadoc-block

**Apply Google Java Style Guide**
The [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html) has been applied