### PR TITLE
Fix fallback behavior of UnsafeReflectionAllocator when AccessibleObject isn't so accessible

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/reflect/UnsafeReflectionAccessor.java
+++ b/gson/src/main/java/com/google/gson/internal/reflect/UnsafeReflectionAccessor.java
@@ -79,7 +79,7 @@ final class UnsafeReflectionAccessor extends ReflectionAccessor {
   private static Field getOverrideField() {
     try {
       return AccessibleObject.class.getDeclaredField("override");
-    } catch (NoSuchFieldException e) {
+    } catch (Exception e) {
       return null;
     }
   }


### PR DESCRIPTION
I'm the lucky owner of a post-jigsaw Java platform that has restrictive security manager installed. Failing to catch the `SecurityException` thrown by a cross-classloader `getDeclaredField` call in `UnsafeReflectionAllocator::getOverrideField` prevents any Gson instances from being created.

I'm hoping the fallback behavior in this class will be enough for us to use Gson without having to loosen our security policy.