### PR TITLE
Fix #1684: Allow explicit JSON null for JsonElement

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonElement.java
+++ b/gson/src/main/java/com/google/gson/JsonElement.java
@@ -16,6 +16,7 @@
 
 package com.google.gson;
 
+import com.google.gson.annotations.ExplicitlyNullableJsonElement;
 import com.google.gson.internal.Streams;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -29,6 +30,8 @@ import java.math.BigInteger;
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
+ *
+ * @see ExplicitlyNullableJsonElement
  */
 public abstract class JsonElement {
   /**

--- a/gson/src/main/java/com/google/gson/annotations/ExplicitlyNullableJsonElement.java
+++ b/gson/src/main/java/com/google/gson/annotations/ExplicitlyNullableJsonElement.java
@@ -1,0 +1,66 @@
+package com.google.gson.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+
+/**
+ * An annotation that indicates that upon deserialization {@code null} will be assigned
+ * to an annotated field of declared type {@link JsonElement} or one of its subclasses
+ * in case it has an explicit {@code null} value in JSON.
+ *
+ * <p>This annotation only has an effect if the JSON representation of the declaring
+ * class of the annotated field is deserialized using Gson's reflection-based
+ * deserialization approach (the default if no type adapter is specified for the class).
+ *
+ * <p>Normally {@link JsonElement} and its subclasses are deserialized as instance of
+ * {@link JsonNull} if they have a JSON value of {@code null}. When the expected type
+ * is {@code JsonElement}, this makes it cumbersome because one has to check for both
+ * {@code null} and {@code JsonNull} after deserializing. And for subclasses of
+ * {@code JsonElement}, such as {@link JsonObject}, an exception is thrown due to the
+ * class mismatch.<br>
+ * However, if the field is annotated with this annotation, no exception is thrown and
+ * the value of the field will be {@code null}.
+ *
+ * <h1>Example</h1>
+ * <pre>
+ * public class Container {
+ *    &#64;ExplicitlyNullableJsonElement private JsonObject attributes;
+ *    &#64;ExplicitlyNullableJsonElement private JsonElement additionalData;
+ *
+ *    public boolean hasAdditionalData() {
+ *      /*
+ *       * Without &#64;ExplicitlyNullableJsonElement this check would have to be:
+ *       *  - `additionalData != null`
+ *       *    In case the property does not exist in JSON: `{}`
+ *       *  - `!additionalData.isJsonNull()`
+ *       *    In case the property has a `null` value in JSON:
+ *       *    `{"additionalData": null}`
+ *       *&#47;
+ *      return additionalData != null;
+ *    }
+ * }
+ * </pre>
+ * Due to {@code @ExplicitlyNullableJsonElement} being present on the <i>attributes</i>
+ * field, this allows explicit {@code null} values in JSON, which would otherwise
+ * cause an exception:
+ * <pre>
+ * {
+ *   "attributes" : null
+ * }
+ * </pre>
+ *
+ * @since 2.8.7
+ */
+@Documented
+@Retention(RUNTIME)
+@Target(FIELD)
+public @interface ExplicitlyNullableJsonElement {
+}

--- a/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
@@ -146,7 +146,7 @@ public class DefaultTypeAdaptersTest extends TestCase {
     URI target = gson.fromJson(json, URI.class);
     assertEquals(uriValue, target.toASCIIString());
   }
-  
+
   public void testNullSerialization() throws Exception {
     testNullSerializationAndDeserialization(Boolean.class);
     testNullSerializationAndDeserialization(Byte.class);
@@ -269,7 +269,7 @@ public class DefaultTypeAdaptersTest extends TestCase {
     ClassWithBigInteger actual = gson.fromJson(json, ClassWithBigInteger.class);
     assertEquals(expected.value, actual.value);
   }
-  
+
   public void testOverrideBigIntegerTypeAdapter() throws Exception {
     gson = new GsonBuilder()
         .registerTypeAdapter(BigInteger.class, new NumberAsStringAdapter(BigInteger.class))
@@ -638,6 +638,15 @@ public class DefaultTypeAdaptersTest extends TestCase {
       fail();
     } catch (JsonSyntaxException expected) {
       assertEquals("Expected a com.google.gson.JsonObject but was com.google.gson.JsonPrimitive",
+          expected.getMessage());
+    }
+
+    // Verify that `null` is always deserialized as JsonNull
+    try {
+      gson.fromJson("null", JsonObject.class);
+      fail();
+    } catch (JsonSyntaxException expected) {
+      assertEquals("Expected a com.google.gson.JsonObject but was com.google.gson.JsonNull",
           expected.getMessage());
     }
   }

--- a/gson/src/test/java/com/google/gson/functional/JsonElementNullTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonElementNullTest.java
@@ -1,0 +1,153 @@
+package com.google.gson.functional;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.ExplicitlyNullableJsonElement;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import junit.framework.TestCase;
+
+public class JsonElementNullTest extends TestCase {
+  private static class AnnotationOnInvalidType {
+    @ExplicitlyNullableJsonElement
+    String f;
+  }
+
+  @Test
+  public void testAnnotationOnInvalidType() {
+    try {
+      new Gson().fromJson("{}", AnnotationOnInvalidType.class);
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertEquals("Non-JsonElement field 'java.lang.String " + AnnotationOnInvalidType.class.getName()
+          + ".f' annotated with @ExplicitlyNullableJsonElement", expected.getMessage());
+    }
+  }
+
+  private static class Annotated {
+    @ExplicitlyNullableJsonElement
+    JsonElement f;
+
+    @ExplicitlyNullableJsonElement
+    JsonObject f2;
+
+    // Should also work for JsonNull
+    @ExplicitlyNullableJsonElement
+    JsonNull f3;
+  }
+
+  @Test
+  public void testNullValues() {
+    Annotated deserialized = new Gson().fromJson("{\"f\": null, \"f2\": null, \"f3\": null}", Annotated.class);
+    assertNull(deserialized.f);
+    assertNull(deserialized.f2);
+    assertNull(deserialized.f3);
+  }
+
+  /**
+   * Verify that fields annotated with {@link ExplicitlyNullableJsonElement} are
+   * assigned the correct value if their JSON value is non-{@code null}
+   */
+  @Test
+  public void testNonNullValues() {
+    Annotated deserialized = new Gson().fromJson("{\"f\": 1, \"f2\": {}}", Annotated.class);
+    assertEquals(new JsonPrimitive(1), deserialized.f);
+    assertEquals(0, deserialized.f2.size());
+  }
+
+  private static class GenericUnboundAnnotated<T> {
+    @ExplicitlyNullableJsonElement
+    protected T f;
+  }
+
+  private static class JsonElementGeneric extends GenericUnboundAnnotated<JsonElement> {
+  }
+
+  private static class GenericBoundAnnotated<T extends JsonElement> {
+    @ExplicitlyNullableJsonElement
+    T f;
+  }
+
+  /**
+   * Verify that declared field type instead of effective type is checked, otherwise
+   * this would allow potentially unsafe constructs
+   */
+  @Test
+  public void testDeclaredFieldType() {
+    /*
+     * Here effective field type is JsonElement, however declared field type
+     * is unbound, so this should fail
+     */
+    try {
+      new Gson().fromJson("{}", JsonElementGeneric.class);
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertEquals("Non-JsonElement field 'protected java.lang.Object " + GenericUnboundAnnotated.class.getName()
+          + ".f' annotated with @ExplicitlyNullableJsonElement", expected.getMessage());
+    }
+
+    // Generic type is bound to JsonElement or subclass, so this should work
+    GenericBoundAnnotated<?> deserialized = new Gson().fromJson("{\"f\": null}", GenericBoundAnnotated.class);
+    assertNull(deserialized.f);
+  }
+
+
+  private static class FieldWithCustomAdapter {
+    @ExplicitlyNullableJsonElement
+    @JsonAdapter(value = CustomAdapter.class, nullSafe = false)
+    JsonElement f;
+  }
+
+  private static class CustomAdapter extends TypeAdapter<JsonElement> {
+    public static final JsonElement DESERIALIZED = new JsonPrimitive(2);
+
+    @Override
+    public JsonElement read(JsonReader in) throws IOException {
+      in.skipValue();
+      // Simply always return the same value
+      return DESERIALIZED;
+    }
+
+    @Override
+    public void write(JsonWriter out, JsonElement value) throws IOException {
+      // Not needed for this test
+      fail();
+    }
+  }
+
+  /**
+   * Verifies that non-{@code null} values are handled by custom adapters
+   * specified using the {@link JsonAdapter} annotation
+   *
+   * <p>Note: Checking for custom adapters registered on {@code GsonBuilder}
+   * is not necessary because built-in {@link JsonElement} adapter cannot
+   * be overwritten.
+   */
+  @Test
+  public void testCustomAdapter() {
+    FieldWithCustomAdapter deserialized = new Gson().fromJson("{\"f\": \"test\"}", FieldWithCustomAdapter.class);
+    assertSame(CustomAdapter.DESERIALIZED, deserialized.f);
+  }
+
+  /**
+   * Verifies that even if {@link JsonAdapter} annotation specifies that
+   * adapter handles {@code null}, {@link ExplicitlyNullableJsonElement}
+   * should have higher precedence
+   */
+  @Test
+  public void testCustomAdapterNull() {
+    FieldWithCustomAdapter deserialized = new Gson().fromJson("{\"f\": null}", FieldWithCustomAdapter.class);
+    // If custom adapter was used, this would be CustomAdapter.DESERIALIZED
+    assertNull(deserialized.f);
+  }
+}


### PR DESCRIPTION
Adds a new annotation `@ExplicitlyNullableJsonElement` which can be placed on fields of type JsonElement or subclasses. When deserialized using the reflection-based approach, `null` instead of JsonNull will be used as value. This allows explicit `null` JSON values for JsonElement subclasses which would otherwise cause an exception (except for JsonNull).

Note that this does not cover all use cases where one might want `JsonElement` or some of its subclasses to be deserialized as `null`, see discussion in #1684.
Additionally a user might also be able to use `Object` instead of `JsonElement` as type of fields to prevent the issue this pull request tries to solve. However, numbers are treated differently: Deserializing `Object` treats all numbers as  `double` (see `ObjectTypeAdapter`).

E.g. the following currently throws an exception:
```
class MyClass {
  JsonObject f;
}

new Gson().fromJson("{\"f\": null}", MyClass.class);
```

With the changes of this pull request, the following would be possible:
```
class MyClass {
  @ExplicitlyNullableJsonElement
  JsonObject f;
}

new Gson().fromJson("{\"f\": null}", MyClass.class);
```

Edit: It would also be possible to solve this by using the `@JsonAdapter` annotation on the fields and implementing a `TypeAdapterFactory` which creates type adapters which return `null` in case of JSON `null` or otherwise delegate to the default adapter. Edit 2: Probably not possible due to  #1028.