### PR TITLE
Clarify doc about TypeAdapter fieldNamingStrategy default behavior

### DIFF
--- a/gson/src/main/java/com/google/gson/FieldNamingPolicy.java
+++ b/gson/src/main/java/com/google/gson/FieldNamingPolicy.java
@@ -24,6 +24,10 @@ import java.util.Locale;
  * This enumeration should be used in conjunction with {@link com.google.gson.GsonBuilder}
  * to configure a {@link com.google.gson.Gson} instance to properly translate Java field
  * names into the desired JSON field names.
+ * <p>
+ * {@link org.immutables.gson.Gson.TypeAdapters#fieldNamingStrategy()} - Naming strategy is 
+ * ignored if fieldNamingStrategy is not set to true. 
+ * E.g. {@code @TypeAdapters(fieldNamingStrategy=true)}.
  *
  * @author Inderjeet Singh
  * @author Joel Leitch


### PR DESCRIPTION
When using TypeAdapter and Gson with setFieldNamingPolicy, if you are not setting TypeAdapter @Gson.TypeAdapters(fieldNamingStrategy = true), then fieldNamingStrategy is ignored.