### PR TITLE
Improve JsonWriter / JsonTreeWriter handling of invalid JSON structure

### DIFF
--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -388,16 +388,26 @@ public class JsonWriter implements Closeable, Flushable {
     if (deferredName != null) {
       throw new IllegalStateException("Already wrote a name, expecting a value");
     }
-    if (stackSize == 0) {
-      throw new IllegalStateException("JsonWriter is closed.");
+    int peeked = peek();
+    if (peeked == EMPTY_OBJECT || peeked == NONEMPTY_OBJECT) {
+      deferredName = name;
+      return this;
+    } else { // array or empty document
+      throw new IllegalStateException("Currently not writing an object");
     }
-    deferredName = name;
-    return this;
   }
 
   private void writeDeferredName() throws IOException {
-    if (deferredName != null) {
-      beforeName();
+    int context = peek();
+    if (context == EMPTY_OBJECT || context == NONEMPTY_OBJECT) {
+      if (deferredName == null) {
+        throw new IllegalStateException("Expecting a name but got a value");
+      }
+      if (context == NONEMPTY_OBJECT) { // first in object
+        out.write(',');
+      }
+      newline();
+      replaceTop(DANGLING_NAME);
       string(deferredName);
       deferredName = null;
     }
@@ -601,21 +611,6 @@ public class JsonWriter implements Closeable, Flushable {
     for (int i = 1, size = stackSize; i < size; i++) {
       out.write(indent);
     }
-  }
-
-  /**
-   * Inserts any necessary separators and whitespace before a name. Also
-   * adjusts the stack to expect the name's value.
-   */
-  private void beforeName() throws IOException {
-    int context = peek();
-    if (context == NONEMPTY_OBJECT) { // first in object
-      out.write(',');
-    } else if (context != EMPTY_OBJECT) { // not in an object!
-      throw new IllegalStateException("Nesting problem.");
-    }
-    newline();
-    replaceTop(DANGLING_NAME);
   }
 
   /**

--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -386,7 +386,7 @@ public class JsonWriter implements Closeable, Flushable {
       throw new NullPointerException("name == null");
     }
     if (deferredName != null) {
-      throw new IllegalStateException();
+      throw new IllegalStateException("Already wrote a name, expecting a value");
     }
     if (stackSize == 0) {
       throw new IllegalStateException("JsonWriter is closed.");

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
@@ -81,6 +81,7 @@ public final class JsonTreeWriterTest extends TestCase {
       writer.beginArray();
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("Writer is closed", expected.getMessage());
     }
   }
 
@@ -142,10 +143,108 @@ public final class JsonTreeWriterTest extends TestCase {
     assertEquals(writer, writer.value(bool));
   }
 
-  public void testBoolMaisValue() throws Exception {
+  public void testBoolBoxedValue() throws Exception {
     JsonTreeWriter writer = new JsonTreeWriter();
     Boolean bool = true;
     assertEquals(writer, writer.value(bool));
+  }
+
+  public void testEmptyEndArray() throws IOException {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    try {
+      writer.endArray();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Currently not writing an array", expected.getMessage());
+    }
+  }
+
+  public void testObjectEndArray() throws IOException {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    writer.beginObject();
+    try {
+      writer.endArray();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Currently not writing an array", expected.getMessage());
+    }
+  }
+
+  public void testEmptyEndObject() throws IOException {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    try {
+      writer.endObject();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Currently not writing an object", expected.getMessage());
+    }
+  }
+
+  public void testPendingNameEndObject() throws IOException {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    writer.beginObject();
+    writer.name("test");
+    try {
+      writer.endObject();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Expecting property value before object can be closed", expected.getMessage());
+    }
+  }
+
+  public void testArrayEndObject() throws IOException {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    writer.beginArray();
+    try {
+      writer.endObject();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Currently not writing an object", expected.getMessage());
+    }
+  }
+
+  public void testEmptyStackWriteName() throws IOException {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    try {
+      writer.name("a");
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Currently not writing an object", expected.getMessage());
+    }
+  }
+
+  public void testArrayWriteName() throws IOException {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    writer.beginArray();
+    try {
+      writer.name("a");
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Currently not writing an object", expected.getMessage());
+    }
+  }
+
+  public void testTwoNames() throws IOException {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    writer.beginObject();
+    writer.name("a");
+    try {
+      writer.name("a");
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Already wrote a name, expecting a value", expected.getMessage());
+    }
+  }
+
+  public void testValueInsteadOfName() throws IOException {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    writer.beginObject();
+    try {
+      writer.value("a");
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Expecting a name but got a value", expected.getMessage());
+    }
   }
 
   public void testLenientNansAndInfinities() throws IOException {

--- a/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
@@ -78,6 +78,7 @@ public final class JsonWriterTest extends TestCase {
       jsonWriter.name("a");
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("Already wrote a name, expecting a value", expected.getMessage());
     }
   }
 

--- a/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
@@ -61,11 +61,11 @@ public final class JsonWriterTest extends TestCase {
   public void testInvalidTopLevelTypes() throws IOException {
     StringWriter stringWriter = new StringWriter();
     JsonWriter jsonWriter = new JsonWriter(stringWriter);
-    jsonWriter.name("hello");
     try {
-      jsonWriter.value("world");
+      jsonWriter.name("hello");
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("Currently not writing an object", expected.getMessage());
     }
   }
 
@@ -91,6 +91,7 @@ public final class JsonWriterTest extends TestCase {
       jsonWriter.endObject();
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("Dangling name: a", expected.getMessage());
     }
   }
 
@@ -102,6 +103,19 @@ public final class JsonWriterTest extends TestCase {
       jsonWriter.value(true);
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("Expecting a name but got a value", expected.getMessage());
+    }
+  }
+
+  public void testArrayWriteName() throws IOException {
+    StringWriter stringWriter = new StringWriter();
+    JsonWriter jsonWriter = new JsonWriter(stringWriter);
+    jsonWriter.beginArray();
+    try {
+      jsonWriter.name("a");
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Currently not writing an object", expected.getMessage());
     }
   }
 


### PR DESCRIPTION
- Adds exception messages to IllegalStateExceptions thrown by JsonTreeWriter
- Fix JsonWriter not detecting invalid name (as top level or as array element) immediately