### PR TITLE
Update links and use HTTPS for them

### DIFF
--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -160,7 +160,7 @@ public final class GsonBuilder {
   /**
    * Makes the output JSON non-executable in Javascript by prefixing the generated JSON with some
    * special text. This prevents attacks from third-party sites through script sourcing. See
-   * <a href="http://code.google.com/p/google-gson/issues/detail?id=42">Gson Issue 42</a>
+   * <a href="https://github.com/google/gson/issues/42">Gson Issue 42</a>
    * for details.
    *
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
@@ -389,7 +389,7 @@ public final class GsonBuilder {
 
   /**
    * By default, Gson is strict and only accepts JSON as specified by
-   * <a href="http://www.ietf.org/rfc/rfc4627.txt">RFC 4627</a>. This option makes the parser
+   * <a href="https://www.ietf.org/rfc/rfc4627.txt">RFC 4627</a>. This option makes the parser
    * liberal in what it accepts.
    *
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
@@ -553,9 +553,9 @@ public final class GsonBuilder {
   }
 
   /**
-   * Section 2.4 of <a href="http://www.ietf.org/rfc/rfc4627.txt">JSON specification</a> disallows
+   * Section 2.4 of <a href="https://www.ietf.org/rfc/rfc4627.txt">JSON specification</a> disallows
    * special double values (NaN, Infinity, -Infinity). However,
-   * <a href="http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf">Javascript
+   * <a href="https://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf">Javascript
    * specification</a> (see section 4.3.20, 4.3.22, 4.3.23) allows these values as valid Javascript
    * values. Moreover, most JavaScript engines will accept these special values in JSON without
    * problem. So, at a practical level, it makes sense to accept these values as valid JSON even

--- a/gson/src/main/java/com/google/gson/internal/JavaVersion.java
+++ b/gson/src/main/java/com/google/gson/internal/JavaVersion.java
@@ -20,7 +20,7 @@ package com.google.gson.internal;
  * Utility to check the major Java version of the current JVM.
  */
 public final class JavaVersion {
-  // Oracle defines naming conventions at http://www.oracle.com/technetwork/java/javase/versioning-naming-139433.html
+  // Oracle defines naming conventions at https://www.oracle.com/technetwork/java/javase/versioning-naming-139433.html
   // However, many alternate implementations differ. For example, Debian used 9-debian as the version string
 
   private static final int majorJavaVersion = determineMajorJavaVersion();

--- a/gson/src/main/java/com/google/gson/internal/bind/util/ISO8601Utils.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/util/ISO8601Utils.java
@@ -10,7 +10,7 @@ import java.util.*;
  * 
  * Supported parse format: [yyyy-MM-dd|yyyyMMdd][T(hh:mm[:ss[.sss]]|hhmm[ss[.sss]])]?[Z|[+-]hh[:]mm]]
  * 
- * @see <a href="http://www.w3.org/TR/NOTE-datetime">this specification</a>
+ * @see <a href="https://www.w3.org/TR/NOTE-datetime">this specification</a>
  */
 //Date parsing code from Jackson databind ISO8601Utils.java
 // https://github.com/FasterXML/jackson-databind/blob/master/src/main/java/com/fasterxml/jackson/databind/util/ISO8601Utils.java

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -25,7 +25,7 @@ import java.io.Reader;
 import java.util.Arrays;
 
 /**
- * Reads a JSON (<a href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>)
+ * Reads a JSON (<a href="https://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>)
  * encoded value as a stream of tokens. This stream includes both literal
  * values (strings, numbers, booleans, and nulls) as well as the begin and
  * end delimiters of objects and arrays. The tokens are traversed in
@@ -172,7 +172,7 @@ import java.util.Arrays;
  *
  * <a id="nonexecuteprefix"/><h3>Non-Execute Prefix</h3>
  * Web servers that serve private data using JSON may be vulnerable to <a
- * href="http://en.wikipedia.org/wiki/JSON#Cross-site_request_forgery">Cross-site
+ * href="https://en.wikipedia.org/wiki/JSON#Cross-site_request_forgery">Cross-site
  * request forgery</a> attacks. In such an attack, a malicious site gains access
  * to a private JSON file by executing it with an HTML {@code <script>} tag.
  *
@@ -295,7 +295,7 @@ public class JsonReader implements Closeable {
   /**
    * Configure this parser to be liberal in what it accepts. By default,
    * this parser is strict and only accepts JSON as specified by <a
-   * href="http://www.ietf.org/rfc/rfc4627.txt">RFC 4627</a>. Setting the
+   * href="https://www.ietf.org/rfc/rfc4627.txt">RFC 4627</a>. Setting the
    * parser to lenient causes it to ignore the following syntax errors:
    *
    * <ul>
@@ -1455,7 +1455,7 @@ public class JsonReader implements Closeable {
   }
 
   /**
-   * Returns a <a href="http://goessner.net/articles/JsonPath/">JsonPath</a> to
+   * Returns a <a href="https://goessner.net/articles/JsonPath/">JsonPath</a> to
    * the current location in the JSON value.
    */
   public String getPath() {

--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -31,7 +31,7 @@ import static com.google.gson.stream.JsonScope.NONEMPTY_DOCUMENT;
 import static com.google.gson.stream.JsonScope.NONEMPTY_OBJECT;
 
 /**
- * Writes a JSON (<a href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>)
+ * Writes a JSON (<a href="https://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>)
  * encoded value to a stream, one token at a time. The stream includes both
  * literal values (strings, numbers, booleans and nulls) as well as the begin
  * and end delimiters of objects and arrays.
@@ -138,7 +138,7 @@ public class JsonWriter implements Closeable, Flushable {
    *
    * We also escape '\u2028' and '\u2029', which JavaScript interprets as
    * newline characters. This prevents eval() from failing with a syntax
-   * error. http://code.google.com/p/google-gson/issues/detail?id=341
+   * error. https://github.com/google/gson/issues/341
    */
   private static final String[] REPLACEMENT_CHARS;
   private static final String[] HTML_SAFE_REPLACEMENT_CHARS;
@@ -223,7 +223,7 @@ public class JsonWriter implements Closeable, Flushable {
   /**
    * Configure this writer to relax its syntax rules. By default, this writer
    * only emits well-formed JSON as specified by <a
-   * href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>. Setting the writer
+   * href="https://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>. Setting the writer
    * to lenient permits the following:
    * <ul>
    *   <li>Top-level values of any type. With strict writing, the top-level

--- a/gson/src/test/java/com/google/gson/JsonObjectTest.java
+++ b/gson/src/test/java/com/google/gson/JsonObjectTest.java
@@ -108,7 +108,7 @@ public class JsonObjectTest extends TestCase {
   }
 
   /**
-   * From bug report http://code.google.com/p/google-gson/issues/detail?id=182
+   * From bug report https://github.com/google/gson/issues/182
    */
   public void testPropertyWithQuotes() {
     JsonObject jsonObj = new JsonObject();

--- a/gson/src/test/java/com/google/gson/functional/ArrayTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ArrayTest.java
@@ -256,7 +256,7 @@ public class ArrayTest extends TestCase {
     assertEquals("Manufacturing", items[1][5]);
   }
 
-  /** http://code.google.com/p/google-gson/issues/detail?id=342 */
+  /** https://github.com/google/gson/issues/342 */
   public void testArrayElementsAreArrays() {
     Object[] stringArrays = {
         new String[] {"test1", "test2"},

--- a/gson/src/test/java/com/google/gson/functional/ConcurrencyTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ConcurrencyTest.java
@@ -41,7 +41,7 @@ public class ConcurrencyTest extends TestCase {
 
   /**
    * Source-code based on
-   * http://groups.google.com/group/google-gson/browse_thread/thread/563bb51ee2495081
+   * https://groups.google.com/d/topic/google-gson/Vju1HuJJUIE/discussion
    */
   public void testSingleThreadSerialization() { 
     MyObject myObj = new MyObject(); 
@@ -52,7 +52,7 @@ public class ConcurrencyTest extends TestCase {
 
   /**
    * Source-code based on
-   * http://groups.google.com/group/google-gson/browse_thread/thread/563bb51ee2495081
+   * https://groups.google.com/d/topic/google-gson/Vju1HuJJUIE/discussion
    */
   public void testSingleThreadDeserialization() { 
     for (int i = 0; i < 10; i++) { 
@@ -62,7 +62,7 @@ public class ConcurrencyTest extends TestCase {
 
   /**
    * Source-code based on
-   * http://groups.google.com/group/google-gson/browse_thread/thread/563bb51ee2495081
+   * https://groups.google.com/d/topic/google-gson/Vju1HuJJUIE/discussion
    */
   public void testMultiThreadSerialization() throws InterruptedException {
     final CountDownLatch startLatch = new CountDownLatch(1);
@@ -93,7 +93,7 @@ public class ConcurrencyTest extends TestCase {
 
   /**
    * Source-code based on
-   * http://groups.google.com/group/google-gson/browse_thread/thread/563bb51ee2495081
+   * https://groups.google.com/d/topic/google-gson/Vju1HuJJUIE/discussion
    */
   public void testMultiThreadDeserialization() throws InterruptedException {
     final CountDownLatch startLatch = new CountDownLatch(1);

--- a/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
@@ -505,7 +505,7 @@ public class DefaultTypeAdaptersTest extends TestCase {
     assertEquals("\"2011-09-11\"", json);
   }
 
-  // http://code.google.com/p/google-gson/issues/detail?id=230
+  // https://github.com/google/gson/issues/230
   public void testDateSerializationInCollection() throws Exception {
     Type listOfDates = new TypeToken<List<Date>>() {}.getType();
     TimeZone defaultTimeZone = TimeZone.getDefault();
@@ -524,7 +524,7 @@ public class DefaultTypeAdaptersTest extends TestCase {
     }
   }
 
-  // http://code.google.com/p/google-gson/issues/detail?id=230
+  // https://github.com/google/gson/issues/230
   public void testTimestampSerialization() throws Exception {
     TimeZone defaultTimeZone = TimeZone.getDefault();
     TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
@@ -542,7 +542,7 @@ public class DefaultTypeAdaptersTest extends TestCase {
     }
   }
 
-  // http://code.google.com/p/google-gson/issues/detail?id=230
+  // https://github.com/google/gson/issues/230
   public void testSqlDateSerialization() throws Exception {
     TimeZone defaultTimeZone = TimeZone.getDefault();
     TimeZone.setDefault(TimeZone.getTimeZone("UTC"));

--- a/gson/src/test/java/com/google/gson/functional/MapTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MapTest.java
@@ -318,14 +318,14 @@ public class MapTest extends TestCase {
   }
 
   /**
-   * Created in response to http://code.google.com/p/google-gson/issues/detail?id=99
+   * Created in response to https://github.com/google/gson/issues/99
    */
   private static class ClassWithAMap {
     Map<String, String> map = new TreeMap<String, String>();
   }
 
   /**
-   * Created in response to http://code.google.com/p/google-gson/issues/detail?id=99
+   * Created in response to https://github.com/google/gson/issues/99
    */
   public void testMapSerializationWithNullValues() {
     ClassWithAMap target = new ClassWithAMap();
@@ -337,7 +337,7 @@ public class MapTest extends TestCase {
   }
 
   /**
-   * Created in response to http://code.google.com/p/google-gson/issues/detail?id=99
+   * Created in response to https://github.com/google/gson/issues/99
    */
   public void testMapSerializationWithNullValuesSerialized() {
     Gson gson = new GsonBuilder().serializeNulls().create();
@@ -376,7 +376,7 @@ public class MapTest extends TestCase {
   }
 
   /**
-   * From bug report http://code.google.com/p/google-gson/issues/detail?id=95
+   * From bug report https://github.com/google/gson/issues/95
    */
   public void testMapOfMapSerialization() {
     Map<String, Map<String, String>> map = new HashMap<String, Map<String, String>>();
@@ -391,7 +391,7 @@ public class MapTest extends TestCase {
   }
 
   /**
-   * From bug report http://code.google.com/p/google-gson/issues/detail?id=95
+   * From bug report https://github.com/google/gson/issues/95
    */
   public void testMapOfMapDeserialization() {
     String json = "{nestedMap:{'2':'2','1':'1'}}";
@@ -403,7 +403,7 @@ public class MapTest extends TestCase {
   }
 
   /**
-   * From bug report http://code.google.com/p/google-gson/issues/detail?id=178
+   * From bug report https://github.com/google/gson/issues/178
    */
   public void testMapWithQuotes() {
     Map<String, String> map = new HashMap<String, String>();
@@ -428,7 +428,7 @@ public class MapTest extends TestCase {
   }
 
   /**
-   * From bug report http://code.google.com/p/google-gson/issues/detail?id=204
+   * From bug report https://github.com/google/gson/issues/204
    */
   public void testSerializeMaps() {
     Map<String, Object> map = new LinkedHashMap<String, Object>();

--- a/gson/src/test/java/com/google/gson/functional/NamingPolicyTest.java
+++ b/gson/src/test/java/com/google/gson/functional/NamingPolicyTest.java
@@ -158,7 +158,7 @@ public class NamingPolicyTest extends TestCase {
     assertEquals(10, obj.value);
   }
 
-  /** http://code.google.com/p/google-gson/issues/detail?id=349 */
+  /** https://github.com/google/gson/issues/349 */
   public void testAtSignInSerializedName() {
     assertEquals("{\"@foo\":\"bar\"}", new Gson().toJson(new AtName()));
   }

--- a/gson/src/test/java/com/google/gson/functional/NullObjectAndFieldTest.java
+++ b/gson/src/test/java/com/google/gson/functional/NullObjectAndFieldTest.java
@@ -85,7 +85,7 @@ public class NullObjectAndFieldTest extends TestCase {
   }
   
   /** 
-   * Added to verify http://code.google.com/p/google-gson/issues/detail?id=68
+   * Added to verify https://github.com/google/gson/issues/68
    */
   public void testNullWrappedPrimitiveMemberSerialization() {
     Gson gson = gsonBuilder.serializeNulls().create();
@@ -95,7 +95,7 @@ public class NullObjectAndFieldTest extends TestCase {
   }
   
   /** 
-   * Added to verify http://code.google.com/p/google-gson/issues/detail?id=68
+   * Added to verify https://github.com/google/gson/issues/68
    */
   public void testNullWrappedPrimitiveMemberDeserialization() {
     Gson gson = gsonBuilder.create();

--- a/gson/src/test/java/com/google/gson/functional/ObjectTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ObjectTest.java
@@ -229,7 +229,7 @@ public class ObjectTest extends TestCase {
   }
 
   /**
-   * Created in response to Issue 14: http://code.google.com/p/google-gson/issues/detail?id=14
+   * Created in response to Issue 14: https://github.com/google/gson/issues/14
    */
   public void testNullArraysDeserialization() throws Exception {
     String json = "{\"array\": null}";
@@ -238,7 +238,7 @@ public class ObjectTest extends TestCase {
   }
 
   /**
-   * Created in response to Issue 14: http://code.google.com/p/google-gson/issues/detail?id=14
+   * Created in response to Issue 14: https://github.com/google/gson/issues/14
    */
   public void testNullObjectFieldsDeserialization() throws Exception {
     String json = "{\"bag\": null}";
@@ -264,7 +264,7 @@ public class ObjectTest extends TestCase {
   }
 
   /**
-   * Created in response to Issue 14: http://code.google.com/p/google-gson/issues/detail?id=14
+   * Created in response to Issue 14: https://github.com/google/gson/issues/14
    */
   public void testNullPrimitiveFieldsDeserialization() throws Exception {
     String json = "{\"longValue\":null}";
@@ -399,7 +399,7 @@ public class ObjectTest extends TestCase {
   }
 
   /**
-   * In response to Issue 41 http://code.google.com/p/google-gson/issues/detail?id=41
+   * In response to Issue 41 https://github.com/google/gson/issues/41
    */
   public void testObjectFieldNamesWithoutQuotesDeserialization() {
     String json = "{longValue:1,'booleanValue':true,\"stringValue\":'bar'}";
@@ -480,7 +480,7 @@ public class ObjectTest extends TestCase {
     gson.fromJson(gson.toJson(product), Product.class);
   }
 
-  // http://code.google.com/p/google-gson/issues/detail?id=270
+  // https://github.com/google/gson/issues/270
   public void testDateAsMapObjectField() {
     HasObjectMap a = new HasObjectMap();
     a.map.put("date", new Date(0));

--- a/gson/src/test/java/com/google/gson/functional/StringTest.java
+++ b/gson/src/test/java/com/google/gson/functional/StringTest.java
@@ -105,7 +105,7 @@ public class StringTest extends TestCase {
   }
 
   /**
-   * Created in response to http://groups.google.com/group/google-gson/browse_thread/thread/2431d4a3d0d6cb23
+   * Created in response to https://groups.google.com/d/topic/google-gson/JDHUo9DWyyM/discussion
    */
   public void testAssignmentCharSerialization() {
     String value = "abc=";
@@ -114,7 +114,7 @@ public class StringTest extends TestCase {
   }
 
   /**
-   * Created in response to http://groups.google.com/group/google-gson/browse_thread/thread/2431d4a3d0d6cb23
+   * Created in response to https://groups.google.com/d/topic/google-gson/JDHUo9DWyyM/discussion
    */
   public void testAssignmentCharDeserialization() {
     String json = "\"abc=\"";

--- a/gson/src/test/java/com/google/gson/functional/UncategorizedTest.java
+++ b/gson/src/test/java/com/google/gson/functional/UncategorizedTest.java
@@ -82,7 +82,7 @@ public class UncategorizedTest extends TestCase {
   /**
    * This test ensures that a custom deserializer is able to return a derived class instance for a
    * base class object. For a motivation for this test, see Issue 37 and
-   * http://groups.google.com/group/google-gson/browse_thread/thread/677d56e9976d7761
+   * https://groups.google.com/d/topic/google-gson/Z31W6Zdtd2E/discussion
    */
   public void testReturningDerivedClassesDuringDeserialization() {
     Gson gson = new GsonBuilder().registerTypeAdapter(Base.class, new BaseTypeAdapter()).create();
@@ -99,7 +99,7 @@ public class UncategorizedTest extends TestCase {
 
   /**
    * Test that trailing whitespace is ignored.
-   * http://code.google.com/p/google-gson/issues/detail?id=302
+   * https://github.com/google/gson/issues/302
    */
   public void testTrailingWhitespace() throws Exception {
     List<Integer> integers = gson.fromJson("[1,2,3]  \n\n  ",

--- a/gson/src/test/java/com/google/gson/internal/JavaVersionTest.java
+++ b/gson/src/test/java/com/google/gson/internal/JavaVersionTest.java
@@ -36,12 +36,12 @@ public class JavaVersionTest {
 
   @Test
   public void testJava6() {
-    assertEquals(6, JavaVersion.getMajorJavaVersion("1.6.0")); // http://www.oracle.com/technetwork/java/javase/version-6-141920.html
+    assertEquals(6, JavaVersion.getMajorJavaVersion("1.6.0")); // https://www.oracle.com/technetwork/java/javase/version-6-141920.html
   }
 
   @Test
   public void testJava7() {
-    assertEquals(7, JavaVersion.getMajorJavaVersion("1.7.0")); // http://www.oracle.com/technetwork/java/javase/jdk7-naming-418744.html
+    assertEquals(7, JavaVersion.getMajorJavaVersion("1.7.0")); // https://www.oracle.com/technetwork/java/javase/jdk7-naming-418744.html
   }
 
   @Test

--- a/gson/src/test/java/com/google/gson/metrics/PerformanceTest.java
+++ b/gson/src/test/java/com/google/gson/metrics/PerformanceTest.java
@@ -109,7 +109,7 @@ public class PerformanceTest extends TestCase {
   }
   
   /**
-   * Created in response to http://code.google.com/p/google-gson/issues/detail?id=96
+   * Created in response to https://github.com/google/gson/issues/96
    */
   public void disabled_testLargeCollectionSerialization() {
     int count = 1400000;
@@ -121,7 +121,7 @@ public class PerformanceTest extends TestCase {
   }
   
   /**
-   * Created in response to http://code.google.com/p/google-gson/issues/detail?id=96
+   * Created in response to https://github.com/google/gson/issues/96
    */
   public void disabled_testLargeCollectionDeserialization() {
     StringBuilder sb = new StringBuilder();
@@ -144,7 +144,7 @@ public class PerformanceTest extends TestCase {
   }
 
   /**
-   * Created in response to http://code.google.com/p/google-gson/issues/detail?id=96
+   * Created in response to https://github.com/google/gson/issues/96
    */
   // Last I tested, Gson was able to serialize upto 14MB byte array
   public void disabled_testByteArraySerialization() {
@@ -159,7 +159,7 @@ public class PerformanceTest extends TestCase {
   }
   
   /**
-   * Created in response to http://code.google.com/p/google-gson/issues/detail?id=96
+   * Created in response to https://github.com/google/gson/issues/96
    */
   // Last I tested, Gson was able to deserialize a byte array of 11MB
   public void disable_testByteArrayDeserialization() {
@@ -184,7 +184,7 @@ public class PerformanceTest extends TestCase {
 
 // The tests to measure serialization and deserialization performance of Gson
 // Based on the discussion at
-// http://groups.google.com/group/google-gson/browse_thread/thread/7a50b17a390dfaeb
+// https://groups.google.com/d/topic/google-gson/elCxejkN-us/discussion
 // Test results: 10/19/2009 
 // Serialize classes avg time: 60 ms
 // Deserialized classes avg time: 70 ms

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -1494,7 +1494,7 @@ public final class JsonReaderTest extends TestCase {
     assertEquals(JsonToken.END_DOCUMENT, reader.peek());
   }
 
-  // http://code.google.com/p/google-gson/issues/detail?id=409
+  // https://github.com/google/gson/issues/409
   public void testStringEndingInSlash() throws IOException {
     JsonReader reader = new JsonReader(reader("/"));
     reader.setLenient(true);


### PR DESCRIPTION
- Update links to what they are currently redirecting
- Use HTTPS for links

I have verified that all the links where I changed `http` -> `https` actually support HTTPS.