### PR TITLE
Improved type handling

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
+++ b/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
@@ -236,19 +236,19 @@ public final class $Gson$Types {
    * IntegerSet}, the result for when supertype is {@code Set.class} is {@code Set<Integer>} and the
    * result when the supertype is {@code Collection.class} is {@code Collection<Integer>}.
    */
-  private static Type getGenericSupertype(Type context, Class<?> rawType, Class<?> toResolve) {
-    if (toResolve == rawType) {
+  private static Type getGenericSupertype(Type context, Class<?> rawType, Class<?> supertype) {
+    if (supertype == rawType) {
       return context;
     }
 
     // we skip searching through interfaces if unknown is an interface
-    if (toResolve.isInterface()) {
+    if (supertype.isInterface()) {
       Class<?>[] interfaces = rawType.getInterfaces();
       for (int i = 0, length = interfaces.length; i < length; i++) {
-        if (interfaces[i] == toResolve) {
+        if (interfaces[i] == supertype) {
           return rawType.getGenericInterfaces()[i];
-        } else if (toResolve.isAssignableFrom(interfaces[i])) {
-          return getGenericSupertype(rawType.getGenericInterfaces()[i], interfaces[i], toResolve);
+        } else if (supertype.isAssignableFrom(interfaces[i])) {
+          return getGenericSupertype(rawType.getGenericInterfaces()[i], interfaces[i], supertype);
         }
       }
     }
@@ -257,17 +257,17 @@ public final class $Gson$Types {
     if (!rawType.isInterface()) {
       while (rawType != Object.class) {
         Class<?> rawSupertype = rawType.getSuperclass();
-        if (rawSupertype == toResolve) {
+        if (rawSupertype == supertype) {
           return rawType.getGenericSuperclass();
-        } else if (toResolve.isAssignableFrom(rawSupertype)) {
-          return getGenericSupertype(rawType.getGenericSuperclass(), rawSupertype, toResolve);
+        } else if (supertype.isAssignableFrom(rawSupertype)) {
+          return getGenericSupertype(rawType.getGenericSuperclass(), rawSupertype, supertype);
         }
         rawType = rawSupertype;
       }
     }
 
     // we can't resolve this further
-    return toResolve;
+    return supertype;
   }
 
   /**

--- a/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
+++ b/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
@@ -307,9 +307,6 @@ public final class $Gson$Types {
   public static Type getCollectionElementType(Type context, Class<?> contextRawType) {
     Type collectionType = getSupertype(context, contextRawType, Collection.class);
 
-    if (collectionType instanceof WildcardType) {
-      collectionType = ((WildcardType)collectionType).getUpperBounds()[0];
-    }
     if (collectionType instanceof ParameterizedType) {
       return ((ParameterizedType) collectionType).getActualTypeArguments()[0];
     }

--- a/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
+++ b/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
@@ -37,7 +37,7 @@ import static com.google.gson.internal.$Gson$Preconditions.checkNotNull;
  * @author Jesse Wilson
  */
 public final class $Gson$Types {
-  static final Type[] EMPTY_TYPE_ARRAY = new Type[] {};
+  private static final Type[] EMPTY_TYPE_ARRAY = new Type[] {};
 
   private $Gson$Types() {
     throw new UnsupportedOperationException();
@@ -161,7 +161,7 @@ public final class $Gson$Types {
     }
   }
 
-  static boolean equal(Object a, Object b) {
+  private static boolean equal(Object a, Object b) {
     return a == b || (a != null && a.equals(b));
   }
 
@@ -223,7 +223,7 @@ public final class $Gson$Types {
     }
   }
 
-  static int hashCodeOrZero(Object o) {
+  private static int hashCodeOrZero(Object o) {
     return o != null ? o.hashCode() : 0;
   }
 
@@ -236,7 +236,7 @@ public final class $Gson$Types {
    * IntegerSet}, the result for when supertype is {@code Set.class} is {@code Set<Integer>} and the
    * result when the supertype is {@code Collection.class} is {@code Collection<Integer>}.
    */
-  static Type getGenericSupertype(Type context, Class<?> rawType, Class<?> toResolve) {
+  private static Type getGenericSupertype(Type context, Class<?> rawType, Class<?> toResolve) {
     if (toResolve == rawType) {
       return context;
     }
@@ -277,7 +277,7 @@ public final class $Gson$Types {
    *
    * @param supertype a superclass of, or interface implemented by, this.
    */
-  static Type getSupertype(Type context, Class<?> contextRawType, Class<?> supertype) {
+  private static Type getSupertype(Type context, Class<?> contextRawType, Class<?> supertype) {
     if (context instanceof WildcardType) {
       // wildcards are useless for resolving supertypes. As the upper bound has the same raw type, use it instead
       Type[] bounds = ((WildcardType)context).getUpperBounds();
@@ -419,7 +419,7 @@ public final class $Gson$Types {
     }
   }
 
-  static Type resolveTypeVariable(Type context, Class<?> contextRawType, TypeVariable<?> unknown) {
+  private static Type resolveTypeVariable(Type context, Class<?> contextRawType, TypeVariable<?> unknown) {
     Class<?> declaredByRaw = declaringClassOf(unknown);
 
     // we can't reduce this further
@@ -456,7 +456,7 @@ public final class $Gson$Types {
         : null;
   }
 
-  static void checkNotPrimitive(Type type) {
+  private static void checkNotPrimitive(Type type) {
     checkArgument(!(type instanceof Class<?>) || !((Class<?>) type).isPrimitive());
   }
 

--- a/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
@@ -120,8 +120,7 @@ public final class MapTypeAdapterFactory implements TypeAdapterFactory {
       return null;
     }
 
-    Class<?> rawTypeOfSrc = $Gson$Types.getRawType(type);
-    Type[] keyAndValueTypes = $Gson$Types.getMapKeyAndValueTypes(type, rawTypeOfSrc);
+    Type[] keyAndValueTypes = $Gson$Types.getMapKeyAndValueTypes(type, rawType);
     TypeAdapter<?> keyAdapter = getKeyAdapter(gson, keyAndValueTypes[0]);
     TypeAdapter<?> valueAdapter = gson.getAdapter(TypeToken.get(keyAndValueTypes[1]));
     ObjectConstructor<T> constructor = constructorConstructor.get(typeToken);

--- a/gson/src/main/java/com/google/gson/reflect/TypeToken.java
+++ b/gson/src/main/java/com/google/gson/reflect/TypeToken.java
@@ -45,9 +45,9 @@ import java.util.Map;
  * @author Jesse Wilson
  */
 public class TypeToken<T> {
-  final Class<? super T> rawType;
-  final Type type;
-  final int hashCode;
+  private final Class<? super T> rawType;
+  private final Type type;
+  private final int hashCode;
 
   /**
    * Constructs a new type literal. Derives represented class from type
@@ -68,7 +68,7 @@ public class TypeToken<T> {
    * Unsafe. Constructs a type literal manually.
    */
   @SuppressWarnings("unchecked")
-  TypeToken(Type type) {
+  private TypeToken(Type type) {
     this.type = $Gson$Types.canonicalize($Gson$Preconditions.checkNotNull(type));
     this.rawType = (Class<? super T>) $Gson$Types.getRawType(this.type);
     this.hashCode = this.type.hashCode();
@@ -78,7 +78,7 @@ public class TypeToken<T> {
    * Returns the type from super class's type parameter in {@link $Gson$Types#canonicalize
    * canonical form}.
    */
-  static Type getSuperclassTypeParameter(Class<?> subclass) {
+  private static Type getSuperclassTypeParameter(Class<?> subclass) {
     Type superclass = subclass.getGenericSuperclass();
     if (superclass instanceof Class) {
       throw new RuntimeException("Missing type parameter.");

--- a/gson/src/main/java/com/google/gson/reflect/TypeToken.java
+++ b/gson/src/main/java/com/google/gson/reflect/TypeToken.java
@@ -56,7 +56,7 @@ public class TypeToken<T> {
    */
   @SuppressWarnings("unchecked")
   protected TypeToken() {
-    this.type = getSuperclassTypeParameter(getClass());
+    this.type = getTypeTokenTypeArgument();
     this.rawType = (Class<? super T>) $Gson$Types.getRawType(type);
     this.hashCode = type.hashCode();
   }
@@ -72,16 +72,21 @@ public class TypeToken<T> {
   }
 
   /**
-   * Returns the type from super class's type parameter in {@link $Gson$Types#canonicalize
+   * Verifies that {@code this} is an instance of a direct subclass of TypeToken and
+   * returns the type argument for {@code T} in {@link $Gson$Types#canonicalize
    * canonical form}.
    */
-  private static Type getSuperclassTypeParameter(Class<?> subclass) {
-    Type superclass = subclass.getGenericSuperclass();
-    if (superclass instanceof Class) {
-      throw new RuntimeException("Missing type parameter.");
+  private Type getTypeTokenTypeArgument() {
+    Type superclass = getClass().getGenericSuperclass();
+    if (superclass instanceof ParameterizedType) {
+      ParameterizedType parameterized = (ParameterizedType) superclass;
+      if (parameterized.getRawType() == TypeToken.class) {
+        return $Gson$Types.canonicalize(parameterized.getActualTypeArguments()[0]);
+      }
     }
-    ParameterizedType parameterized = (ParameterizedType) superclass;
-    return $Gson$Types.canonicalize(parameterized.getActualTypeArguments()[0]);
+
+    // User created subclass of subclass of TypeToken
+    throw new IllegalStateException("Must only create direct subclasses of TypeToken");
   }
 
   /**

--- a/gson/src/main/java/com/google/gson/reflect/TypeToken.java
+++ b/gson/src/main/java/com/google/gson/reflect/TypeToken.java
@@ -37,9 +37,6 @@ import java.util.Map;
  * <p>
  * {@code TypeToken<List<String>> list = new TypeToken<List<String>>() {};}
  *
- * <p>This syntax cannot be used to create type literals that have wildcard
- * parameters, such as {@code Class<?>} or {@code List<? extends CharSequence>}.
- *
  * @author Bob Lee
  * @author Sven Mawson
  * @author Jesse Wilson

--- a/gson/src/test/java/com/google/gson/reflect/TypeTokenTest.java
+++ b/gson/src/test/java/com/google/gson/reflect/TypeTokenTest.java
@@ -27,9 +27,8 @@ import junit.framework.TestCase;
 /**
  * @author Jesse Wilson
  */
-@SuppressWarnings({"deprecation"})
 public final class TypeTokenTest extends TestCase {
-
+  // These fields are accessed using reflection by the tests below
   List<Integer> listOfInteger = null;
   List<Number> listOfNumber = null;
   List<String> listOfString = null;
@@ -37,6 +36,7 @@ public final class TypeTokenTest extends TestCase {
   List<Set<String>> listOfSetOfString = null;
   List<Set<?>> listOfSetOfUnknown = null;
 
+  @SuppressWarnings({"deprecation"})
   public void testIsAssignableFromRawTypes() {
     assertTrue(TypeToken.get(Object.class).isAssignableFrom(String.class));
     assertFalse(TypeToken.get(String.class).isAssignableFrom(Object.class));
@@ -44,6 +44,7 @@ public final class TypeTokenTest extends TestCase {
     assertFalse(TypeToken.get(ArrayList.class).isAssignableFrom(RandomAccess.class));
   }
 
+  @SuppressWarnings({"deprecation"})
   public void testIsAssignableFromWithTypeParameters() throws Exception {
     Type a = getClass().getDeclaredField("listOfInteger").getGenericType();
     Type b = getClass().getDeclaredField("listOfNumber").getGenericType();
@@ -56,6 +57,7 @@ public final class TypeTokenTest extends TestCase {
     assertFalse(TypeToken.get(b).isAssignableFrom(a));
   }
 
+  @SuppressWarnings({"deprecation"})
   public void testIsAssignableFromWithBasicWildcards() throws Exception {
     Type a = getClass().getDeclaredField("listOfString").getGenericType();
     Type b = getClass().getDeclaredField("listOfUnknown").getGenericType();
@@ -69,6 +71,7 @@ public final class TypeTokenTest extends TestCase {
     // assertTrue(TypeToken.get(b).isAssignableFrom(a));
   }
 
+  @SuppressWarnings({"deprecation"})
   public void testIsAssignableFromWithNestedWildcards() throws Exception {
     Type a = getClass().getDeclaredField("listOfSetOfString").getGenericType();
     Type b = getClass().getDeclaredField("listOfSetOfUnknown").getGenericType();
@@ -101,5 +104,33 @@ public final class TypeTokenTest extends TestCase {
     Type listOfString = TypeToken.getParameterized(List.class, String.class).getType();
     Type listOfListOfString = TypeToken.getParameterized(List.class, listOfString).getType();
     assertEquals(expectedListOfListOfListOfString, TypeToken.getParameterized(List.class, listOfListOfString));
+  }
+
+  /**
+   * User must only create direct subclasses of TypeToken, but not subclasses
+   * of subclasses (...) of TypeToken.
+   */
+  public void testTypeTokenSubSubClass() {
+    class SubTypeToken<T> extends TypeToken<String> {}
+    class SubSubTypeToken1<T> extends SubTypeToken<T> {}
+    class SubSubTypeToken2 extends SubTypeToken<Integer> {}
+
+    try {
+      new SubTypeToken<Integer>() {};
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+
+    try {
+      new SubSubTypeToken1<Integer>();
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+
+    try {
+      new SubSubTypeToken2();
+      fail();
+    } catch (IllegalStateException expected) {
+    }
   }
 }

--- a/gson/src/test/java/com/google/gson/reflect/TypeTokenTest.java
+++ b/gson/src/test/java/com/google/gson/reflect/TypeTokenTest.java
@@ -133,4 +133,45 @@ public final class TypeTokenTest extends TestCase {
     } catch (IllegalStateException expected) {
     }
   }
+
+  /**
+   * TypeToken type argument must not contain a type variable because, due to
+   * type erasure, at runtime only the bound of the type variable is available
+   * which is likely not what the user wanted.
+   *
+   * <p>Note that type variables are allowed for the methods calling {@code TypeToken(Type)}
+   * because there the return type is {@code TypeToken<?>} which does not give
+   * a false sense of type-safety.
+   */
+  public <T> void testTypeTokenTypeVariable() {
+    try {
+      new TypeToken<T>() {};
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+
+    try {
+      new TypeToken<List<T>>() {};
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+
+    try {
+      new TypeToken<List<? extends T>>() {};
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+
+    try {
+      new TypeToken<List<? super T>>() {};
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+
+    try {
+      new TypeToken<List<T[]>>() {};
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
 }


### PR DESCRIPTION
Tries to improve type handling of Gson. Related to https://github.com/google/gson/issues/1741#issuecomment-663917879.
Currently still a draft because there are certain further improvements which I am not sure how to implement (listed below). This would probably also have to include the changes done by #1391.

# TODO
## Type variables
The following type variable logic should also apply to type variables declared by methods and constructors.

### Serialization
When serializing should get the bounds of the type variable:
- if one bound: Should try to use its type. For type variables being part of the bound (e.g. `T extends List<U>`) apply this logic recursively. However, if there is a cycle, e.g. `X extends Comparable<X>`, should throw exception.
- if multiple bounds: Should throw exception. Intersection types cannot be represented using Gson's `TypeToken` and even if they could it might result in conflicts between different libraries when for example multiple libraries register different `CharSequence & Number` adapters which behave differently.

### Deserialization
When deserializing and the type is not raw should always throw exception because at runtime the type argument for that type variable is likely a subtype of the bound. This would then at unrelated places cause unexpected `ClassCastException`s so it would be better if Gson already failed on deserialization.

If the type is raw then the same logic for resolving the type variable as described in the "Serialization" section above should be used.

### Implementation notes
Throwing the exceptions directly on calls to `$Gson$Types.resolve(Type, Class<?>, Type)` should not be done because the problematic type variable might not be considered by the type adapter. For example for a class `MyGenericClass<T>`, if the custom adapter for `MyGenericClass` does not even consider the type variable then it is not an issue that an unresolved type variable exists. So maybe the exception should only be thrown on calls to `Gson.getAdapter(TypeToken)`.

However, the other problem is then to determine when the caller is serializing and when it is deserializing. This could be solved in a somewhat reliable way by having the `ReflectiveTypeAdapterFactory` resolve the type twice, once for serialization and a second time for deserialization. `$Gson$Types.resolve` could then return different resolved types which are then detected by `Gson.getAdapter` and cause it to throw an exception.

## Wildcards
### Wildcards without or with lower bounds
Wildcards without bounds or with lower bounds should be treated as if the class declaring the type variable for which the wildcard is a type argument is raw, i.e. `private List<?> f` should be treated like `private List f` (raw type) as described in the "Type variables" section above.
However, the bound of that wildcard should be resolved with the respective type arguments for the other type variables. For example:
```java
class GenericClass<T, U extends T> { }

...

// Resolved type should be GenericClass<String, String>
private GenericClass<String, ?> f;
```

### Wildcards with upper bounds
Due to [JDK-8250936](https://bugs.openjdk.java.net/browse/JDK-8250936) handling of wildcards with upper bounds is slightly more complicated. First the wildcard should be treated like "Wildcards without or with lower bounds" described above. The resolved type should then be compared with the resolved type of the wildcard bound and the more specific one of them should be used as resolved type.
For example:
```java
class BaseClass { }
class SubClass extends BaseClass { }
class SubSubClass extends SubClass { }
class GenericClass<T extends SubClass> { }

...

// Illogical wildcard bound (JDK-8250936); resolved type should be GenericClass<SubClass>
private GenericClass<? extends BaseClass> f;
// Resolved type should be GenericClass<SubSubClass>
private GenericClass<? extends SubSubClass> f;

class OtherGenericClass<T> {
    private GenericClass<? extends T> f;
}
// Resolved type of OtherGenericClass.f should be GenericClass<String>
private OtherGenericClass<String> f2;
```
