### PR TITLE
doc(UserGuide): mention TypeAdapters class

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -301,11 +301,12 @@ This approach is practical only if the array appears as a top-level element or i
 
 ### <a name="TOC-Built-in-Serializers-and-Deserializers"></a>Built-in Serializers and Deserializers
 
-Gson has built-in serializers and deserializers for commonly used classes whose default representation may be inappropriate.
-Here is a list of such classes:
+Gson has built-in serializers and deserializers for commonly used classes whose default representation may be inappropriate, for instance
 
-1. `java.net.URL` to match it with strings like `"https://github.com/google/gson/"`
-2. `java.net.URI` to match it with strings like `"/google/gson/"`
+* `java.net.URL` to match it with strings like `"https://github.com/google/gson/"`
+* `java.net.URI` to match it with strings like `"/google/gson/"`
+
+For many more, see the internal class [`TypeAdapters`](https://github.com/google/gson/blob/master/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java).
 
 You can also find source code for some commonly used classes such as JodaTime at [this page](https://sites.google.com/site/gson/gson-type-adapters-for-common-classes-1).
 


### PR DESCRIPTION
In the section Built-in Serializers and Deserializers,
* clarify that URL, URI are only examples
* link to TypeAdapters class