### PR TITLE
Fix JsonReader.nextDouble() throwing wrong exception type for NaN and Infinity

### DIFF
--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -907,7 +907,7 @@ public class JsonReader implements Closeable {
     peeked = PEEKED_BUFFERED;
     double result = Double.parseDouble(peekedString); // don't catch this NumberFormatException.
     if (!lenient && (Double.isNaN(result) || Double.isInfinite(result))) {
-      throw new MalformedJsonException(
+      throw new NumberFormatException(
           "JSON forbids NaN and infinities: " + result + locationString());
     }
     peekedString = null;

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -341,7 +341,8 @@ public final class JsonReaderTest extends TestCase {
     try {
       reader.nextDouble();
       fail();
-    } catch (MalformedJsonException expected) {
+    } catch (NumberFormatException expected) {
+      assertEquals("JSON forbids NaN and infinities: NaN at line 1 column 7 path $[0]", expected.getMessage());
     }
   }
 


### PR DESCRIPTION
The documentation says that a NumberFormatException will be thrown in case the value is not finite (i.e. NaN or Infinity). However, the JsonReader implementation actually throws a MalformedJsonException.

Note that JsonTreeReader currently throws a NumberFormatException, as expected.