### PR TITLE
Support force writing null JSON value, ignoring getSerializeNulls()

### DIFF
--- a/gson/src/main/java/com/google/gson/annotations/ForceSerializeNull.java
+++ b/gson/src/main/java/com/google/gson/annotations/ForceSerializeNull.java
@@ -1,0 +1,80 @@
+package com.google.gson.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonWriter;
+
+/**
+ * An annotation which forces that fields whose value are {@code null} are
+ * serialized with a JSON {@code null} value regardless of the
+ * {@link JsonWriter#getSerializeNulls()} setting. The {@link #checkTime()}
+ * element defines when to perform the {@code null} check.
+ *
+ * <p>Here is an example showing how the annotation can be used:
+ * <pre>
+ * public class Person {
+ *   private String name;
+ *   &#64;ForceSerializeNull
+ *   private String favoriteFood;
+ * }
+ * </pre>
+ * By default {@link Gson} will not serialize fields whose value is
+ * {@code null}, so without the annotation {@code favoriteFood} would not
+ * be present in the created JSON data in case its value is {@code null}.
+ * However, because it is annotated the {@code null} value will be present
+ * in the JSON data as well:
+ * <pre>
+ * Person person = new Person();
+ * person.name = "John Doe";
+ * person.favoriteFood = null;
+ *
+ * String json = new Gson().toJson(person);
+ * // {"name":"John Doe","favoriteFood":null}
+ * <pre>
+ *
+ * @see GsonBuilder#serializeNulls()
+ * @see JsonWriter#setSerializeNulls(boolean)
+ * @see JsonWriter#forceNullValue()
+ */
+@Retention(RUNTIME)
+@Target(FIELD)
+public @interface ForceSerializeNull {
+  /**
+   * Determines when the {@code null} check and the corresponding forced
+   * serialization of a JSON {@code null} value happens.
+   */
+  enum CheckTime {
+    /**
+     * The {@code null} check is performed before the type adapter for the
+     * field is applied. If the field value is {@code null} a JSON {@code null}
+     * will be forcefully serialized and the type adapter will not be applied.
+     * However, if the field value is non-{@code null} the type adapter is
+     * applied but its result (in case it is {@code null}) is not forcefully
+     * serialized.
+     */
+    BEFORE_ADAPTER,
+    /**
+     * The {@code null} check is performed after the type adapter for the
+     * field has been applied, i.e. on the result of the type adapter. Only if
+     * the immediately written value is {@code null} it will be forcefully
+     * serialized, {@code null} values nested in JSON arrays or objects are
+     * serialized as usual.
+     */
+    AFTER_ADAPTER
+  }
+
+  /**
+   * Determines at which point to check for a {@code null} field value which should
+   * be forcefully serialized.
+   *
+   * @return when to check for {@code null}.
+   */
+  CheckTime checkTime() default CheckTime.BEFORE_ADAPTER;
+}

--- a/gson/src/main/java/com/google/gson/internal/JsonWriterInternalAccess.java
+++ b/gson/src/main/java/com/google/gson/internal/JsonWriterInternalAccess.java
@@ -1,0 +1,21 @@
+package com.google.gson.internal;
+
+import com.google.gson.stream.JsonWriter;
+
+/**
+ * Internal-only APIs of JsonWriter available only to other classes in Gson.
+ */
+public abstract class JsonWriterInternalAccess {
+  public static JsonWriterInternalAccess INSTANCE;
+
+  /**
+   * Enables / disables {@linkplain JsonWriter#forceNullValue() forced null serialization}
+   * of the next value even if the caller did not explicitly request it.
+   * Is disabled again once any value (regardless of whether it is {@code null}) has
+   * been written.
+   *
+   * @param writer which should be changed.
+   * @param forceSerialize whether the next {@code null} should be forced.
+   */
+  public abstract void forceSerializeNextNull(JsonWriter writer, boolean forceSerialize);
+}

--- a/gson/src/test/java/com/google/gson/functional/ForceSerializeNullTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ForceSerializeNullTest.java
@@ -1,0 +1,182 @@
+package com.google.gson.functional;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.ForceSerializeNull;
+import com.google.gson.annotations.ForceSerializeNull.CheckTime;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import junit.framework.TestCase;
+
+/**
+ * Tests {@link ForceSerializeNull} annotation
+ */
+public class ForceSerializeNullTest extends TestCase {
+  private final Gson gson = new Gson();
+
+  /** Ignores value and always writes {@value #CONSTANT}. */
+  private static class ConstantSerializingAdapter extends TypeAdapter<Object> {
+    public static final String CONSTANT = "test";
+
+    @Override
+    public Object read(JsonReader in) throws IOException {
+      throw new UnsupportedOperationException(); // Not needed for these tests
+    }
+
+    @Override
+    public void write(JsonWriter out, Object value) throws IOException {
+      out.value(CONSTANT);
+    }
+  }
+
+  /** Ignores value and always writes {@code null}. */
+  private static class NullSerializingAdapter extends TypeAdapter<Object> {
+    @Override
+    public Object read(JsonReader in) throws IOException {
+      throw new UnsupportedOperationException(); // Not needed for these tests
+    }
+
+    @Override
+    public void write(JsonWriter out, Object value) throws IOException {
+      out.nullValue();
+    }
+  }
+
+  private static class BeforeAdapterTestClass {
+    @ForceSerializeNull
+    Integer f1;
+
+    @ForceSerializeNull
+    @JsonAdapter(value = ConstantSerializingAdapter.class, nullSafe = false)
+    Boolean f2;
+
+    @ForceSerializeNull
+    @JsonAdapter(value = NullSerializingAdapter.class, nullSafe = false)
+    String f3;
+  }
+
+  /**
+   * Test checkTime == BEFORE_ADAPTER for null field values:
+   * Type adapter should not be used if field value is null
+   */
+  public void testBeforeAdapterNull() {
+    BeforeAdapterTestClass toSerialize = new BeforeAdapterTestClass();
+    toSerialize.f1 = null;
+    toSerialize.f2 = null;
+    toSerialize.f3 = null;
+
+    String json = gson.toJson(toSerialize);
+    assertEquals("{\"f1\":null,\"f2\":null,\"f3\":null}", json);
+  }
+
+  /**
+   * Test checkTime == BEFORE_ADAPTER for non-null field values:
+   * Type adapter should be used in case field values are non-null
+   */
+  public void testBeforeAdapterNonNull() {
+    BeforeAdapterTestClass toSerialize = new BeforeAdapterTestClass();
+    toSerialize.f1 = 123;
+    toSerialize.f2 = true;
+    toSerialize.f3 = "test";
+
+    String json = gson.toJson(toSerialize);
+    // f3 is missing because checkTime == BEFORE_ADAPTER does
+    // not consider value written by adapter, so null written
+    // by adapter is omitted due to getSerializeNulls() = false
+    assertEquals("{\"f1\":123,\"f2\":\"test\"}", json);
+  }
+
+  private static class AfterAdapterTestClass {
+    @ForceSerializeNull(checkTime = CheckTime.AFTER_ADAPTER)
+    Map<Integer, String> f1;
+
+    @ForceSerializeNull(checkTime = CheckTime.AFTER_ADAPTER)
+    @JsonAdapter(value = ConstantSerializingAdapter.class, nullSafe = false)
+    Boolean f2;
+
+    @ForceSerializeNull(checkTime = CheckTime.AFTER_ADAPTER)
+    @JsonAdapter(value = NullSerializingAdapter.class, nullSafe = false)
+    String f3;
+  }
+
+  /**
+   * Test checkTime == AFTER_ADAPTER for null field values
+   */
+  public void testAfterAdapterNull() {
+    AfterAdapterTestClass toSerialize = new AfterAdapterTestClass();
+    toSerialize.f1 = null;
+    toSerialize.f2 = null;
+    toSerialize.f3 = null;
+
+    String json = gson.toJson(toSerialize);
+    assertEquals("{\"f1\":null,\"f2\":\"test\",\"f3\":null}", json);
+  }
+
+  /**
+   * Test checkTime == AFTER_ADAPTER for non-null field values
+   */
+  public void testAfterAdapterNonNull() {
+    AfterAdapterTestClass toSerialize = new AfterAdapterTestClass();
+    Map<Integer, String> map = new HashMap<Integer, String>();
+    map.put(1, "a");
+    // nested nulls should not be affected by annotation, should therefore
+    // be omitted due to getSerializeNulls() = false
+    map.put(2, null);
+    toSerialize.f1 = map;
+    toSerialize.f2 = true;
+    toSerialize.f3 = "test";
+
+    String json = gson.toJson(toSerialize);
+    assertEquals("{\"f1\":{\"1\":\"a\"},\"f2\":\"test\",\"f3\":null}", json);
+  }
+
+  /** Adapter which always throws exception. */
+  private static class ThrowingAdapter extends TypeAdapter<Object> {
+    @Override
+    public Object read(JsonReader in) throws IOException {
+      throw new UnsupportedOperationException(); // Not needed for these tests
+    }
+
+    @Override
+    public void write(JsonWriter out, Object value) throws IOException {
+      throw new NumberFormatException("expected");
+    }
+  }
+
+
+  private static class AfterAdapterThrowingTestClass {
+    @ForceSerializeNull(checkTime = CheckTime.AFTER_ADAPTER)
+    @JsonAdapter(ThrowingAdapter.class)
+    String f1 = "test";
+  }
+
+  /**
+   * Test checkTime == AFTER_ADAPTER for case when the adapter writes no
+   * value because it throws exception:
+   * Should reset forced null serialization in that case
+   */
+  public void testAfterAdapterThrowingAdapter() throws IOException {
+    StringWriter stringWriter = new StringWriter();
+    JsonWriter jsonWriter = new JsonWriter(stringWriter);
+    jsonWriter.setSerializeNulls(false);
+
+    AfterAdapterThrowingTestClass toSerialize = new AfterAdapterThrowingTestClass();
+    try {
+      gson.toJson(toSerialize, AfterAdapterThrowingTestClass.class, jsonWriter);
+      fail();
+    } catch (NumberFormatException expected) {
+    }
+    jsonWriter.nullValue(); // regular null, not forced
+    jsonWriter.endObject();
+    jsonWriter.close();
+    // Regular null was written so should be omitted due to getSerializeNulls() = false
+    assertEquals("{}", stringWriter.toString());
+  }
+}

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
@@ -17,6 +17,8 @@
 package com.google.gson.internal.bind;
 
 import com.google.gson.JsonNull;
+import com.google.gson.stream.JsonWriter;
+
 import java.io.IOException;
 import junit.framework.TestCase;
 
@@ -113,6 +115,27 @@ public final class JsonTreeWriterTest extends TestCase {
     writer.nullValue();
     writer.endObject();
     assertEquals("{\"A\":null}", writer.get().toString());
+  }
+
+  public void testForceNullValue() throws IOException {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    writer.setSerializeNulls(false);
+    writer.beginArray();
+    writer.nullValue();
+    // Force null in array should have no special effect
+    JsonWriter returnedWriter = writer.forceNullValue();
+    assertSame(writer, returnedWriter);
+
+    writer.beginObject();
+    writer.name("regular");
+    writer.nullValue();
+    writer.name("forced");
+    writer.forceNullValue();
+    writer.endObject();
+
+    writer.endArray();
+
+    assertEquals("[null,null,{\"forced\":null}]", writer.get().toString());
   }
 
   public void testEmptyWriter() {

--- a/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
@@ -328,6 +328,29 @@ public final class JsonWriterTest extends TestCase {
     assertEquals("[null]", stringWriter.toString());
   }
 
+  public void testForceNullValue() throws IOException {
+    StringWriter stringWriter = new StringWriter();
+    JsonWriter jsonWriter = new JsonWriter(stringWriter);
+    jsonWriter.setSerializeNulls(false);
+    jsonWriter.beginArray();
+    jsonWriter.nullValue();
+    // Force null in array should have no special effect
+    JsonWriter returnedWriter = jsonWriter.forceNullValue();
+    assertSame(jsonWriter, returnedWriter);
+
+    jsonWriter.beginObject();
+    jsonWriter.name("regular");
+    jsonWriter.nullValue();
+    jsonWriter.name("forced");
+    jsonWriter.forceNullValue();
+    jsonWriter.endObject();
+
+    jsonWriter.endArray();
+    jsonWriter.close();
+
+    assertEquals("[null,null,{\"forced\":null}]", stringWriter.toString());
+  }
+
   public void testStrings() throws IOException {
     StringWriter stringWriter = new StringWriter();
     JsonWriter jsonWriter = new JsonWriter(stringWriter);


### PR DESCRIPTION
Fixes #532

Useful for cases where program is communicating with third-party application which requires explicit `null` for certain fields, but globally enabling `null` serialization is not possible / would be wasteful.