### PR TITLE
Don't parse malformed string as boolean

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonPrimitive.java
+++ b/gson/src/main/java/com/google/gson/JsonPrimitive.java
@@ -92,17 +92,26 @@ public final class JsonPrimitive extends JsonElement {
   }
 
   /**
-   * convenience method to get this element as a boolean value.
+   * Convenience method to get this element as a boolean value.
    *
    * @return get this element as a primitive boolean value.
+   * @throws IllegalStateException if this element does not represent a
+   *   valid boolean value.
    */
   @Override
   public boolean getAsBoolean() {
     if (isBoolean()) {
       return ((Boolean) value).booleanValue();
     }
-	// Check to see if the value as a String is "true" in any case.
-    return Boolean.parseBoolean(getAsString());
+    // Check to see if the value as a String is a boolean
+    String string = getAsString();
+    if (string.equalsIgnoreCase("true")) {
+      return true;
+    } else if (string.equalsIgnoreCase("false")) {
+      return false;
+    } else {
+      throw new IllegalStateException("Not a valid boolean: " + string);
+    }
   }
 
   /**

--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -139,7 +139,14 @@ public final class TypeAdapters {
         return null;
       } else if (peek == JsonToken.STRING) {
         // support strings for compatibility with GSON 1.7
-        return Boolean.parseBoolean(in.nextString());
+        String string = in.nextString();
+        if (string.equalsIgnoreCase("true")) {
+          return true;
+        } else if (string.equalsIgnoreCase("false")) {
+          return false;
+        } else {
+          throw new JsonSyntaxException("Not a valid boolean: " + string);
+        }
       }
       return in.nextBoolean();
     }

--- a/gson/src/test/java/com/google/gson/JsonPrimitiveTest.java
+++ b/gson/src/test/java/com/google/gson/JsonPrimitiveTest.java
@@ -59,29 +59,98 @@ public class JsonPrimitiveTest extends TestCase {
 
     assertTrue(json.isBoolean());
     assertTrue(json.getAsBoolean());
-
-    // Extra support for booleans
-    json = new JsonPrimitive(1);
-    assertFalse(json.getAsBoolean());
-
-    json = new JsonPrimitive("1");
-    assertFalse(json.getAsBoolean());
-
-    json = new JsonPrimitive("true");
-    assertTrue(json.getAsBoolean());
-
-    json = new JsonPrimitive("TrUe");
-    assertTrue(json.getAsBoolean());
-
-    json = new JsonPrimitive("1.3");
-    assertFalse(json.getAsBoolean());
   }
 
   public void testParsingStringAsBoolean() throws Exception {
     JsonPrimitive json = new JsonPrimitive("true");
-
     assertFalse(json.isBoolean());
     assertTrue(json.getAsBoolean());
+
+    json = new JsonPrimitive("TrUe");
+    assertFalse(json.isBoolean());
+    assertTrue(json.getAsBoolean());
+
+    json = new JsonPrimitive("false");
+    assertFalse(json.isBoolean());
+    assertFalse(json.getAsBoolean());
+
+    json = new JsonPrimitive("FaLsE");
+    assertFalse(json.isBoolean());
+    assertFalse(json.getAsBoolean());
+  }
+
+  public void testParsingMalformedStringAsBoolean() {
+    JsonPrimitive json = new JsonPrimitive(1);
+    assertFalse(json.isBoolean());
+    try {
+      json.getAsBoolean();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Not a valid boolean: 1", expected.getMessage());
+    }
+
+    json = new JsonPrimitive(0);
+    assertFalse(json.isBoolean());
+    try {
+      json.getAsBoolean();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Not a valid boolean: 0", expected.getMessage());
+    }
+
+    json = new JsonPrimitive("yes");
+    assertFalse(json.isBoolean());
+    try {
+      json.getAsBoolean();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Not a valid boolean: yes", expected.getMessage());
+    }
+
+    json = new JsonPrimitive("no");
+    assertFalse(json.isBoolean());
+    try {
+      json.getAsBoolean();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Not a valid boolean: no", expected.getMessage());
+    }
+
+    json = new JsonPrimitive("trues");
+    assertFalse(json.isBoolean());
+    try {
+      json.getAsBoolean();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Not a valid boolean: trues", expected.getMessage());
+    }
+
+    json = new JsonPrimitive("falsey");
+    assertFalse(json.isBoolean());
+    try {
+      json.getAsBoolean();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Not a valid boolean: falsey", expected.getMessage());
+    }
+
+    json = new JsonPrimitive("1");
+    assertFalse(json.isBoolean());
+    try {
+      json.getAsBoolean();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Not a valid boolean: 1", expected.getMessage());
+    }
+
+    json = new JsonPrimitive("0");
+    assertFalse(json.isBoolean());
+    try {
+      json.getAsBoolean();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Not a valid boolean: 0", expected.getMessage());
+    }
   }
 
   public void testParsingStringAsNumber() throws Exception {
@@ -256,7 +325,7 @@ public class JsonPrimitiveTest extends TestCase {
   public void testEqualsIntegerAndBigInteger() {
     JsonPrimitive a = new JsonPrimitive(5L);
     JsonPrimitive b = new JsonPrimitive(new BigInteger("18446744073709551621")); // 2^64 + 5
-    // Ideally, the following assertion should have failed but the price is too much to pay 
+    // Ideally, the following assertion should have failed but the price is too much to pay
     // assertFalse(a + " equals " + b, a.equals(b));
     assertTrue(a + " equals " + b, a.equals(b));
   }

--- a/gson/src/test/java/com/google/gson/functional/PrimitiveTest.java
+++ b/gson/src/test/java/com/google/gson/functional/PrimitiveTest.java
@@ -819,8 +819,47 @@ public class PrimitiveTest extends TestCase {
   }
 
   public void testStringsAsBooleans() {
-    String json = "['true', 'false', 'TRUE', 'yes', '1']";
-    assertEquals(Arrays.asList(true, false, true, false, false),
+    String json = "['true', 'TrUe', 'false', 'FaLsE']";
+    assertEquals(Arrays.asList(true, true, false, false),
         gson.<List<Boolean>>fromJson(json, new TypeToken<List<Boolean>>() {}.getType()));
+  }
+
+  public void testMalformedStringsAsBooleans() {
+    try {
+      gson.fromJson("'yes'", Boolean.class);
+      fail();
+    } catch (JsonSyntaxException expected) {
+      assertEquals("Not a valid boolean: yes", expected.getMessage());
+    }
+    try {
+      gson.fromJson("'no'", Boolean.class);
+      fail();
+    } catch (JsonSyntaxException expected) {
+      assertEquals("Not a valid boolean: no", expected.getMessage());
+    }
+    try {
+      gson.fromJson("'trues'", Boolean.class);
+      fail();
+    } catch (JsonSyntaxException expected) {
+      assertEquals("Not a valid boolean: trues", expected.getMessage());
+    }
+    try {
+      gson.fromJson("'falsey'", Boolean.class);
+      fail();
+    } catch (JsonSyntaxException expected) {
+      assertEquals("Not a valid boolean: falsey", expected.getMessage());
+    }
+    try {
+      gson.fromJson("'1'", Boolean.class);
+      fail();
+    } catch (JsonSyntaxException expected) {
+      assertEquals("Not a valid boolean: 1", expected.getMessage());
+    }
+    try {
+      gson.fromJson("'0'", Boolean.class);
+      fail();
+    } catch (JsonSyntaxException expected) {
+      assertEquals("Not a valid boolean: 0", expected.getMessage());
+    }
   }
 }


### PR DESCRIPTION
Fixes #600

Java's [`Boolean.parseBoolean(String)`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Boolean.html#parseBoolean(java.lang.String)) returns for any non-"true" string `false`.
This is extremely error-prone because for strings like "yes" the user likely does not expect `false`.

This pull request changes the methods which were previously using `parseBoolean(...)` to now only accept "true" or "false" (case insensitive) and to throw exceptions for any other value.