### PR TITLE
Improve location information in JsonReader exception messages

### DIFF
--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -1487,13 +1487,13 @@ public class JsonReader implements Closeable {
           return c;
         }
       } else if (c == '#') {
-        pos = p;
         /*
          * Skip a # hash end-of-line comment. The JSON RFC doesn't
          * specify this behaviour, but it's required to parse
          * existing documents. See http://b/2571423.
          */
         checkLenient();
+        pos = p;
         skipToEndOfLine();
         p = pos;
         l = limit;

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -238,10 +238,12 @@ public class JsonReader implements Closeable {
   private int pos = 0;
   private int limit = 0;
 
+  /** 0-based line number within the document where reader is currently reading */
   private int lineNumber = 0;
+  /** 0-based line start relative to {@link #pos} (i.e. {@code 0-based column = pos - lineStart}) */
   private int lineStart = 0;
 
-  int peeked = PEEKED_NONE;
+  private int peeked = PEEKED_NONE;
 
   /**
    * A peeked value that was composed entirely of digits with an optional
@@ -457,73 +459,107 @@ public class JsonReader implements Closeable {
     }
   }
 
-  int doPeek() throws IOException {
+  private int doPeek() throws IOException {
     int peekStack = stack[stackSize - 1];
-    if (peekStack == JsonScope.EMPTY_ARRAY) {
-      stack[stackSize - 1] = JsonScope.NONEMPTY_ARRAY;
-    } else if (peekStack == JsonScope.NONEMPTY_ARRAY) {
+    if (peekStack == JsonScope.EMPTY_ARRAY || peekStack == JsonScope.NONEMPTY_ARRAY || peekStack == JsonScope.EXPECTING_ARRAY_ELEMENT) {
       // Look for a comma before the next element.
       int c = nextNonWhitespace(true);
       switch (c) {
       case ']':
-        return peeked = PEEKED_END_ARRAY;
+        // Handle ",]"
+        // In lenient mode, a 0-length literal in an array means 'null'.
+        if (peekStack == JsonScope.EXPECTING_ARRAY_ELEMENT) {
+          checkLenient();
+          // Don't consume closing bracket yet but update stack to prevent
+          // considering it as 'null' again
+          stack[stackSize - 1] = JsonScope.NONEMPTY_ARRAY;
+          return peeked = PEEKED_NULL;
+        } else {
+          pos++;
+          return peeked = PEEKED_END_ARRAY;
+        }
       case ';':
         checkLenient(); // fall-through
       case ',':
-        break;
+        // In lenient mode, a 0-length literal in an array means 'null'.
+        if (peekStack == JsonScope.EMPTY_ARRAY || peekStack == JsonScope.EXPECTING_ARRAY_ELEMENT) {
+          checkLenient();
+          pos++;
+          stack[stackSize - 1] = JsonScope.EXPECTING_ARRAY_ELEMENT;
+          return peeked = PEEKED_NULL;
+        } else {
+          pos++;
+          stack[stackSize - 1] = JsonScope.EXPECTING_ARRAY_ELEMENT;
+          // Have to call recursively to handle potential 0-length literal in lenient mode
+          return doPeek();
+        }
       default:
-        throw syntaxError("Unterminated array");
-      }
-    } else if (peekStack == JsonScope.EMPTY_OBJECT || peekStack == JsonScope.NONEMPTY_OBJECT) {
-      stack[stackSize - 1] = JsonScope.DANGLING_NAME;
-      // Look for a comma before the next element.
-      if (peekStack == JsonScope.NONEMPTY_OBJECT) {
-        int c = nextNonWhitespace(true);
-        switch (c) {
-        case '}':
-          return peeked = PEEKED_END_OBJECT;
-        case ';':
-          checkLenient(); // fall-through
-        case ',':
-          break;
-        default:
-          throw syntaxError("Unterminated object");
+        if (peekStack == JsonScope.EMPTY_ARRAY || peekStack == JsonScope.EXPECTING_ARRAY_ELEMENT) {
+          peekStack = stack[stackSize - 1] = JsonScope.EXPECTING_ARRAY_ELEMENT;
+          // fall-through to value parsing
+        } else {
+          throw syntaxError("Unterminated array");
         }
       }
+    } else if (peekStack == JsonScope.NONEMPTY_OBJECT) {
+      int c = nextNonWhitespace(true);
+      switch (c) {
+      case '}':
+        pos++;
+        return peeked = PEEKED_END_OBJECT;
+      case ';':
+        checkLenient(); // fall-through
+      case ',':
+        pos++;
+        stack[stackSize - 1] = JsonScope.EXPECTING_NAME;
+        return doPeek();
+      default:
+        throw syntaxError("Unterminated object");
+      }
+    } else if (peekStack == JsonScope.EMPTY_OBJECT || peekStack == JsonScope.EXPECTING_NAME) {
       int c = nextNonWhitespace(true);
       switch (c) {
       case '"':
+        pos++;
+        stack[stackSize - 1] = JsonScope.DANGLING_NAME;
         return peeked = PEEKED_DOUBLE_QUOTED_NAME;
       case '\'':
         checkLenient();
+        pos++;
+        stack[stackSize - 1] = JsonScope.DANGLING_NAME;
         return peeked = PEEKED_SINGLE_QUOTED_NAME;
       case '}':
-        if (peekStack != JsonScope.NONEMPTY_OBJECT) {
+        if (peekStack == JsonScope.EMPTY_OBJECT) {
+          pos++;
           return peeked = PEEKED_END_OBJECT;
         } else {
           throw syntaxError("Expected name");
         }
       default:
+        // Don't increment pos to consider `c` as part of unquoted name
+
         checkLenient();
-        pos--; // Don't consume the first character in an unquoted string.
         if (isLiteral((char) c)) {
+          stack[stackSize - 1] = JsonScope.DANGLING_NAME;
           return peeked = PEEKED_UNQUOTED_NAME;
         } else {
           throw syntaxError("Expected name");
         }
       }
     } else if (peekStack == JsonScope.DANGLING_NAME) {
-      stack[stackSize - 1] = JsonScope.NONEMPTY_OBJECT;
       // Look for a colon before the value.
       int c = nextNonWhitespace(true);
       switch (c) {
-      case ':':
-        break;
       case '=':
         checkLenient();
-        if ((pos < limit || fillBuffer(1)) && buffer[pos] == '>') {
+        if ((pos + 1 < limit || fillBuffer(1)) && buffer[pos + 1] == '>') {
           pos++;
         }
+        // fall-through
+      case ':':
+        pos++;
+        peekStack = stack[stackSize - 1] = JsonScope.EXPECTING_PROPERTY_VALUE;
+        // fall-through to value parsing
         break;
       default:
         throw syntaxError("Expected ':'");
@@ -531,66 +567,76 @@ public class JsonReader implements Closeable {
     } else if (peekStack == JsonScope.EMPTY_DOCUMENT) {
       if (lenient) {
         consumeNonExecutePrefix();
+        /*
+         * Don't need to update stack because consuming second non-execute prefix
+         * is not possible.
+         * ')' of second prefix would be considered part of unquoted string so
+         * value parsing succeeds and stack is updated.
+         */
       }
-      stack[stackSize - 1] = JsonScope.NONEMPTY_DOCUMENT;
+      // fall-through to value parsing
     } else if (peekStack == JsonScope.NONEMPTY_DOCUMENT) {
       int c = nextNonWhitespace(false);
       if (c == -1) {
         return peeked = PEEKED_EOF;
       } else {
+        // In lenient mode multiple JSON values may appear behind each other
+        // e.g. "test"true[1,2,3]
         checkLenient();
-        pos--;
+        // fall-through to value parsing
       }
+    } else if (peekStack == JsonScope.EXPECTING_BLOCK_COMMENT_END) {
+      throw syntaxError("Unterminated comment");
     } else if (peekStack == JsonScope.CLOSED) {
       throw new IllegalStateException("JsonReader is closed");
     }
 
+    // parse value
     int c = nextNonWhitespace(true);
     switch (c) {
-    case ']':
-      if (peekStack == JsonScope.EMPTY_ARRAY) {
-        return peeked = PEEKED_END_ARRAY;
-      }
-      // fall-through to handle ",]"
-    case ';':
-    case ',':
-      // In lenient mode, a 0-length literal in an array means 'null'.
-      if (peekStack == JsonScope.EMPTY_ARRAY || peekStack == JsonScope.NONEMPTY_ARRAY) {
-        checkLenient();
-        pos--;
-        return peeked = PEEKED_NULL;
-      } else {
-        throw syntaxError("Unexpected value");
-      }
     case '\'':
       checkLenient();
-      return peeked = PEEKED_SINGLE_QUOTED;
+      peeked = PEEKED_SINGLE_QUOTED;
+      break;
     case '"':
-      return peeked = PEEKED_DOUBLE_QUOTED;
+      peeked = PEEKED_DOUBLE_QUOTED;
+      break;
     case '[':
-      return peeked = PEEKED_BEGIN_ARRAY;
+      peeked = PEEKED_BEGIN_ARRAY;
+      break;
     case '{':
-      return peeked = PEEKED_BEGIN_OBJECT;
-    default:
-      pos--; // Don't consume the first character in a literal value.
+      peeked = PEEKED_BEGIN_OBJECT;
+      break;
     }
 
-    int result = peekKeyword();
-    if (result != PEEKED_NONE) {
-      return result;
+    // Nested if-statements to always update stack before returning
+    if (peeked != PEEKED_NONE) {
+      pos++; // consume peeked char
+    } else {
+      peeked = peekKeyword();
+      if (peeked == PEEKED_NONE) {
+        peeked = peekNumber();
+
+        if (peeked == PEEKED_NONE) {
+          if (!isLiteral(buffer[pos])) {
+            throw syntaxError("Expected value");
+          }
+
+          checkLenient();
+          peeked = PEEKED_UNQUOTED;
+        }
+      }
     }
 
-    result = peekNumber();
-    if (result != PEEKED_NONE) {
-      return result;
+    // Only update stack after value was successfully parsed
+    if (peekStack == JsonScope.EXPECTING_ARRAY_ELEMENT) {
+      stack[stackSize - 1] = JsonScope.NONEMPTY_ARRAY;
+    } else if (peekStack == JsonScope.EXPECTING_PROPERTY_VALUE) {
+      stack[stackSize - 1] = JsonScope.NONEMPTY_OBJECT;
+    } else if (peekStack == JsonScope.EMPTY_DOCUMENT) {
+      stack[stackSize - 1] = JsonScope.NONEMPTY_DOCUMENT;
     }
-
-    if (!isLiteral(buffer[pos])) {
-      throw syntaxError("Expected value");
-    }
-
-    checkLenient();
-    return peeked = PEEKED_UNQUOTED;
+    return peeked;
   }
 
   private int peekKeyword() throws IOException {
@@ -1003,7 +1049,7 @@ public class JsonReader implements Closeable {
             return builder.toString();
           }
         } else if (c == '\\') {
-          pos = p;
+          pos = p - 1; // don't consume '\' yet
           int len = p - start - 1;
           if (builder == null) {
             int estimatedLength = (len + 1) * 2;
@@ -1085,7 +1131,7 @@ public class JsonReader implements Closeable {
         break;
       }
     }
-   
+
     String result = (null == builder) ? new String(buffer, pos, i) : builder.append(buffer, pos, i).toString();
     pos += i;
     return result;
@@ -1104,7 +1150,7 @@ public class JsonReader implements Closeable {
           pos = p;
           return;
         } else if (c == '\\') {
-          pos = p;
+          pos = p - 1; // don't consume '\' yet
           readEscapeCharacter();
           p = pos;
           l = limit;
@@ -1306,8 +1352,8 @@ public class JsonReader implements Closeable {
   /**
    * Returns the next character in the stream that is neither whitespace nor a
    * part of a comment. When this returns, the returned character is always at
-   * {@code buffer[pos-1]}; this means the caller can always push back the
-   * returned character by decrementing {@code pos}.
+   * {@code buffer[pos]}; this means that the caller has to increment {@code pos}
+   * to consume that character.
    */
   private int nextNonWhitespace(boolean throwOnEof) throws IOException {
     /*
@@ -1325,7 +1371,11 @@ public class JsonReader implements Closeable {
       if (p == l) {
         pos = p;
         if (!fillBuffer(1)) {
-          break;
+          if (throwOnEof) {
+            throw new EOFException("End of input" + locationString());
+          } else {
+            return -1;
+          }
         }
         p = pos;
         l = limit;
@@ -1341,38 +1391,43 @@ public class JsonReader implements Closeable {
       }
 
       if (c == '/') {
-        pos = p;
         if (p == l) {
-          pos--; // push back '/' so it's still in the buffer when this method returns
+          pos = p - 1; // don't consume '/' yet
           boolean charsLoaded = fillBuffer(2);
-          pos++; // consume the '/' again
-          if (!charsLoaded) {
+          if (charsLoaded) {
+            p = pos + 1; // skip '/'
+          } else {
             return c;
           }
         }
 
         checkLenient();
-        char peek = buffer[pos];
+        char peek = buffer[p++];
         switch (peek) {
         case '*':
           // skip a /* c-style comment */
-          pos++;
-          if (!skipTo("*/")) {
+          pos = p;
+          if (!skipToIncluding("*/")) {
+            // skipToIncluding(...) might have skipped some chars already
+            // therefore update stack so subsequent call fails again for same reason
+            push(JsonScope.EXPECTING_BLOCK_COMMENT_END);
             throw syntaxError("Unterminated comment");
           }
-          p = pos + 2;
+          p = pos;
           l = limit;
           continue;
 
         case '/':
           // skip a // end-of-line comment
-          pos++;
+          pos = p;
           skipToEndOfLine();
           p = pos;
           l = limit;
           continue;
 
         default:
+          // Consume neither '/' nor `peek` character
+          pos = p - 2;
           return c;
         }
       } else if (c == '#') {
@@ -1387,14 +1442,9 @@ public class JsonReader implements Closeable {
         p = pos;
         l = limit;
       } else {
-        pos = p;
+        pos = p - 1; // push back char
         return c;
       }
-    }
-    if (throwOnEof) {
-      throw new EOFException("End of input" + locationString());
-    } else {
-      return -1;
     }
   }
 
@@ -1405,9 +1455,9 @@ public class JsonReader implements Closeable {
   }
 
   /**
-   * Advances the position until after the next newline character. If the line
-   * is terminated by "\r\n", the '\n' must be consumed as whitespace by the
-   * caller.
+   * Advances the position until after the next newline character or to the end of
+   * the document. If the line is terminated by "\r\n", the '\n' must be consumed
+   * as whitespace by the caller.
    */
   private void skipToEndOfLine() throws IOException {
     while (pos < limit || fillBuffer(1)) {
@@ -1423,9 +1473,13 @@ public class JsonReader implements Closeable {
   }
 
   /**
+   * Skips to, including, the string {@code toFind} and returns true if successful.
+   * Afterwards {@link #pos} is behind the last char of {@code toFind}. Returns
+   * false if the string was not found.
+   *
    * @param toFind a string to search for. Must not contain a newline.
    */
-  private boolean skipTo(String toFind) throws IOException {
+  private boolean skipToIncluding(String toFind) throws IOException {
     int length = toFind.length();
     outer:
     for (; pos + length <= limit || fillBuffer(length); pos++) {
@@ -1439,6 +1493,7 @@ public class JsonReader implements Closeable {
           continue outer;
         }
       }
+      pos += length;
       return true;
     }
     return false;
@@ -1448,7 +1503,7 @@ public class JsonReader implements Closeable {
     return getClass().getSimpleName() + locationString();
   }
 
-  String locationString() {
+  private String locationString() {
     int line = lineNumber + 1;
     int column = pos - lineStart + 1;
     return " at line " + line + " column " + column + " path " + getPath();
@@ -1462,12 +1517,18 @@ public class JsonReader implements Closeable {
     StringBuilder result = new StringBuilder().append('$');
     for (int i = 0, size = stackSize; i < size; i++) {
       switch (stack[i]) {
+        // The following ones use the index of next element or, if currently
+        // reading an element, the index of the current element
         case JsonScope.EMPTY_ARRAY:
+        case JsonScope.EXPECTING_ARRAY_ELEMENT:
         case JsonScope.NONEMPTY_ARRAY:
           result.append('[').append(pathIndices[i]).append(']');
           break;
 
         case JsonScope.EMPTY_OBJECT:
+        case JsonScope.EXPECTING_PROPERTY_VALUE:
+        // For the following ones it uses the name of the previous property
+        case JsonScope.EXPECTING_NAME:
         case JsonScope.DANGLING_NAME:
         case JsonScope.NONEMPTY_OBJECT:
           result.append('.');
@@ -1476,8 +1537,9 @@ public class JsonReader implements Closeable {
           }
           break;
 
-        case JsonScope.NONEMPTY_DOCUMENT:
+        case JsonScope.EXPECTING_BLOCK_COMMENT_END:
         case JsonScope.EMPTY_DOCUMENT:
+        case JsonScope.NONEMPTY_DOCUMENT:
         case JsonScope.CLOSED:
           break;
       }
@@ -1487,28 +1549,30 @@ public class JsonReader implements Closeable {
 
   /**
    * Unescapes the character identified by the character or characters that
-   * immediately follow a backslash. The backslash '\' should have already
-   * been read. This supports both unicode escapes "u000A" and two-character
-   * escapes "\n".
+   * immediately follow a backslash. The backslash '\' should not have been
+   * read yet, i.e. {@code buffer[pos]} should be the backslash.
+   * <p>This supports both unicode escapes "u000A" and two-character escapes "\n".
    *
    * @throws NumberFormatException if any unicode escape sequences are
    *     malformed.
    */
   private char readEscapeCharacter() throws IOException {
-    if (pos == limit && !fillBuffer(1)) {
+    if (pos + 1 == limit && !fillBuffer(1)) {
       throw syntaxError("Unterminated escape sequence");
     }
 
-    char escaped = buffer[pos++];
+    int peekedPos = pos + 1; // skip '\'
+    char escaped = buffer[peekedPos++];
+    char result;
     switch (escaped) {
     case 'u':
-      if (pos + 4 > limit && !fillBuffer(4)) {
+      if (peekedPos + 4 > limit && !fillBuffer(4)) {
         throw syntaxError("Unterminated escape sequence");
       }
-      // Equivalent to Integer.parseInt(stringPool.get(buffer, pos, 4), 16);
-      char result = 0;
-      for (int i = pos, end = i + 4; i < end; i++) {
-        char c = buffer[i];
+      // Equivalent to Integer.parseInt(new String(buffer, pos + 2, 4), 16);
+      result = 0;
+      for (int end = peekedPos + 4; peekedPos < end; peekedPos++) {
+        char c = buffer[peekedPos];
         result <<= 4;
         if (c >= '0' && c <= '9') {
           result += (c - '0');
@@ -1517,41 +1581,43 @@ public class JsonReader implements Closeable {
         } else if (c >= 'A' && c <= 'F') {
           result += (c - 'A' + 10);
         } else {
-          throw new NumberFormatException("\\u" + new String(buffer, pos, 4));
+          throw new NumberFormatException(new String(buffer, pos, 6));
         }
       }
-      pos += 4;
-      return result;
-
+      break;
     case 't':
-      return '\t';
-
+      result = '\t';
+      break;
     case 'b':
-      return '\b';
-
+      result = '\b';
+      break;
     case 'n':
-      return '\n';
-
+      result = '\n';
+      break;
     case 'r':
-      return '\r';
-
+      result = '\r';
+      break;
     case 'f':
-      return '\f';
-
+      result = '\f';
+      break;
     case '\n':
       lineNumber++;
-      lineStart = pos;
+      lineStart = peekedPos;
       // fall-through
 
     case '\'':
     case '"':
     case '\\':
-    case '/':	
-    	return escaped;
+    case '/':
+      result = escaped;
+      break;
     default:
-    	// throw error when none of the above cases are matched
-    	throw syntaxError("Invalid escape sequence");
+        // throw error when none of the above cases are matched
+        throw syntaxError("Invalid escape sequence");
     }
+
+    pos = peekedPos;
+    return result;
   }
 
   /**
@@ -1568,7 +1634,6 @@ public class JsonReader implements Closeable {
   private void consumeNonExecutePrefix() throws IOException {
     // fast forward through the leading whitespace
     nextNonWhitespace(true);
-    pos--;
 
     int p = pos;
     if (p + 5 > limit && !fillBuffer(5)) {

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -973,7 +973,16 @@ public class JsonReader implements Closeable {
     }
 
     peeked = PEEKED_BUFFERED;
-    double result = Double.parseDouble(peekedString); // don't catch this NumberFormatException.
+    double result;
+    try {
+      result = Double.parseDouble(peekedString);
+    } catch (NumberFormatException numberFormatException) {
+      // Add location information; don't include peekedString because it might not
+      // be a number at all making the exception message unreadable
+      NumberFormatException toThrow = new NumberFormatException("Value cannot be parsed as double" + locationString(true));
+      toThrow.initCause(numberFormatException);
+      throw toThrow;
+    }
     if (!lenient && (Double.isNaN(result) || Double.isInfinite(result))) {
       throw new MalformedJsonException(
           "JSON forbids NaN and infinities: " + result + locationString(true));
@@ -1028,7 +1037,16 @@ public class JsonReader implements Closeable {
     }
 
     peeked = PEEKED_BUFFERED;
-    double asDouble = Double.parseDouble(peekedString); // don't catch this NumberFormatException.
+    double asDouble;
+    try {
+      asDouble = Double.parseDouble(peekedString);
+    } catch (NumberFormatException numberFormatException) {
+      // Add location information; don't include peekedString because it might not
+      // be a number at all making the exception message unreadable
+      NumberFormatException toThrow = new NumberFormatException("Value cannot be parsed as long" + locationString(true));
+      toThrow.initCause(numberFormatException);
+      throw toThrow;
+    }
     long result = (long) asDouble;
     if (result != asDouble) { // Make sure no precision was lost casting to 'long'.
       throw new NumberFormatException("Expected a long but was " + peekedString + locationString(true));
@@ -1265,7 +1283,16 @@ public class JsonReader implements Closeable {
     }
 
     peeked = PEEKED_BUFFERED;
-    double asDouble = Double.parseDouble(peekedString); // don't catch this NumberFormatException.
+    double asDouble;
+    try {
+      asDouble = Double.parseDouble(peekedString);
+    } catch (NumberFormatException numberFormatException) {
+      // Add location information; don't include peekedString because it might not
+      // be a number at all making the exception message unreadable
+      NumberFormatException toThrow = new NumberFormatException("Value cannot be parsed as int" + locationString(true));
+      toThrow.initCause(numberFormatException);
+      throw toThrow;
+    }
     result = (int) asDouble;
     if (result != asDouble) { // Make sure no precision was lost casting to 'int'.
       throw new NumberFormatException("Expected an int but was " + peekedString + locationString(true));
@@ -1612,7 +1639,8 @@ public class JsonReader implements Closeable {
         } else if (c >= 'A' && c <= 'F') {
           result += (c - 'A' + 10);
         } else {
-          throw new NumberFormatException(new String(buffer, pos, 6));
+          throw new NumberFormatException("Malformed unicode escape sequence " + new String(buffer, pos, 6)
+              + locationString(false));
         }
       }
       break;

--- a/gson/src/main/java/com/google/gson/stream/JsonScope.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonScope.java
@@ -24,48 +24,76 @@ package com.google.gson.stream;
  */
 final class JsonScope {
 
-    /**
-     * An array with no elements requires no separators or newlines before
-     * it is closed.
-     */
-    static final int EMPTY_ARRAY = 1;
+  /**
+   * An array with no elements requires no separator before it is closed.
+   */
+  static final int EMPTY_ARRAY = 1;
 
-    /**
-     * A array with at least one value requires a comma and newline before
-     * the next element.
-     */
-    static final int NONEMPTY_ARRAY = 2;
+  /**
+   * An array with at least one value requires an element separator (e.g. comma) before
+   * the next element.
+   */
+  static final int NONEMPTY_ARRAY = 2;
 
-    /**
-     * An object with no name/value pairs requires no separators or newlines
-     * before it is closed.
-     */
-    static final int EMPTY_OBJECT = 3;
+  /**
+   * An array with a value followed by an element separator (e.g. comma) requires a
+   * subsequent element before it is closed.
+   * <p>Note: Only used by {@link JsonReader}.
+   */
+  static final int EXPECTING_ARRAY_ELEMENT = 3;
 
-    /**
-     * An object whose most recent element is a key. The next element must
-     * be a value.
-     */
-    static final int DANGLING_NAME = 4;
+  /**
+   * An object with no name/value pairs requires no separator (e.g. comma) before
+   * it is closed.
+   */
+  static final int EMPTY_OBJECT = 4;
 
-    /**
-     * An object with at least one name/value pair requires a comma and
-     * newline before the next element.
-     */
-    static final int NONEMPTY_OBJECT = 5;
+  /**
+   * An object with at least one name/value pair followed by a separator (e.g. comma)
+   * requires a subsequent name/value pair before it is closed.
+   * <p>Note: Only used by {@link JsonReader}.
+   */
+  static final int EXPECTING_NAME = 5;
 
-    /**
-     * No object or array has been started.
-     */
-    static final int EMPTY_DOCUMENT = 6;
+  /**
+   * An object whose most recent element is a property name requires a name/value
+   * separator (e.g. colon) and afterwards a {@link #EXPECTING_PROPERTY_VALUE value}.
+   */
+  static final int DANGLING_NAME = 6;
 
-    /**
-     * A document with at an array or object.
-     */
-    static final int NONEMPTY_DOCUMENT = 7;
+  /**
+   * An object property name followed by a name/value separator (e.g. colon) requires
+   * a property value.
+   * <p>Note: Only used by {@link JsonReader}.
+   */
+  static final int EXPECTING_PROPERTY_VALUE = 7;
 
-    /**
-     * A document that's been closed and cannot be accessed.
-     */
-    static final int CLOSED = 8;
+  /**
+   * An object with at least one name/value pair requires a separator (e.g. comma)
+   * before the next name/value pair.
+   */
+  static final int NONEMPTY_OBJECT = 8;
+
+  /**
+   * A block comment <code>/* ... *&#x2F;</code> which has been started and
+   * requires the closing <code>*&#x2F;</code>.
+   * <p>Note: Only used by {@link JsonReader}.
+   */
+  static final int EXPECTING_BLOCK_COMMENT_END = 9;
+
+  /**
+   * No object or array has been started.
+   */
+  static final int EMPTY_DOCUMENT = 10;
+
+  /**
+   * A document with an array or object.
+   */
+  static final int NONEMPTY_DOCUMENT = 11;
+
+  /**
+   * A document that's been closed and cannot be accessed.
+   * <p>Note: Only used by {@link JsonReader}.
+   */
+  static final int CLOSED = 12;
 }

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
@@ -92,6 +92,7 @@ public final class JsonTreeWriterTest extends TestCase {
       writer.close();
       fail();
     } catch (IOException expected) {
+      assertEquals("Incomplete document", expected.getMessage());
     }
   }
 
@@ -167,16 +168,19 @@ public final class JsonTreeWriterTest extends TestCase {
       writer.value(Double.NaN);
       fail();
     } catch (IllegalArgumentException expected) {
+      assertEquals("JSON forbids NaN and infinities: NaN", expected.getMessage());
     }
     try {
       writer.value(Double.NEGATIVE_INFINITY);
       fail();
     } catch (IllegalArgumentException expected) {
+      assertEquals("JSON forbids NaN and infinities: -Infinity", expected.getMessage());
     }
     try {
       writer.value(Double.POSITIVE_INFINITY);
       fail();
     } catch (IllegalArgumentException expected) {
+      assertEquals("JSON forbids NaN and infinities: Infinity", expected.getMessage());
     }
   }
 
@@ -188,16 +192,19 @@ public final class JsonTreeWriterTest extends TestCase {
       writer.value(Double.valueOf(Double.NaN));
       fail();
     } catch (IllegalArgumentException expected) {
+      assertEquals("JSON forbids NaN and infinities: NaN", expected.getMessage());
     }
     try {
       writer.value(Double.valueOf(Double.NEGATIVE_INFINITY));
       fail();
     } catch (IllegalArgumentException expected) {
+      assertEquals("JSON forbids NaN and infinities: -Infinity", expected.getMessage());
     }
     try {
       writer.value(Double.valueOf(Double.POSITIVE_INFINITY));
       fail();
     } catch (IllegalArgumentException expected) {
+      assertEquals("JSON forbids NaN and infinities: Infinity", expected.getMessage());
     }
   }
 }

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -185,29 +185,33 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.nextName();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals("Invalid escape sequence at line 2 column 8 path $.", expected.getMessage());
     }
   }
-  
+
   @SuppressWarnings("unused")
   public void testNulls() {
     try {
       new JsonReader(null);
       fail();
     } catch (NullPointerException expected) {
+      assertEquals("in == null", expected.getMessage());
     }
   }
 
-  public void testEmptyString() {
+  public void testEmptyString() throws IOException {
     try {
       new JsonReader(reader("")).beginArray();
       fail();
-    } catch (IOException expected) {
+    } catch (EOFException expected) {
+      assertEquals("End of input at line 1 column 1 path $", expected.getMessage());
     }
     try {
       new JsonReader(reader("")).beginObject();
       fail();
-    } catch (IOException expected) {
+    } catch (EOFException expected) {
+      assertEquals("End of input at line 1 column 1 path $", expected.getMessage());
     }
   }
 
@@ -265,6 +269,7 @@ public final class JsonReaderTest extends TestCase {
       reader.nextString();
       fail();
     } catch (NumberFormatException expected) {
+      assertEquals("\\u000g", expected.getMessage());
     }
   }
 
@@ -275,7 +280,8 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.nextString();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals("Unterminated escape sequence at line 1 column 5 path $[0]", expected.getMessage());
     }
   }
 
@@ -286,7 +292,8 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.nextString();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals("Unterminated escape sequence at line 1 column 4 path $[0]", expected.getMessage());
     }
   }
 
@@ -331,6 +338,10 @@ public final class JsonReaderTest extends TestCase {
       reader.nextDouble();
       fail();
     } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]",
+        expected.getMessage()
+      );
     }
   }
 
@@ -342,6 +353,7 @@ public final class JsonReaderTest extends TestCase {
       reader.nextDouble();
       fail();
     } catch (MalformedJsonException expected) {
+      assertEquals("JSON forbids NaN and infinities: NaN at line 1 column 7 path $[0]", expected.getMessage());
     }
   }
 
@@ -375,6 +387,10 @@ public final class JsonReaderTest extends TestCase {
       reader.skipValue();
       fail();
     } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]",
+        expected.getMessage()
+      );
     }
   }
 
@@ -399,12 +415,14 @@ public final class JsonReaderTest extends TestCase {
       reader.nextInt();
       fail();
     } catch (NumberFormatException expected) {
+      assertEquals("Expected an int but was -9223372036854775808 at line 1 column 43 path $[9]", expected.getMessage());
     }
     assertEquals(Long.MIN_VALUE, reader.nextLong());
     try {
       reader.nextInt();
       fail();
     } catch (NumberFormatException expected) {
+      assertEquals("Expected an int but was 9223372036854775807 at line 1 column 63 path $[10]", expected.getMessage());
     }
     assertEquals(Long.MAX_VALUE, reader.nextLong());
     reader.endArray();
@@ -419,21 +437,28 @@ public final class JsonReaderTest extends TestCase {
       reader.peek();
       fail();
     } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]",
+        expected.getMessage()
+      );
     }
     try {
       reader.nextInt();
       fail();
     } catch (MalformedJsonException expected) {
+      assertEquals("", expected.getMessage()); // Have to adjust this
     }
     try {
       reader.nextLong();
       fail();
     } catch (MalformedJsonException expected) {
+      assertEquals("", expected.getMessage()); // Have to adjust this
     }
     try {
       reader.nextDouble();
       fail();
     } catch (MalformedJsonException expected) {
+      assertEquals("", expected.getMessage()); // Have to adjust this
     }
     assertEquals("01", reader.nextString());
     reader.endArray();
@@ -458,6 +483,7 @@ public final class JsonReaderTest extends TestCase {
       reader.nextBoolean();
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("Expected a boolean but was STRING at line 1 column 2 path $[0]", expected.getMessage());
     }
     assertEquals("truey", reader.nextString());
     reader.endArray();
@@ -547,6 +573,7 @@ public final class JsonReaderTest extends TestCase {
       reader.nextLong();
       fail();
     } catch (NumberFormatException expected) {
+      assertEquals("Expected a long but was 22233720368547758070 at line 1 column 22 path $[0]", expected.getMessage());
     }
   }
 
@@ -559,9 +586,10 @@ public final class JsonReaderTest extends TestCase {
       reader.nextLong();
       fail();
     } catch (NumberFormatException expected) {
+      assertEquals("Expected a long but was -22233720368547758070 at line 1 column 23 path $[0]", expected.getMessage());
     }
   }
-  
+
   /**
    * Issue 1053, negative zero.
    * @throws Exception
@@ -586,7 +614,8 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.nextLong();
       fail();
-    } catch (NumberFormatException e) {
+    } catch (NumberFormatException expected) {
+      assertEquals("", expected.getMessage()); // Have to adjust this
     }
   }
 
@@ -603,6 +632,7 @@ public final class JsonReaderTest extends TestCase {
       reader.nextLong();
       fail();
     } catch (NumberFormatException expected) {
+      assertEquals("", expected.getMessage()); // Have to adjust this
     }
     assertEquals(-9223372036854775809d, reader.nextDouble());
   }
@@ -628,6 +658,7 @@ public final class JsonReaderTest extends TestCase {
       reader.nextLong();
       fail();
     } catch (NumberFormatException expected) {
+      assertEquals("Expected a long but was -92233720368547758080 at line 1 column 23 path $[0]", expected.getMessage());
     }
     assertEquals(-92233720368547758080d, reader.nextDouble());
   }
@@ -660,7 +691,8 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.nextString();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals("Expected value at line 1 column 6 path $.a", expected.getMessage());
     }
   }
 
@@ -672,7 +704,8 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.nextName();
       fail();
-    } catch (IOException expected) {
+    } catch (EOFException expected) {
+      assertEquals("End of input at line 1 column 11 path $.a", expected.getMessage());
     }
   }
 
@@ -684,6 +717,7 @@ public final class JsonReaderTest extends TestCase {
       reader.nextName();
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("JsonReader is closed", expected.getMessage());
     }
 
     try {
@@ -692,6 +726,7 @@ public final class JsonReaderTest extends TestCase {
       reader.beginObject();
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("JsonReader is closed", expected.getMessage());
     }
 
     try {
@@ -703,6 +738,7 @@ public final class JsonReaderTest extends TestCase {
       reader.nextBoolean();
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("JsonReader is closed", expected.getMessage());
     }
   }
 
@@ -713,53 +749,63 @@ public final class JsonReaderTest extends TestCase {
       reader.nextString();
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("Expected a string but was NAME at line 1 column 3 path $.", expected.getMessage());
     }
     assertEquals("a", reader.nextName());
     try {
       reader.nextName();
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("Expected a name but was BOOLEAN at line 1 column 10 path $.a", expected.getMessage());
     }
     try {
       reader.beginArray();
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("Expected BEGIN_ARRAY but was BOOLEAN at line 1 column 10 path $.a", expected.getMessage());
     }
     try {
       reader.endArray();
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("Expected END_ARRAY but was BOOLEAN at line 1 column 10 path $.a", expected.getMessage());
     }
     try {
       reader.beginObject();
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("Expected BEGIN_OBJECT but was BOOLEAN at line 1 column 10 path $.a", expected.getMessage());
     }
     try {
       reader.endObject();
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("Expected END_OBJECT but was BOOLEAN at line 1 column 10 path $.a", expected.getMessage());
     }
     assertEquals(true, reader.nextBoolean());
     try {
       reader.nextString();
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("Expected a string but was END_OBJECT at line 1 column 11 path $.a", expected.getMessage());
     }
     try {
       reader.nextName();
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("Expected a name but was END_OBJECT at line 1 column 11 path $.a", expected.getMessage());
     }
     try {
       reader.beginArray();
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("Expected BEGIN_ARRAY but was END_OBJECT at line 1 column 11 path $.a", expected.getMessage());
     }
     try {
       reader.endArray();
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("Expected END_ARRAY but was END_OBJECT at line 1 column 11 path $.a", expected.getMessage());
     }
     reader.endObject();
     assertEquals(JsonToken.END_DOCUMENT, reader.peek());
@@ -773,6 +819,7 @@ public final class JsonReaderTest extends TestCase {
       reader.nextInt();
       fail();
     } catch (NumberFormatException expected) {
+      assertEquals("Expected an int but was 1.5 at line 1 column 5 path $[0]", expected.getMessage());
     }
     assertEquals(1.5d, reader.nextDouble());
     reader.endArray();
@@ -785,6 +832,7 @@ public final class JsonReaderTest extends TestCase {
       reader.nextNull();
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("Expected null but was STRING at line 1 column 3 path $[0]", expected.getMessage());
     }
   }
 
@@ -795,6 +843,7 @@ public final class JsonReaderTest extends TestCase {
       reader.nextString();
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("Expected a string but was NULL at line 1 column 6 path $[0]", expected.getMessage());
     }
   }
 
@@ -805,7 +854,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.nextBoolean();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 6 path $.a",
+        expected.getMessage()
+      );
     }
 
     reader = new JsonReader(reader("{\"a\"=>true}"));
@@ -814,7 +867,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.nextBoolean();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 6 path $.a",
+        expected.getMessage()
+      );
     }
   }
 
@@ -839,7 +896,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.skipValue();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 6 path $.a",
+        expected.getMessage()
+      );
     }
 
     reader = new JsonReader(reader("{\"a\"=>true}"));
@@ -848,7 +909,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.skipValue();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 6 path $.a",
+        expected.getMessage()
+      );
     }
   }
 
@@ -877,7 +942,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.nextBoolean();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $[0]",
+        expected.getMessage()
+      );
     }
 
     reader = new JsonReader(reader("[# comment \n true]"));
@@ -885,7 +954,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.nextBoolean();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $[0]",
+        expected.getMessage()
+      );
     }
 
     reader = new JsonReader(reader("[/* comment */ true]"));
@@ -893,7 +966,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.nextBoolean();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $[0]",
+        expected.getMessage()
+      );
     }
   }
 
@@ -920,7 +997,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.skipValue();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $[0]",
+        expected.getMessage()
+      );
     }
 
     reader = new JsonReader(reader("[# comment \n true]"));
@@ -928,7 +1009,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.skipValue();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $[0]",
+        expected.getMessage()
+      );
     }
 
     reader = new JsonReader(reader("[/* comment */ true]"));
@@ -936,7 +1021,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.skipValue();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $[0]",
+        expected.getMessage()
+      );
     }
   }
 
@@ -946,7 +1035,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.nextName();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $.",
+        expected.getMessage()
+      );
     }
   }
 
@@ -963,7 +1056,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.skipValue();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $.",
+        expected.getMessage()
+      );
     }
   }
 
@@ -973,7 +1070,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.nextName();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $.",
+        expected.getMessage()
+      );
     }
   }
 
@@ -990,7 +1091,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.skipValue();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $.",
+        expected.getMessage()
+      );
     }
   }
 
@@ -1001,6 +1106,10 @@ public final class JsonReaderTest extends TestCase {
       reader.nextString();
       fail();
     } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]",
+        expected.getMessage()
+      );
     }
   }
 
@@ -1011,6 +1120,10 @@ public final class JsonReaderTest extends TestCase {
       reader.skipValue();
       fail();
     } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]",
+        expected.getMessage()
+      );
     }
   }
 
@@ -1027,7 +1140,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.nextString();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $[0]",
+        expected.getMessage()
+      );
     }
   }
 
@@ -1044,7 +1161,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.skipValue();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $[0]",
+        expected.getMessage()
+      );
     }
   }
 
@@ -1053,9 +1174,12 @@ public final class JsonReaderTest extends TestCase {
     reader.beginArray();
     try {
       reader.nextBoolean();
-      reader.nextBoolean();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]",
+        expected.getMessage()
+      );
     }
   }
 
@@ -1072,9 +1196,12 @@ public final class JsonReaderTest extends TestCase {
     reader.beginArray();
     try {
       reader.skipValue();
-      reader.skipValue();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]",
+        expected.getMessage()
+      );
     }
   }
 
@@ -1084,9 +1211,12 @@ public final class JsonReaderTest extends TestCase {
     assertEquals("a", reader.nextName());
     try {
       reader.nextBoolean();
-      reader.nextName();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 6 path $.a",
+        expected.getMessage()
+      );
     }
   }
 
@@ -1105,9 +1235,12 @@ public final class JsonReaderTest extends TestCase {
     assertEquals("a", reader.nextName());
     try {
       reader.skipValue();
-      reader.skipValue();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 6 path $.a",
+        expected.getMessage()
+      );
     }
   }
 
@@ -1118,7 +1251,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.nextNull();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 8 path $[1]",
+        expected.getMessage()
+      );
     }
 
     reader = new JsonReader(reader("[,true]"));
@@ -1126,7 +1263,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.nextNull();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $[0]",
+        expected.getMessage()
+      );
     }
 
     reader = new JsonReader(reader("[true,]"));
@@ -1135,7 +1276,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.nextNull();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 8 path $[1]",
+        expected.getMessage()
+      );
     }
 
     reader = new JsonReader(reader("[,]"));
@@ -1143,7 +1288,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.nextNull();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $[0]",
+        expected.getMessage()
+      );
     }
   }
 
@@ -1185,7 +1334,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.skipValue();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 8 path $[1]",
+        expected.getMessage()
+      );
     }
 
     reader = new JsonReader(reader("[,true]"));
@@ -1193,7 +1346,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.skipValue();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $[0]",
+        expected.getMessage()
+      );
     }
 
     reader = new JsonReader(reader("[true,]"));
@@ -1202,7 +1359,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.skipValue();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 8 path $[1]",
+        expected.getMessage()
+      );
     }
 
     reader = new JsonReader(reader("[,]"));
@@ -1210,7 +1371,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.skipValue();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $[0]",
+        expected.getMessage()
+      );
     }
   }
 
@@ -1221,7 +1386,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.peek();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 5 path $",
+        expected.getMessage()
+      );
     }
   }
 
@@ -1243,7 +1412,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.skipValue();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 5 path $",
+        expected.getMessage()
+      );
     }
   }
 
@@ -1280,21 +1453,29 @@ public final class JsonReaderTest extends TestCase {
     assertEquals(JsonToken.END_DOCUMENT, reader.peek());
   }
 
-  public void testStrictNonExecutePrefix() {
+  public void testStrictNonExecutePrefix() throws IOException {
     JsonReader reader = new JsonReader(reader(")]}'\n []"));
     try {
       reader.beginArray();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 1 path $",
+        expected.getMessage()
+      );
     }
   }
 
-  public void testStrictNonExecutePrefixWithSkipValue() {
+  public void testStrictNonExecutePrefixWithSkipValue() throws IOException {
     JsonReader reader = new JsonReader(reader(")]}'\n []"));
     try {
       reader.skipValue();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 1 path $",
+        expected.getMessage()
+      );
     }
   }
 
@@ -1314,14 +1495,15 @@ public final class JsonReaderTest extends TestCase {
     assertEquals(JsonToken.END_DOCUMENT, reader.peek());
   }
 
-  public void testLenientPartialNonExecutePrefix() {
+  public void testLenientPartialNonExecutePrefix() throws IOException {
     JsonReader reader = new JsonReader(reader(")]}' []"));
     reader.setLenient(true);
+    assertEquals(")", reader.nextString());
     try {
-      assertEquals(")", reader.nextString());
       reader.nextString();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals("Unexpected value at line 1 column 3 path $", expected.getMessage());
     }
   }
 
@@ -1337,7 +1519,11 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.endArray();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]",
+        expected.getMessage()
+      );
     }
   }
 
@@ -1394,7 +1580,7 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader1.peek();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
       assertEquals(message, expected.getMessage());
     }
 
@@ -1406,7 +1592,7 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader2.peek();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
       assertEquals(message, expected.getMessage());
     }
   }
@@ -1423,7 +1609,7 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.peek();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
       assertEquals("Expected value at line 1 column 14 path $[1].a[2]", expected.getMessage());
     }
   }
@@ -1432,9 +1618,15 @@ public final class JsonReaderTest extends TestCase {
     JsonReader reader = new JsonReader(reader("[0." + repeat('9', 8192) + "]"));
     reader.beginArray();
     try {
-      assertEquals(1d, reader.nextDouble());
+      // Fails because JsonReader does not support arbitrarily long numbers in
+      // strict mode
+      reader.nextDouble();
       fail();
     } catch (MalformedJsonException expected) {
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]",
+        expected.getMessage()
+      );
     }
   }
 
@@ -1502,6 +1694,7 @@ public final class JsonReaderTest extends TestCase {
       reader.peek();
       fail();
     } catch (MalformedJsonException expected) {
+      assertEquals("Expected value at line 1 column 1 path $", expected.getMessage());
     }
   }
 
@@ -1512,6 +1705,7 @@ public final class JsonReaderTest extends TestCase {
       reader.peek();
       fail();
     } catch (MalformedJsonException expected) {
+      assertEquals("Expected value at line 1 column 10 path $", expected.getMessage());
     }
   }
 
@@ -1522,6 +1716,7 @@ public final class JsonReaderTest extends TestCase {
       reader.peek();
       fail();
     } catch (MalformedJsonException expected) {
+      assertEquals("Expected value at line 1 column 1 path $", expected.getMessage());
     }
   }
 
@@ -1535,6 +1730,7 @@ public final class JsonReaderTest extends TestCase {
       reader.peek();
       fail();
     } catch (MalformedJsonException expected) {
+      assertEquals("Unterminated object at line 1 column 16 path $.a", expected.getMessage());
     }
   }
 
@@ -1574,6 +1770,7 @@ public final class JsonReaderTest extends TestCase {
       reader.peek();
       fail();
     } catch (EOFException expected) {
+      assertEquals("End of input at line 1 column 16386 path $[1]", expected.getMessage());
     }
   }
 
@@ -1649,7 +1846,8 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.peek();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals("Expected name at line 1 column 11 path $.a", expected.getMessage());
     }
   }
 
@@ -1662,7 +1860,8 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.peek();
       fail();
-    } catch (IOException expected) {
+    } catch (MalformedJsonException expected) {
+      assertEquals("Expected name at line 1 column 11 path $.a", expected.getMessage());
     }
   }
 
@@ -1673,45 +1872,45 @@ public final class JsonReaderTest extends TestCase {
   }
 
   public void testMalformedDocuments() throws IOException {
-    assertDocument("{]", BEGIN_OBJECT, IOException.class);
-    assertDocument("{,", BEGIN_OBJECT, IOException.class);
-    assertDocument("{{", BEGIN_OBJECT, IOException.class);
-    assertDocument("{[", BEGIN_OBJECT, IOException.class);
-    assertDocument("{:", BEGIN_OBJECT, IOException.class);
-    assertDocument("{\"name\",", BEGIN_OBJECT, NAME, IOException.class);
-    assertDocument("{\"name\",", BEGIN_OBJECT, NAME, IOException.class);
-    assertDocument("{\"name\":}", BEGIN_OBJECT, NAME, IOException.class);
-    assertDocument("{\"name\"::", BEGIN_OBJECT, NAME, IOException.class);
-    assertDocument("{\"name\":,", BEGIN_OBJECT, NAME, IOException.class);
-    assertDocument("{\"name\"=}", BEGIN_OBJECT, NAME, IOException.class);
-    assertDocument("{\"name\"=>}", BEGIN_OBJECT, NAME, IOException.class);
-    assertDocument("{\"name\"=>\"string\":", BEGIN_OBJECT, NAME, STRING, IOException.class);
-    assertDocument("{\"name\"=>\"string\"=", BEGIN_OBJECT, NAME, STRING, IOException.class);
-    assertDocument("{\"name\"=>\"string\"=>", BEGIN_OBJECT, NAME, STRING, IOException.class);
-    assertDocument("{\"name\"=>\"string\",", BEGIN_OBJECT, NAME, STRING, IOException.class);
+    assertDocument("{]", BEGIN_OBJECT, MalformedJsonException.class);
+    assertDocument("{,", BEGIN_OBJECT, MalformedJsonException.class);
+    assertDocument("{{", BEGIN_OBJECT, MalformedJsonException.class);
+    assertDocument("{[", BEGIN_OBJECT, MalformedJsonException.class);
+    assertDocument("{:", BEGIN_OBJECT, MalformedJsonException.class);
+    assertDocument("{\"name\",", BEGIN_OBJECT, NAME, MalformedJsonException.class);
+    assertDocument("{\"name\",", BEGIN_OBJECT, NAME, MalformedJsonException.class);
+    assertDocument("{\"name\":}", BEGIN_OBJECT, NAME, MalformedJsonException.class);
+    assertDocument("{\"name\"::", BEGIN_OBJECT, NAME, MalformedJsonException.class);
+    assertDocument("{\"name\":,", BEGIN_OBJECT, NAME, MalformedJsonException.class);
+    assertDocument("{\"name\"=}", BEGIN_OBJECT, NAME, MalformedJsonException.class);
+    assertDocument("{\"name\"=>}", BEGIN_OBJECT, NAME, MalformedJsonException.class);
+    assertDocument("{\"name\"=>\"string\":", BEGIN_OBJECT, NAME, STRING, MalformedJsonException.class);
+    assertDocument("{\"name\"=>\"string\"=", BEGIN_OBJECT, NAME, STRING, MalformedJsonException.class);
+    assertDocument("{\"name\"=>\"string\"=>", BEGIN_OBJECT, NAME, STRING, MalformedJsonException.class);
+    assertDocument("{\"name\"=>\"string\",", BEGIN_OBJECT, NAME, STRING, EOFException.class);
     assertDocument("{\"name\"=>\"string\",\"name\"", BEGIN_OBJECT, NAME, STRING, NAME);
-    assertDocument("[}", BEGIN_ARRAY, IOException.class);
+    assertDocument("[}", BEGIN_ARRAY, MalformedJsonException.class);
     assertDocument("[,]", BEGIN_ARRAY, NULL, NULL, END_ARRAY);
-    assertDocument("{", BEGIN_OBJECT, IOException.class);
-    assertDocument("{\"name\"", BEGIN_OBJECT, NAME, IOException.class);
-    assertDocument("{\"name\",", BEGIN_OBJECT, NAME, IOException.class);
-    assertDocument("{'name'", BEGIN_OBJECT, NAME, IOException.class);
-    assertDocument("{'name',", BEGIN_OBJECT, NAME, IOException.class);
-    assertDocument("{name", BEGIN_OBJECT, NAME, IOException.class);
-    assertDocument("[", BEGIN_ARRAY, IOException.class);
-    assertDocument("[string", BEGIN_ARRAY, STRING, IOException.class);
-    assertDocument("[\"string\"", BEGIN_ARRAY, STRING, IOException.class);
-    assertDocument("['string'", BEGIN_ARRAY, STRING, IOException.class);
-    assertDocument("[123", BEGIN_ARRAY, NUMBER, IOException.class);
-    assertDocument("[123,", BEGIN_ARRAY, NUMBER, IOException.class);
-    assertDocument("{\"name\":123", BEGIN_OBJECT, NAME, NUMBER, IOException.class);
-    assertDocument("{\"name\":123,", BEGIN_OBJECT, NAME, NUMBER, IOException.class);
-    assertDocument("{\"name\":\"string\"", BEGIN_OBJECT, NAME, STRING, IOException.class);
-    assertDocument("{\"name\":\"string\",", BEGIN_OBJECT, NAME, STRING, IOException.class);
-    assertDocument("{\"name\":'string'", BEGIN_OBJECT, NAME, STRING, IOException.class);
-    assertDocument("{\"name\":'string',", BEGIN_OBJECT, NAME, STRING, IOException.class);
-    assertDocument("{\"name\":false", BEGIN_OBJECT, NAME, BOOLEAN, IOException.class);
-    assertDocument("{\"name\":false,,", BEGIN_OBJECT, NAME, BOOLEAN, IOException.class);
+    assertDocument("{", BEGIN_OBJECT, EOFException.class);
+    assertDocument("{\"name\"", BEGIN_OBJECT, NAME, EOFException.class);
+    assertDocument("{\"name\",", BEGIN_OBJECT, NAME, MalformedJsonException.class);
+    assertDocument("{'name'", BEGIN_OBJECT, NAME, EOFException.class);
+    assertDocument("{'name',", BEGIN_OBJECT, NAME, MalformedJsonException.class);
+    assertDocument("{name", BEGIN_OBJECT, NAME, EOFException.class);
+    assertDocument("[", BEGIN_ARRAY, EOFException.class);
+    assertDocument("[string", BEGIN_ARRAY, STRING, EOFException.class);
+    assertDocument("[\"string\"", BEGIN_ARRAY, STRING, EOFException.class);
+    assertDocument("['string'", BEGIN_ARRAY, STRING, EOFException.class);
+    assertDocument("[123", BEGIN_ARRAY, NUMBER, EOFException.class);
+    assertDocument("[123,", BEGIN_ARRAY, NUMBER, EOFException.class);
+    assertDocument("{\"name\":123", BEGIN_OBJECT, NAME, NUMBER, EOFException.class);
+    assertDocument("{\"name\":123,", BEGIN_OBJECT, NAME, NUMBER, EOFException.class);
+    assertDocument("{\"name\":\"string\"", BEGIN_OBJECT, NAME, STRING, EOFException.class);
+    assertDocument("{\"name\":\"string\",", BEGIN_OBJECT, NAME, STRING, EOFException.class);
+    assertDocument("{\"name\":'string'", BEGIN_OBJECT, NAME, STRING, EOFException.class);
+    assertDocument("{\"name\":'string',", BEGIN_OBJECT, NAME, STRING, EOFException.class);
+    assertDocument("{\"name\":false", BEGIN_OBJECT, NAME, BOOLEAN, EOFException.class);
+    assertDocument("{\"name\":false,,", BEGIN_OBJECT, NAME, BOOLEAN, MalformedJsonException.class);
   }
 
   /**
@@ -1727,6 +1926,7 @@ public final class JsonReaderTest extends TestCase {
       reader.nextString();
       fail();
     } catch (MalformedJsonException expected) {
+      assertEquals("Unterminated string at line 1 column 9 path $[0]", expected.getMessage());
     }
   }
 
@@ -1752,11 +1952,12 @@ public final class JsonReaderTest extends TestCase {
         assertEquals(123, reader.nextInt());
       } else if (expectation == NULL) {
         reader.nextNull();
-      } else if (expectation == IOException.class) {
+      } else if (expectation instanceof Class<?> && Exception.class.isAssignableFrom((Class<?>) expectation)) {
         try {
           reader.peek();
           fail();
-        } catch (IOException expected) {
+        } catch (Exception expected) {
+          assertSame(expectation, expected.getClass());
         }
       } else {
         throw new AssertionError();
@@ -1764,9 +1965,6 @@ public final class JsonReaderTest extends TestCase {
     }
   }
 
-  /**
-   * Returns a reader that returns one character at a time.
-   */
   private Reader reader(final String s) {
     /* if (true) */ return new StringReader(s);
     /* return new Reader() {

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -269,7 +269,7 @@ public final class JsonReaderTest extends TestCase {
       reader.nextString();
       fail();
     } catch (NumberFormatException expected) {
-      assertEquals("\\u000g", expected.getMessage());
+      assertEquals("Malformed unicode escape sequence \\u000g at line 1 column 3 path $[0]", expected.getMessage());
     }
   }
 
@@ -577,8 +577,33 @@ public final class JsonReaderTest extends TestCase {
       reader.nextInt();
       fail();
     } catch (NumberFormatException expected) {
+      assertEquals("Value cannot be parsed as int at line 1 column 2 path $[0]", expected.getMessage());
     }
     assertEquals("12.34e5x", reader.nextString());
+  }
+
+  public void testMalformedLong() throws IOException {
+    JsonReader reader = new JsonReader(reader("12xyz"));
+    reader.setLenient(true);
+    assertEquals(STRING, reader.peek());
+    try {
+      reader.nextLong();
+      fail();
+    } catch (NumberFormatException expected) {
+      assertEquals("Value cannot be parsed as long at line 1 column 1 path $", expected.getMessage());
+    }
+  }
+
+  public void testMalformedDouble() throws IOException {
+    JsonReader reader = new JsonReader(reader("12xyz"));
+    reader.setLenient(true);
+    assertEquals(STRING, reader.peek());
+    try {
+      reader.nextDouble();
+      fail();
+    } catch (NumberFormatException expected) {
+      assertEquals("Value cannot be parsed as double at line 1 column 1 path $", expected.getMessage());
+    }
   }
 
   public void testPeekLongMinValue() throws IOException {

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -1484,13 +1484,19 @@ public final class JsonReaderTest extends TestCase {
   }
 
   public void testLenientMultipleTopLevelValues() throws IOException {
-    JsonReader reader = new JsonReader(reader("[] true {}"));
+    JsonReader reader = new JsonReader(reader("[] true {} a 'abc' /* test */ \"def\" # comment \n 123 null"));
     reader.setLenient(true);
     reader.beginArray();
     reader.endArray();
     assertEquals(true, reader.nextBoolean());
     reader.beginObject();
     reader.endObject();
+    assertEquals("a", reader.nextString());
+    assertEquals("abc", reader.nextString());
+    assertEquals("def", reader.nextString());
+    assertEquals(JsonToken.NUMBER, reader.peek());
+    assertEquals(123, reader.nextInt());
+    reader.nextNull();
     assertEquals(JsonToken.END_DOCUMENT, reader.peek());
   }
 
@@ -2136,17 +2142,17 @@ public final class JsonReaderTest extends TestCase {
 
     assertStrictDocument("false/", BOOLEAN, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 6 path $"));
     assertStrictDocument("false#", BOOLEAN, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 6 path $"));
-    assertStrictDocument("false:", BOOLEAN, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 6 path $"));
-    assertStrictDocument("false,", BOOLEAN, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 6 path $"));
-    assertStrictDocument("false;", BOOLEAN, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 6 path $"));
+    assertStrictDocument("false:", BOOLEAN, new MalformedJsonException("Unexpected character at line 1 column 6 path $"));
+    assertStrictDocument("false,", BOOLEAN, new MalformedJsonException("Unexpected character at line 1 column 6 path $"));
+    assertStrictDocument("false;", BOOLEAN, new MalformedJsonException("Unexpected character at line 1 column 6 path $"));
     assertStrictDocument("falsea", new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 1 path $"));
     assertStrictDocument("false ", BOOLEAN, END_DOCUMENT); // well-formed
 
     assertStrictDocument("123/", NUMBER, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 4 path $"));
     assertStrictDocument("123#", NUMBER, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 4 path $"));
-    assertStrictDocument("123:", NUMBER, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 4 path $"));
-    assertStrictDocument("123,", NUMBER, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 4 path $"));
-    assertStrictDocument("123;", NUMBER, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 4 path $"));
+    assertStrictDocument("123:", NUMBER, new MalformedJsonException("Unexpected character at line 1 column 4 path $"));
+    assertStrictDocument("123,", NUMBER, new MalformedJsonException("Unexpected character at line 1 column 4 path $"));
+    assertStrictDocument("123;", NUMBER, new MalformedJsonException("Unexpected character at line 1 column 4 path $"));
     assertStrictDocument("123a", new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 1 path $"));
     assertStrictDocument("123 ", NUMBER, END_DOCUMENT); // well-formed
   }

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -2112,35 +2112,53 @@ public final class JsonReaderTest extends TestCase {
   }
 
   public void testStrictMalformedDocuments() throws IOException {
-    // `/` and `#` should be considered comment starts which can
-    // be read only in lenient mode
-    assertStrictDocument("{/", BEGIN_OBJECT, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $."));
+    // Incomplete or malformed comment should be considered not-a-name
+    assertStrictDocument("{/", BEGIN_OBJECT, new MalformedJsonException("Expected name at line 1 column 2 path $."));
+    assertStrictDocument("{/a", BEGIN_OBJECT, new MalformedJsonException("Expected name at line 1 column 2 path $."));
+    assertStrictDocument("{//", BEGIN_OBJECT, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $."));
+    assertStrictDocument("{/*", BEGIN_OBJECT, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $."));
     assertStrictDocument("{#", BEGIN_OBJECT, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $."));
     assertStrictDocument("{:", BEGIN_OBJECT, new MalformedJsonException("Expected name at line 1 column 2 path $."));
     assertStrictDocument("{,", BEGIN_OBJECT, new MalformedJsonException("Expected name at line 1 column 2 path $."));
     assertStrictDocument("{;", BEGIN_OBJECT, new MalformedJsonException("Expected name at line 1 column 2 path $."));
     assertStrictDocument("{a", BEGIN_OBJECT, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $."));
-    assertStrictDocument("{\"name\":/", BEGIN_OBJECT, NAME, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 9 path $.name"));
+    // Incomplete or malformed comment should be considered not-a-value
+    assertStrictDocument("{\"name\":/", BEGIN_OBJECT, NAME, new MalformedJsonException("Expected value at line 1 column 9 path $.name"));
+    assertStrictDocument("{\"name\":/a", BEGIN_OBJECT, NAME, new MalformedJsonException("Expected value at line 1 column 9 path $.name"));
+    assertStrictDocument("{\"name\"://", BEGIN_OBJECT, NAME, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 9 path $.name"));
+    assertStrictDocument("{\"name\":/*", BEGIN_OBJECT, NAME, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 9 path $.name"));
     assertStrictDocument("{\"name\":#", BEGIN_OBJECT, NAME, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 9 path $.name"));
     assertStrictDocument("{\"name\"::", BEGIN_OBJECT, NAME, new MalformedJsonException("Expected value at line 1 column 9 path $.name"));
     assertStrictDocument("{\"name\":,", BEGIN_OBJECT, NAME, new MalformedJsonException("Expected value at line 1 column 9 path $.name"));
     assertStrictDocument("{\"name\":;", BEGIN_OBJECT, NAME, new MalformedJsonException("Expected value at line 1 column 9 path $.name"));
     assertStrictDocument("{\"name\":a", BEGIN_OBJECT, NAME, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 9 path $.name"));
 
-    assertStrictDocument("[/", BEGIN_ARRAY, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]"));
+    // Incomplete or malformed comment should be considered not-a-value
+    assertStrictDocument("[/", BEGIN_ARRAY, new MalformedJsonException("Expected value at line 1 column 2 path $[0]"));
+    assertStrictDocument("[/a", BEGIN_ARRAY, new MalformedJsonException("Expected value at line 1 column 2 path $[0]"));
+    assertStrictDocument("[//", BEGIN_ARRAY, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]"));
+    assertStrictDocument("[/*", BEGIN_ARRAY, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]"));
     assertStrictDocument("[#", BEGIN_ARRAY, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]"));
     assertStrictDocument("[:", BEGIN_ARRAY, new MalformedJsonException("Expected value at line 1 column 2 path $[0]"));
     assertStrictDocument("[;", BEGIN_ARRAY, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]"));
     assertStrictDocument("[a", BEGIN_ARRAY, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]"));
 
-    assertStrictDocument("/", new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 1 path $"));
+    // Incomplete or malformed comment should be considered not-a-value
+    assertStrictDocument("/", new MalformedJsonException("Expected value at line 1 column 1 path $"));
+    assertStrictDocument("/a", new MalformedJsonException("Expected value at line 1 column 1 path $"));
+    assertStrictDocument("//", new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 1 path $"));
+    assertStrictDocument("/*", new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 1 path $"));
     assertStrictDocument("#", new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 1 path $"));
     assertStrictDocument(":", new MalformedJsonException("Expected value at line 1 column 1 path $"));
     assertStrictDocument(";", new MalformedJsonException("Expected value at line 1 column 1 path $"));
     assertStrictDocument("a", new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 1 path $"));
     assertStrictDocument(" ", new EOFException("End of input at line 1 column 2 path $"));
 
-    assertStrictDocument("false/", BOOLEAN, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 6 path $"));
+    // Incomplete or malformed comment should be considered not-a-value
+    assertStrictDocument("false/", BOOLEAN, new MalformedJsonException("Unexpected character at line 1 column 6 path $"));
+    assertStrictDocument("false/a", BOOLEAN, new MalformedJsonException("Unexpected character at line 1 column 6 path $"));
+    assertStrictDocument("false//", BOOLEAN, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 6 path $"));
+    assertStrictDocument("false/*", BOOLEAN, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 6 path $"));
     assertStrictDocument("false#", BOOLEAN, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 6 path $"));
     assertStrictDocument("false:", BOOLEAN, new MalformedJsonException("Unexpected character at line 1 column 6 path $"));
     assertStrictDocument("false,", BOOLEAN, new MalformedJsonException("Unexpected character at line 1 column 6 path $"));
@@ -2148,7 +2166,11 @@ public final class JsonReaderTest extends TestCase {
     assertStrictDocument("falsea", new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 1 path $"));
     assertStrictDocument("false ", BOOLEAN, END_DOCUMENT); // well-formed
 
-    assertStrictDocument("123/", NUMBER, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 4 path $"));
+    // Incomplete or malformed comment should be considered not-a-value
+    assertStrictDocument("123/", NUMBER, new MalformedJsonException("Unexpected character at line 1 column 4 path $"));
+    assertStrictDocument("123/a", NUMBER, new MalformedJsonException("Unexpected character at line 1 column 4 path $"));
+    assertStrictDocument("123/*", NUMBER, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 4 path $"));
+    assertStrictDocument("123//", NUMBER, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 4 path $"));
     assertStrictDocument("123#", NUMBER, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 4 path $"));
     assertStrictDocument("123:", NUMBER, new MalformedJsonException("Unexpected character at line 1 column 4 path $"));
     assertStrictDocument("123,", NUMBER, new MalformedJsonException("Unexpected character at line 1 column 4 path $"));
@@ -2159,6 +2181,8 @@ public final class JsonReaderTest extends TestCase {
 
   public void testLenientMalformedDocuments() throws IOException {
     assertLenientDocument("{", BEGIN_OBJECT, new EOFException("End of input at line 1 column 2 path $."));
+    assertLenientDocument("{/", BEGIN_OBJECT, new MalformedJsonException("Expected name at line 1 column 2 path $."));
+    assertLenientDocument("{/a", BEGIN_OBJECT, new MalformedJsonException("Expected name at line 1 column 2 path $."));
     assertLenientDocument("{]", BEGIN_OBJECT, new MalformedJsonException("Expected name at line 1 column 2 path $."));
     assertLenientDocument("{,", BEGIN_OBJECT, new MalformedJsonException("Expected name at line 1 column 2 path $."));
     assertLenientDocument("{{", BEGIN_OBJECT, new MalformedJsonException("Expected name at line 1 column 2 path $."));

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -1041,7 +1041,7 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
       assertEquals(
-        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $[0]",
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]",
         expected.getMessage()
       );
     }
@@ -1096,7 +1096,7 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
       assertEquals(
-        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $[0]",
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]",
         expected.getMessage()
       );
     }
@@ -2109,33 +2109,33 @@ public final class JsonReaderTest extends TestCase {
     // `/` and `#` should be considered comment starts which can
     // be read only in lenient mode
     assertStrictDocument("{/", BEGIN_OBJECT, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $."));
-    assertStrictDocument("{#", BEGIN_OBJECT, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $."));
+    assertStrictDocument("{#", BEGIN_OBJECT, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $."));
     assertStrictDocument("{:", BEGIN_OBJECT, new MalformedJsonException("Expected name at line 1 column 2 path $."));
     assertStrictDocument("{,", BEGIN_OBJECT, new MalformedJsonException("Expected name at line 1 column 2 path $."));
     assertStrictDocument("{;", BEGIN_OBJECT, new MalformedJsonException("Expected name at line 1 column 2 path $."));
     assertStrictDocument("{a", BEGIN_OBJECT, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $."));
     assertStrictDocument("{\"name\":/", BEGIN_OBJECT, NAME, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 9 path $.name"));
-    assertStrictDocument("{\"name\":#", BEGIN_OBJECT, NAME, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 10 path $.name"));
+    assertStrictDocument("{\"name\":#", BEGIN_OBJECT, NAME, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 9 path $.name"));
     assertStrictDocument("{\"name\"::", BEGIN_OBJECT, NAME, new MalformedJsonException("Expected value at line 1 column 9 path $.name"));
     assertStrictDocument("{\"name\":,", BEGIN_OBJECT, NAME, new MalformedJsonException("Expected value at line 1 column 9 path $.name"));
     assertStrictDocument("{\"name\":;", BEGIN_OBJECT, NAME, new MalformedJsonException("Expected value at line 1 column 9 path $.name"));
     assertStrictDocument("{\"name\":a", BEGIN_OBJECT, NAME, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 9 path $.name"));
 
     assertStrictDocument("[/", BEGIN_ARRAY, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]"));
-    assertStrictDocument("[#", BEGIN_ARRAY, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $[0]"));
+    assertStrictDocument("[#", BEGIN_ARRAY, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]"));
     assertStrictDocument("[:", BEGIN_ARRAY, new MalformedJsonException("Expected value at line 1 column 2 path $[0]"));
     assertStrictDocument("[;", BEGIN_ARRAY, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]"));
     assertStrictDocument("[a", BEGIN_ARRAY, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]"));
 
     assertStrictDocument("/", new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 1 path $"));
-    assertStrictDocument("#", new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $"));
+    assertStrictDocument("#", new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 1 path $"));
     assertStrictDocument(":", new MalformedJsonException("Expected value at line 1 column 1 path $"));
     assertStrictDocument(";", new MalformedJsonException("Expected value at line 1 column 1 path $"));
     assertStrictDocument("a", new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 1 path $"));
     assertStrictDocument(" ", new EOFException("End of input at line 1 column 2 path $"));
 
     assertStrictDocument("false/", BOOLEAN, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 6 path $"));
-    assertStrictDocument("false#", BOOLEAN, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 7 path $"));
+    assertStrictDocument("false#", BOOLEAN, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 6 path $"));
     assertStrictDocument("false:", BOOLEAN, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 6 path $"));
     assertStrictDocument("false,", BOOLEAN, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 6 path $"));
     assertStrictDocument("false;", BOOLEAN, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 6 path $"));
@@ -2143,7 +2143,7 @@ public final class JsonReaderTest extends TestCase {
     assertStrictDocument("false ", BOOLEAN, END_DOCUMENT); // well-formed
 
     assertStrictDocument("123/", NUMBER, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 4 path $"));
-    assertStrictDocument("123#", NUMBER, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 5 path $"));
+    assertStrictDocument("123#", NUMBER, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 4 path $"));
     assertStrictDocument("123:", NUMBER, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 4 path $"));
     assertStrictDocument("123,", NUMBER, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 4 path $"));
     assertStrictDocument("123;", NUMBER, new MalformedJsonException("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 4 path $"));

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -353,7 +353,7 @@ public final class JsonReaderTest extends TestCase {
       reader.nextDouble();
       fail();
     } catch (MalformedJsonException expected) {
-      assertEquals("JSON forbids NaN and infinities: NaN at line 1 column 7 path $[0]", expected.getMessage());
+      assertEquals("JSON forbids NaN and infinities: NaN at line 1 column 2 path $[0]", expected.getMessage());
     }
   }
 
@@ -415,14 +415,14 @@ public final class JsonReaderTest extends TestCase {
       reader.nextInt();
       fail();
     } catch (NumberFormatException expected) {
-      assertEquals("Expected an int but was -9223372036854775808 at line 1 column 43 path $[9]", expected.getMessage());
+      assertEquals("Expected an int but was -9223372036854775808 at line 1 column 23 path $[9]", expected.getMessage());
     }
     assertEquals(Long.MIN_VALUE, reader.nextLong());
     try {
       reader.nextInt();
       fail();
     } catch (NumberFormatException expected) {
-      assertEquals("Expected an int but was 9223372036854775807 at line 1 column 63 path $[10]", expected.getMessage());
+      assertEquals("Expected an int but was 9223372036854775807 at line 1 column 44 path $[10]", expected.getMessage());
     }
     assertEquals(Long.MAX_VALUE, reader.nextLong());
     reader.endArray();
@@ -606,7 +606,7 @@ public final class JsonReaderTest extends TestCase {
       reader.nextLong();
       fail();
     } catch (NumberFormatException expected) {
-      assertEquals("Expected a long but was 22233720368547758070 at line 1 column 22 path $[0]", expected.getMessage());
+      assertEquals("Expected a long but was 22233720368547758070 at line 1 column 2 path $[0]", expected.getMessage());
     }
   }
 
@@ -619,7 +619,7 @@ public final class JsonReaderTest extends TestCase {
       reader.nextLong();
       fail();
     } catch (NumberFormatException expected) {
-      assertEquals("Expected a long but was -22233720368547758070 at line 1 column 23 path $[0]", expected.getMessage());
+      assertEquals("Expected a long but was -22233720368547758070 at line 1 column 2 path $[0]", expected.getMessage());
     }
   }
 
@@ -691,7 +691,7 @@ public final class JsonReaderTest extends TestCase {
       reader.nextLong();
       fail();
     } catch (NumberFormatException expected) {
-      assertEquals("Expected a long but was -92233720368547758080 at line 1 column 23 path $[0]", expected.getMessage());
+      assertEquals("Expected a long but was -92233720368547758080 at line 1 column 2 path $[0]", expected.getMessage());
     }
     assertEquals(-92233720368547758080d, reader.nextDouble());
   }
@@ -782,63 +782,63 @@ public final class JsonReaderTest extends TestCase {
       reader.nextString();
       fail();
     } catch (IllegalStateException expected) {
-      assertEquals("Expected a string but was NAME at line 1 column 3 path $.", expected.getMessage());
+      assertEquals("Expected a string but was NAME at line 1 column 2 path $.", expected.getMessage());
     }
     assertEquals("a", reader.nextName());
     try {
       reader.nextName();
       fail();
     } catch (IllegalStateException expected) {
-      assertEquals("Expected a name but was BOOLEAN at line 1 column 10 path $.a", expected.getMessage());
+      assertEquals("Expected a name but was BOOLEAN at line 1 column 6 path $.a", expected.getMessage());
     }
     try {
       reader.beginArray();
       fail();
     } catch (IllegalStateException expected) {
-      assertEquals("Expected BEGIN_ARRAY but was BOOLEAN at line 1 column 10 path $.a", expected.getMessage());
+      assertEquals("Expected BEGIN_ARRAY but was BOOLEAN at line 1 column 6 path $.a", expected.getMessage());
     }
     try {
       reader.endArray();
       fail();
     } catch (IllegalStateException expected) {
-      assertEquals("Expected END_ARRAY but was BOOLEAN at line 1 column 10 path $.a", expected.getMessage());
+      assertEquals("Expected END_ARRAY but was BOOLEAN at line 1 column 6 path $.a", expected.getMessage());
     }
     try {
       reader.beginObject();
       fail();
     } catch (IllegalStateException expected) {
-      assertEquals("Expected BEGIN_OBJECT but was BOOLEAN at line 1 column 10 path $.a", expected.getMessage());
+      assertEquals("Expected BEGIN_OBJECT but was BOOLEAN at line 1 column 6 path $.a", expected.getMessage());
     }
     try {
       reader.endObject();
       fail();
     } catch (IllegalStateException expected) {
-      assertEquals("Expected END_OBJECT but was BOOLEAN at line 1 column 10 path $.a", expected.getMessage());
+      assertEquals("Expected END_OBJECT but was BOOLEAN at line 1 column 6 path $.a", expected.getMessage());
     }
     assertEquals(true, reader.nextBoolean());
     try {
       reader.nextString();
       fail();
     } catch (IllegalStateException expected) {
-      assertEquals("Expected a string but was END_OBJECT at line 1 column 11 path $.a", expected.getMessage());
+      assertEquals("Expected a string but was END_OBJECT at line 1 column 10 path $.a", expected.getMessage());
     }
     try {
       reader.nextName();
       fail();
     } catch (IllegalStateException expected) {
-      assertEquals("Expected a name but was END_OBJECT at line 1 column 11 path $.a", expected.getMessage());
+      assertEquals("Expected a name but was END_OBJECT at line 1 column 10 path $.a", expected.getMessage());
     }
     try {
       reader.beginArray();
       fail();
     } catch (IllegalStateException expected) {
-      assertEquals("Expected BEGIN_ARRAY but was END_OBJECT at line 1 column 11 path $.a", expected.getMessage());
+      assertEquals("Expected BEGIN_ARRAY but was END_OBJECT at line 1 column 10 path $.a", expected.getMessage());
     }
     try {
       reader.endArray();
       fail();
     } catch (IllegalStateException expected) {
-      assertEquals("Expected END_ARRAY but was END_OBJECT at line 1 column 11 path $.a", expected.getMessage());
+      assertEquals("Expected END_ARRAY but was END_OBJECT at line 1 column 10 path $.a", expected.getMessage());
     }
     reader.endObject();
     assertEquals(JsonToken.END_DOCUMENT, reader.peek());
@@ -852,10 +852,27 @@ public final class JsonReaderTest extends TestCase {
       reader.nextInt();
       fail();
     } catch (NumberFormatException expected) {
-      assertEquals("Expected an int but was 1.5 at line 1 column 5 path $[0]", expected.getMessage());
+      assertEquals("Expected an int but was 1.5 at line 1 column 2 path $[0]", expected.getMessage());
     }
     assertEquals(1.5d, reader.nextDouble());
     reader.endArray();
+  }
+
+  public void testPeekLocationWithWrappedString() throws IOException {
+    JsonReader reader = new JsonReader(reader("\"a\nb\nc\""));
+    try {
+      reader.nextBoolean();
+    } catch (IllegalStateException expected) {
+      // After peeking, reader is already in line 3, however token mismatch
+      // exception message should use line number of peeked token start
+      assertEquals("Expected a boolean but was STRING at line 1 column 1 path $", expected.getMessage());
+    }
+    assertEquals("a\nb\nc", reader.nextString());
+    try {
+      reader.nextBoolean();
+    } catch (IllegalStateException expected) {
+      assertEquals("Expected a boolean but was END_DOCUMENT at line 3 column 3 path $", expected.getMessage());
+    }
   }
 
   public void testStringNullIsNotNull() throws IOException {
@@ -865,7 +882,7 @@ public final class JsonReaderTest extends TestCase {
       reader.nextNull();
       fail();
     } catch (IllegalStateException expected) {
-      assertEquals("Expected null but was STRING at line 1 column 3 path $[0]", expected.getMessage());
+      assertEquals("Expected null but was STRING at line 1 column 2 path $[0]", expected.getMessage());
     }
   }
 
@@ -876,7 +893,7 @@ public final class JsonReaderTest extends TestCase {
       reader.nextString();
       fail();
     } catch (IllegalStateException expected) {
-      assertEquals("Expected a string but was NULL at line 1 column 6 path $[0]", expected.getMessage());
+      assertEquals("Expected a string but was NULL at line 1 column 2 path $[0]", expected.getMessage());
     }
   }
 

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -186,7 +186,7 @@ public final class JsonReaderTest extends TestCase {
       reader.nextName();
       fail();
     } catch (MalformedJsonException expected) {
-      assertEquals("Invalid escape sequence at line 2 column 8 path $.", expected.getMessage());
+      assertEquals("Invalid escape sequence at line 2 column 6 path $.", expected.getMessage());
     }
   }
 
@@ -281,7 +281,7 @@ public final class JsonReaderTest extends TestCase {
       reader.nextString();
       fail();
     } catch (MalformedJsonException expected) {
-      assertEquals("Unterminated escape sequence at line 1 column 5 path $[0]", expected.getMessage());
+      assertEquals("Unterminated escape sequence at line 1 column 3 path $[0]", expected.getMessage());
     }
   }
 
@@ -293,7 +293,7 @@ public final class JsonReaderTest extends TestCase {
       reader.nextString();
       fail();
     } catch (MalformedJsonException expected) {
-      assertEquals("Unterminated escape sequence at line 1 column 4 path $[0]", expected.getMessage());
+      assertEquals("Unterminated escape sequence at line 1 column 3 path $[0]", expected.getMessage());
     }
   }
 
@@ -429,8 +429,12 @@ public final class JsonReaderTest extends TestCase {
     assertEquals(JsonToken.END_DOCUMENT, reader.peek());
   }
 
-  public void disabled_testNumberWithOctalPrefix() throws IOException {
-    String json = "[01]";
+  /**
+   * Octal number notation is not supported so non-lenient JsonReader
+   * should throw exception.
+   */
+  public void testNumberWithOctalPrefix() throws IOException {
+    String json = "[012]";
     JsonReader reader = new JsonReader(reader(json));
     reader.beginArray();
     try {
@@ -446,21 +450,50 @@ public final class JsonReaderTest extends TestCase {
       reader.nextInt();
       fail();
     } catch (MalformedJsonException expected) {
-      assertEquals("", expected.getMessage()); // Have to adjust this
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]",
+        expected.getMessage()
+      );
     }
     try {
       reader.nextLong();
       fail();
     } catch (MalformedJsonException expected) {
-      assertEquals("", expected.getMessage()); // Have to adjust this
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]",
+        expected.getMessage()
+      );
     }
     try {
       reader.nextDouble();
       fail();
     } catch (MalformedJsonException expected) {
-      assertEquals("", expected.getMessage()); // Have to adjust this
+      assertEquals(
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]",
+        expected.getMessage()
+      );
     }
-    assertEquals("01", reader.nextString());
+  }
+
+  /**
+   * Octal number notation is not supported. In lenient mode it is
+   * read as unquoted string and then {@link Integer#parseInt(String)}
+   * parses it with radix 10 (simply ignoring leading 0).
+   */
+  public void testNumberWithOctalPrefixLenient() throws IOException {
+    String json = "[012, 012, 012, 012]";
+    JsonReader reader = new JsonReader(reader(json));
+    reader.setLenient(true);
+    reader.beginArray();
+    assertEquals(JsonToken.STRING, reader.peek());
+    assertEquals("012", reader.nextString());
+
+    // If it would be parsed as octal, decimal result would be 10
+    // However, it is parsed with radix 10 so leading 0 is simply ignored
+    assertEquals(12, reader.nextInt());
+    assertEquals(12, reader.nextLong());
+    assertEquals(12.0, reader.nextDouble());
+
     reader.endArray();
     assertEquals(JsonToken.END_DOCUMENT, reader.peek());
   }
@@ -595,11 +628,11 @@ public final class JsonReaderTest extends TestCase {
    * @throws Exception
    */
   public void testNegativeZero() throws Exception {
-	  	JsonReader reader = new JsonReader(reader("[-0]"));
-	    reader.setLenient(false);
-	    reader.beginArray();
-	    assertEquals(NUMBER, reader.peek());
-	    assertEquals("-0", reader.nextString());
+    JsonReader reader = new JsonReader(reader("[-0]"));
+    reader.setLenient(false);
+    reader.beginArray();
+    assertEquals(NUMBER, reader.peek());
+    assertEquals("-0", reader.nextString());
   }
 
   /**
@@ -856,7 +889,7 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
       assertEquals(
-        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 6 path $.a",
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 5 path $.a",
         expected.getMessage()
       );
     }
@@ -869,7 +902,7 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
       assertEquals(
-        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 6 path $.a",
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 5 path $.a",
         expected.getMessage()
       );
     }
@@ -898,7 +931,7 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
       assertEquals(
-        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 6 path $.a",
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 5 path $.a",
         expected.getMessage()
       );
     }
@@ -911,7 +944,7 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
       assertEquals(
-        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 6 path $.a",
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 5 path $.a",
         expected.getMessage()
       );
     }
@@ -944,7 +977,7 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
       assertEquals(
-        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $[0]",
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]",
         expected.getMessage()
       );
     }
@@ -968,7 +1001,7 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
       assertEquals(
-        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $[0]",
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]",
         expected.getMessage()
       );
     }
@@ -999,7 +1032,7 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
       assertEquals(
-        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $[0]",
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]",
         expected.getMessage()
       );
     }
@@ -1023,7 +1056,7 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
       assertEquals(
-        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $[0]",
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]",
         expected.getMessage()
       );
     }
@@ -1037,7 +1070,7 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
       assertEquals(
-        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $.",
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $.",
         expected.getMessage()
       );
     }
@@ -1058,7 +1091,7 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
       assertEquals(
-        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $.",
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $.",
         expected.getMessage()
       );
     }
@@ -1072,7 +1105,7 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
       assertEquals(
-        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $.",
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $.",
         expected.getMessage()
       );
     }
@@ -1093,7 +1126,7 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
       assertEquals(
-        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $.",
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $.",
         expected.getMessage()
       );
     }
@@ -1142,7 +1175,7 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
       assertEquals(
-        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $[0]",
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]",
         expected.getMessage()
       );
     }
@@ -1163,7 +1196,7 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
       assertEquals(
-        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $[0]",
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]",
         expected.getMessage()
       );
     }
@@ -1253,7 +1286,7 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
       assertEquals(
-        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 8 path $[1]",
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 7 path $[1]",
         expected.getMessage()
       );
     }
@@ -1265,7 +1298,7 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
       assertEquals(
-        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $[0]",
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]",
         expected.getMessage()
       );
     }
@@ -1278,7 +1311,7 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
       assertEquals(
-        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 8 path $[1]",
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 7 path $[1]",
         expected.getMessage()
       );
     }
@@ -1290,7 +1323,7 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
       assertEquals(
-        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $[0]",
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]",
         expected.getMessage()
       );
     }
@@ -1336,7 +1369,7 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
       assertEquals(
-        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 8 path $[1]",
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 7 path $[1]",
         expected.getMessage()
       );
     }
@@ -1348,7 +1381,7 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
       assertEquals(
-        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $[0]",
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]",
         expected.getMessage()
       );
     }
@@ -1361,7 +1394,7 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
       assertEquals(
-        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 8 path $[1]",
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 7 path $[1]",
         expected.getMessage()
       );
     }
@@ -1373,7 +1406,7 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
       assertEquals(
-        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $[0]",
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]",
         expected.getMessage()
       );
     }
@@ -1388,7 +1421,7 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
       assertEquals(
-        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 5 path $",
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 4 path $",
         expected.getMessage()
       );
     }
@@ -1414,7 +1447,7 @@ public final class JsonReaderTest extends TestCase {
       fail();
     } catch (MalformedJsonException expected) {
       assertEquals(
-        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 5 path $",
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 4 path $",
         expected.getMessage()
       );
     }
@@ -1503,7 +1536,23 @@ public final class JsonReaderTest extends TestCase {
       reader.nextString();
       fail();
     } catch (MalformedJsonException expected) {
-      assertEquals("Unexpected value at line 1 column 3 path $", expected.getMessage());
+      assertEquals("Expected value at line 1 column 2 path $", expected.getMessage());
+    }
+  }
+
+  /**
+   * At most one non-execute prefix must be consumed.
+   */
+  public void testLenientDoubleNonExecutePrefix() throws IOException {
+    JsonReader reader = new JsonReader(reader(")]}'\n)]}'\n 1"));
+    reader.setLenient(true);
+    // Consumes the parenthesis after the first non-execute prefix
+    assertEquals(")", reader.nextString());
+    try {
+      reader.peek();
+      fail();
+    } catch (MalformedJsonException expected) {
+      assertEquals("Expected value at line 1 column 7 path $", expected.getMessage());
     }
   }
 
@@ -1730,7 +1779,7 @@ public final class JsonReaderTest extends TestCase {
       reader.peek();
       fail();
     } catch (MalformedJsonException expected) {
-      assertEquals("Unterminated object at line 1 column 16 path $.a", expected.getMessage());
+      assertEquals("Unterminated object at line 1 column 15 path $.a", expected.getMessage());
     }
   }
 
@@ -1847,7 +1896,7 @@ public final class JsonReaderTest extends TestCase {
       reader.peek();
       fail();
     } catch (MalformedJsonException expected) {
-      assertEquals("Expected name at line 1 column 11 path $.a", expected.getMessage());
+      assertEquals("Expected name at line 1 column 10 path $.a", expected.getMessage());
     }
   }
 
@@ -1861,7 +1910,119 @@ public final class JsonReaderTest extends TestCase {
       reader.peek();
       fail();
     } catch (MalformedJsonException expected) {
-      assertEquals("Expected name at line 1 column 11 path $.a", expected.getMessage());
+      assertEquals("Expected name at line 1 column 10 path $.a", expected.getMessage());
+    }
+  }
+
+  /**
+   * When {@link JsonReader#peek()} throws an exception due to malformed JSON
+   * it should not have advanced in the stream yet.
+   */
+  public void testThrowingPeekArray() throws IOException {
+    JsonReader reader = new JsonReader(reader("[a?$,1]"));
+    reader.beginArray();
+    for (int i = 0; i < 10; i++) {
+      try {
+        reader.peek();
+      } catch (MalformedJsonException expected) {
+        assertEquals(
+          "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 2 path $[0]",
+          expected.getMessage()
+        );
+      }
+    }
+  }
+
+  /**
+   * When {@link JsonReader#peek()} throws an exception due to malformed JSON
+   * it should not have advanced in the stream yet.
+   */
+  public void testThrowingPeekObject() throws IOException {
+    JsonReader reader = new JsonReader(reader("{\"test\"::}"));
+    reader.beginObject();
+    for (int i = 0; i < 10; i++) {
+      try {
+        reader.peek();
+      } catch (MalformedJsonException expected) {
+        assertEquals("Expected name at line 1 column 11 path $.a", expected.getMessage());
+      }
+    }
+  }
+
+  public void testThrowingPeekIncompleteBlockComment() throws IOException {
+    JsonReader reader = new JsonReader(reader("[/*]"));
+    reader.setLenient(true); // lenient to support block comments
+    reader.beginArray();
+    /*
+     * Make sure that incomplete block comment (i.e. missing closing * /)
+     * is not skipped after first unsuccessful peek.
+     *
+     * In previous Gson versions a subsequent peek would have skipped the
+     * comment start (i.e. "/*") and therefore could have read "valid"
+     * JSON afterwards.
+     */
+    for (int i = 0; i < 3; i++) {
+      try {
+        reader.peek();
+      } catch (MalformedJsonException expected) {
+        assertEquals("Unterminated comment at line 1 column 4 path $[0]", expected.getMessage());
+      }
+    }
+
+    assertEquals("$[0]", reader.getPath());
+  }
+
+  public void testThrowingPeekEmptyDocument() throws IOException {
+    JsonReader reader = new JsonReader(reader(":"));
+    try {
+      reader.peek();
+      fail();
+    } catch (MalformedJsonException expected) {
+      assertEquals("Expected value at line 1 column 1 path $", expected.getMessage());
+    }
+    /*
+     * Make sure that JsonReader still considers document empty
+     *
+     * In previous Gson versions JsonReader would have marked document
+     * as non-empty even though value parsing failed and would have
+     * now thrown a non-lenient exception because it thought there were
+     * multiple top-level values
+     */
+    try {
+      reader.peek();
+      fail();
+    } catch (MalformedJsonException expected) {
+      assertEquals("Expected value at line 1 column 1 path $", expected.getMessage());
+    }
+  }
+
+  public void testThrowingStringEscapeSequence() throws IOException {
+    JsonReader reader = new JsonReader(reader("\"\\z\"")); // "\z" is not a valid escape sequence
+    assertEquals(JsonToken.STRING, reader.peek());
+
+    /*
+     * Make sure that neither nextString() nor skipValue() already advanced
+     * before throwing exception.
+     *
+     * In previous Gson versions they would have already consumed the '\' before
+     * the exception was thrown so a subsequent read would have read a "valid"
+     * string.
+     */
+    for (int i = 0; i < 3; i++) {
+      try {
+        reader.nextString();
+        fail();
+      } catch (MalformedJsonException expected) {
+        assertEquals("Invalid escape sequence at line 1 column 2 path $", expected.getMessage());
+      }
+    }
+    for (int i = 0; i < 3; i++) {
+      try {
+        reader.skipValue();
+        fail();
+      } catch (MalformedJsonException expected) {
+        assertEquals("Invalid escape sequence at line 1 column 2 path $", expected.getMessage());
+      }
     }
   }
 

--- a/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
@@ -112,6 +112,7 @@ public final class JsonWriterTest extends TestCase {
       jsonWriter.beginArray();
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("JSON must have only one top-level value.", expected.getMessage());
     }
   }
 
@@ -124,6 +125,7 @@ public final class JsonWriterTest extends TestCase {
       jsonWriter.endArray();
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("Nesting problem.", expected.getMessage());
     }
   }
 
@@ -136,6 +138,7 @@ public final class JsonWriterTest extends TestCase {
       jsonWriter.endObject();
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("Nesting problem.", expected.getMessage());
     }
   }
 
@@ -147,6 +150,7 @@ public final class JsonWriterTest extends TestCase {
       jsonWriter.name(null);
       fail();
     } catch (NullPointerException expected) {
+      assertEquals("name == null", expected.getMessage());
     }
   }
 
@@ -180,16 +184,19 @@ public final class JsonWriterTest extends TestCase {
       jsonWriter.value(Double.NaN);
       fail();
     } catch (IllegalArgumentException expected) {
+      assertEquals("Numeric values must be finite, but was NaN", expected.getMessage());
     }
     try {
       jsonWriter.value(Double.NEGATIVE_INFINITY);
       fail();
     } catch (IllegalArgumentException expected) {
+      assertEquals("Numeric values must be finite, but was -Infinity", expected.getMessage());
     }
     try {
       jsonWriter.value(Double.POSITIVE_INFINITY);
       fail();
     } catch (IllegalArgumentException expected) {
+      assertEquals("Numeric values must be finite, but was Infinity", expected.getMessage());
     }
   }
 
@@ -201,16 +208,19 @@ public final class JsonWriterTest extends TestCase {
       jsonWriter.value(Double.valueOf(Double.NaN));
       fail();
     } catch (IllegalArgumentException expected) {
+      assertEquals("Numeric values must be finite, but was NaN", expected.getMessage());
     }
     try {
       jsonWriter.value(Double.valueOf(Double.NEGATIVE_INFINITY));
       fail();
     } catch (IllegalArgumentException expected) {
+      assertEquals("Numeric values must be finite, but was -Infinity", expected.getMessage());
     }
     try {
       jsonWriter.value(Double.valueOf(Double.POSITIVE_INFINITY));
       fail();
     } catch (IllegalArgumentException expected) {
+      assertEquals("Numeric values must be finite, but was Infinity", expected.getMessage());
     }
   }
 
@@ -558,18 +568,6 @@ public final class JsonWriterTest extends TestCase {
     assertEquals("[][]", stringWriter.toString());
   }
 
-  public void testStrictWriterDoesNotPermitMultipleTopLevelValues() throws IOException {
-    StringWriter stringWriter = new StringWriter();
-    JsonWriter writer = new JsonWriter(stringWriter);
-    writer.beginArray();
-    writer.endArray();
-    try {
-      writer.beginArray();
-      fail();
-    } catch (IllegalStateException expected) {
-    }
-  }
-
   public void testClosedWriterThrowsOnStructure() throws IOException {
     StringWriter stringWriter = new StringWriter();
     JsonWriter writer = new JsonWriter(stringWriter);
@@ -580,21 +578,25 @@ public final class JsonWriterTest extends TestCase {
       writer.beginArray();
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("JsonWriter is closed.", expected.getMessage());
     }
     try {
       writer.endArray();
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("JsonWriter is closed.", expected.getMessage());
     }
     try {
       writer.beginObject();
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("JsonWriter is closed.", expected.getMessage());
     }
     try {
       writer.endObject();
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("JsonWriter is closed.", expected.getMessage());
     }
   }
 
@@ -608,6 +610,7 @@ public final class JsonWriterTest extends TestCase {
       writer.name("a");
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("JsonWriter is closed.", expected.getMessage());
     }
   }
 
@@ -621,6 +624,7 @@ public final class JsonWriterTest extends TestCase {
       writer.value("a");
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("JsonWriter is closed.", expected.getMessage());
     }
   }
 
@@ -634,6 +638,7 @@ public final class JsonWriterTest extends TestCase {
       writer.flush();
       fail();
     } catch (IllegalStateException expected) {
+      assertEquals("JsonWriter is closed.", expected.getMessage());
     }
   }
 


### PR DESCRIPTION
Based on #1743

Improves the location information shown in JsonReader exception messages and improves the tests by making them check the exception messages as well.

Improved location information:
- Partially due to #1743 since the position is not changed if malformed JSON is encountered
- Unexpected token will report start of peeked token:
Previously when the peeked token did not match the expected one, the exception message reported the location behind the token (instead of in front of it), e.g.:
    ```java
    new JsonReader(new StringReader("true")).beginObject();
    // Expected BEGIN_OBJECT but was BOOLEAN at line 1 column 5 path $
    ```
- Add location information to some exceptions which previously did not have location information
- Don't have strict reader suggest lenient mode when that would not help:
Previously a strict reader would suggest lenient mode even in cases where lenient mode would not be able to read the JSON either.