### PR TITLE
Fix JsonReader advancing before throwing exception due to malformed JSON

### DIFF
--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -567,6 +567,12 @@ public class JsonReader implements Closeable {
     } else if (peekStack == JsonScope.EMPTY_DOCUMENT) {
       if (lenient) {
         consumeNonExecutePrefix();
+        /*
+         * Don't need to update stack because consuming second non-execute prefix
+         * is not possible.
+         * ')' of second prefix would be considered part of unquoted string so
+         * value parsing succeeds and stack is updated.
+         */
       }
       // fall-through to value parsing
     } else if (peekStack == JsonScope.NONEMPTY_DOCUMENT) {

--- a/gson/src/main/java/com/google/gson/stream/JsonScope.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonScope.java
@@ -24,48 +24,69 @@ package com.google.gson.stream;
  */
 final class JsonScope {
 
-    /**
-     * An array with no elements requires no separators or newlines before
-     * it is closed.
-     */
-    static final int EMPTY_ARRAY = 1;
+  /**
+   * An array with no elements requires no separator before it is closed.
+   */
+  static final int EMPTY_ARRAY = 1;
 
-    /**
-     * A array with at least one value requires a comma and newline before
-     * the next element.
-     */
-    static final int NONEMPTY_ARRAY = 2;
+  /**
+   * An array with at least one value requires an element separator (e.g. comma) before
+   * the next element.
+   */
+  static final int NONEMPTY_ARRAY = 2;
 
-    /**
-     * An object with no name/value pairs requires no separators or newlines
-     * before it is closed.
-     */
-    static final int EMPTY_OBJECT = 3;
+  /**
+   * An array with a value followed by an element separator (e.g. comma) requires a
+   * subsequent element before it is closed.
+   * <p>Note: Only used by {@link JsonReader}.
+   */
+  static final int EXPECTING_ARRAY_ELEMENT = 3;
 
-    /**
-     * An object whose most recent element is a key. The next element must
-     * be a value.
-     */
-    static final int DANGLING_NAME = 4;
+  /**
+   * An object with no name/value pairs requires no separator (e.g. comma) before
+   * it is closed.
+   */
+  static final int EMPTY_OBJECT = 4;
 
-    /**
-     * An object with at least one name/value pair requires a comma and
-     * newline before the next element.
-     */
-    static final int NONEMPTY_OBJECT = 5;
+  /**
+   * An object with at least one name/value pair followed by a separator (e.g. comma)
+   * requires a subsequent name/value pair before it is closed.
+   * <p>Note: Only used by {@link JsonReader}.
+   */
+  static final int EXPECTING_NAME = 5;
 
-    /**
-     * No object or array has been started.
-     */
-    static final int EMPTY_DOCUMENT = 6;
+  /**
+   * An object whose most recent element is a property name requires a name/value
+   * separator (e.g. colon) and afterwards a {@link #EXPECTING_PROPERTY_VALUE value}.
+   */
+  static final int DANGLING_NAME = 6;
 
-    /**
-     * A document with at an array or object.
-     */
-    static final int NONEMPTY_DOCUMENT = 7;
+  /**
+   * An object property name followed by a name/value separator (e.g. colon) requires
+   * a property value.
+   * <p>Note: Only used by {@link JsonReader}.
+   */
+  static final int EXPECTING_PROPERTY_VALUE = 7;
 
-    /**
-     * A document that's been closed and cannot be accessed.
-     */
-    static final int CLOSED = 8;
+  /**
+   * An object with at least one name/value pair requires a separator (e.g. comma)
+   * before the next name/value pair.
+   */
+  static final int NONEMPTY_OBJECT = 8;
+
+  /**
+   * No object or array has been started.
+   */
+  static final int EMPTY_DOCUMENT = 9;
+
+  /**
+   * A document with an array or object.
+   */
+  static final int NONEMPTY_DOCUMENT = 10;
+
+  /**
+   * A document that's been closed and cannot be accessed.
+   * <p>Note: Only used by {@link JsonReader}.
+   */
+  static final int CLOSED = 11;
 }

--- a/gson/src/main/java/com/google/gson/stream/JsonScope.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonScope.java
@@ -75,18 +75,25 @@ final class JsonScope {
   static final int NONEMPTY_OBJECT = 8;
 
   /**
+   * A block comment <code>/* ... *&#x2F;</code> which has been started and
+   * requires the closing <code>*&#x2F;</code>.
+   * <p>Note: Only used by {@link JsonReader}.
+   */
+  static final int EXPECTING_BLOCK_COMMENT_END = 9;
+
+  /**
    * No object or array has been started.
    */
-  static final int EMPTY_DOCUMENT = 9;
+  static final int EMPTY_DOCUMENT = 10;
 
   /**
    * A document with an array or object.
    */
-  static final int NONEMPTY_DOCUMENT = 10;
+  static final int NONEMPTY_DOCUMENT = 11;
 
   /**
    * A document that's been closed and cannot be accessed.
    * <p>Note: Only used by {@link JsonReader}.
    */
-  static final int CLOSED = 11;
+  static final int CLOSED = 12;
 }

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -188,7 +188,7 @@ public final class JsonReaderTest extends TestCase {
     } catch (IOException expected) {
     }
   }
-  
+
   @SuppressWarnings("unused")
   public void testNulls() {
     try {
@@ -411,8 +411,12 @@ public final class JsonReaderTest extends TestCase {
     assertEquals(JsonToken.END_DOCUMENT, reader.peek());
   }
 
-  public void disabled_testNumberWithOctalPrefix() throws IOException {
-    String json = "[01]";
+  /**
+   * Octal number notation is not supported so non-lenient JsonReader
+   * should throw exception.
+   */
+  public void testNumberWithOctalPrefix() throws IOException {
+    String json = "[012]";
     JsonReader reader = new JsonReader(reader(json));
     reader.beginArray();
     try {
@@ -420,22 +424,27 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
     }
-    try {
-      reader.nextInt();
-      fail();
-    } catch (MalformedJsonException expected) {
-    }
-    try {
-      reader.nextLong();
-      fail();
-    } catch (MalformedJsonException expected) {
-    }
-    try {
-      reader.nextDouble();
-      fail();
-    } catch (MalformedJsonException expected) {
-    }
-    assertEquals("01", reader.nextString());
+  }
+
+  /**
+   * Octal number notation is not supported. In lenient mode it is
+   * read as unquoted string and then {@link Integer#parseInt(String)}
+   * parses it with radix 10 (simply ignoring leading 0).
+   */
+  public void testNumberWithOctalPrefixLenient() throws IOException {
+    String json = "[012, 012, 012, 012]";
+    JsonReader reader = new JsonReader(reader(json));
+    reader.setLenient(true);
+    reader.beginArray();
+    assertEquals(JsonToken.STRING, reader.peek());
+    assertEquals("012", reader.nextString());
+
+    // If it would be parsed as octal, decimal result would be 10
+    // However, it is parsed with radix 10 so leading 0 is simply ignored
+    assertEquals(12, reader.nextInt());
+    assertEquals(12, reader.nextLong());
+    assertEquals(12.0, reader.nextDouble());
+
     reader.endArray();
     assertEquals(JsonToken.END_DOCUMENT, reader.peek());
   }
@@ -561,17 +570,17 @@ public final class JsonReaderTest extends TestCase {
     } catch (NumberFormatException expected) {
     }
   }
-  
+
   /**
    * Issue 1053, negative zero.
    * @throws Exception
    */
   public void testNegativeZero() throws Exception {
-	  	JsonReader reader = new JsonReader(reader("[-0]"));
-	    reader.setLenient(false);
-	    reader.beginArray();
-	    assertEquals(NUMBER, reader.peek());
-	    assertEquals("-0", reader.nextString());
+    JsonReader reader = new JsonReader(reader("[-0]"));
+    reader.setLenient(false);
+    reader.beginArray();
+    assertEquals(NUMBER, reader.peek());
+    assertEquals("-0", reader.nextString());
   }
 
   /**
@@ -1663,6 +1672,62 @@ public final class JsonReaderTest extends TestCase {
       reader.peek();
       fail();
     } catch (IOException expected) {
+    }
+  }
+
+  /**
+   * When {@link JsonReader#peek()} throws an exception due to malformed JSON
+   * it should not have advanced in the stream yet.
+   */
+  public void testThrowingPeekArray() throws IOException {
+    JsonReader reader = new JsonReader(reader("[a?$,1]"));
+    reader.beginArray();
+    for (int i = 0; i < 10; i++) {
+      try {
+        reader.peek();
+      } catch (MalformedJsonException expected) {
+      }
+    }
+  }
+
+  /**
+   * When {@link JsonReader#peek()} throws an exception due to malformed JSON
+   * it should not have advanced in the stream yet.
+   */
+  public void testThrowingPeekObject() throws IOException {
+    JsonReader reader = new JsonReader(reader("{\"test\"::}"));
+    reader.beginObject();
+    for (int i = 0; i < 10; i++) {
+      try {
+        reader.peek();
+      } catch (MalformedJsonException expected) {
+      }
+    }
+  }
+
+  public void testThrowingPeekEmptyDocument() throws IOException {
+    JsonReader reader = new JsonReader(reader(":"));
+    try {
+      reader.peek();
+      fail();
+    } catch (MalformedJsonException expected) {
+      // Note: Exact exception message does not matter, may be changed in the future
+      assertTrue(expected.getMessage().startsWith("Expected value"));
+    }
+    /*
+     * Make sure that JsonReader still considers document empty
+     *
+     * In previous Gson versions JsonReader would have marked document
+     * as non-empty even though value parsing failed and would have
+     * now thrown a non-lenient exception because it thought there were
+     * multiple top-level values
+     */
+    try {
+      reader.peek();
+      fail();
+    } catch (MalformedJsonException expected) {
+      // Note: Exact exception message does not matter, may be changed in the future
+      assertTrue(expected.getMessage().startsWith("Expected value"));
     }
   }
 

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -1334,6 +1334,21 @@ public final class JsonReaderTest extends TestCase {
     }
   }
 
+  /**
+   * At most one non-execute prefix must be consumed.
+   */
+  public void testLenientDoubleNonExecutePrefix() throws IOException {
+    JsonReader reader = new JsonReader(reader(")]}'\n)]}'\n 1"));
+    reader.setLenient(true);
+    // Consumes the parenthesis after the first non-execute prefix
+    assertEquals(")", reader.nextString());
+    try {
+      reader.peek();
+      fail();
+    } catch (MalformedJsonException expected) {
+    }
+  }
+
   public void testBomIgnoredAsFirstCharacterOfDocument() throws IOException {
     JsonReader reader = new JsonReader(reader("\ufeff[]"));
     reader.beginArray();

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -1731,6 +1731,34 @@ public final class JsonReaderTest extends TestCase {
     }
   }
 
+  public void testThrowingStringEscapeSequence() throws IOException {
+    JsonReader reader = new JsonReader(reader("\"\\z\"")); // "\z" is not a valid escape sequence
+    assertEquals(JsonToken.STRING, reader.peek());
+
+    /*
+     * Make sure that neither nextString() nor skipValue() already advanced
+     * before throwing exception.
+     *
+     * In previous Gson versions they would have already consumed the '\' before
+     * the exception was thrown so a subsequent read would have read a "valid"
+     * string.
+     */
+    for (int i = 0; i < 3; i++) {
+      try {
+        reader.nextString();
+        fail();
+      } catch (MalformedJsonException expected) {
+      }
+    }
+    for (int i = 0; i < 3; i++) {
+      try {
+        reader.skipValue();
+        fail();
+      } catch (MalformedJsonException expected) {
+      }
+    }
+  }
+
   private String repeat(char c, int count) {
     char[] array = new char[count];
     Arrays.fill(array, c);

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -1705,6 +1705,30 @@ public final class JsonReaderTest extends TestCase {
     }
   }
 
+  public void testThrowingPeekIncompleteBlockComment() throws IOException {
+    JsonReader reader = new JsonReader(reader("[/*]"));
+    reader.setLenient(true); // lenient to support block comments
+    reader.beginArray();
+    /*
+     * Make sure that incomplete block comment (i.e. missing closing * /)
+     * is not skipped after first unsuccessful peek.
+     *
+     * In previous Gson versions a subsequent peek would have skipped the
+     * comment start (i.e. "/*") and therefore could have read "valid"
+     * JSON afterwards.
+     */
+    for (int i = 0; i < 3; i++) {
+      try {
+        reader.peek();
+      } catch (MalformedJsonException expected) {
+        // Note: Exact exception message does not matter, may be changed in the future
+        assertTrue(expected.getMessage().startsWith("Unterminated comment"));
+      }
+    }
+
+    assertEquals("$[0]", reader.getPath());
+  }
+
   public void testThrowingPeekEmptyDocument() throws IOException {
     JsonReader reader = new JsonReader(reader(":"));
     try {


### PR DESCRIPTION
Fixes #1735

Previously the JsonReader methods `doPeek()` (internal method called for example by `peek()`), `nextString()` and `skipValue()` advanced in the stream before throwing an exception due to malformed JSON.
This allowed them to "skip" malformed JSON making the JSON valid again for subsequent calls, which is likely undesired.

This pull request changes it so that if malformed JSON is encountered all subsequent method calls will throw the same exception.
Additionally it introduces more `JsonScope` constants because it was not possible with the existing ones to handle cases where a variable amount of characters is skipped, e.g. whitespaces between `:` after an object property name and before the property value.