### PR TITLE
Allow usage of JsonReader::peek() on empty stream in lenient mode

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -925,7 +925,10 @@ public final class Gson {
     boolean oldLenient = reader.isLenient();
     reader.setLenient(true);
     try {
-      reader.peek();
+      JsonToken token = reader.peek();
+      if (token == JsonToken.END_DOCUMENT) {
+        return null; // we can also throw EOFException here but...
+      }
       isEmpty = false;
       TypeToken<T> typeToken = (TypeToken<T>) TypeToken.get(typeOfT);
       TypeAdapter<T> typeAdapter = getAdapter(typeToken);

--- a/gson/src/main/java/com/google/gson/internal/Streams.java
+++ b/gson/src/main/java/com/google/gson/internal/Streams.java
@@ -23,6 +23,7 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.internal.bind.TypeAdapters;
 import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import com.google.gson.stream.MalformedJsonException;
 import java.io.EOFException;
@@ -43,7 +44,10 @@ public final class Streams {
   public static JsonElement parse(JsonReader reader) throws JsonParseException {
     boolean isEmpty = true;
     try {
-      reader.peek();
+      JsonToken token = reader.peek();
+      if (token == JsonToken.END_DOCUMENT) {
+        return JsonNull.INSTANCE; // we can also throw EOFException here but...
+      }
       isEmpty = false;
       return TypeAdapters.JSON_ELEMENT.read(reader);
     } catch (EOFException e) {

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -529,8 +529,8 @@ public class JsonReader implements Closeable {
         throw syntaxError("Expected ':'");
       }
     } else if (peekStack == JsonScope.EMPTY_DOCUMENT) {
-      if (lenient) {
-        consumeNonExecutePrefix();
+      if (lenient && consumeNonExecutePrefix()) {
+        return peeked = PEEKED_EOF;
       }
       stack[stackSize - 1] = JsonScope.NONEMPTY_DOCUMENT;
     } else if (peekStack == JsonScope.NONEMPTY_DOCUMENT) {
@@ -1563,25 +1563,30 @@ public class JsonReader implements Closeable {
   }
 
   /**
-   * Consumes the non-execute prefix if it exists.
+   * Consumes the non-execute prefix if it exists and return whether eof has
+   * been reached.
    */
-  private void consumeNonExecutePrefix() throws IOException {
+  private boolean consumeNonExecutePrefix() throws IOException {
     // fast forward through the leading whitespace
-    nextNonWhitespace(true);
-    pos--;
+    int c = nextNonWhitespace(false);
+    if (c == -1) {
+      return true;
+    } else {
+      pos--;
+    }
 
     int p = pos;
     if (p + 5 > limit && !fillBuffer(5)) {
-      return;
+      return false;
     }
 
     char[] buf = buffer;
-    if(buf[p] != ')' || buf[p + 1] != ']' || buf[p + 2] != '}' || buf[p + 3] != '\'' || buf[p + 4] != '\n') {
-      return; // not a security token!
+    if(! (buf[p] != ')' || buf[p + 1] != ']' || buf[p + 2] != '}' ||
+          buf[p + 3] != '\'' || buf[p + 4] != '\n')) {
+      // we consumed a security token!
+      pos += 5;
     }
-
-    // we consumed a security token!
-    pos += 5;
+    return false;
   }
 
   static {

--- a/gson/src/test/java/com/google/gson/JsonParserTest.java
+++ b/gson/src/test/java/com/google/gson/JsonParserTest.java
@@ -19,12 +19,14 @@ package com.google.gson;
 import java.io.CharArrayReader;
 import java.io.CharArrayWriter;
 import java.io.StringReader;
+import java.io.IOException;
 
 import junit.framework.TestCase;
 
 import com.google.gson.common.TestTypes.BagOfPrimitives;
 import com.google.gson.internal.Streams;
 import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
 
 /**
  * Unit test for {@link JsonParser}
@@ -115,5 +117,19 @@ public class JsonParserTest extends TestCase {
     assertEquals("one", actualOne.stringValue);
     BagOfPrimitives actualTwo = gson.fromJson(element2, BagOfPrimitives.class);
     assertEquals("two", actualTwo.stringValue);
+  }
+
+  public void testPeekEmptyStream() throws IOException {
+    JsonReader reader = new JsonReader(new StringReader(""));
+    try {
+      assertEquals(JsonToken.END_DOCUMENT, reader.peek());
+      fail();
+    } catch (java.io.EOFException expected) { }
+  }
+
+  public void testPeekEmptyStreamLenient() throws IOException {
+    JsonReader reader = new JsonReader(new StringReader(""));
+    reader.setLenient(true);
+    assertEquals(JsonToken.END_DOCUMENT, reader.peek());
   }
 }


### PR DESCRIPTION
**Repro**
```java
void processStreamOfJsonValues(Reader stream) throws IOException {
  JsonReader jReader = new JsonReader(stream);
  jReader.setLenient(true)
  while (jReader.peek() != JsonToken.END_DOCUMENT) {
    JsonElement e = JsonParser.parseReader(jReader);
    // handle `e`
  }
}
...
```
**Expected**: Working even if `stream` is empty (i.e. has reached EOF).
**Actual**: If `stream` is empty, `jReader.peek()` throws an `EOFException`

## Summary
In the above function, the input Reader stream could be a socket stream, string stream, or STDIN, and it could be empty.
However, currently `jReader.peek()` will throw an `EOFException`. This issue has been discussed in #330, and the conclusion seems to be "we can allow empty stream in lenient mode", yet the issue is left unresolved.