### PR TITLE
Fix JsonReader and JsonTreeReader nextLong() not failing on precision loss

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
@@ -227,7 +227,21 @@ public final class JsonTreeReader extends JsonReader {
       throw new IllegalStateException(
           "Expected " + JsonToken.NUMBER + " but was " + token + locationString());
     }
-    long result = ((JsonPrimitive) peekStack()).getAsLong();
+
+    JsonPrimitive primitive = (JsonPrimitive) peekStack();
+    long result;
+    if (primitive.isNumber()) {
+      Number number = primitive.getAsNumber();
+      result = number.longValue();
+
+      if (result != number.doubleValue()) { // Precision loss
+        throw new NumberFormatException(
+            "Expected a long but was " + token + locationString());
+      }
+    } else { // If not Number, parseLong is used which is safe
+      result = primitive.getAsLong();
+    }
+
     popStack();
     if (stackSize > 0) {
       pathIndices[stackSize - 1]++;
@@ -241,7 +255,21 @@ public final class JsonTreeReader extends JsonReader {
       throw new IllegalStateException(
           "Expected " + JsonToken.NUMBER + " but was " + token + locationString());
     }
-    int result = ((JsonPrimitive) peekStack()).getAsInt();
+
+    JsonPrimitive primitive = (JsonPrimitive) peekStack();
+    int result;
+    if (primitive.isNumber()) {
+      Number number = primitive.getAsNumber();
+      result = number.intValue();
+
+      if (result != number.doubleValue()) { // Precision loss
+        throw new NumberFormatException(
+            "Expected an int but was " + token + locationString());
+      }
+    } else { // If not Number, parseInt is used which is safe
+      result = primitive.getAsInt();
+    }
+
     popStack();
     if (stackSize > 0) {
       pathIndices[stackSize - 1]++;

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -209,8 +209,21 @@ public class JsonReader implements Closeable {
   private static final int PEEKED_UNQUOTED_NAME = 14;
   /** When this is returned, the integer value is stored in peekedLong. */
   private static final int PEEKED_LONG = 15;
-  private static final int PEEKED_NUMBER = 16;
-  private static final int PEEKED_EOF = 17;
+  /**
+   * When this is returned, number had the format accepted by
+   * {@link Long#parseLong(String)} but could not be parsed as {@code long}
+   * because it is too large. For -0 {@link #PEEKED_NUMBER} is used.
+   * <p>The start of the number is at {@link #pos} and it has the
+   * length {@link #peekedNumberLength}.
+   */
+  private static final int PEEKED_INTEGRAL = 16;
+  /**
+   * Neither {@link #PEEKED_LONG} nor {@link #PEEKED_INTEGRAL}.
+   * <p>The start of the number is at {@link #pos} and it has the
+   * length {@link #peekedNumberLength}.
+   */
+  private static final int PEEKED_NUMBER = 17;
+  private static final int PEEKED_EOF = 18;
 
   /* State machine when parsing numbers */
   private static final int NUMBER_CHAR_NONE = 0;
@@ -448,6 +461,7 @@ public class JsonReader implements Closeable {
     case PEEKED_BUFFERED:
       return JsonToken.STRING;
     case PEEKED_LONG:
+    case PEEKED_INTEGRAL:
     case PEEKED_NUMBER:
       return JsonToken.NUMBER;
     case PEEKED_EOF:
@@ -726,15 +740,25 @@ public class JsonReader implements Closeable {
       }
     }
 
-    // We've read a complete number. Decide if it's a PEEKED_LONG or a PEEKED_NUMBER.
-    if (last == NUMBER_CHAR_DIGIT && fitsInLong && (value != Long.MIN_VALUE || negative) && (value!=0 || false==negative)) {
+    // We've read a complete number. Decide if it's a PEEKED_LONG, PEEKED_INTEGRAL or PEEKED_NUMBER.
+    if (last == NUMBER_CHAR_DIGIT && fitsInLong && (value != Long.MIN_VALUE || negative)
+      // Don't lose information about -0, maybe user wants it as double -0.0
+      && !(value == 0 && negative))
+    {
       peekedLong = negative ? value : -value;
       pos += i;
       return peeked = PEEKED_LONG;
     } else if (last == NUMBER_CHAR_DIGIT || last == NUMBER_CHAR_FRACTION_DIGIT
         || last == NUMBER_CHAR_EXP_DIGIT) {
       peekedNumberLength = i;
-      return peeked = PEEKED_NUMBER;
+
+      // Use PEEKED_NUMBER for -0 to allow nextLong to parse it
+      if (last == NUMBER_CHAR_DIGIT && !(fitsInLong && value == 0 && negative)) {
+        peeked = PEEKED_INTEGRAL;
+      } else {
+        peeked = PEEKED_NUMBER;
+      }
+      return peeked;
     } else {
       return PEEKED_NONE;
     }
@@ -817,7 +841,7 @@ public class JsonReader implements Closeable {
       peekedString = null;
     } else if (p == PEEKED_LONG) {
       result = Long.toString(peekedLong);
-    } else if (p == PEEKED_NUMBER) {
+    } else if (p == PEEKED_INTEGRAL || p == PEEKED_NUMBER) {
       result = new String(buffer, pos, peekedNumberLength);
       pos += peekedNumberLength;
     } else {
@@ -893,7 +917,7 @@ public class JsonReader implements Closeable {
       return (double) peekedLong;
     }
 
-    if (p == PEEKED_NUMBER) {
+    if (p == PEEKED_INTEGRAL || p == PEEKED_NUMBER) {
       peekedString = new String(buffer, pos, peekedNumberLength);
       pos += peekedNumberLength;
     } else if (p == PEEKED_SINGLE_QUOTED || p == PEEKED_DOUBLE_QUOTED) {
@@ -917,10 +941,44 @@ public class JsonReader implements Closeable {
   }
 
   /**
+   * Tests whether the string matches the syntax accepted by {@link Long#parseLong(String)},
+   * ignoring whether or not the value fits in the {@code long} value range.
+   */
+  private static boolean matchesLongSyntax(String string) {
+    int position = 0;
+    int end = string.length();
+
+    if (position < end) {
+      char firstChar = string.charAt(position);
+      if (firstChar == '-' || firstChar == '+') {
+        position++;
+      }
+    }
+
+    if (position >= end) {
+      // No digit
+      return false;
+    }
+
+    for (; position < end; position++) {
+      char c = string.charAt(position);
+
+      if (c < '0' || c > '9') {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
    * Returns the {@link com.google.gson.stream.JsonToken#NUMBER long} value of the next token,
    * consuming it. If the next token is a string, this method will attempt to
-   * parse it as a long. If the next token's numeric value cannot be exactly
-   * represented by a Java {@code long}, this method throws.
+   * parse it as a long. If this is not possible and the token does not match the syntax defined
+   * by {@link Long#parseLong(String)}, it will be parsed as double according to
+   * {@link Double#valueOf(String)} and then converted to a long, unless this conversion causes
+   * precision loss in which case an exception is thrown. This can cause precision loss if the
+   * value cannot be exactly represented as {@code double}.
    *
    * @throws IllegalStateException if the next token is not a literal value.
    * @throws NumberFormatException if the next literal value cannot be parsed
@@ -941,28 +999,47 @@ public class JsonReader implements Closeable {
     if (p == PEEKED_NUMBER) {
       peekedString = new String(buffer, pos, peekedNumberLength);
       pos += peekedNumberLength;
+      peeked = PEEKED_BUFFERED;
     } else if (p == PEEKED_SINGLE_QUOTED || p == PEEKED_DOUBLE_QUOTED || p == PEEKED_UNQUOTED) {
       if (p == PEEKED_UNQUOTED) {
         peekedString = nextUnquotedValue();
       } else {
         peekedString = nextQuotedValue(p == PEEKED_SINGLE_QUOTED ? '\'' : '"');
       }
+      peeked = PEEKED_BUFFERED;
+
       try {
         long result = Long.parseLong(peekedString);
         peeked = PEEKED_NONE;
         pathIndices[stackSize - 1]++;
         return result;
-      } catch (NumberFormatException ignored) {
-        // Fall back to parse as a double below.
+      } catch (NumberFormatException numberFormatException) {
+        /*
+         * If value matches long syntax throw exception, otherwise try parsing as double
+         * Have to check this since large (positive and negative) long values cannot be
+         * precisely represented as double and parsing would otherwise erroneously
+         * successfully parse integral numbers outside of long range
+         * E.g. 9223372036854775808 as double = 9223372036854775807 (7 as last digit)
+         */
+        if (matchesLongSyntax(peekedString)) {
+          throw numberFormatException;
+        }
       }
+    } else if (p == PEEKED_INTEGRAL) { // value to large for long range
+      throw new NumberFormatException("Expected a long but was " + peekedString + locationString());
     } else {
       throw new IllegalStateException("Expected a long but was " + peek() + locationString());
     }
 
-    peeked = PEEKED_BUFFERED;
     double asDouble = Double.parseDouble(peekedString); // don't catch this NumberFormatException.
     long result = (long) asDouble;
-    if (result != asDouble) { // Make sure no precision was lost casting to 'long'.
+    /*
+     * Make sure no precision was lost casting to 'long'.
+     * Can cause false negatives for values which cannot be precisely represented as double
+     * (e.g. 9223372036854775808e0), but that is acceptable because value uses double syntax
+     * and therefore source of data is likely aware of precision loss
+     */
+    if (result != asDouble) {
       throw new NumberFormatException("Expected a long but was " + peekedString + locationString());
     }
     peekedString = null;
@@ -1085,7 +1162,7 @@ public class JsonReader implements Closeable {
         break;
       }
     }
-   
+
     String result = (null == builder) ? new String(buffer, pos, i) : builder.append(buffer, pos, i).toString();
     pos += i;
     return result;
@@ -1151,8 +1228,9 @@ public class JsonReader implements Closeable {
   /**
    * Returns the {@link com.google.gson.stream.JsonToken#NUMBER int} value of the next token,
    * consuming it. If the next token is a string, this method will attempt to
-   * parse it as an int. If the next token's numeric value cannot be exactly
-   * represented by a Java {@code int}, this method throws.
+   * parse it as an int. If this is not possible it will be parsed as double according to
+   * {@link Double#valueOf(String)} and then converted to an int, unless this conversion causes
+   * precision loss in which case an exception is thrown.
    *
    * @throws IllegalStateException if the next token is not a literal value.
    * @throws NumberFormatException if the next literal value cannot be parsed
@@ -1175,7 +1253,7 @@ public class JsonReader implements Closeable {
       return result;
     }
 
-    if (p == PEEKED_NUMBER) {
+    if (p == PEEKED_INTEGRAL || p == PEEKED_NUMBER) {
       peekedString = new String(buffer, pos, peekedNumberLength);
       pos += peekedNumberLength;
     } else if (p == PEEKED_SINGLE_QUOTED || p == PEEKED_DOUBLE_QUOTED || p == PEEKED_UNQUOTED) {
@@ -1249,7 +1327,7 @@ public class JsonReader implements Closeable {
         skipQuotedValue('\'');
       } else if (p == PEEKED_DOUBLE_QUOTED || p == PEEKED_DOUBLE_QUOTED_NAME) {
         skipQuotedValue('"');
-      } else if (p == PEEKED_NUMBER) {
+      } else if (p == PEEKED_INTEGRAL || p == PEEKED_NUMBER) {
         pos += peekedNumberLength;
       }
       peeked = PEEKED_NONE;
@@ -1546,7 +1624,7 @@ public class JsonReader implements Closeable {
     case '\'':
     case '"':
     case '\\':
-    case '/':	
+    case '/':
     	return escaped;
     default:
     	// throw error when none of the above cases are matched

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeReaderTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeReaderTest.java
@@ -47,4 +47,93 @@ public class JsonTreeReaderTest extends TestCase {
     in.skipValue();
     assertEquals(JsonToken.END_DOCUMENT, in.peek());
   }
+
+  public void testNextInt() throws IOException {
+    JsonArray jsonArray = new JsonArray();
+    jsonArray.add(10);
+    jsonArray.add((long) Integer.MAX_VALUE);
+    jsonArray.add((double) Integer.MIN_VALUE);
+    jsonArray.add(Double.parseDouble("-0"));
+    jsonArray.add("-0");
+    jsonArray.add("+1234");
+    JsonTreeReader reader = new JsonTreeReader(jsonArray);
+
+    reader.beginArray();
+    assertEquals(10, reader.nextInt());
+    assertEquals(Integer.MAX_VALUE, reader.nextInt());
+    assertEquals(Integer.MIN_VALUE, reader.nextInt());
+    assertEquals(0, reader.nextInt());
+    assertEquals(0, reader.nextInt());
+    assertEquals(1234, reader.nextInt());
+    reader.endArray();
+  }
+
+  public void testNextIntFailing() throws IOException {
+    JsonArray jsonArray = new JsonArray();
+    jsonArray.add(1.5);
+    jsonArray.add(((long) Integer.MAX_VALUE) + 1);
+    jsonArray.add(((double) Integer.MIN_VALUE) - 10);
+    jsonArray.add(Float.POSITIVE_INFINITY);
+    jsonArray.add(Float.NaN);
+    jsonArray.add("1.5");
+    jsonArray.add("0xABCD");
+    jsonArray.add("+");
+    JsonTreeReader reader = new JsonTreeReader(jsonArray);
+
+    reader.beginArray();
+    while (reader.hasNext()) {
+      try {
+        reader.nextInt();
+        fail();
+      } catch (IllegalArgumentException expected) {
+      }
+      reader.skipValue();
+    }
+    reader.endArray();
+  }
+
+  public void testNextLong() throws IOException {
+    JsonArray jsonArray = new JsonArray();
+    jsonArray.add(10);
+    jsonArray.add(Long.MAX_VALUE);
+    jsonArray.add((double) Long.MIN_VALUE);
+    jsonArray.add(Double.parseDouble("-0"));
+    jsonArray.add("-0");
+    jsonArray.add("+1234");
+    JsonTreeReader reader = new JsonTreeReader(jsonArray);
+
+    reader.beginArray();
+    assertEquals(10, reader.nextLong());
+    assertEquals(Long.MAX_VALUE, reader.nextLong());
+    assertEquals(Long.MIN_VALUE, reader.nextLong());
+    assertEquals(0, reader.nextLong());
+    assertEquals(0, reader.nextLong());
+    assertEquals(1234, reader.nextLong());
+    reader.endArray();
+  }
+
+  public void testNextLongFailing() throws IOException {
+    JsonArray jsonArray = new JsonArray();
+    jsonArray.add(1.5);
+    jsonArray.add((double) Long.MAX_VALUE + 10000);
+    jsonArray.add((double) Long.MIN_VALUE - 10000);
+    jsonArray.add(Float.POSITIVE_INFINITY);
+    jsonArray.add(Float.NaN);
+    jsonArray.add("1.5");
+    jsonArray.add("0xABCD");
+    jsonArray.add("1L");
+    jsonArray.add("+");
+    JsonTreeReader reader = new JsonTreeReader(jsonArray);
+
+    reader.beginArray();
+    while (reader.hasNext()) {
+      try {
+        reader.nextLong();
+        fail();
+      } catch (IllegalArgumentException expected) {
+      }
+      reader.skipValue();
+    }
+    reader.endArray();
+  }
 }


### PR DESCRIPTION
Fixes #1727

`JsonReader.nextLong()` tries to parse a value as double in case parsing as long failed. An exception should be thrown if converting the double to long causes precision loss.
However, previously if the parsed value could not be represented exactly as double, the precision loss was not detected.
For example:
```java
// Last digit is different but values are considered equal
Double.parseDouble("9223372036854775808") == 9223372036854775807L
```

This pull request changes it so if the number (or number string) represents a value which matches the syntax required by [`Long.parseLong(String)`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Long.html#parseLong(java.lang.String)), then the value is not parsed as double.
However, if the value does not match that syntax precision loss is still possible. But since the value uses `double` syntax, it is assumed that the source of this data is aware that floating point can cause precision loss. Trying to prevent this as well would require writing an own parsing method similar to `Double.parseDouble` to remain backward compatible and the amount of effort is likely not worth it.

This pull request also updates JsonTreeReader to fall back to parsing as double when parsing as int / long fails and to check for precision loss as well.