### PR TITLE
If there are unpaired quotes , should be to throw an exception .

### DIFF
--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -1049,6 +1049,7 @@ public class JsonReader implements Closeable {
         case ';':
         case '#':
         case '=':
+        case '\'':
           checkLenient(); // fall-through
         case '{':
         case '}':
@@ -1057,6 +1058,7 @@ public class JsonReader implements Closeable {
         case ':':
         case ',':
         case ' ':
+        case '\"':
         case '\t':
         case '\f':
         case '\r':


### PR DESCRIPTION
I think this situation should not continue to be parsed, an exception should be thrown, even if `setLenient(true)` has been set

```
{
  id" : 123
}
```
```
{
  id' : 123
}
```