### PR TITLE
Fix #1028: Gson.getDelegateAdapter not working correctly for @JsonAdapter field

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/Excluder.java
+++ b/gson/src/main/java/com/google/gson/internal/Excluder.java
@@ -221,16 +221,16 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
       return false;
   }
 
-  private boolean isAnonymousOrLocal(Class<?> clazz) {
+  private static boolean isAnonymousOrLocal(Class<?> clazz) {
     return !Enum.class.isAssignableFrom(clazz)
         && (clazz.isAnonymousClass() || clazz.isLocalClass());
   }
 
-  private boolean isInnerClass(Class<?> clazz) {
+  private static boolean isInnerClass(Class<?> clazz) {
     return clazz.isMemberClass() && !isStatic(clazz);
   }
 
-  private boolean isStatic(Class<?> clazz) {
+  private static boolean isStatic(Class<?> clazz) {
     return (clazz.getModifiers() & Modifier.STATIC) != 0;
   }
 

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -61,11 +61,11 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
     this.jsonAdapterFactory = jsonAdapterFactory;
   }
 
-  public boolean excludeField(Field f, boolean serialize) {
-    return excludeField(f, serialize, excluder);
+  public boolean includeField(Field f, boolean serialize) {
+    return includeField(f, serialize, excluder);
   }
 
-  static boolean excludeField(Field f, boolean serialize, Excluder excluder) {
+  static boolean includeField(Field f, boolean serialize, Excluder excluder) {
     return !excluder.excludeClass(f.getType(), serialize) && !excluder.excludeField(f, serialize);
   }
 
@@ -111,7 +111,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
     TypeAdapter<?> mapped = null;
     if (annotation != null) {
       mapped = jsonAdapterFactory.getTypeAdapter(
-          constructorConstructor, context, fieldType, annotation);
+          constructorConstructor, context, fieldType, annotation, true);
     }
     final boolean jsonAdapterPresent = mapped != null;
     if (mapped == null) mapped = context.getAdapter(fieldType);
@@ -151,8 +151,8 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
     while (raw != Object.class) {
       Field[] fields = raw.getDeclaredFields();
       for (Field field : fields) {
-        boolean serialize = excludeField(field, true);
-        boolean deserialize = excludeField(field, false);
+        boolean serialize = includeField(field, true);
+        boolean deserialize = includeField(field, false);
         if (!serialize && !deserialize) {
           continue;
         }

--- a/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java
@@ -281,4 +281,58 @@ public final class JsonAdapterAnnotationOnClassesTest extends TestCase {
       }
     }
   }
+
+  /**
+   * Tests usage of {@link JsonSerializer} as {@link JsonAdapter} value
+   */
+  public void testJsonSerializer() {
+    Gson gson = new Gson();
+    // Verify that delegate deserializer (reflection deserializer) is used
+    JsonSerializerTest deserialized = gson.fromJson("{\"f\":\"test\"}", JsonSerializerTest.class);
+    assertEquals("test", deserialized.f);
+
+    String json = gson.toJson(new JsonSerializerTest());
+    // Uses custom serializer which always returns `true`
+    assertEquals("true", json);
+  }
+  @JsonAdapter(JsonSerializerTest.Serializer.class)
+  private static class JsonSerializerTest {
+    String f = "";
+
+    static class Serializer implements JsonSerializer<JsonSerializerTest> {
+      @Override
+      public JsonElement serialize(JsonSerializerTest src, Type typeOfSrc, JsonSerializationContext context) {
+        return new JsonPrimitive(true);
+      }
+    }
+  }
+
+  /**
+   * Tests usage of {@link JsonDeserializer} as {@link JsonAdapter} value
+   */
+  public void testJsonDeserializer() {
+    Gson gson = new Gson();
+    JsonDeserializerTest deserialized = gson.fromJson("{\"f\":\"test\"}", JsonDeserializerTest.class);
+    // Uses custom deserializer which always uses "123" as field value
+    assertEquals("123", deserialized.f);
+
+    // Verify that delegate serializer (reflection serializer) is used
+    String json = gson.toJson(new JsonDeserializerTest("abc"));
+    assertEquals("{\"f\":\"abc\"}", json);
+  }
+  @JsonAdapter(JsonDeserializerTest.Deserializer.class)
+  private static class JsonDeserializerTest {
+    String f;
+
+    JsonDeserializerTest(String f) {
+      this.f = f;
+    }
+
+    static class Deserializer implements JsonDeserializer<JsonDeserializerTest> {
+      @Override
+      public JsonDeserializerTest deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
+        return new JsonDeserializerTest("123");
+      }
+    }
+  }
 }

--- a/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java
@@ -260,4 +260,25 @@ public final class JsonAdapterAnnotationOnClassesTest extends TestCase {
   private static final class D {
     @SuppressWarnings("unused") final String value = "a";
   }
+
+  /**
+   * Verifies that {@link TypeAdapterFactory} specified by JsonAdapter can
+   * call Gson.getDelegateAdapter without any issues, despite the factory
+   * not being directly registered on Gson.
+   */
+  public void testDelegatingAdapterFactory() {
+    E deserialized = new Gson().fromJson("{\"f\":\"test\"}", E.class);
+    assertEquals("test", deserialized.f);
+  }
+  @JsonAdapter(E.DelegatingAdapterFactory.class)
+  private static class E {
+    String f;
+
+    static class DelegatingAdapterFactory implements TypeAdapterFactory {
+      @Override
+      public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+        return gson.getDelegateAdapter(this, type);
+      }
+    }
+  }
 }


### PR DESCRIPTION
Previously `TypeAdapterFactory` classes specified using the `@JsonAdapter` annotation for fields were only be able to get type adapters created by the enum and reflection-based factories when calling `Gson.getDelegateAdapter(...)`.
This pull request changes it so they are able to get type adapters created by all factories registered on the Gson instance.

The behavior for `@JsonAdapter` on types (in contrast to fields) remains unchanged.

Note that this is an backwards incompatible change in case someone relies on `Gson.getDelegateAdapter(...)` returning a reflection-based type adapter. However, this might be a rare corner case and it appears keeping this behavior while also fixing #1028 is not possible.

Also note that this solution breaks if the created `TypeAdapterFactory` leaks a reference to itself, e.g. by storing a reference to itself in a static field or adding it to a static collection, and then later calling `getDelegateAdapter`. Or if `TypeAdapterFactory.create(...)` calls `getDelegateAdapter` from a separate thread. Though both cases are likely rare corner cases.