### PR TITLE
Update to latest version of bnd-maven-plugin

### DIFF
--- a/gson/bnd.bnd
+++ b/gson/bnd.bnd
@@ -3,8 +3,9 @@ Bundle-Name: ${project.name}
 Bundle-Description: ${project.description}
 Bundle-Vendor: Google Gson Project
 Bundle-ContactAddress: ${project.parent.url}
+Bundle-DocURL: ${project.parent.url}/blob/master/UserGuide.md
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6, JavaSE-1.7, JavaSE-1.8
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.6))"
+Import-Package: sun.misc;resolution:=optional,*
 
 -removeheaders: Private-Package
 

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -34,7 +34,7 @@
       <plugin>
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-maven-plugin</artifactId>
-        <version>4.0.0</version>
+        <version>5.1.2</version>
         <executions>
           <execution>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -103,12 +103,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
         </plugin>
-        <plugin>
-          <groupId>org.apache.felix</groupId>
-          <artifactId>maven-bundle-plugin</artifactId>
-          <version>3.3.0</version>
-          <inherited>true</inherited>
-        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>


### PR DESCRIPTION
This version has a couple of advantages:

1) It is aware of module-info.class files, which means we don't
need to manually override the "Require-Capability" header.

2) External packages used by reflection are now detected, i.e.
the "sun.misc" package is now added to the "Import-Package"
header. This is manually given optional resolution since it
is obviously not present on all JVMs.

3) It also introduces some new useful OSGi headers:
 - Bundle-DocURL (overriden with correct URL for manual)
 - Bundle-License
 - Bundle-SCM

This change also removes unnecessary mention of the felix
bundle-plugin in the pluginManagement section of the parent pom.

Signed-off-by: Mat Booth <mat.booth@redhat.com>