### PR TITLE
Improve JsonWriter / JsonTreeWriter exception behavior

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeWriter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeWriter.java
@@ -242,6 +242,8 @@ public final class JsonTreeWriter extends JsonWriter {
   }
 
   @Override public void flush() throws IOException {
+    // Ensure open to be consistent with JsonWriter
+    ensureOpen();
   }
 
   @Override public void close() throws IOException {

--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeWriter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeWriter.java
@@ -71,7 +71,20 @@ public final class JsonTreeWriter extends JsonWriter {
     if (product == null) {
       throw new IllegalStateException("No value has been written yet");
     } else if (!stack.isEmpty()) {
-      throw new IllegalStateException("Expected one JSON element but was " + stack);
+      StringBuilder stringBuilder = new StringBuilder(8);
+      for (JsonElement stackElement : stack) {
+        if (stackElement instanceof JsonArray) {
+          stringBuilder.append('[');
+        } else {
+          assert stackElement instanceof JsonObject;
+          stringBuilder.append('{');
+        }
+      }
+      if (pendingName != null) {
+        // Append colon to indicate that member value is missing as well
+        stringBuilder.append(':');
+      }
+      throw new IllegalStateException("JSON value is incomplete; open values: " + stringBuilder);
     }
     return product;
   }

--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeWriter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeWriter.java
@@ -233,7 +233,7 @@ public final class JsonTreeWriter extends JsonWriter {
   }
 
   @Override public void close() throws IOException {
-    if (!stack.isEmpty()) {
+    if (product == null || !stack.isEmpty()) {
       throw new IOException("Incomplete document");
     }
     stack.add(SENTINEL_CLOSED);

--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeWriter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeWriter.java
@@ -103,6 +103,7 @@ public final class JsonTreeWriter extends JsonWriter {
   }
 
   private void put(JsonElement value) {
+    ensureOpen();
     if (pendingName != null) {
       if (!value.isJsonNull() || getSerializeNulls()) {
         JsonObject object = (JsonObject) peek();
@@ -110,7 +111,6 @@ public final class JsonTreeWriter extends JsonWriter {
       }
       pendingName = null;
     } else if (stack.isEmpty()) {
-      ensureOpen();
       if (product != null) {
         throw new IllegalStateException("JSON must have only one top-level value.");
       }

--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeWriter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeWriter.java
@@ -51,8 +51,11 @@ public final class JsonTreeWriter extends JsonWriter {
   /** The name for the next JSON object value. If non-null, the top of the stack is a JsonObject. */
   private String pendingName;
 
-  /** the JSON element constructed by this writer. */
-  private JsonElement product = JsonNull.INSTANCE; // TODO: is this really what we want?;
+  /**
+   * The JSON element constructed by this writer; {@code null} if no value has been
+   * written yet.
+   */
+  private JsonElement product = null;
 
   public JsonTreeWriter() {
     super(UNWRITABLE_WRITER);
@@ -60,9 +63,14 @@ public final class JsonTreeWriter extends JsonWriter {
 
   /**
    * Returns the top level object produced by this writer.
+   *
+   * @throws IllegalStateException if no value has been written yet.
+   * @throws IllegalStateException if the currently written value is incomplete.
    */
   public JsonElement get() {
-    if (!stack.isEmpty()) {
+    if (product == null) {
+      throw new IllegalStateException("No value has been written yet");
+    } else if (!stack.isEmpty()) {
       throw new IllegalStateException("Expected one JSON element but was " + stack);
     }
     return product;

--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeWriter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeWriter.java
@@ -55,6 +55,9 @@ public final class JsonTreeWriter extends JsonWriter {
    */
   private JsonElement product = null;
 
+  /** Whether this writer is {@link #close() closed}. */
+  private boolean isClosed = false;
+
   public JsonTreeWriter() {
     super(UNWRITABLE_WRITER);
   }
@@ -88,7 +91,7 @@ public final class JsonTreeWriter extends JsonWriter {
   }
 
   private void ensureOpen() {
-    if (product != null && stack.isEmpty()) {
+    if (isClosed) {
       throw new IllegalStateException("Writer is closed");
     }
   }
@@ -108,6 +111,9 @@ public final class JsonTreeWriter extends JsonWriter {
       pendingName = null;
     } else if (stack.isEmpty()) {
       ensureOpen();
+      if (product != null) {
+        throw new IllegalStateException("JSON must have only one top-level value.");
+      }
       product = value;
     } else {
       JsonElement element = peek();
@@ -239,10 +245,9 @@ public final class JsonTreeWriter extends JsonWriter {
   }
 
   @Override public void close() throws IOException {
+    isClosed = true;
     if (product == null || !stack.isEmpty()) {
       throw new IOException("Incomplete document");
     }
-    // Do nothing; product != null && stack.isEmpty() prevents
-    // any further interaction
   }
 }

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
@@ -92,6 +92,13 @@ public final class JsonTreeWriterTest extends TestCase {
       writer.close();
       fail();
     } catch (IOException expected) {
+      assertEquals("Incomplete document", expected.getMessage());
+    }
+    // Should prevent further interaction nonetheless
+    try {
+      writer.endArray();
+    } catch (IllegalStateException expected) {
+      assertEquals("Writer is closed", expected.getMessage());
     }
   }
 
@@ -423,6 +430,35 @@ public final class JsonTreeWriterTest extends TestCase {
       writer.value(Double.valueOf(Double.POSITIVE_INFINITY));
       fail();
     } catch (IllegalArgumentException expected) {
+    }
+  }
+
+  public void testStrictMultipleTopLevelValues() throws IOException {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    writer.setLenient(false);
+    writer.value(123);
+    try {
+      writer.value(123);
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("JSON must have only one top-level value.", expected.getMessage());
+    }
+  }
+
+  /**
+   * Even if writer is in lenient mode it should not support multiple
+   * top-level values because they cannot be represented using a single
+   * JsonElement.
+   */
+  public void testLenientMultipleTopLevelValues() throws IOException {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    writer.setLenient(true);
+    writer.value(123);
+    try {
+      writer.value(123);
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("JSON must have only one top-level value.", expected.getMessage());
     }
   }
 }

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
@@ -207,11 +207,7 @@ public final class JsonTreeWriterTest extends TestCase {
     }
   }
 
-  public void testClosedWriterThrowsOnValue() throws IOException {
-    JsonTreeWriter writer = new JsonTreeWriter();
-    writer.beginArray();
-    writer.endArray();
-    writer.close();
+  private static void testClosedWriterThrowsOnValue(JsonTreeWriter writer) throws IOException {
     try {
       writer.value("a");
       fail();
@@ -274,6 +270,28 @@ public final class JsonTreeWriterTest extends TestCase {
     } catch (IllegalArgumentException expected) {
       assertEquals("JSON forbids NaN and infinities: NaN", expected.getMessage());
     }
+  }
+
+  public void testClosedWriterThrowsOnValue() throws IOException {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    writer.beginArray();
+    writer.endArray();
+    writer.close();
+    testClosedWriterThrowsOnValue(writer);
+  }
+
+  public void testClosedWriterThrowsOnPropertyValue() throws IOException {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    writer.setSerializeNulls(true);
+    writer.beginObject();
+    writer.name("test");
+    try {
+      writer.close();
+      fail();
+    } catch (IOException expected) {
+      assertEquals("Incomplete document", expected.getMessage());
+    }
+    testClosedWriterThrowsOnValue(writer);
   }
 
   public void testClosedWriterThrowsOnFlush() throws IOException {

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
@@ -16,7 +16,6 @@
 
 package com.google.gson.internal.bind;
 
-import com.google.gson.JsonNull;
 import java.io.IOException;
 import junit.framework.TestCase;
 
@@ -117,7 +116,23 @@ public final class JsonTreeWriterTest extends TestCase {
 
   public void testEmptyWriter() {
     JsonTreeWriter writer = new JsonTreeWriter();
-    assertEquals(JsonNull.INSTANCE, writer.get());
+    try {
+      writer.get();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("No value has been written yet", expected.getMessage());
+    }
+  }
+
+  public void testGetImcompleteValue() throws IOException {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    writer.beginArray();
+    try {
+      writer.get();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Expected one JSON element but was [[]]", expected.getMessage());
+    }
   }
 
   public void testBeginArray() throws Exception {

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
@@ -127,11 +127,19 @@ public final class JsonTreeWriterTest extends TestCase {
   public void testGetImcompleteValue() throws IOException {
     JsonTreeWriter writer = new JsonTreeWriter();
     writer.beginArray();
+    writer.beginObject();
+    writer.name("test");
+    writer.beginObject();
+    writer.name("test2");
+    writer.beginArray();
+    writer.beginArray();
+    writer.beginObject();
+    writer.name("test3");
     try {
       writer.get();
       fail();
     } catch (IllegalStateException expected) {
-      assertEquals("Expected one JSON element but was [[]]", expected.getMessage());
+      assertEquals("JSON value is incomplete; open values: [{{[[{:", expected.getMessage());
     }
   }
 

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
@@ -95,6 +95,16 @@ public final class JsonTreeWriterTest extends TestCase {
     }
   }
 
+  public void testCloseEmptyWriter() {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    try {
+      writer.close();
+      fail();
+    } catch (IOException expected) {
+      assertEquals("Incomplete document", expected.getMessage());
+    }
+  }
+
   public void testSerializeNullsFalse() throws IOException {
     JsonTreeWriter writer = new JsonTreeWriter();
     writer.setSerializeNulls(false);

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
@@ -105,6 +105,99 @@ public final class JsonTreeWriterTest extends TestCase {
     }
   }
 
+  public void testGetAfterClose() throws IOException {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    writer.value("test");
+    writer.close();
+    assertEquals("\"test\"", writer.get().toString());
+  }
+
+  public void testClosedWriterThrowsOnStructure() throws IOException {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    writer.beginArray();
+    writer.endArray();
+    writer.close();
+    try {
+      writer.beginArray();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Writer is closed", expected.getMessage());
+    }
+    try {
+      writer.endArray();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Writer is closed", expected.getMessage());
+    }
+    try {
+      writer.beginObject();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Writer is closed", expected.getMessage());
+    }
+    try {
+      writer.endObject();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Writer is closed", expected.getMessage());
+    }
+  }
+
+  public void testClosedWriterThrowsOnName() throws IOException {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    writer.beginArray();
+    writer.endArray();
+    writer.close();
+    try {
+      writer.name("a");
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Writer is closed", expected.getMessage());
+    }
+    // Argument validation should have higher precedence
+    try {
+      writer.name(null);
+      fail();
+    } catch (NullPointerException expected) {
+      assertEquals("name == null", expected.getMessage());
+    }
+  }
+
+  public void testClosedWriterThrowsOnValue() throws IOException {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    writer.beginArray();
+    writer.endArray();
+    writer.close();
+    try {
+      writer.value("a");
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Writer is closed", expected.getMessage());
+    }
+
+    // Argument validation should have higher precedence
+    try {
+      writer.value((double) Double.NaN);
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertEquals("JSON forbids NaN and infinities: NaN", expected.getMessage());
+    }
+    try {
+      writer.value((Number) Double.NaN);
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertEquals("JSON forbids NaN and infinities: NaN", expected.getMessage());
+    }
+  }
+
+  public void testWriterCloseIsIdempotent() throws IOException {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    writer.beginArray();
+    writer.endArray();
+    writer.close();
+    writer.close();
+  }
+
   public void testSerializeNullsFalse() throws IOException {
     JsonTreeWriter writer = new JsonTreeWriter();
     writer.setSerializeNulls(false);

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
@@ -197,6 +197,19 @@ public final class JsonTreeWriterTest extends TestCase {
     }
   }
 
+  public void testClosedWriterThrowsOnFlush() throws IOException {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    writer.beginArray();
+    writer.endArray();
+    writer.close();
+    try {
+      writer.flush();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Writer is closed", expected.getMessage());
+    }
+  }
+
   public void testWriterCloseIsIdempotent() throws IOException {
     JsonTreeWriter writer = new JsonTreeWriter();
     writer.beginArray();

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
@@ -102,6 +102,43 @@ public final class JsonTreeWriterTest extends TestCase {
     }
   }
 
+  public void testClosedWriterDuplicateName() throws IOException {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    writer.beginObject();
+    writer.name("test");
+    try {
+      writer.close();
+      fail();
+    } catch (IOException expected) {
+      assertEquals("Incomplete document", expected.getMessage());
+    }
+    // JsonTreeWriter being closed should have higher precedence than duplicate name
+    try {
+      writer.name("test");
+    } catch (IllegalStateException expected) {
+      assertEquals("Writer is closed", expected.getMessage());
+    }
+  }
+
+  public void testClosedWriterDontSerializeNulls() throws IOException {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    writer.setSerializeNulls(false);
+    writer.beginObject();
+    writer.name("test");
+    try {
+      writer.close();
+      fail();
+    } catch (IOException expected) {
+      assertEquals("Incomplete document", expected.getMessage());
+    }
+    // JsonTreeWriter being closed should be checked, even if null is not serialized
+    try {
+      writer.nullValue();
+    } catch (IllegalStateException expected) {
+      assertEquals("Writer is closed", expected.getMessage());
+    }
+  }
+
   public void testCloseEmptyWriter() {
     JsonTreeWriter writer = new JsonTreeWriter();
     try {
@@ -177,6 +214,48 @@ public final class JsonTreeWriterTest extends TestCase {
     writer.close();
     try {
       writer.value("a");
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Writer is closed", expected.getMessage());
+    }
+    try {
+      writer.value(true);
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Writer is closed", expected.getMessage());
+    }
+    try {
+      writer.value(Boolean.TRUE);
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Writer is closed", expected.getMessage());
+    }
+    try {
+      writer.value((Boolean) null);
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Writer is closed", expected.getMessage());
+    }
+    try {
+      writer.value(1.0);
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Writer is closed", expected.getMessage());
+    }
+    try {
+      writer.value(1L);
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Writer is closed", expected.getMessage());
+    }
+    try {
+      writer.value((Number) 1.0);
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Writer is closed", expected.getMessage());
+    }
+    try {
+      writer.value((Number) null);
       fail();
     } catch (IllegalStateException expected) {
       assertEquals("Writer is closed", expected.getMessage());

--- a/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
@@ -695,4 +695,15 @@ public final class JsonWriterTest extends TestCase {
     // Make sure underlying writer was closed even though document is incomplete
     assertTrue(dummyWriter.isClosed);
   }
+
+  public void testCloseEmptyWriter() {
+    StringWriter stringWriter = new StringWriter();
+    JsonWriter writer = new JsonWriter(stringWriter);
+    try {
+      writer.close();
+      fail();
+    } catch (IOException expected) {
+      assertEquals("Incomplete document", expected.getMessage());
+    }
+  }
 }


### PR DESCRIPTION
Based on #1763

- Throw exception when calling `JsonTreeWriter.get()` if no value has been written (previously it returned `JsonNull`)
- Improve `JsonTreeWriter.get()` exception messages for incomplete JSON
- Throw exception when closing empty JsonTreeWriter (to be consistent with JsonWriter)
- Allow `JsonTreeWriter.get()` even after writer has been closed
- Prevent JsonTreeWriter from writing multiple top-level values (since they would overwrite each other)