### PR TITLE
Prevent custom JsonElement subclasses

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonElement.java
+++ b/gson/src/main/java/com/google/gson/JsonElement.java
@@ -31,6 +31,11 @@ import java.math.BigInteger;
  * @author Joel Leitch
  */
 public abstract class JsonElement {
+  // Package-private to prevent custom subclasses because they would cause issues for
+  // the default type adapter
+  JsonElement() {
+  }
+
   /**
    * Returns a deep copy of this element. Immutable elements like primitives
    * and nulls are not copied.


### PR DESCRIPTION
Adds a package-private constructor to JsonElement to prevent custom subclasses. JsonElement models the JSON data types so there should probably be no need for custom subclasses because the existing JsonElement subclasses cover all of them. Additionally custom subclasses would cause issues during (de-)serialization because the default type adapter does not support them.

However, maybe there are use cases (in unit tests?) where custom subclasses are desired?
Would it be better to only deprecate the public constructor for now?