### PR TITLE
Mutable/Recycle JsonWriter/JsonReader types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ build
 .DS_Store
 
 examples/android-proguard-example/gen
+/gson/nb-configuration.xml

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -94,7 +94,7 @@ import com.google.gson.stream.MalformedJsonException;
  * </pre></p>
  *
  * <p>See the <a href="https://sites.google.com/site/gson/gson-user-guide">Gson User Guide</a>
- * for a more complete set of examples.</p>
+ for a more complete reset of examples.</p>
  *
  * @see com.google.gson.reflect.TypeToken
  *

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.gson.stream;
 
 import com.google.gson.internal.JsonReaderInternalAccess;
@@ -26,43 +25,48 @@ import java.util.Arrays;
 
 /**
  * Reads a JSON (<a href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>)
- * encoded value as a stream of tokens. This stream includes both literal
- * values (strings, numbers, booleans, and nulls) as well as the begin and
- * end delimiters of objects and arrays. The tokens are traversed in
- * depth-first order, the same order that they appear in the JSON document.
- * Within JSON objects, name/value pairs are represented by a single token.
+ * encoded value as a stream of tokens. This stream includes both literal values
+ * (strings, numbers, booleans, and nulls) as well as the begin and end
+ * delimiters of objects and arrays. The tokens are traversed in depth-first
+ * order, the same order that they appear in the JSON document. Within JSON
+ * objects, name/value pairs are represented by a single token.
  *
  * <h3>Parsing JSON</h3>
  * To create a recursive descent parser for your own JSON streams, first create
  * an entry point method that creates a {@code JsonReader}.
  *
- * <p>Next, create handler methods for each structure in your JSON text. You'll
+ * <p>
+ * Next, create handler methods for each structure in your JSON text. You'll
  * need a method for each object type and for each array type.
  * <ul>
- *   <li>Within <strong>array handling</strong> methods, first call {@link
- *       #beginArray} to consume the array's opening bracket. Then create a
- *       while loop that accumulates values, terminating when {@link #hasNext}
- *       is false. Finally, read the array's closing bracket by calling {@link
+ * <li>Within <strong>array handling</strong> methods, first call {@link
+ *       #beginArray} to consume the array's opening bracket. Then create a while loop
+ * that accumulates values, terminating when {@link #hasNext} is false. Finally,
+ * read the array's closing bracket by calling {@link
  *       #endArray}.
- *   <li>Within <strong>object handling</strong> methods, first call {@link
- *       #beginObject} to consume the object's opening brace. Then create a
- *       while loop that assigns values to local variables based on their name.
- *       This loop should terminate when {@link #hasNext} is false. Finally,
- *       read the object's closing brace by calling {@link #endObject}.
+ * <li>Within <strong>object handling</strong> methods, first call {@link
+ *       #beginObject} to consume the object's opening brace. Then create a while loop
+ * that assigns values to local variables based on their name. This loop should
+ * terminate when {@link #hasNext} is false. Finally, read the object's closing
+ * brace by calling {@link #endObject}.
  * </ul>
- * <p>When a nested object or array is encountered, delegate to the
- * corresponding handler method.
+ * <p>
+ * When a nested object or array is encountered, delegate to the corresponding
+ * handler method.
  *
- * <p>When an unknown name is encountered, strict parsers should fail with an
+ * <p>
+ * When an unknown name is encountered, strict parsers should fail with an
  * exception. Lenient parsers should call {@link #skipValue()} to recursively
  * skip the value's nested tokens, which may otherwise conflict.
  *
- * <p>If a value may be null, you should first check using {@link #peek()}.
- * Null literals can be consumed using either {@link #nextNull()} or {@link
+ * <p>
+ * If a value may be null, you should first check using {@link #peek()}. Null
+ * literals can be consumed using either {@link #nextNull()} or {@link
  * #skipValue()}.
  *
  * <h3>Example</h3>
- * Suppose we'd like to parse a stream of messages such as the following: <pre> {@code
+ * Suppose we'd like to parse a stream of messages such as the following:
+ * <pre> {@code
  * [
  *   {
  *     "id": 912345678901,
@@ -82,8 +86,8 @@ import java.util.Arrays;
  *       "followers_count": 2
  *     }
  *   }
- * ]}</pre>
- * This code implements the parser for the above structure: <pre>   {@code
+ * ]}</pre> This code implements the parser for the above structure:
+ * <pre>   {@code
  *
  *   public List<Message> readJsonStream(InputStream in) throws IOException {
  *     JsonReader reader = new JsonReader(new InputStreamReader(in, "UTF-8"));
@@ -176,1436 +180,1534 @@ import java.util.Arrays;
  * request forgery</a> attacks. In such an attack, a malicious site gains access
  * to a private JSON file by executing it with an HTML {@code <script>} tag.
  *
- * <p>Prefixing JSON files with <code>")]}'\n"</code> makes them non-executable
- * by {@code <script>} tags, disarming the attack. Since the prefix is malformed
+ * <p>
+ * Prefixing JSON files with <code>")]}'\n"</code> makes them non-executable by
+ * {@code <script>} tags, disarming the attack. Since the prefix is malformed
  * JSON, strict parsing fails when it is encountered. This class permits the
  * non-execute prefix when {@link #setLenient(boolean) lenient parsing} is
  * enabled.
  *
- * <p>Each {@code JsonReader} may be used to read a single JSON stream. Instances
+ * <p>
+ * Each {@code JsonReader} may be used to read a single JSON stream. Instances
  * of this class are not thread safe.
- *
+ * <p>
+ * This type is immutable. Considering {@link MutableJsonReader} which is a
+ * mutable version of this.
+ * 
  * @author Jesse Wilson
+ * @author https://github.com/911992
  * @since 1.6
  */
 public class JsonReader implements Closeable {
-  private static final long MIN_INCOMPLETE_INTEGER = Long.MIN_VALUE / 10;
 
-  private static final int PEEKED_NONE = 0;
-  private static final int PEEKED_BEGIN_OBJECT = 1;
-  private static final int PEEKED_END_OBJECT = 2;
-  private static final int PEEKED_BEGIN_ARRAY = 3;
-  private static final int PEEKED_END_ARRAY = 4;
-  private static final int PEEKED_TRUE = 5;
-  private static final int PEEKED_FALSE = 6;
-  private static final int PEEKED_NULL = 7;
-  private static final int PEEKED_SINGLE_QUOTED = 8;
-  private static final int PEEKED_DOUBLE_QUOTED = 9;
-  private static final int PEEKED_UNQUOTED = 10;
-  /** When this is returned, the string value is stored in peekedString. */
-  private static final int PEEKED_BUFFERED = 11;
-  private static final int PEEKED_SINGLE_QUOTED_NAME = 12;
-  private static final int PEEKED_DOUBLE_QUOTED_NAME = 13;
-  private static final int PEEKED_UNQUOTED_NAME = 14;
-  /** When this is returned, the integer value is stored in peekedLong. */
-  private static final int PEEKED_LONG = 15;
-  private static final int PEEKED_NUMBER = 16;
-  private static final int PEEKED_EOF = 17;
+    private static final long MIN_INCOMPLETE_INTEGER = Long.MIN_VALUE / 10;
 
-  /* State machine when parsing numbers */
-  private static final int NUMBER_CHAR_NONE = 0;
-  private static final int NUMBER_CHAR_SIGN = 1;
-  private static final int NUMBER_CHAR_DIGIT = 2;
-  private static final int NUMBER_CHAR_DECIMAL = 3;
-  private static final int NUMBER_CHAR_FRACTION_DIGIT = 4;
-  private static final int NUMBER_CHAR_EXP_E = 5;
-  private static final int NUMBER_CHAR_EXP_SIGN = 6;
-  private static final int NUMBER_CHAR_EXP_DIGIT = 7;
+    private static final int PEEKED_NONE = 0;
+    private static final int PEEKED_BEGIN_OBJECT = 1;
+    private static final int PEEKED_END_OBJECT = 2;
+    private static final int PEEKED_BEGIN_ARRAY = 3;
+    private static final int PEEKED_END_ARRAY = 4;
+    private static final int PEEKED_TRUE = 5;
+    private static final int PEEKED_FALSE = 6;
+    private static final int PEEKED_NULL = 7;
+    private static final int PEEKED_SINGLE_QUOTED = 8;
+    private static final int PEEKED_DOUBLE_QUOTED = 9;
+    private static final int PEEKED_UNQUOTED = 10;
+    /**
+     * When this is returned, the string value is stored in peekedString.
+     */
+    private static final int PEEKED_BUFFERED = 11;
+    private static final int PEEKED_SINGLE_QUOTED_NAME = 12;
+    private static final int PEEKED_DOUBLE_QUOTED_NAME = 13;
+    private static final int PEEKED_UNQUOTED_NAME = 14;
+    /**
+     * When this is returned, the integer value is stored in peekedLong.
+     */
+    private static final int PEEKED_LONG = 15;
+    private static final int PEEKED_NUMBER = 16;
+    private static final int PEEKED_EOF = 17;
 
-  /** The input JSON. */
-  private final Reader in;
+    /* State machine when parsing numbers */
+    private static final int NUMBER_CHAR_NONE = 0;
+    private static final int NUMBER_CHAR_SIGN = 1;
+    private static final int NUMBER_CHAR_DIGIT = 2;
+    private static final int NUMBER_CHAR_DECIMAL = 3;
+    private static final int NUMBER_CHAR_FRACTION_DIGIT = 4;
+    private static final int NUMBER_CHAR_EXP_E = 5;
+    private static final int NUMBER_CHAR_EXP_SIGN = 6;
+    private static final int NUMBER_CHAR_EXP_DIGIT = 7;
 
-  /** True to accept non-spec compliant JSON */
-  private boolean lenient = false;
+    /**
+     * The input JSON.
+     */
+    protected Reader in;
 
-  /**
-   * Use a manual buffer to easily read and unread upcoming characters, and
-   * also so we can create strings without an intermediate StringBuilder.
-   * We decode literals directly out of this buffer, so it must be at least as
-   * long as the longest token that can be reported as a number.
-   */
-  private final char[] buffer = new char[1024];
-  private int pos = 0;
-  private int limit = 0;
+    /**
+     * True to accept non-spec compliant JSON
+     */
+    private boolean lenient = false;
 
-  private int lineNumber = 0;
-  private int lineStart = 0;
+    /**
+     * Use a manual buffer to easily read and unread upcoming characters, and
+     * also so we can create strings without an intermediate StringBuilder. We
+     * decode literals directly out of this buffer, so it must be at least as
+     * long as the longest token that can be reported as a number.
+     */
+    private final char[] buffer = new char[1024];
+    private int pos = 0;
+    private int limit = 0;
 
-  int peeked = PEEKED_NONE;
+    private int lineNumber = 0;
+    private int lineStart = 0;
 
-  /**
-   * A peeked value that was composed entirely of digits with an optional
-   * leading dash. Positive values may not have a leading 0.
-   */
-  private long peekedLong;
+    int peeked = PEEKED_NONE;
 
-  /**
-   * The number of characters in a peeked number literal. Increment 'pos' by
-   * this after reading a number.
-   */
-  private int peekedNumberLength;
+    /**
+     * A peeked value that was composed entirely of digits with an optional
+     * leading dash. Positive values may not have a leading 0.
+     */
+    private long peekedLong;
 
-  /**
-   * A peeked string that should be parsed on the next double, long or string.
-   * This is populated before a numeric value is parsed and used if that parsing
-   * fails.
-   */
-  private String peekedString;
+    /**
+     * The number of characters in a peeked number literal. Increment 'pos' by
+     * this after reading a number.
+     */
+    private int peekedNumberLength;
 
-  /*
+    /**
+     * A peeked string that should be parsed on the next double, long or string.
+     * This is populated before a numeric value is parsed and used if that
+     * parsing fails.
+     */
+    private String peekedString;
+
+    /*
    * The nesting stack. Using a manual array rather than an ArrayList saves 20%.
-   */
-  private int[] stack = new int[32];
-  private int stackSize = 0;
-  {
-    stack[stackSize++] = JsonScope.EMPTY_DOCUMENT;
-  }
+     */
+    private int[] stack = new int[32];
+    private int stackSize = 0;
 
-  /*
+    /**
+     * Sets the working {@code in}({@link Reader}), also call for
+     * {@link #_init()} if appreciated.
+     * <p>
+     * It <b>does not</b> closes the current associated
+     * {@link Reader}({@code in}).
+     * </p>
+     * <p>
+     * <b>Note:</b> It also does not resets the reading policies(such as
+     * lenient)
+     * </p>
+     *
+     * @param arg_in the non-{@code null} reader instance to be reset for out
+     * @param arg_reset_state when {@code true}, then {@link #_init()} will be
+     * called too
+     * @since +2.8.7-SNAPSHOT ?
+     */
+    protected void reset(Reader arg_in, boolean arg_reset_state) {
+        this.in = arg_in;
+        if (arg_reset_state) {
+            _init();
+        }
+    }
+
+    /**
+     * Sets the object state as _init.
+     */
+    protected void _init() {
+        Arrays.fill(buffer, (char) 0);
+        pos = 0;
+        limit = 0;
+        lineNumber = 0;
+        lineStart = 0;
+        peeked = PEEKED_NONE;
+
+        peekedLong = 0;
+        peekedNumberLength = 0;
+        peekedString = null;
+
+        Arrays.fill(stack, 0);
+        stackSize = 0;
+        stack[stackSize++] = JsonScope.EMPTY_DOCUMENT;
+
+        Arrays.fill(pathNames, null);
+        Arrays.fill(pathIndices, 0);
+    }
+
+    /*
    * The path members. It corresponds directly to stack: At indices where the
    * stack contains an object (EMPTY_OBJECT, DANGLING_NAME or NONEMPTY_OBJECT),
    * pathNames contains the name at this scope. Where it contains an array
    * (EMPTY_ARRAY, NONEMPTY_ARRAY) pathIndices contains the current index in
    * that array. Otherwise the value is undefined, and we take advantage of that
    * by incrementing pathIndices when doing so isn't useful.
-   */
-  private String[] pathNames = new String[32];
-  private int[] pathIndices = new int[32];
+     */
+    private String[] pathNames = new String[32];
+    private int[] pathIndices = new int[32];
 
-  /**
-   * Creates a new instance that reads a JSON-encoded stream from {@code in}.
-   */
-  public JsonReader(Reader in) {
-    if (in == null) {
-      throw new NullPointerException("in == null");
-    }
-    this.in = in;
-  }
+    /**
+     * Tells if associated {@link #in} should be closed when this instance is
+     * closed or not.
+     */
+    protected boolean closeReaderOnClose = true;
 
-  /**
-   * Configure this parser to be liberal in what it accepts. By default,
-   * this parser is strict and only accepts JSON as specified by <a
-   * href="http://www.ietf.org/rfc/rfc4627.txt">RFC 4627</a>. Setting the
-   * parser to lenient causes it to ignore the following syntax errors:
-   *
-   * <ul>
-   *   <li>Streams that start with the <a href="#nonexecuteprefix">non-execute
-   *       prefix</a>, <code>")]}'\n"</code>.
-   *   <li>Streams that include multiple top-level values. With strict parsing,
-   *       each stream must contain exactly one top-level value.
-   *   <li>Top-level values of any type. With strict parsing, the top-level
-   *       value must be an object or an array.
-   *   <li>Numbers may be {@link Double#isNaN() NaNs} or {@link
-   *       Double#isInfinite() infinities}.
-   *   <li>End of line comments starting with {@code //} or {@code #} and
-   *       ending with a newline character.
-   *   <li>C-style comments starting with {@code /*} and ending with
-   *       {@code *}{@code /}. Such comments may not be nested.
-   *   <li>Names that are unquoted or {@code 'single quoted'}.
-   *   <li>Strings that are unquoted or {@code 'single quoted'}.
-   *   <li>Array elements separated by {@code ;} instead of {@code ,}.
-   *   <li>Unnecessary array separators. These are interpreted as if null
-   *       was the omitted value.
-   *   <li>Names and values separated by {@code =} or {@code =>} instead of
-   *       {@code :}.
-   *   <li>Name/value pairs separated by {@code ;} instead of {@code ,}.
-   * </ul>
-   */
-  public final void setLenient(boolean lenient) {
-    this.lenient = lenient;
-  }
-
-  /**
-   * Returns true if this parser is liberal in what it accepts.
-   */
-  public final boolean isLenient() {
-    return lenient;
-  }
-
-  /**
-   * Consumes the next token from the JSON stream and asserts that it is the
-   * beginning of a new array.
-   */
-  public void beginArray() throws IOException {
-    int p = peeked;
-    if (p == PEEKED_NONE) {
-      p = doPeek();
-    }
-    if (p == PEEKED_BEGIN_ARRAY) {
-      push(JsonScope.EMPTY_ARRAY);
-      pathIndices[stackSize - 1] = 0;
-      peeked = PEEKED_NONE;
-    } else {
-      throw new IllegalStateException("Expected BEGIN_ARRAY but was " + peek() + locationString());
-    }
-  }
-
-  /**
-   * Consumes the next token from the JSON stream and asserts that it is the
-   * end of the current array.
-   */
-  public void endArray() throws IOException {
-    int p = peeked;
-    if (p == PEEKED_NONE) {
-      p = doPeek();
-    }
-    if (p == PEEKED_END_ARRAY) {
-      stackSize--;
-      pathIndices[stackSize - 1]++;
-      peeked = PEEKED_NONE;
-    } else {
-      throw new IllegalStateException("Expected END_ARRAY but was " + peek() + locationString());
-    }
-  }
-
-  /**
-   * Consumes the next token from the JSON stream and asserts that it is the
-   * beginning of a new object.
-   */
-  public void beginObject() throws IOException {
-    int p = peeked;
-    if (p == PEEKED_NONE) {
-      p = doPeek();
-    }
-    if (p == PEEKED_BEGIN_OBJECT) {
-      push(JsonScope.EMPTY_OBJECT);
-      peeked = PEEKED_NONE;
-    } else {
-      throw new IllegalStateException("Expected BEGIN_OBJECT but was " + peek() + locationString());
-    }
-  }
-
-  /**
-   * Consumes the next token from the JSON stream and asserts that it is the
-   * end of the current object.
-   */
-  public void endObject() throws IOException {
-    int p = peeked;
-    if (p == PEEKED_NONE) {
-      p = doPeek();
-    }
-    if (p == PEEKED_END_OBJECT) {
-      stackSize--;
-      pathNames[stackSize] = null; // Free the last path name so that it can be garbage collected!
-      pathIndices[stackSize - 1]++;
-      peeked = PEEKED_NONE;
-    } else {
-      throw new IllegalStateException("Expected END_OBJECT but was " + peek() + locationString());
-    }
-  }
-
-  /**
-   * Returns true if the current array or object has another element.
-   */
-  public boolean hasNext() throws IOException {
-    int p = peeked;
-    if (p == PEEKED_NONE) {
-      p = doPeek();
-    }
-    return p != PEEKED_END_OBJECT && p != PEEKED_END_ARRAY;
-  }
-
-  /**
-   * Returns the type of the next token without consuming it.
-   */
-  public JsonToken peek() throws IOException {
-    int p = peeked;
-    if (p == PEEKED_NONE) {
-      p = doPeek();
+    /**
+     * Creates a new instance that reads a JSON-encoded stream from {@code in}.
+     */
+    public JsonReader(Reader in) {
+        if (in == null) {
+            throw new NullPointerException("in == null");
+        }
+        this.in = in;
+        _init();
     }
 
-    switch (p) {
-    case PEEKED_BEGIN_OBJECT:
-      return JsonToken.BEGIN_OBJECT;
-    case PEEKED_END_OBJECT:
-      return JsonToken.END_OBJECT;
-    case PEEKED_BEGIN_ARRAY:
-      return JsonToken.BEGIN_ARRAY;
-    case PEEKED_END_ARRAY:
-      return JsonToken.END_ARRAY;
-    case PEEKED_SINGLE_QUOTED_NAME:
-    case PEEKED_DOUBLE_QUOTED_NAME:
-    case PEEKED_UNQUOTED_NAME:
-      return JsonToken.NAME;
-    case PEEKED_TRUE:
-    case PEEKED_FALSE:
-      return JsonToken.BOOLEAN;
-    case PEEKED_NULL:
-      return JsonToken.NULL;
-    case PEEKED_SINGLE_QUOTED:
-    case PEEKED_DOUBLE_QUOTED:
-    case PEEKED_UNQUOTED:
-    case PEEKED_BUFFERED:
-      return JsonToken.STRING;
-    case PEEKED_LONG:
-    case PEEKED_NUMBER:
-      return JsonToken.NUMBER;
-    case PEEKED_EOF:
-      return JsonToken.END_DOCUMENT;
-    default:
-      throw new AssertionError();
-    }
-  }
+    protected JsonReader() {
 
-  int doPeek() throws IOException {
-    int peekStack = stack[stackSize - 1];
-    if (peekStack == JsonScope.EMPTY_ARRAY) {
-      stack[stackSize - 1] = JsonScope.NONEMPTY_ARRAY;
-    } else if (peekStack == JsonScope.NONEMPTY_ARRAY) {
-      // Look for a comma before the next element.
-      int c = nextNonWhitespace(true);
-      switch (c) {
-      case ']':
-        return peeked = PEEKED_END_ARRAY;
-      case ';':
-        checkLenient(); // fall-through
-      case ',':
-        break;
-      default:
-        throw syntaxError("Unterminated array");
-      }
-    } else if (peekStack == JsonScope.EMPTY_OBJECT || peekStack == JsonScope.NONEMPTY_OBJECT) {
-      stack[stackSize - 1] = JsonScope.DANGLING_NAME;
-      // Look for a comma before the next element.
-      if (peekStack == JsonScope.NONEMPTY_OBJECT) {
+    }
+
+    /**
+     * Configure this parser to be liberal in what it accepts. By default, this
+     * parser is strict and only accepts JSON as specified by <a
+     * href="http://www.ietf.org/rfc/rfc4627.txt">RFC 4627</a>. Setting the
+     * parser to lenient causes it to ignore the following syntax errors:
+     *
+     * <ul>
+     * <li>Streams that start with the <a href="#nonexecuteprefix">non-execute
+     * prefix</a>, <code>")]}'\n"</code>.
+     * <li>Streams that include multiple top-level values. With strict parsing,
+     * each stream must contain exactly one top-level value.
+     * <li>Top-level values of any type. With strict parsing, the top-level
+     * value must be an object or an array.
+     * <li>Numbers may be {@link Double#isNaN() NaNs} or {@link
+     *       Double#isInfinite() infinities}.
+     * <li>End of line comments starting with {@code //} or {@code #} and ending
+     * with a newline character.
+     * <li>C-style comments starting with {@code /*} and ending with
+     * {@code *}{@code /}. Such comments may not be nested.
+     * <li>Names that are unquoted or {@code 'single quoted'}.
+     * <li>Strings that are unquoted or {@code 'single quoted'}.
+     * <li>Array elements separated by {@code ;} instead of {@code ,}.
+     * <li>Unnecessary array separators. These are interpreted as if null was
+     * the omitted value.
+     * <li>Names and values separated by {@code =} or {@code =>} instead of
+     * {@code :}.
+     * <li>Name/value pairs separated by {@code ;} instead of {@code ,}.
+     * </ul>
+     */
+    public final void setLenient(boolean lenient) {
+        this.lenient = lenient;
+    }
+
+    /**
+     * Returns true if this parser is liberal in what it accepts.
+     */
+    public final boolean isLenient() {
+        return lenient;
+    }
+
+    /**
+     * Consumes the next token from the JSON stream and asserts that it is the
+     * beginning of a new array.
+     */
+    public void beginArray() throws IOException {
+        int p = peeked;
+        if (p == PEEKED_NONE) {
+            p = doPeek();
+        }
+        if (p == PEEKED_BEGIN_ARRAY) {
+            push(JsonScope.EMPTY_ARRAY);
+            pathIndices[stackSize - 1] = 0;
+            peeked = PEEKED_NONE;
+        } else {
+            throw new IllegalStateException("Expected BEGIN_ARRAY but was " + peek() + locationString());
+        }
+    }
+
+    /**
+     * Consumes the next token from the JSON stream and asserts that it is the
+     * end of the current array.
+     */
+    public void endArray() throws IOException {
+        int p = peeked;
+        if (p == PEEKED_NONE) {
+            p = doPeek();
+        }
+        if (p == PEEKED_END_ARRAY) {
+            stackSize--;
+            pathIndices[stackSize - 1]++;
+            peeked = PEEKED_NONE;
+        } else {
+            throw new IllegalStateException("Expected END_ARRAY but was " + peek() + locationString());
+        }
+    }
+
+    /**
+     * Consumes the next token from the JSON stream and asserts that it is the
+     * beginning of a new object.
+     */
+    public void beginObject() throws IOException {
+        int p = peeked;
+        if (p == PEEKED_NONE) {
+            p = doPeek();
+        }
+        if (p == PEEKED_BEGIN_OBJECT) {
+            push(JsonScope.EMPTY_OBJECT);
+            peeked = PEEKED_NONE;
+        } else {
+            throw new IllegalStateException("Expected BEGIN_OBJECT but was " + peek() + locationString());
+        }
+    }
+
+    /**
+     * Consumes the next token from the JSON stream and asserts that it is the
+     * end of the current object.
+     */
+    public void endObject() throws IOException {
+        int p = peeked;
+        if (p == PEEKED_NONE) {
+            p = doPeek();
+        }
+        if (p == PEEKED_END_OBJECT) {
+            stackSize--;
+            pathNames[stackSize] = null; // Free the last path name so that it can be garbage collected!
+            pathIndices[stackSize - 1]++;
+            peeked = PEEKED_NONE;
+        } else {
+            throw new IllegalStateException("Expected END_OBJECT but was " + peek() + locationString());
+        }
+    }
+
+    /**
+     * Returns true if the current array or object has another element.
+     */
+    public boolean hasNext() throws IOException {
+        int p = peeked;
+        if (p == PEEKED_NONE) {
+            p = doPeek();
+        }
+        return p != PEEKED_END_OBJECT && p != PEEKED_END_ARRAY;
+    }
+
+    /**
+     * Returns the type of the next token without consuming it.
+     */
+    public JsonToken peek() throws IOException {
+        int p = peeked;
+        if (p == PEEKED_NONE) {
+            p = doPeek();
+        }
+
+        switch (p) {
+            case PEEKED_BEGIN_OBJECT:
+                return JsonToken.BEGIN_OBJECT;
+            case PEEKED_END_OBJECT:
+                return JsonToken.END_OBJECT;
+            case PEEKED_BEGIN_ARRAY:
+                return JsonToken.BEGIN_ARRAY;
+            case PEEKED_END_ARRAY:
+                return JsonToken.END_ARRAY;
+            case PEEKED_SINGLE_QUOTED_NAME:
+            case PEEKED_DOUBLE_QUOTED_NAME:
+            case PEEKED_UNQUOTED_NAME:
+                return JsonToken.NAME;
+            case PEEKED_TRUE:
+            case PEEKED_FALSE:
+                return JsonToken.BOOLEAN;
+            case PEEKED_NULL:
+                return JsonToken.NULL;
+            case PEEKED_SINGLE_QUOTED:
+            case PEEKED_DOUBLE_QUOTED:
+            case PEEKED_UNQUOTED:
+            case PEEKED_BUFFERED:
+                return JsonToken.STRING;
+            case PEEKED_LONG:
+            case PEEKED_NUMBER:
+                return JsonToken.NUMBER;
+            case PEEKED_EOF:
+                return JsonToken.END_DOCUMENT;
+            default:
+                throw new AssertionError();
+        }
+    }
+
+    int doPeek() throws IOException {
+        int peekStack = stack[stackSize - 1];
+        if (peekStack == JsonScope.EMPTY_ARRAY) {
+            stack[stackSize - 1] = JsonScope.NONEMPTY_ARRAY;
+        } else if (peekStack == JsonScope.NONEMPTY_ARRAY) {
+            // Look for a comma before the next element.
+            int c = nextNonWhitespace(true);
+            switch (c) {
+                case ']':
+                    return peeked = PEEKED_END_ARRAY;
+                case ';':
+                    checkLenient(); // fall-through
+                case ',':
+                    break;
+                default:
+                    throw syntaxError("Unterminated array");
+            }
+        } else if (peekStack == JsonScope.EMPTY_OBJECT || peekStack == JsonScope.NONEMPTY_OBJECT) {
+            stack[stackSize - 1] = JsonScope.DANGLING_NAME;
+            // Look for a comma before the next element.
+            if (peekStack == JsonScope.NONEMPTY_OBJECT) {
+                int c = nextNonWhitespace(true);
+                switch (c) {
+                    case '}':
+                        return peeked = PEEKED_END_OBJECT;
+                    case ';':
+                        checkLenient(); // fall-through
+                    case ',':
+                        break;
+                    default:
+                        throw syntaxError("Unterminated object");
+                }
+            }
+            int c = nextNonWhitespace(true);
+            switch (c) {
+                case '"':
+                    return peeked = PEEKED_DOUBLE_QUOTED_NAME;
+                case '\'':
+                    checkLenient();
+                    return peeked = PEEKED_SINGLE_QUOTED_NAME;
+                case '}':
+                    if (peekStack != JsonScope.NONEMPTY_OBJECT) {
+                        return peeked = PEEKED_END_OBJECT;
+                    } else {
+                        throw syntaxError("Expected name");
+                    }
+                default:
+                    checkLenient();
+                    pos--; // Don't consume the first character in an unquoted string.
+                    if (isLiteral((char) c)) {
+                        return peeked = PEEKED_UNQUOTED_NAME;
+                    } else {
+                        throw syntaxError("Expected name");
+                    }
+            }
+        } else if (peekStack == JsonScope.DANGLING_NAME) {
+            stack[stackSize - 1] = JsonScope.NONEMPTY_OBJECT;
+            // Look for a colon before the value.
+            int c = nextNonWhitespace(true);
+            switch (c) {
+                case ':':
+                    break;
+                case '=':
+                    checkLenient();
+                    if ((pos < limit || fillBuffer(1)) && buffer[pos] == '>') {
+                        pos++;
+                    }
+                    break;
+                default:
+                    throw syntaxError("Expected ':'");
+            }
+        } else if (peekStack == JsonScope.EMPTY_DOCUMENT) {
+            if (lenient) {
+                consumeNonExecutePrefix();
+            }
+            stack[stackSize - 1] = JsonScope.NONEMPTY_DOCUMENT;
+        } else if (peekStack == JsonScope.NONEMPTY_DOCUMENT) {
+            int c = nextNonWhitespace(false);
+            if (c == -1) {
+                return peeked = PEEKED_EOF;
+            } else {
+                checkLenient();
+                pos--;
+            }
+        } else if (peekStack == JsonScope.CLOSED) {
+            throw new IllegalStateException("JsonReader is closed");
+        }
+
         int c = nextNonWhitespace(true);
         switch (c) {
-        case '}':
-          return peeked = PEEKED_END_OBJECT;
-        case ';':
-          checkLenient(); // fall-through
-        case ',':
-          break;
-        default:
-          throw syntaxError("Unterminated object");
+            case ']':
+                if (peekStack == JsonScope.EMPTY_ARRAY) {
+                    return peeked = PEEKED_END_ARRAY;
+                }
+            // fall-through to handle ",]"
+            case ';':
+            case ',':
+                // In lenient mode, a 0-length literal in an array means 'null'.
+                if (peekStack == JsonScope.EMPTY_ARRAY || peekStack == JsonScope.NONEMPTY_ARRAY) {
+                    checkLenient();
+                    pos--;
+                    return peeked = PEEKED_NULL;
+                } else {
+                    throw syntaxError("Unexpected value");
+                }
+            case '\'':
+                checkLenient();
+                return peeked = PEEKED_SINGLE_QUOTED;
+            case '"':
+                return peeked = PEEKED_DOUBLE_QUOTED;
+            case '[':
+                return peeked = PEEKED_BEGIN_ARRAY;
+            case '{':
+                return peeked = PEEKED_BEGIN_OBJECT;
+            default:
+                pos--; // Don't consume the first character in a literal value.
         }
-      }
-      int c = nextNonWhitespace(true);
-      switch (c) {
-      case '"':
-        return peeked = PEEKED_DOUBLE_QUOTED_NAME;
-      case '\'':
+
+        int result = peekKeyword();
+        if (result != PEEKED_NONE) {
+            return result;
+        }
+
+        result = peekNumber();
+        if (result != PEEKED_NONE) {
+            return result;
+        }
+
+        if (!isLiteral(buffer[pos])) {
+            throw syntaxError("Expected value");
+        }
+
         checkLenient();
-        return peeked = PEEKED_SINGLE_QUOTED_NAME;
-      case '}':
-        if (peekStack != JsonScope.NONEMPTY_OBJECT) {
-          return peeked = PEEKED_END_OBJECT;
+        return peeked = PEEKED_UNQUOTED;
+    }
+
+    private int peekKeyword() throws IOException {
+        // Figure out which keyword we're matching against by its first character.
+        char c = buffer[pos];
+        String keyword;
+        String keywordUpper;
+        int peeking;
+        if (c == 't' || c == 'T') {
+            keyword = "true";
+            keywordUpper = "TRUE";
+            peeking = PEEKED_TRUE;
+        } else if (c == 'f' || c == 'F') {
+            keyword = "false";
+            keywordUpper = "FALSE";
+            peeking = PEEKED_FALSE;
+        } else if (c == 'n' || c == 'N') {
+            keyword = "null";
+            keywordUpper = "NULL";
+            peeking = PEEKED_NULL;
         } else {
-          throw syntaxError("Expected name");
+            return PEEKED_NONE;
         }
-      default:
-        checkLenient();
-        pos--; // Don't consume the first character in an unquoted string.
-        if (isLiteral((char) c)) {
-          return peeked = PEEKED_UNQUOTED_NAME;
+
+        // Confirm that chars [1..length) match the keyword.
+        int length = keyword.length();
+        for (int i = 1; i < length; i++) {
+            if (pos + i >= limit && !fillBuffer(i + 1)) {
+                return PEEKED_NONE;
+            }
+            c = buffer[pos + i];
+            if (c != keyword.charAt(i) && c != keywordUpper.charAt(i)) {
+                return PEEKED_NONE;
+            }
+        }
+
+        if ((pos + length < limit || fillBuffer(length + 1))
+                && isLiteral(buffer[pos + length])) {
+            return PEEKED_NONE; // Don't match trues, falsey or nullsoft!
+        }
+
+        // We've found the keyword followed either by EOF or by a non-literal character.
+        pos += length;
+        return peeked = peeking;
+    }
+
+    private int peekNumber() throws IOException {
+        // Like nextNonWhitespace, this uses locals 'p' and 'l' to save inner-loop field access.
+        char[] buffer = this.buffer;
+        int p = pos;
+        int l = limit;
+
+        long value = 0; // Negative to accommodate Long.MIN_VALUE more easily.
+        boolean negative = false;
+        boolean fitsInLong = true;
+        int last = NUMBER_CHAR_NONE;
+
+        int i = 0;
+
+        charactersOfNumber:
+        for (; true; i++) {
+            if (p + i == l) {
+                if (i == buffer.length) {
+                    // Though this looks like a well-formed number, it's too long to continue reading. Give up
+                    // and let the application handle this as an unquoted literal.
+                    return PEEKED_NONE;
+                }
+                if (!fillBuffer(i + 1)) {
+                    break;
+                }
+                p = pos;
+                l = limit;
+            }
+
+            char c = buffer[p + i];
+            switch (c) {
+                case '-':
+                    if (last == NUMBER_CHAR_NONE) {
+                        negative = true;
+                        last = NUMBER_CHAR_SIGN;
+                        continue;
+                    } else if (last == NUMBER_CHAR_EXP_E) {
+                        last = NUMBER_CHAR_EXP_SIGN;
+                        continue;
+                    }
+                    return PEEKED_NONE;
+
+                case '+':
+                    if (last == NUMBER_CHAR_EXP_E) {
+                        last = NUMBER_CHAR_EXP_SIGN;
+                        continue;
+                    }
+                    return PEEKED_NONE;
+
+                case 'e':
+                case 'E':
+                    if (last == NUMBER_CHAR_DIGIT || last == NUMBER_CHAR_FRACTION_DIGIT) {
+                        last = NUMBER_CHAR_EXP_E;
+                        continue;
+                    }
+                    return PEEKED_NONE;
+
+                case '.':
+                    if (last == NUMBER_CHAR_DIGIT) {
+                        last = NUMBER_CHAR_DECIMAL;
+                        continue;
+                    }
+                    return PEEKED_NONE;
+
+                default:
+                    if (c < '0' || c > '9') {
+                        if (!isLiteral(c)) {
+                            break charactersOfNumber;
+                        }
+                        return PEEKED_NONE;
+                    }
+                    if (last == NUMBER_CHAR_SIGN || last == NUMBER_CHAR_NONE) {
+                        value = -(c - '0');
+                        last = NUMBER_CHAR_DIGIT;
+                    } else if (last == NUMBER_CHAR_DIGIT) {
+                        if (value == 0) {
+                            return PEEKED_NONE; // Leading '0' prefix is not allowed (since it could be octal).
+                        }
+                        long newValue = value * 10 - (c - '0');
+                        fitsInLong &= value > MIN_INCOMPLETE_INTEGER
+                                || (value == MIN_INCOMPLETE_INTEGER && newValue < value);
+                        value = newValue;
+                    } else if (last == NUMBER_CHAR_DECIMAL) {
+                        last = NUMBER_CHAR_FRACTION_DIGIT;
+                    } else if (last == NUMBER_CHAR_EXP_E || last == NUMBER_CHAR_EXP_SIGN) {
+                        last = NUMBER_CHAR_EXP_DIGIT;
+                    }
+            }
+        }
+
+        // We've read a complete number. Decide if it's a PEEKED_LONG or a PEEKED_NUMBER.
+        if (last == NUMBER_CHAR_DIGIT && fitsInLong && (value != Long.MIN_VALUE || negative) && (value != 0 || false == negative)) {
+            peekedLong = negative ? value : -value;
+            pos += i;
+            return peeked = PEEKED_LONG;
+        } else if (last == NUMBER_CHAR_DIGIT || last == NUMBER_CHAR_FRACTION_DIGIT
+                || last == NUMBER_CHAR_EXP_DIGIT) {
+            peekedNumberLength = i;
+            return peeked = PEEKED_NUMBER;
         } else {
-          throw syntaxError("Expected name");
+            return PEEKED_NONE;
         }
-      }
-    } else if (peekStack == JsonScope.DANGLING_NAME) {
-      stack[stackSize - 1] = JsonScope.NONEMPTY_OBJECT;
-      // Look for a colon before the value.
-      int c = nextNonWhitespace(true);
-      switch (c) {
-      case ':':
-        break;
-      case '=':
-        checkLenient();
-        if ((pos < limit || fillBuffer(1)) && buffer[pos] == '>') {
-          pos++;
+    }
+
+    private boolean isLiteral(char c) throws IOException {
+        switch (c) {
+            case '/':
+            case '\\':
+            case ';':
+            case '#':
+            case '=':
+                checkLenient(); // fall-through
+            case '{':
+            case '}':
+            case '[':
+            case ']':
+            case ':':
+            case ',':
+            case ' ':
+            case '\t':
+            case '\f':
+            case '\r':
+            case '\n':
+                return false;
+            default:
+                return true;
         }
-        break;
-      default:
-        throw syntaxError("Expected ':'");
-      }
-    } else if (peekStack == JsonScope.EMPTY_DOCUMENT) {
-      if (lenient) {
-        consumeNonExecutePrefix();
-      }
-      stack[stackSize - 1] = JsonScope.NONEMPTY_DOCUMENT;
-    } else if (peekStack == JsonScope.NONEMPTY_DOCUMENT) {
-      int c = nextNonWhitespace(false);
-      if (c == -1) {
-        return peeked = PEEKED_EOF;
-      } else {
-        checkLenient();
-        pos--;
-      }
-    } else if (peekStack == JsonScope.CLOSED) {
-      throw new IllegalStateException("JsonReader is closed");
     }
 
-    int c = nextNonWhitespace(true);
-    switch (c) {
-    case ']':
-      if (peekStack == JsonScope.EMPTY_ARRAY) {
-        return peeked = PEEKED_END_ARRAY;
-      }
-      // fall-through to handle ",]"
-    case ';':
-    case ',':
-      // In lenient mode, a 0-length literal in an array means 'null'.
-      if (peekStack == JsonScope.EMPTY_ARRAY || peekStack == JsonScope.NONEMPTY_ARRAY) {
-        checkLenient();
-        pos--;
-        return peeked = PEEKED_NULL;
-      } else {
-        throw syntaxError("Unexpected value");
-      }
-    case '\'':
-      checkLenient();
-      return peeked = PEEKED_SINGLE_QUOTED;
-    case '"':
-      return peeked = PEEKED_DOUBLE_QUOTED;
-    case '[':
-      return peeked = PEEKED_BEGIN_ARRAY;
-    case '{':
-      return peeked = PEEKED_BEGIN_OBJECT;
-    default:
-      pos--; // Don't consume the first character in a literal value.
-    }
-
-    int result = peekKeyword();
-    if (result != PEEKED_NONE) {
-      return result;
-    }
-
-    result = peekNumber();
-    if (result != PEEKED_NONE) {
-      return result;
-    }
-
-    if (!isLiteral(buffer[pos])) {
-      throw syntaxError("Expected value");
-    }
-
-    checkLenient();
-    return peeked = PEEKED_UNQUOTED;
-  }
-
-  private int peekKeyword() throws IOException {
-    // Figure out which keyword we're matching against by its first character.
-    char c = buffer[pos];
-    String keyword;
-    String keywordUpper;
-    int peeking;
-    if (c == 't' || c == 'T') {
-      keyword = "true";
-      keywordUpper = "TRUE";
-      peeking = PEEKED_TRUE;
-    } else if (c == 'f' || c == 'F') {
-      keyword = "false";
-      keywordUpper = "FALSE";
-      peeking = PEEKED_FALSE;
-    } else if (c == 'n' || c == 'N') {
-      keyword = "null";
-      keywordUpper = "NULL";
-      peeking = PEEKED_NULL;
-    } else {
-      return PEEKED_NONE;
-    }
-
-    // Confirm that chars [1..length) match the keyword.
-    int length = keyword.length();
-    for (int i = 1; i < length; i++) {
-      if (pos + i >= limit && !fillBuffer(i + 1)) {
-        return PEEKED_NONE;
-      }
-      c = buffer[pos + i];
-      if (c != keyword.charAt(i) && c != keywordUpper.charAt(i)) {
-        return PEEKED_NONE;
-      }
-    }
-
-    if ((pos + length < limit || fillBuffer(length + 1))
-        && isLiteral(buffer[pos + length])) {
-      return PEEKED_NONE; // Don't match trues, falsey or nullsoft!
-    }
-
-    // We've found the keyword followed either by EOF or by a non-literal character.
-    pos += length;
-    return peeked = peeking;
-  }
-
-  private int peekNumber() throws IOException {
-    // Like nextNonWhitespace, this uses locals 'p' and 'l' to save inner-loop field access.
-    char[] buffer = this.buffer;
-    int p = pos;
-    int l = limit;
-
-    long value = 0; // Negative to accommodate Long.MIN_VALUE more easily.
-    boolean negative = false;
-    boolean fitsInLong = true;
-    int last = NUMBER_CHAR_NONE;
-
-    int i = 0;
-
-    charactersOfNumber:
-    for (; true; i++) {
-      if (p + i == l) {
-        if (i == buffer.length) {
-          // Though this looks like a well-formed number, it's too long to continue reading. Give up
-          // and let the application handle this as an unquoted literal.
-          return PEEKED_NONE;
+    /**
+     * Returns the next token, a
+     * {@link com.google.gson.stream.JsonToken#NAME property name}, and consumes
+     * it.
+     *
+     * @throws java.io.IOException if the next token in the stream is not a
+     * property name.
+     */
+    public String nextName() throws IOException {
+        int p = peeked;
+        if (p == PEEKED_NONE) {
+            p = doPeek();
         }
-        if (!fillBuffer(i + 1)) {
-          break;
+        String result;
+        if (p == PEEKED_UNQUOTED_NAME) {
+            result = nextUnquotedValue();
+        } else if (p == PEEKED_SINGLE_QUOTED_NAME) {
+            result = nextQuotedValue('\'');
+        } else if (p == PEEKED_DOUBLE_QUOTED_NAME) {
+            result = nextQuotedValue('"');
+        } else {
+            throw new IllegalStateException("Expected a name but was " + peek() + locationString());
         }
-        p = pos;
-        l = limit;
-      }
+        peeked = PEEKED_NONE;
+        pathNames[stackSize - 1] = result;
+        return result;
+    }
 
-      char c = buffer[p + i];
-      switch (c) {
-      case '-':
-        if (last == NUMBER_CHAR_NONE) {
-          negative = true;
-          last = NUMBER_CHAR_SIGN;
-          continue;
-        } else if (last == NUMBER_CHAR_EXP_E) {
-          last = NUMBER_CHAR_EXP_SIGN;
-          continue;
+    /**
+     * Returns the {@link com.google.gson.stream.JsonToken#STRING string} value
+     * of the next token, consuming it. If the next token is a number, this
+     * method will return its string form.
+     *
+     * @throws IllegalStateException if the next token is not a string or if
+     * this reader is closed.
+     */
+    public String nextString() throws IOException {
+        int p = peeked;
+        if (p == PEEKED_NONE) {
+            p = doPeek();
         }
-        return PEEKED_NONE;
-
-      case '+':
-        if (last == NUMBER_CHAR_EXP_E) {
-          last = NUMBER_CHAR_EXP_SIGN;
-          continue;
+        String result;
+        if (p == PEEKED_UNQUOTED) {
+            result = nextUnquotedValue();
+        } else if (p == PEEKED_SINGLE_QUOTED) {
+            result = nextQuotedValue('\'');
+        } else if (p == PEEKED_DOUBLE_QUOTED) {
+            result = nextQuotedValue('"');
+        } else if (p == PEEKED_BUFFERED) {
+            result = peekedString;
+            peekedString = null;
+        } else if (p == PEEKED_LONG) {
+            result = Long.toString(peekedLong);
+        } else if (p == PEEKED_NUMBER) {
+            result = new String(buffer, pos, peekedNumberLength);
+            pos += peekedNumberLength;
+        } else {
+            throw new IllegalStateException("Expected a string but was " + peek() + locationString());
         }
-        return PEEKED_NONE;
-
-      case 'e':
-      case 'E':
-        if (last == NUMBER_CHAR_DIGIT || last == NUMBER_CHAR_FRACTION_DIGIT) {
-          last = NUMBER_CHAR_EXP_E;
-          continue;
-        }
-        return PEEKED_NONE;
-
-      case '.':
-        if (last == NUMBER_CHAR_DIGIT) {
-          last = NUMBER_CHAR_DECIMAL;
-          continue;
-        }
-        return PEEKED_NONE;
-
-      default:
-        if (c < '0' || c > '9') {
-          if (!isLiteral(c)) {
-            break charactersOfNumber;
-          }
-          return PEEKED_NONE;
-        }
-        if (last == NUMBER_CHAR_SIGN || last == NUMBER_CHAR_NONE) {
-          value = -(c - '0');
-          last = NUMBER_CHAR_DIGIT;
-        } else if (last == NUMBER_CHAR_DIGIT) {
-          if (value == 0) {
-            return PEEKED_NONE; // Leading '0' prefix is not allowed (since it could be octal).
-          }
-          long newValue = value * 10 - (c - '0');
-          fitsInLong &= value > MIN_INCOMPLETE_INTEGER
-              || (value == MIN_INCOMPLETE_INTEGER && newValue < value);
-          value = newValue;
-        } else if (last == NUMBER_CHAR_DECIMAL) {
-          last = NUMBER_CHAR_FRACTION_DIGIT;
-        } else if (last == NUMBER_CHAR_EXP_E || last == NUMBER_CHAR_EXP_SIGN) {
-          last = NUMBER_CHAR_EXP_DIGIT;
-        }
-      }
-    }
-
-    // We've read a complete number. Decide if it's a PEEKED_LONG or a PEEKED_NUMBER.
-    if (last == NUMBER_CHAR_DIGIT && fitsInLong && (value != Long.MIN_VALUE || negative) && (value!=0 || false==negative)) {
-      peekedLong = negative ? value : -value;
-      pos += i;
-      return peeked = PEEKED_LONG;
-    } else if (last == NUMBER_CHAR_DIGIT || last == NUMBER_CHAR_FRACTION_DIGIT
-        || last == NUMBER_CHAR_EXP_DIGIT) {
-      peekedNumberLength = i;
-      return peeked = PEEKED_NUMBER;
-    } else {
-      return PEEKED_NONE;
-    }
-  }
-
-  private boolean isLiteral(char c) throws IOException {
-    switch (c) {
-    case '/':
-    case '\\':
-    case ';':
-    case '#':
-    case '=':
-      checkLenient(); // fall-through
-    case '{':
-    case '}':
-    case '[':
-    case ']':
-    case ':':
-    case ',':
-    case ' ':
-    case '\t':
-    case '\f':
-    case '\r':
-    case '\n':
-      return false;
-    default:
-      return true;
-    }
-  }
-
-  /**
-   * Returns the next token, a {@link com.google.gson.stream.JsonToken#NAME property name}, and
-   * consumes it.
-   *
-   * @throws java.io.IOException if the next token in the stream is not a property
-   *     name.
-   */
-  public String nextName() throws IOException {
-    int p = peeked;
-    if (p == PEEKED_NONE) {
-      p = doPeek();
-    }
-    String result;
-    if (p == PEEKED_UNQUOTED_NAME) {
-      result = nextUnquotedValue();
-    } else if (p == PEEKED_SINGLE_QUOTED_NAME) {
-      result = nextQuotedValue('\'');
-    } else if (p == PEEKED_DOUBLE_QUOTED_NAME) {
-      result = nextQuotedValue('"');
-    } else {
-      throw new IllegalStateException("Expected a name but was " + peek() + locationString());
-    }
-    peeked = PEEKED_NONE;
-    pathNames[stackSize - 1] = result;
-    return result;
-  }
-
-  /**
-   * Returns the {@link com.google.gson.stream.JsonToken#STRING string} value of the next token,
-   * consuming it. If the next token is a number, this method will return its
-   * string form.
-   *
-   * @throws IllegalStateException if the next token is not a string or if
-   *     this reader is closed.
-   */
-  public String nextString() throws IOException {
-    int p = peeked;
-    if (p == PEEKED_NONE) {
-      p = doPeek();
-    }
-    String result;
-    if (p == PEEKED_UNQUOTED) {
-      result = nextUnquotedValue();
-    } else if (p == PEEKED_SINGLE_QUOTED) {
-      result = nextQuotedValue('\'');
-    } else if (p == PEEKED_DOUBLE_QUOTED) {
-      result = nextQuotedValue('"');
-    } else if (p == PEEKED_BUFFERED) {
-      result = peekedString;
-      peekedString = null;
-    } else if (p == PEEKED_LONG) {
-      result = Long.toString(peekedLong);
-    } else if (p == PEEKED_NUMBER) {
-      result = new String(buffer, pos, peekedNumberLength);
-      pos += peekedNumberLength;
-    } else {
-      throw new IllegalStateException("Expected a string but was " + peek() + locationString());
-    }
-    peeked = PEEKED_NONE;
-    pathIndices[stackSize - 1]++;
-    return result;
-  }
-
-  /**
-   * Returns the {@link com.google.gson.stream.JsonToken#BOOLEAN boolean} value of the next token,
-   * consuming it.
-   *
-   * @throws IllegalStateException if the next token is not a boolean or if
-   *     this reader is closed.
-   */
-  public boolean nextBoolean() throws IOException {
-    int p = peeked;
-    if (p == PEEKED_NONE) {
-      p = doPeek();
-    }
-    if (p == PEEKED_TRUE) {
-      peeked = PEEKED_NONE;
-      pathIndices[stackSize - 1]++;
-      return true;
-    } else if (p == PEEKED_FALSE) {
-      peeked = PEEKED_NONE;
-      pathIndices[stackSize - 1]++;
-      return false;
-    }
-    throw new IllegalStateException("Expected a boolean but was " + peek() + locationString());
-  }
-
-  /**
-   * Consumes the next token from the JSON stream and asserts that it is a
-   * literal null.
-   *
-   * @throws IllegalStateException if the next token is not null or if this
-   *     reader is closed.
-   */
-  public void nextNull() throws IOException {
-    int p = peeked;
-    if (p == PEEKED_NONE) {
-      p = doPeek();
-    }
-    if (p == PEEKED_NULL) {
-      peeked = PEEKED_NONE;
-      pathIndices[stackSize - 1]++;
-    } else {
-      throw new IllegalStateException("Expected null but was " + peek() + locationString());
-    }
-  }
-
-  /**
-   * Returns the {@link com.google.gson.stream.JsonToken#NUMBER double} value of the next token,
-   * consuming it. If the next token is a string, this method will attempt to
-   * parse it as a double using {@link Double#parseDouble(String)}.
-   *
-   * @throws IllegalStateException if the next token is not a literal value.
-   * @throws NumberFormatException if the next literal value cannot be parsed
-   *     as a double, or is non-finite.
-   */
-  public double nextDouble() throws IOException {
-    int p = peeked;
-    if (p == PEEKED_NONE) {
-      p = doPeek();
-    }
-
-    if (p == PEEKED_LONG) {
-      peeked = PEEKED_NONE;
-      pathIndices[stackSize - 1]++;
-      return (double) peekedLong;
-    }
-
-    if (p == PEEKED_NUMBER) {
-      peekedString = new String(buffer, pos, peekedNumberLength);
-      pos += peekedNumberLength;
-    } else if (p == PEEKED_SINGLE_QUOTED || p == PEEKED_DOUBLE_QUOTED) {
-      peekedString = nextQuotedValue(p == PEEKED_SINGLE_QUOTED ? '\'' : '"');
-    } else if (p == PEEKED_UNQUOTED) {
-      peekedString = nextUnquotedValue();
-    } else if (p != PEEKED_BUFFERED) {
-      throw new IllegalStateException("Expected a double but was " + peek() + locationString());
-    }
-
-    peeked = PEEKED_BUFFERED;
-    double result = Double.parseDouble(peekedString); // don't catch this NumberFormatException.
-    if (!lenient && (Double.isNaN(result) || Double.isInfinite(result))) {
-      throw new MalformedJsonException(
-          "JSON forbids NaN and infinities: " + result + locationString());
-    }
-    peekedString = null;
-    peeked = PEEKED_NONE;
-    pathIndices[stackSize - 1]++;
-    return result;
-  }
-
-  /**
-   * Returns the {@link com.google.gson.stream.JsonToken#NUMBER long} value of the next token,
-   * consuming it. If the next token is a string, this method will attempt to
-   * parse it as a long. If the next token's numeric value cannot be exactly
-   * represented by a Java {@code long}, this method throws.
-   *
-   * @throws IllegalStateException if the next token is not a literal value.
-   * @throws NumberFormatException if the next literal value cannot be parsed
-   *     as a number, or exactly represented as a long.
-   */
-  public long nextLong() throws IOException {
-    int p = peeked;
-    if (p == PEEKED_NONE) {
-      p = doPeek();
-    }
-
-    if (p == PEEKED_LONG) {
-      peeked = PEEKED_NONE;
-      pathIndices[stackSize - 1]++;
-      return peekedLong;
-    }
-
-    if (p == PEEKED_NUMBER) {
-      peekedString = new String(buffer, pos, peekedNumberLength);
-      pos += peekedNumberLength;
-    } else if (p == PEEKED_SINGLE_QUOTED || p == PEEKED_DOUBLE_QUOTED || p == PEEKED_UNQUOTED) {
-      if (p == PEEKED_UNQUOTED) {
-        peekedString = nextUnquotedValue();
-      } else {
-        peekedString = nextQuotedValue(p == PEEKED_SINGLE_QUOTED ? '\'' : '"');
-      }
-      try {
-        long result = Long.parseLong(peekedString);
         peeked = PEEKED_NONE;
         pathIndices[stackSize - 1]++;
         return result;
-      } catch (NumberFormatException ignored) {
-        // Fall back to parse as a double below.
-      }
-    } else {
-      throw new IllegalStateException("Expected a long but was " + peek() + locationString());
     }
 
-    peeked = PEEKED_BUFFERED;
-    double asDouble = Double.parseDouble(peekedString); // don't catch this NumberFormatException.
-    long result = (long) asDouble;
-    if (result != asDouble) { // Make sure no precision was lost casting to 'long'.
-      throw new NumberFormatException("Expected a long but was " + peekedString + locationString());
-    }
-    peekedString = null;
-    peeked = PEEKED_NONE;
-    pathIndices[stackSize - 1]++;
-    return result;
-  }
-
-  /**
-   * Returns the string up to but not including {@code quote}, unescaping any
-   * character escape sequences encountered along the way. The opening quote
-   * should have already been read. This consumes the closing quote, but does
-   * not include it in the returned string.
-   *
-   * @param quote either ' or ".
-   * @throws NumberFormatException if any unicode escape sequences are
-   *     malformed.
-   */
-  private String nextQuotedValue(char quote) throws IOException {
-    // Like nextNonWhitespace, this uses locals 'p' and 'l' to save inner-loop field access.
-    char[] buffer = this.buffer;
-    StringBuilder builder = null;
-    while (true) {
-      int p = pos;
-      int l = limit;
-      /* the index of the first character not yet appended to the builder. */
-      int start = p;
-      while (p < l) {
-        int c = buffer[p++];
-
-        if (c == quote) {
-          pos = p;
-          int len = p - start - 1;
-          if (builder == null) {
-            return new String(buffer, start, len);
-          } else {
-            builder.append(buffer, start, len);
-            return builder.toString();
-          }
-        } else if (c == '\\') {
-          pos = p;
-          int len = p - start - 1;
-          if (builder == null) {
-            int estimatedLength = (len + 1) * 2;
-            builder = new StringBuilder(Math.max(estimatedLength, 16));
-          }
-          builder.append(buffer, start, len);
-          builder.append(readEscapeCharacter());
-          p = pos;
-          l = limit;
-          start = p;
-        } else if (c == '\n') {
-          lineNumber++;
-          lineStart = p;
+    /**
+     * Returns the {@link com.google.gson.stream.JsonToken#BOOLEAN boolean}
+     * value of the next token, consuming it.
+     *
+     * @throws IllegalStateException if the next token is not a boolean or if
+     * this reader is closed.
+     */
+    public boolean nextBoolean() throws IOException {
+        int p = peeked;
+        if (p == PEEKED_NONE) {
+            p = doPeek();
         }
-      }
+        if (p == PEEKED_TRUE) {
+            peeked = PEEKED_NONE;
+            pathIndices[stackSize - 1]++;
+            return true;
+        } else if (p == PEEKED_FALSE) {
+            peeked = PEEKED_NONE;
+            pathIndices[stackSize - 1]++;
+            return false;
+        }
+        throw new IllegalStateException("Expected a boolean but was " + peek() + locationString());
+    }
 
-      if (builder == null) {
-        int estimatedLength = (p - start) * 2;
-        builder = new StringBuilder(Math.max(estimatedLength, 16));
-      }
-      builder.append(buffer, start, p - start);
-      pos = p;
-      if (!fillBuffer(1)) {
+    /**
+     * Consumes the next token from the JSON stream and asserts that it is a
+     * literal null.
+     *
+     * @throws IllegalStateException if the next token is not null or if this
+     * reader is closed.
+     */
+    public void nextNull() throws IOException {
+        int p = peeked;
+        if (p == PEEKED_NONE) {
+            p = doPeek();
+        }
+        if (p == PEEKED_NULL) {
+            peeked = PEEKED_NONE;
+            pathIndices[stackSize - 1]++;
+        } else {
+            throw new IllegalStateException("Expected null but was " + peek() + locationString());
+        }
+    }
+
+    /**
+     * Returns the {@link com.google.gson.stream.JsonToken#NUMBER double} value
+     * of the next token, consuming it. If the next token is a string, this
+     * method will attempt to parse it as a double using
+     * {@link Double#parseDouble(String)}.
+     *
+     * @throws IllegalStateException if the next token is not a literal value.
+     * @throws NumberFormatException if the next literal value cannot be parsed
+     * as a double, or is non-finite.
+     */
+    public double nextDouble() throws IOException {
+        int p = peeked;
+        if (p == PEEKED_NONE) {
+            p = doPeek();
+        }
+
+        if (p == PEEKED_LONG) {
+            peeked = PEEKED_NONE;
+            pathIndices[stackSize - 1]++;
+            return (double) peekedLong;
+        }
+
+        if (p == PEEKED_NUMBER) {
+            peekedString = new String(buffer, pos, peekedNumberLength);
+            pos += peekedNumberLength;
+        } else if (p == PEEKED_SINGLE_QUOTED || p == PEEKED_DOUBLE_QUOTED) {
+            peekedString = nextQuotedValue(p == PEEKED_SINGLE_QUOTED ? '\'' : '"');
+        } else if (p == PEEKED_UNQUOTED) {
+            peekedString = nextUnquotedValue();
+        } else if (p != PEEKED_BUFFERED) {
+            throw new IllegalStateException("Expected a double but was " + peek() + locationString());
+        }
+
+        peeked = PEEKED_BUFFERED;
+        double result = Double.parseDouble(peekedString); // don't catch this NumberFormatException.
+        if (!lenient && (Double.isNaN(result) || Double.isInfinite(result))) {
+            throw new MalformedJsonException(
+                    "JSON forbids NaN and infinities: " + result + locationString());
+        }
+        peekedString = null;
+        peeked = PEEKED_NONE;
+        pathIndices[stackSize - 1]++;
+        return result;
+    }
+
+    /**
+     * Returns the {@link com.google.gson.stream.JsonToken#NUMBER long} value of
+     * the next token, consuming it. If the next token is a string, this method
+     * will attempt to parse it as a long. If the next token's numeric value
+     * cannot be exactly represented by a Java {@code long}, this method throws.
+     *
+     * @throws IllegalStateException if the next token is not a literal value.
+     * @throws NumberFormatException if the next literal value cannot be parsed
+     * as a number, or exactly represented as a long.
+     */
+    public long nextLong() throws IOException {
+        int p = peeked;
+        if (p == PEEKED_NONE) {
+            p = doPeek();
+        }
+
+        if (p == PEEKED_LONG) {
+            peeked = PEEKED_NONE;
+            pathIndices[stackSize - 1]++;
+            return peekedLong;
+        }
+
+        if (p == PEEKED_NUMBER) {
+            peekedString = new String(buffer, pos, peekedNumberLength);
+            pos += peekedNumberLength;
+        } else if (p == PEEKED_SINGLE_QUOTED || p == PEEKED_DOUBLE_QUOTED || p == PEEKED_UNQUOTED) {
+            if (p == PEEKED_UNQUOTED) {
+                peekedString = nextUnquotedValue();
+            } else {
+                peekedString = nextQuotedValue(p == PEEKED_SINGLE_QUOTED ? '\'' : '"');
+            }
+            try {
+                long result = Long.parseLong(peekedString);
+                peeked = PEEKED_NONE;
+                pathIndices[stackSize - 1]++;
+                return result;
+            } catch (NumberFormatException ignored) {
+                // Fall back to parse as a double below.
+            }
+        } else {
+            throw new IllegalStateException("Expected a long but was " + peek() + locationString());
+        }
+
+        peeked = PEEKED_BUFFERED;
+        double asDouble = Double.parseDouble(peekedString); // don't catch this NumberFormatException.
+        long result = (long) asDouble;
+        if (result != asDouble) { // Make sure no precision was lost casting to 'long'.
+            throw new NumberFormatException("Expected a long but was " + peekedString + locationString());
+        }
+        peekedString = null;
+        peeked = PEEKED_NONE;
+        pathIndices[stackSize - 1]++;
+        return result;
+    }
+
+    /**
+     * Returns the string up to but not including {@code quote}, unescaping any
+     * character escape sequences encountered along the way. The opening quote
+     * should have already been read. This consumes the closing quote, but does
+     * not include it in the returned string.
+     *
+     * @param quote either ' or ".
+     * @throws NumberFormatException if any unicode escape sequences are
+     * malformed.
+     */
+    private String nextQuotedValue(char quote) throws IOException {
+        // Like nextNonWhitespace, this uses locals 'p' and 'l' to save inner-loop field access.
+        char[] buffer = this.buffer;
+        StringBuilder builder = null;
+        while (true) {
+            int p = pos;
+            int l = limit;
+            /* the index of the first character not yet appended to the builder. */
+            int start = p;
+            while (p < l) {
+                int c = buffer[p++];
+
+                if (c == quote) {
+                    pos = p;
+                    int len = p - start - 1;
+                    if (builder == null) {
+                        return new String(buffer, start, len);
+                    } else {
+                        builder.append(buffer, start, len);
+                        return builder.toString();
+                    }
+                } else if (c == '\\') {
+                    pos = p;
+                    int len = p - start - 1;
+                    if (builder == null) {
+                        int estimatedLength = (len + 1) * 2;
+                        builder = new StringBuilder(Math.max(estimatedLength, 16));
+                    }
+                    builder.append(buffer, start, len);
+                    builder.append(readEscapeCharacter());
+                    p = pos;
+                    l = limit;
+                    start = p;
+                } else if (c == '\n') {
+                    lineNumber++;
+                    lineStart = p;
+                }
+            }
+
+            if (builder == null) {
+                int estimatedLength = (p - start) * 2;
+                builder = new StringBuilder(Math.max(estimatedLength, 16));
+            }
+            builder.append(buffer, start, p - start);
+            pos = p;
+            if (!fillBuffer(1)) {
+                throw syntaxError("Unterminated string");
+            }
+        }
+    }
+
+    /**
+     * Returns an unquoted value as a string.
+     */
+    @SuppressWarnings("fallthrough")
+    private String nextUnquotedValue() throws IOException {
+        StringBuilder builder = null;
+        int i = 0;
+
+        findNonLiteralCharacter:
+        while (true) {
+            for (; pos + i < limit; i++) {
+                switch (buffer[pos + i]) {
+                    case '/':
+                    case '\\':
+                    case ';':
+                    case '#':
+                    case '=':
+                        checkLenient(); // fall-through
+                    case '{':
+                    case '}':
+                    case '[':
+                    case ']':
+                    case ':':
+                    case ',':
+                    case ' ':
+                    case '\t':
+                    case '\f':
+                    case '\r':
+                    case '\n':
+                        break findNonLiteralCharacter;
+                }
+            }
+
+            // Attempt to load the entire literal into the buffer at once.
+            if (i < buffer.length) {
+                if (fillBuffer(i + 1)) {
+                    continue;
+                } else {
+                    break;
+                }
+            }
+
+            // use a StringBuilder when the value is too long. This is too long to be a number!
+            if (builder == null) {
+                builder = new StringBuilder(Math.max(i, 16));
+            }
+            builder.append(buffer, pos, i);
+            pos += i;
+            i = 0;
+            if (!fillBuffer(1)) {
+                break;
+            }
+        }
+
+        String result = (null == builder) ? new String(buffer, pos, i) : builder.append(buffer, pos, i).toString();
+        pos += i;
+        return result;
+    }
+
+    private void skipQuotedValue(char quote) throws IOException {
+        // Like nextNonWhitespace, this uses locals 'p' and 'l' to save inner-loop field access.
+        char[] buffer = this.buffer;
+        do {
+            int p = pos;
+            int l = limit;
+            /* the index of the first character not yet appended to the builder. */
+            while (p < l) {
+                int c = buffer[p++];
+                if (c == quote) {
+                    pos = p;
+                    return;
+                } else if (c == '\\') {
+                    pos = p;
+                    readEscapeCharacter();
+                    p = pos;
+                    l = limit;
+                } else if (c == '\n') {
+                    lineNumber++;
+                    lineStart = p;
+                }
+            }
+            pos = p;
+        } while (fillBuffer(1));
         throw syntaxError("Unterminated string");
-      }
     }
-  }
 
-  /**
-   * Returns an unquoted value as a string.
-   */
-  @SuppressWarnings("fallthrough")
-  private String nextUnquotedValue() throws IOException {
-    StringBuilder builder = null;
-    int i = 0;
+    private void skipUnquotedValue() throws IOException {
+        do {
+            int i = 0;
+            for (; pos + i < limit; i++) {
+                switch (buffer[pos + i]) {
+                    case '/':
+                    case '\\':
+                    case ';':
+                    case '#':
+                    case '=':
+                        checkLenient(); // fall-through
+                    case '{':
+                    case '}':
+                    case '[':
+                    case ']':
+                    case ':':
+                    case ',':
+                    case ' ':
+                    case '\t':
+                    case '\f':
+                    case '\r':
+                    case '\n':
+                        pos += i;
+                        return;
+                }
+            }
+            pos += i;
+        } while (fillBuffer(1));
+    }
 
-    findNonLiteralCharacter:
-    while (true) {
-      for (; pos + i < limit; i++) {
-        switch (buffer[pos + i]) {
-        case '/':
-        case '\\':
-        case ';':
-        case '#':
-        case '=':
-          checkLenient(); // fall-through
-        case '{':
-        case '}':
-        case '[':
-        case ']':
-        case ':':
-        case ',':
-        case ' ':
-        case '\t':
-        case '\f':
-        case '\r':
-        case '\n':
-          break findNonLiteralCharacter;
+    /**
+     * Returns the {@link com.google.gson.stream.JsonToken#NUMBER int} value of
+     * the next token, consuming it. If the next token is a string, this method
+     * will attempt to parse it as an int. If the next token's numeric value
+     * cannot be exactly represented by a Java {@code int}, this method throws.
+     *
+     * @throws IllegalStateException if the next token is not a literal value.
+     * @throws NumberFormatException if the next literal value cannot be parsed
+     * as a number, or exactly represented as an int.
+     */
+    public int nextInt() throws IOException {
+        int p = peeked;
+        if (p == PEEKED_NONE) {
+            p = doPeek();
         }
-      }
 
-      // Attempt to load the entire literal into the buffer at once.
-      if (i < buffer.length) {
-        if (fillBuffer(i + 1)) {
-          continue;
+        int result;
+        if (p == PEEKED_LONG) {
+            result = (int) peekedLong;
+            if (peekedLong != result) { // Make sure no precision was lost casting to 'int'.
+                throw new NumberFormatException("Expected an int but was " + peekedLong + locationString());
+            }
+            peeked = PEEKED_NONE;
+            pathIndices[stackSize - 1]++;
+            return result;
+        }
+
+        if (p == PEEKED_NUMBER) {
+            peekedString = new String(buffer, pos, peekedNumberLength);
+            pos += peekedNumberLength;
+        } else if (p == PEEKED_SINGLE_QUOTED || p == PEEKED_DOUBLE_QUOTED || p == PEEKED_UNQUOTED) {
+            if (p == PEEKED_UNQUOTED) {
+                peekedString = nextUnquotedValue();
+            } else {
+                peekedString = nextQuotedValue(p == PEEKED_SINGLE_QUOTED ? '\'' : '"');
+            }
+            try {
+                result = Integer.parseInt(peekedString);
+                peeked = PEEKED_NONE;
+                pathIndices[stackSize - 1]++;
+                return result;
+            } catch (NumberFormatException ignored) {
+                // Fall back to parse as a double below.
+            }
         } else {
-          break;
+            throw new IllegalStateException("Expected an int but was " + peek() + locationString());
         }
-      }
 
-      // use a StringBuilder when the value is too long. This is too long to be a number!
-      if (builder == null) {
-        builder = new StringBuilder(Math.max(i,16));
-      }
-      builder.append(buffer, pos, i);
-      pos += i;
-      i = 0;
-      if (!fillBuffer(1)) {
-        break;
-      }
-    }
-   
-    String result = (null == builder) ? new String(buffer, pos, i) : builder.append(buffer, pos, i).toString();
-    pos += i;
-    return result;
-  }
-
-  private void skipQuotedValue(char quote) throws IOException {
-    // Like nextNonWhitespace, this uses locals 'p' and 'l' to save inner-loop field access.
-    char[] buffer = this.buffer;
-    do {
-      int p = pos;
-      int l = limit;
-      /* the index of the first character not yet appended to the builder. */
-      while (p < l) {
-        int c = buffer[p++];
-        if (c == quote) {
-          pos = p;
-          return;
-        } else if (c == '\\') {
-          pos = p;
-          readEscapeCharacter();
-          p = pos;
-          l = limit;
-        } else if (c == '\n') {
-          lineNumber++;
-          lineStart = p;
+        peeked = PEEKED_BUFFERED;
+        double asDouble = Double.parseDouble(peekedString); // don't catch this NumberFormatException.
+        result = (int) asDouble;
+        if (result != asDouble) { // Make sure no precision was lost casting to 'int'.
+            throw new NumberFormatException("Expected an int but was " + peekedString + locationString());
         }
-      }
-      pos = p;
-    } while (fillBuffer(1));
-    throw syntaxError("Unterminated string");
-  }
-
-  private void skipUnquotedValue() throws IOException {
-    do {
-      int i = 0;
-      for (; pos + i < limit; i++) {
-        switch (buffer[pos + i]) {
-        case '/':
-        case '\\':
-        case ';':
-        case '#':
-        case '=':
-          checkLenient(); // fall-through
-        case '{':
-        case '}':
-        case '[':
-        case ']':
-        case ':':
-        case ',':
-        case ' ':
-        case '\t':
-        case '\f':
-        case '\r':
-        case '\n':
-          pos += i;
-          return;
-        }
-      }
-      pos += i;
-    } while (fillBuffer(1));
-  }
-
-  /**
-   * Returns the {@link com.google.gson.stream.JsonToken#NUMBER int} value of the next token,
-   * consuming it. If the next token is a string, this method will attempt to
-   * parse it as an int. If the next token's numeric value cannot be exactly
-   * represented by a Java {@code int}, this method throws.
-   *
-   * @throws IllegalStateException if the next token is not a literal value.
-   * @throws NumberFormatException if the next literal value cannot be parsed
-   *     as a number, or exactly represented as an int.
-   */
-  public int nextInt() throws IOException {
-    int p = peeked;
-    if (p == PEEKED_NONE) {
-      p = doPeek();
-    }
-
-    int result;
-    if (p == PEEKED_LONG) {
-      result = (int) peekedLong;
-      if (peekedLong != result) { // Make sure no precision was lost casting to 'int'.
-        throw new NumberFormatException("Expected an int but was " + peekedLong + locationString());
-      }
-      peeked = PEEKED_NONE;
-      pathIndices[stackSize - 1]++;
-      return result;
-    }
-
-    if (p == PEEKED_NUMBER) {
-      peekedString = new String(buffer, pos, peekedNumberLength);
-      pos += peekedNumberLength;
-    } else if (p == PEEKED_SINGLE_QUOTED || p == PEEKED_DOUBLE_QUOTED || p == PEEKED_UNQUOTED) {
-      if (p == PEEKED_UNQUOTED) {
-        peekedString = nextUnquotedValue();
-      } else {
-        peekedString = nextQuotedValue(p == PEEKED_SINGLE_QUOTED ? '\'' : '"');
-      }
-      try {
-        result = Integer.parseInt(peekedString);
+        peekedString = null;
         peeked = PEEKED_NONE;
         pathIndices[stackSize - 1]++;
         return result;
-      } catch (NumberFormatException ignored) {
-        // Fall back to parse as a double below.
-      }
-    } else {
-      throw new IllegalStateException("Expected an int but was " + peek() + locationString());
     }
 
-    peeked = PEEKED_BUFFERED;
-    double asDouble = Double.parseDouble(peekedString); // don't catch this NumberFormatException.
-    result = (int) asDouble;
-    if (result != asDouble) { // Make sure no precision was lost casting to 'int'.
-      throw new NumberFormatException("Expected an int but was " + peekedString + locationString());
-    }
-    peekedString = null;
-    peeked = PEEKED_NONE;
-    pathIndices[stackSize - 1]++;
-    return result;
-  }
-
-  /**
-   * Closes this JSON reader and the underlying {@link java.io.Reader}.
-   */
-  public void close() throws IOException {
-    peeked = PEEKED_NONE;
-    stack[0] = JsonScope.CLOSED;
-    stackSize = 1;
-    in.close();
-  }
-
-  /**
-   * Skips the next value recursively. If it is an object or array, all nested
-   * elements are skipped. This method is intended for use when the JSON token
-   * stream contains unrecognized or unhandled values.
-   */
-  public void skipValue() throws IOException {
-    int count = 0;
-    do {
-      int p = peeked;
-      if (p == PEEKED_NONE) {
-        p = doPeek();
-      }
-
-      if (p == PEEKED_BEGIN_ARRAY) {
-        push(JsonScope.EMPTY_ARRAY);
-        count++;
-      } else if (p == PEEKED_BEGIN_OBJECT) {
-        push(JsonScope.EMPTY_OBJECT);
-        count++;
-      } else if (p == PEEKED_END_ARRAY) {
-        stackSize--;
-        count--;
-      } else if (p == PEEKED_END_OBJECT) {
-        stackSize--;
-        count--;
-      } else if (p == PEEKED_UNQUOTED_NAME || p == PEEKED_UNQUOTED) {
-        skipUnquotedValue();
-      } else if (p == PEEKED_SINGLE_QUOTED || p == PEEKED_SINGLE_QUOTED_NAME) {
-        skipQuotedValue('\'');
-      } else if (p == PEEKED_DOUBLE_QUOTED || p == PEEKED_DOUBLE_QUOTED_NAME) {
-        skipQuotedValue('"');
-      } else if (p == PEEKED_NUMBER) {
-        pos += peekedNumberLength;
-      }
-      peeked = PEEKED_NONE;
-    } while (count != 0);
-
-    pathIndices[stackSize - 1]++;
-    pathNames[stackSize - 1] = "null";
-  }
-
-  private void push(int newTop) {
-    if (stackSize == stack.length) {
-      int newLength = stackSize * 2;
-      stack = Arrays.copyOf(stack, newLength);
-      pathIndices = Arrays.copyOf(pathIndices, newLength);
-      pathNames = Arrays.copyOf(pathNames, newLength);
-    }
-    stack[stackSize++] = newTop;
-  }
-
-  /**
-   * Returns true once {@code limit - pos >= minimum}. If the data is
-   * exhausted before that many characters are available, this returns
-   * false.
-   */
-  private boolean fillBuffer(int minimum) throws IOException {
-    char[] buffer = this.buffer;
-    lineStart -= pos;
-    if (limit != pos) {
-      limit -= pos;
-      System.arraycopy(buffer, pos, buffer, 0, limit);
-    } else {
-      limit = 0;
+    /**
+     * Invalidates(closes) this JSON reader instance.
+     */
+    protected void _invalidateInstance() {
+        peeked = PEEKED_NONE;
+        stack[0] = JsonScope.CLOSED;
+        stackSize = 1;
     }
 
-    pos = 0;
-    int total;
-    while ((total = in.read(buffer, limit, buffer.length - limit)) != -1) {
-      limit += total;
-
-      // if this is the first read, consume an optional byte order mark (BOM) if it exists
-      if (lineNumber == 0 && lineStart == 0 && limit > 0 && buffer[0] == '\ufeff') {
-        pos++;
-        lineStart++;
-        minimum++;
-      }
-
-      if (limit >= minimum) {
-        return true;
-      }
+    /**
+     * Closes the underlying {@link Reader} instance
+     *
+     * @throws IOException if closing the reader fails
+     * @throws NullPointerException if the underlying reader has not been set
+     * yet
+     */
+    protected void _closeReader() throws IOException {
+        in.close();
     }
-    return false;
-  }
 
-  /**
-   * Returns the next character in the stream that is neither whitespace nor a
-   * part of a comment. When this returns, the returned character is always at
-   * {@code buffer[pos-1]}; this means the caller can always push back the
-   * returned character by decrementing {@code pos}.
-   */
-  private int nextNonWhitespace(boolean throwOnEof) throws IOException {
-    /*
+    /**
+     * Closes this JSON reader and the underlying {@link java.io.Reader}.
+     *
+     * @throws IOException if closing the underlying {@link Reader} fails
+     * @throws NullPointerException if underlying {@link Reader} is null, and
+     * should be closed.
+     */
+    @Override
+    public void close() throws IOException {
+        _invalidateInstance();
+        if (closeReaderOnClose) {
+            _closeReader();
+        }
+    }
+
+    /**
+     * Skips the next value recursively. If it is an object or array, all nested
+     * elements are skipped. This method is intended for use when the JSON token
+     * stream contains unrecognized or unhandled values.
+     */
+    public void skipValue() throws IOException {
+        int count = 0;
+        do {
+            int p = peeked;
+            if (p == PEEKED_NONE) {
+                p = doPeek();
+            }
+
+            if (p == PEEKED_BEGIN_ARRAY) {
+                push(JsonScope.EMPTY_ARRAY);
+                count++;
+            } else if (p == PEEKED_BEGIN_OBJECT) {
+                push(JsonScope.EMPTY_OBJECT);
+                count++;
+            } else if (p == PEEKED_END_ARRAY) {
+                stackSize--;
+                count--;
+            } else if (p == PEEKED_END_OBJECT) {
+                stackSize--;
+                count--;
+            } else if (p == PEEKED_UNQUOTED_NAME || p == PEEKED_UNQUOTED) {
+                skipUnquotedValue();
+            } else if (p == PEEKED_SINGLE_QUOTED || p == PEEKED_SINGLE_QUOTED_NAME) {
+                skipQuotedValue('\'');
+            } else if (p == PEEKED_DOUBLE_QUOTED || p == PEEKED_DOUBLE_QUOTED_NAME) {
+                skipQuotedValue('"');
+            } else if (p == PEEKED_NUMBER) {
+                pos += peekedNumberLength;
+            }
+            peeked = PEEKED_NONE;
+        } while (count != 0);
+
+        pathIndices[stackSize - 1]++;
+        pathNames[stackSize - 1] = "null";
+    }
+
+    private void push(int newTop) {
+        if (stackSize == stack.length) {
+            int newLength = stackSize * 2;
+            stack = Arrays.copyOf(stack, newLength);
+            pathIndices = Arrays.copyOf(pathIndices, newLength);
+            pathNames = Arrays.copyOf(pathNames, newLength);
+        }
+        stack[stackSize++] = newTop;
+    }
+
+    /**
+     * Returns true once {@code limit - pos >= minimum}. If the data is
+     * exhausted before that many characters are available, this returns false.
+     */
+    private boolean fillBuffer(int minimum) throws IOException {
+        char[] buffer = this.buffer;
+        lineStart -= pos;
+        if (limit != pos) {
+            limit -= pos;
+            System.arraycopy(buffer, pos, buffer, 0, limit);
+        } else {
+            limit = 0;
+        }
+
+        pos = 0;
+        int total;
+        while ((total = in.read(buffer, limit, buffer.length - limit)) != -1) {
+            limit += total;
+
+            // if this is the first read, consume an optional byte order mark (BOM) if it exists
+            if (lineNumber == 0 && lineStart == 0 && limit > 0 && buffer[0] == '\ufeff') {
+                pos++;
+                lineStart++;
+                minimum++;
+            }
+
+            if (limit >= minimum) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns the next character in the stream that is neither whitespace nor a
+     * part of a comment. When this returns, the returned character is always at
+     * {@code buffer[pos-1]}; this means the caller can always push back the
+     * returned character by decrementing {@code pos}.
+     */
+    private int nextNonWhitespace(boolean throwOnEof) throws IOException {
+        /*
      * This code uses ugly local variables 'p' and 'l' representing the 'pos'
      * and 'limit' fields respectively. Using locals rather than fields saves
      * a few field reads for each whitespace character in a pretty-printed
      * document, resulting in a 5% speedup. We need to flush 'p' to its field
      * before any (potentially indirect) call to fillBuffer() and reread both
      * 'p' and 'l' after any (potentially indirect) call to the same method.
-     */
-    char[] buffer = this.buffer;
-    int p = pos;
-    int l = limit;
-    while (true) {
-      if (p == l) {
-        pos = p;
-        if (!fillBuffer(1)) {
-          break;
-        }
-        p = pos;
-        l = limit;
-      }
+         */
+        char[] buffer = this.buffer;
+        int p = pos;
+        int l = limit;
+        while (true) {
+            if (p == l) {
+                pos = p;
+                if (!fillBuffer(1)) {
+                    break;
+                }
+                p = pos;
+                l = limit;
+            }
 
-      int c = buffer[p++];
-      if (c == '\n') {
-        lineNumber++;
-        lineStart = p;
-        continue;
-      } else if (c == ' ' || c == '\r' || c == '\t') {
-        continue;
-      }
+            int c = buffer[p++];
+            if (c == '\n') {
+                lineNumber++;
+                lineStart = p;
+                continue;
+            } else if (c == ' ' || c == '\r' || c == '\t') {
+                continue;
+            }
 
-      if (c == '/') {
-        pos = p;
-        if (p == l) {
-          pos--; // push back '/' so it's still in the buffer when this method returns
-          boolean charsLoaded = fillBuffer(2);
-          pos++; // consume the '/' again
-          if (!charsLoaded) {
-            return c;
-          }
-        }
+            if (c == '/') {
+                pos = p;
+                if (p == l) {
+                    pos--; // push back '/' so it's still in the buffer when this method returns
+                    boolean charsLoaded = fillBuffer(2);
+                    pos++; // consume the '/' again
+                    if (!charsLoaded) {
+                        return c;
+                    }
+                }
 
-        checkLenient();
-        char peek = buffer[pos];
-        switch (peek) {
-        case '*':
-          // skip a /* c-style comment */
-          pos++;
-          if (!skipTo("*/")) {
-            throw syntaxError("Unterminated comment");
-          }
-          p = pos + 2;
-          l = limit;
-          continue;
+                checkLenient();
+                char peek = buffer[pos];
+                switch (peek) {
+                    case '*':
+                        // skip a /* c-style comment */
+                        pos++;
+                        if (!skipTo("*/")) {
+                            throw syntaxError("Unterminated comment");
+                        }
+                        p = pos + 2;
+                        l = limit;
+                        continue;
 
-        case '/':
-          // skip a // end-of-line comment
-          pos++;
-          skipToEndOfLine();
-          p = pos;
-          l = limit;
-          continue;
+                    case '/':
+                        // skip a // end-of-line comment
+                        pos++;
+                        skipToEndOfLine();
+                        p = pos;
+                        l = limit;
+                        continue;
 
-        default:
-          return c;
-        }
-      } else if (c == '#') {
-        pos = p;
-        /*
+                    default:
+                        return c;
+                }
+            } else if (c == '#') {
+                pos = p;
+                /*
          * Skip a # hash end-of-line comment. The JSON RFC doesn't
          * specify this behaviour, but it's required to parse
          * existing documents. See http://b/2571423.
-         */
-        checkLenient();
-        skipToEndOfLine();
-        p = pos;
-        l = limit;
-      } else {
-        pos = p;
-        return c;
-      }
-    }
-    if (throwOnEof) {
-      throw new EOFException("End of input" + locationString());
-    } else {
-      return -1;
-    }
-  }
-
-  private void checkLenient() throws IOException {
-    if (!lenient) {
-      throw syntaxError("Use JsonReader.setLenient(true) to accept malformed JSON");
-    }
-  }
-
-  /**
-   * Advances the position until after the next newline character. If the line
-   * is terminated by "\r\n", the '\n' must be consumed as whitespace by the
-   * caller.
-   */
-  private void skipToEndOfLine() throws IOException {
-    while (pos < limit || fillBuffer(1)) {
-      char c = buffer[pos++];
-      if (c == '\n') {
-        lineNumber++;
-        lineStart = pos;
-        break;
-      } else if (c == '\r') {
-        break;
-      }
-    }
-  }
-
-  /**
-   * @param toFind a string to search for. Must not contain a newline.
-   */
-  private boolean skipTo(String toFind) throws IOException {
-    int length = toFind.length();
-    outer:
-    for (; pos + length <= limit || fillBuffer(length); pos++) {
-      if (buffer[pos] == '\n') {
-        lineNumber++;
-        lineStart = pos + 1;
-        continue;
-      }
-      for (int c = 0; c < length; c++) {
-        if (buffer[pos + c] != toFind.charAt(c)) {
-          continue outer;
+                 */
+                checkLenient();
+                skipToEndOfLine();
+                p = pos;
+                l = limit;
+            } else {
+                pos = p;
+                return c;
+            }
         }
-      }
-      return true;
-    }
-    return false;
-  }
-
-  @Override public String toString() {
-    return getClass().getSimpleName() + locationString();
-  }
-
-  String locationString() {
-    int line = lineNumber + 1;
-    int column = pos - lineStart + 1;
-    return " at line " + line + " column " + column + " path " + getPath();
-  }
-
-  /**
-   * Returns a <a href="http://goessner.net/articles/JsonPath/">JsonPath</a> to
-   * the current location in the JSON value.
-   */
-  public String getPath() {
-    StringBuilder result = new StringBuilder().append('$');
-    for (int i = 0, size = stackSize; i < size; i++) {
-      switch (stack[i]) {
-        case JsonScope.EMPTY_ARRAY:
-        case JsonScope.NONEMPTY_ARRAY:
-          result.append('[').append(pathIndices[i]).append(']');
-          break;
-
-        case JsonScope.EMPTY_OBJECT:
-        case JsonScope.DANGLING_NAME:
-        case JsonScope.NONEMPTY_OBJECT:
-          result.append('.');
-          if (pathNames[i] != null) {
-            result.append(pathNames[i]);
-          }
-          break;
-
-        case JsonScope.NONEMPTY_DOCUMENT:
-        case JsonScope.EMPTY_DOCUMENT:
-        case JsonScope.CLOSED:
-          break;
-      }
-    }
-    return result.toString();
-  }
-
-  /**
-   * Unescapes the character identified by the character or characters that
-   * immediately follow a backslash. The backslash '\' should have already
-   * been read. This supports both unicode escapes "u000A" and two-character
-   * escapes "\n".
-   *
-   * @throws NumberFormatException if any unicode escape sequences are
-   *     malformed.
-   */
-  private char readEscapeCharacter() throws IOException {
-    if (pos == limit && !fillBuffer(1)) {
-      throw syntaxError("Unterminated escape sequence");
-    }
-
-    char escaped = buffer[pos++];
-    switch (escaped) {
-    case 'u':
-      if (pos + 4 > limit && !fillBuffer(4)) {
-        throw syntaxError("Unterminated escape sequence");
-      }
-      // Equivalent to Integer.parseInt(stringPool.get(buffer, pos, 4), 16);
-      char result = 0;
-      for (int i = pos, end = i + 4; i < end; i++) {
-        char c = buffer[i];
-        result <<= 4;
-        if (c >= '0' && c <= '9') {
-          result += (c - '0');
-        } else if (c >= 'a' && c <= 'f') {
-          result += (c - 'a' + 10);
-        } else if (c >= 'A' && c <= 'F') {
-          result += (c - 'A' + 10);
+        if (throwOnEof) {
+            throw new EOFException("End of input" + locationString());
         } else {
-          throw new NumberFormatException("\\u" + new String(buffer, pos, 4));
+            return -1;
         }
-      }
-      pos += 4;
-      return result;
-
-    case 't':
-      return '\t';
-
-    case 'b':
-      return '\b';
-
-    case 'n':
-      return '\n';
-
-    case 'r':
-      return '\r';
-
-    case 'f':
-      return '\f';
-
-    case '\n':
-      lineNumber++;
-      lineStart = pos;
-      // fall-through
-
-    case '\'':
-    case '"':
-    case '\\':
-    case '/':	
-    	return escaped;
-    default:
-    	// throw error when none of the above cases are matched
-    	throw syntaxError("Invalid escape sequence");
-    }
-  }
-
-  /**
-   * Throws a new IO exception with the given message and a context snippet
-   * with this reader's content.
-   */
-  private IOException syntaxError(String message) throws IOException {
-    throw new MalformedJsonException(message + locationString());
-  }
-
-  /**
-   * Consumes the non-execute prefix if it exists.
-   */
-  private void consumeNonExecutePrefix() throws IOException {
-    // fast forward through the leading whitespace
-    nextNonWhitespace(true);
-    pos--;
-
-    int p = pos;
-    if (p + 5 > limit && !fillBuffer(5)) {
-      return;
     }
 
-    char[] buf = buffer;
-    if(buf[p] != ')' || buf[p + 1] != ']' || buf[p + 2] != '}' || buf[p + 3] != '\'' || buf[p + 4] != '\n') {
-      return; // not a security token!
+    private void checkLenient() throws IOException {
+        if (!lenient) {
+            throw syntaxError("Use JsonReader.setLenient(true) to accept malformed JSON");
+        }
     }
 
-    // we consumed a security token!
-    pos += 5;
-  }
+    /**
+     * Advances the position until after the next newline character. If the line
+     * is terminated by "\r\n", the '\n' must be consumed as whitespace by the
+     * caller.
+     */
+    private void skipToEndOfLine() throws IOException {
+        while (pos < limit || fillBuffer(1)) {
+            char c = buffer[pos++];
+            if (c == '\n') {
+                lineNumber++;
+                lineStart = pos;
+                break;
+            } else if (c == '\r') {
+                break;
+            }
+        }
+    }
 
-  static {
-    JsonReaderInternalAccess.INSTANCE = new JsonReaderInternalAccess() {
-      @Override public void promoteNameToValue(JsonReader reader) throws IOException {
-        if (reader instanceof JsonTreeReader) {
-          ((JsonTreeReader)reader).promoteNameToValue();
-          return;
+    /**
+     * @param toFind a string to search for. Must not contain a newline.
+     */
+    private boolean skipTo(String toFind) throws IOException {
+        int length = toFind.length();
+        outer:
+        for (; pos + length <= limit || fillBuffer(length); pos++) {
+            if (buffer[pos] == '\n') {
+                lineNumber++;
+                lineStart = pos + 1;
+                continue;
+            }
+            for (int c = 0; c < length; c++) {
+                if (buffer[pos + c] != toFind.charAt(c)) {
+                    continue outer;
+                }
+            }
+            return true;
         }
-        int p = reader.peeked;
-        if (p == PEEKED_NONE) {
-          p = reader.doPeek();
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + locationString();
+    }
+
+    String locationString() {
+        int line = lineNumber + 1;
+        int column = pos - lineStart + 1;
+        return " at line " + line + " column " + column + " path " + getPath();
+    }
+
+    /**
+     * Returns a <a href="http://goessner.net/articles/JsonPath/">JsonPath</a>
+     * to the current location in the JSON value.
+     */
+    public String getPath() {
+        StringBuilder result = new StringBuilder().append('$');
+        for (int i = 0, size = stackSize; i < size; i++) {
+            switch (stack[i]) {
+                case JsonScope.EMPTY_ARRAY:
+                case JsonScope.NONEMPTY_ARRAY:
+                    result.append('[').append(pathIndices[i]).append(']');
+                    break;
+
+                case JsonScope.EMPTY_OBJECT:
+                case JsonScope.DANGLING_NAME:
+                case JsonScope.NONEMPTY_OBJECT:
+                    result.append('.');
+                    if (pathNames[i] != null) {
+                        result.append(pathNames[i]);
+                    }
+                    break;
+
+                case JsonScope.NONEMPTY_DOCUMENT:
+                case JsonScope.EMPTY_DOCUMENT:
+                case JsonScope.CLOSED:
+                    break;
+            }
         }
-        if (p == PEEKED_DOUBLE_QUOTED_NAME) {
-          reader.peeked = PEEKED_DOUBLE_QUOTED;
-        } else if (p == PEEKED_SINGLE_QUOTED_NAME) {
-          reader.peeked = PEEKED_SINGLE_QUOTED;
-        } else if (p == PEEKED_UNQUOTED_NAME) {
-          reader.peeked = PEEKED_UNQUOTED;
-        } else {
-          throw new IllegalStateException(
-              "Expected a name but was " + reader.peek() + reader.locationString());
+        return result.toString();
+    }
+
+    /**
+     * Unescapes the character identified by the character or characters that
+     * immediately follow a backslash. The backslash '\' should have already
+     * been read. This supports both unicode escapes "u000A" and two-character
+     * escapes "\n".
+     *
+     * @throws NumberFormatException if any unicode escape sequences are
+     * malformed.
+     */
+    private char readEscapeCharacter() throws IOException {
+        if (pos == limit && !fillBuffer(1)) {
+            throw syntaxError("Unterminated escape sequence");
         }
-      }
-    };
-  }
+
+        char escaped = buffer[pos++];
+        switch (escaped) {
+            case 'u':
+                if (pos + 4 > limit && !fillBuffer(4)) {
+                    throw syntaxError("Unterminated escape sequence");
+                }
+                // Equivalent to Integer.parseInt(stringPool.get(buffer, pos, 4), 16);
+                char result = 0;
+                for (int i = pos, end = i + 4; i < end; i++) {
+                    char c = buffer[i];
+                    result <<= 4;
+                    if (c >= '0' && c <= '9') {
+                        result += (c - '0');
+                    } else if (c >= 'a' && c <= 'f') {
+                        result += (c - 'a' + 10);
+                    } else if (c >= 'A' && c <= 'F') {
+                        result += (c - 'A' + 10);
+                    } else {
+                        throw new NumberFormatException("\\u" + new String(buffer, pos, 4));
+                    }
+                }
+                pos += 4;
+                return result;
+
+            case 't':
+                return '\t';
+
+            case 'b':
+                return '\b';
+
+            case 'n':
+                return '\n';
+
+            case 'r':
+                return '\r';
+
+            case 'f':
+                return '\f';
+
+            case '\n':
+                lineNumber++;
+                lineStart = pos;
+            // fall-through
+
+            case '\'':
+            case '"':
+            case '\\':
+            case '/':
+                return escaped;
+            default:
+                // throw error when none of the above cases are matched
+                throw syntaxError("Invalid escape sequence");
+        }
+    }
+
+    /**
+     * Throws a new IO exception with the given message and a context snippet
+     * with this reader's content.
+     */
+    private IOException syntaxError(String message) throws IOException {
+        throw new MalformedJsonException(message + locationString());
+    }
+
+    /**
+     * Consumes the non-execute prefix if it exists.
+     */
+    private void consumeNonExecutePrefix() throws IOException {
+        // fast forward through the leading whitespace
+        nextNonWhitespace(true);
+        pos--;
+
+        int p = pos;
+        if (p + 5 > limit && !fillBuffer(5)) {
+            return;
+        }
+
+        char[] buf = buffer;
+        if (buf[p] != ')' || buf[p + 1] != ']' || buf[p + 2] != '}' || buf[p + 3] != '\'' || buf[p + 4] != '\n') {
+            return; // not a security token!
+        }
+
+        // we consumed a security token!
+        pos += 5;
+    }
+
+    static {
+        JsonReaderInternalAccess.INSTANCE = new JsonReaderInternalAccess() {
+            @Override
+            public void promoteNameToValue(JsonReader reader) throws IOException {
+                if (reader instanceof JsonTreeReader) {
+                    ((JsonTreeReader) reader).promoteNameToValue();
+                    return;
+                }
+                int p = reader.peeked;
+                if (p == PEEKED_NONE) {
+                    p = reader.doPeek();
+                }
+                if (p == PEEKED_DOUBLE_QUOTED_NAME) {
+                    reader.peeked = PEEKED_DOUBLE_QUOTED;
+                } else if (p == PEEKED_SINGLE_QUOTED_NAME) {
+                    reader.peeked = PEEKED_SINGLE_QUOTED;
+                } else if (p == PEEKED_UNQUOTED_NAME) {
+                    reader.peeked = PEEKED_UNQUOTED;
+                } else {
+                    throw new IllegalStateException(
+                            "Expected a name but was " + reader.peek() + reader.locationString());
+                }
+            }
+        };
+    }
 }

--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.gson.stream;
 
 import java.io.Closeable;
@@ -42,19 +41,20 @@ import static com.google.gson.stream.JsonScope.NONEMPTY_OBJECT;
  * writer as you walk the structure's contents, nesting arrays and objects as
  * necessary:
  * <ul>
- *   <li>To write <strong>arrays</strong>, first call {@link #beginArray()}.
- *       Write each of the array's elements with the appropriate {@link #value}
- *       methods or by nesting other arrays and objects. Finally close the array
- *       using {@link #endArray()}.
- *   <li>To write <strong>objects</strong>, first call {@link #beginObject()}.
- *       Write each of the object's properties by alternating calls to
- *       {@link #name} with the property's value. Write property values with the
- *       appropriate {@link #value} method or by nesting other objects or arrays.
- *       Finally close the object using {@link #endObject()}.
+ * <li>To write <strong>arrays</strong>, first call {@link #beginArray()}. Write
+ * each of the array's elements with the appropriate {@link #value} methods or
+ * by nesting other arrays and objects. Finally close the array using
+ * {@link #endArray()}.
+ * <li>To write <strong>objects</strong>, first call {@link #beginObject()}.
+ * Write each of the object's properties by alternating calls to {@link #name}
+ * with the property's value. Write property values with the appropriate
+ * {@link #value} method or by nesting other objects or arrays. Finally close
+ * the object using {@link #endObject()}.
  * </ul>
  *
  * <h3>Example</h3>
- * Suppose we'd like to encode a stream of messages such as the following: <pre> {@code
+ * Suppose we'd like to encode a stream of messages such as the following:
+ * <pre> {@code
  * [
  *   {
  *     "id": 912345678901,
@@ -74,8 +74,8 @@ import static com.google.gson.stream.JsonScope.NONEMPTY_OBJECT;
  *       "followers_count": 2
  *     }
  *   }
- * ]}</pre>
- * This code encodes the above structure: <pre>   {@code
+ * ]}</pre> This code encodes the above structure:
+ * <pre>   {@code
  *   public void writeJsonStream(OutputStream out, List<Message> messages) throws IOException {
  *     JsonWriter writer = new JsonWriter(new OutputStreamWriter(out, "UTF-8"));
  *     writer.setIndent("    ");
@@ -121,16 +121,21 @@ import static com.google.gson.stream.JsonScope.NONEMPTY_OBJECT;
  *     writer.endArray();
  *   }}</pre>
  *
- * <p>Each {@code JsonWriter} may be used to write a single JSON stream.
- * Instances of this class are not thread safe. Calls that would result in a
- * malformed JSON string will fail with an {@link IllegalStateException}.
+ * <p>
+ * Each {@code JsonWriter} may be used to write a single JSON stream. Instances
+ * of this class are not thread safe. Calls that would result in a malformed
+ * JSON string will fail with an {@link IllegalStateException}.
+ * <p>
+ * This type is immutable. Considering {@link MutableJsonWriter} which is a
+ * mutable version of this.
  *
  * @author Jesse Wilson
+ * @author https://github.com/911992
  * @since 1.6
  */
 public class JsonWriter implements Closeable, Flushable {
 
-  /*
+    /*
    * From RFC 7159, "All Unicode characters may be placed within the
    * quotation marks except for the characters that must be escaped:
    * quotation mark, reverse solidus, and the control characters
@@ -139,520 +144,560 @@ public class JsonWriter implements Closeable, Flushable {
    * We also escape '\u2028' and '\u2029', which JavaScript interprets as
    * newline characters. This prevents eval() from failing with a syntax
    * error. http://code.google.com/p/google-gson/issues/detail?id=341
-   */
-  private static final String[] REPLACEMENT_CHARS;
-  private static final String[] HTML_SAFE_REPLACEMENT_CHARS;
-  static {
-    REPLACEMENT_CHARS = new String[128];
-    for (int i = 0; i <= 0x1f; i++) {
-      REPLACEMENT_CHARS[i] = String.format("\\u%04x", (int) i);
-    }
-    REPLACEMENT_CHARS['"'] = "\\\"";
-    REPLACEMENT_CHARS['\\'] = "\\\\";
-    REPLACEMENT_CHARS['\t'] = "\\t";
-    REPLACEMENT_CHARS['\b'] = "\\b";
-    REPLACEMENT_CHARS['\n'] = "\\n";
-    REPLACEMENT_CHARS['\r'] = "\\r";
-    REPLACEMENT_CHARS['\f'] = "\\f";
-    HTML_SAFE_REPLACEMENT_CHARS = REPLACEMENT_CHARS.clone();
-    HTML_SAFE_REPLACEMENT_CHARS['<'] = "\\u003c";
-    HTML_SAFE_REPLACEMENT_CHARS['>'] = "\\u003e";
-    HTML_SAFE_REPLACEMENT_CHARS['&'] = "\\u0026";
-    HTML_SAFE_REPLACEMENT_CHARS['='] = "\\u003d";
-    HTML_SAFE_REPLACEMENT_CHARS['\''] = "\\u0027";
-  }
+     */
+    private static final String[] REPLACEMENT_CHARS;
+    private static final String[] HTML_SAFE_REPLACEMENT_CHARS;
 
-  /** The output data, containing at most one top-level array or object. */
-  private final Writer out;
-
-  private int[] stack = new int[32];
-  private int stackSize = 0;
-  {
-    push(EMPTY_DOCUMENT);
-  }
-
-  /**
-   * A string containing a full set of spaces for a single level of
-   * indentation, or null for no pretty printing.
-   */
-  private String indent;
-
-  /**
-   * The name/value separator; either ":" or ": ".
-   */
-  private String separator = ":";
-
-  private boolean lenient;
-
-  private boolean htmlSafe;
-
-  private String deferredName;
-
-  private boolean serializeNulls = true;
-
-  /**
-   * Creates a new instance that writes a JSON-encoded stream to {@code out}.
-   * For best performance, ensure {@link Writer} is buffered; wrapping in
-   * {@link java.io.BufferedWriter BufferedWriter} if necessary.
-   */
-  public JsonWriter(Writer out) {
-    if (out == null) {
-      throw new NullPointerException("out == null");
-    }
-    this.out = out;
-  }
-
-  /**
-   * Sets the indentation string to be repeated for each level of indentation
-   * in the encoded document. If {@code indent.isEmpty()} the encoded document
-   * will be compact. Otherwise the encoded document will be more
-   * human-readable.
-   *
-   * @param indent a string containing only whitespace.
-   */
-  public final void setIndent(String indent) {
-    if (indent.length() == 0) {
-      this.indent = null;
-      this.separator = ":";
-    } else {
-      this.indent = indent;
-      this.separator = ": ";
-    }
-  }
-
-  /**
-   * Configure this writer to relax its syntax rules. By default, this writer
-   * only emits well-formed JSON as specified by <a
-   * href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>. Setting the writer
-   * to lenient permits the following:
-   * <ul>
-   *   <li>Top-level values of any type. With strict writing, the top-level
-   *       value must be an object or an array.
-   *   <li>Numbers may be {@link Double#isNaN() NaNs} or {@link
-   *       Double#isInfinite() infinities}.
-   * </ul>
-   */
-  public final void setLenient(boolean lenient) {
-    this.lenient = lenient;
-  }
-
-  /**
-   * Returns true if this writer has relaxed syntax rules.
-   */
-  public boolean isLenient() {
-    return lenient;
-  }
-
-  /**
-   * Configure this writer to emit JSON that's safe for direct inclusion in HTML
-   * and XML documents. This escapes the HTML characters {@code <}, {@code >},
-   * {@code &} and {@code =} before writing them to the stream. Without this
-   * setting, your XML/HTML encoder should replace these characters with the
-   * corresponding escape sequences.
-   */
-  public final void setHtmlSafe(boolean htmlSafe) {
-    this.htmlSafe = htmlSafe;
-  }
-
-  /**
-   * Returns true if this writer writes JSON that's safe for inclusion in HTML
-   * and XML documents.
-   */
-  public final boolean isHtmlSafe() {
-    return htmlSafe;
-  }
-
-  /**
-   * Sets whether object members are serialized when their value is null.
-   * This has no impact on array elements. The default is true.
-   */
-  public final void setSerializeNulls(boolean serializeNulls) {
-    this.serializeNulls = serializeNulls;
-  }
-
-  /**
-   * Returns true if object members are serialized when their value is null.
-   * This has no impact on array elements. The default is true.
-   */
-  public final boolean getSerializeNulls() {
-    return serializeNulls;
-  }
-
-  /**
-   * Begins encoding a new array. Each call to this method must be paired with
-   * a call to {@link #endArray}.
-   *
-   * @return this writer.
-   */
-  public JsonWriter beginArray() throws IOException {
-    writeDeferredName();
-    return open(EMPTY_ARRAY, '[');
-  }
-
-  /**
-   * Ends encoding the current array.
-   *
-   * @return this writer.
-   */
-  public JsonWriter endArray() throws IOException {
-    return close(EMPTY_ARRAY, NONEMPTY_ARRAY, ']');
-  }
-
-  /**
-   * Begins encoding a new object. Each call to this method must be paired
-   * with a call to {@link #endObject}.
-   *
-   * @return this writer.
-   */
-  public JsonWriter beginObject() throws IOException {
-    writeDeferredName();
-    return open(EMPTY_OBJECT, '{');
-  }
-
-  /**
-   * Ends encoding the current object.
-   *
-   * @return this writer.
-   */
-  public JsonWriter endObject() throws IOException {
-    return close(EMPTY_OBJECT, NONEMPTY_OBJECT, '}');
-  }
-
-  /**
-   * Enters a new scope by appending any necessary whitespace and the given
-   * bracket.
-   */
-  private JsonWriter open(int empty, char openBracket) throws IOException {
-    beforeValue();
-    push(empty);
-    out.write(openBracket);
-    return this;
-  }
-
-  /**
-   * Closes the current scope by appending any necessary whitespace and the
-   * given bracket.
-   */
-  private JsonWriter close(int empty, int nonempty, char closeBracket)
-      throws IOException {
-    int context = peek();
-    if (context != nonempty && context != empty) {
-      throw new IllegalStateException("Nesting problem.");
-    }
-    if (deferredName != null) {
-      throw new IllegalStateException("Dangling name: " + deferredName);
-    }
-
-    stackSize--;
-    if (context == nonempty) {
-      newline();
-    }
-    out.write(closeBracket);
-    return this;
-  }
-
-  private void push(int newTop) {
-    if (stackSize == stack.length) {
-      stack = Arrays.copyOf(stack, stackSize * 2);
-    }
-    stack[stackSize++] = newTop;
-  }
-
-  /**
-   * Returns the value on the top of the stack.
-   */
-  private int peek() {
-    if (stackSize == 0) {
-      throw new IllegalStateException("JsonWriter is closed.");
-    }
-    return stack[stackSize - 1];
-  }
-
-  /**
-   * Replace the value on the top of the stack with the given value.
-   */
-  private void replaceTop(int topOfStack) {
-    stack[stackSize - 1] = topOfStack;
-  }
-
-  /**
-   * Encodes the property name.
-   *
-   * @param name the name of the forthcoming value. May not be null.
-   * @return this writer.
-   */
-  public JsonWriter name(String name) throws IOException {
-    if (name == null) {
-      throw new NullPointerException("name == null");
-    }
-    if (deferredName != null) {
-      throw new IllegalStateException();
-    }
-    if (stackSize == 0) {
-      throw new IllegalStateException("JsonWriter is closed.");
-    }
-    deferredName = name;
-    return this;
-  }
-
-  private void writeDeferredName() throws IOException {
-    if (deferredName != null) {
-      beforeName();
-      string(deferredName);
-      deferredName = null;
-    }
-  }
-
-  /**
-   * Encodes {@code value}.
-   *
-   * @param value the literal string value, or null to encode a null literal.
-   * @return this writer.
-   */
-  public JsonWriter value(String value) throws IOException {
-    if (value == null) {
-      return nullValue();
-    }
-    writeDeferredName();
-    beforeValue();
-    string(value);
-    return this;
-  }
-
-  /**
-   * Writes {@code value} directly to the writer without quoting or
-   * escaping.
-   *
-   * @param value the literal string value, or null to encode a null literal.
-   * @return this writer.
-   */
-  public JsonWriter jsonValue(String value) throws IOException {
-    if (value == null) {
-      return nullValue();
-    }
-    writeDeferredName();
-    beforeValue();
-    out.append(value);
-    return this;
-  }
-
-  /**
-   * Encodes {@code null}.
-   *
-   * @return this writer.
-   */
-  public JsonWriter nullValue() throws IOException {
-    if (deferredName != null) {
-      if (serializeNulls) {
-        writeDeferredName();
-      } else {
-        deferredName = null;
-        return this; // skip the name and the value
-      }
-    }
-    beforeValue();
-    out.write("null");
-    return this;
-  }
-
-  /**
-   * Encodes {@code value}.
-   *
-   * @return this writer.
-   */
-  public JsonWriter value(boolean value) throws IOException {
-    writeDeferredName();
-    beforeValue();
-    out.write(value ? "true" : "false");
-    return this;
-  }
-
-  /**
-   * Encodes {@code value}.
-   *
-   * @return this writer.
-   */
-  public JsonWriter value(Boolean value) throws IOException {
-    if (value == null) {
-      return nullValue();
-    }
-    writeDeferredName();
-    beforeValue();
-    out.write(value ? "true" : "false");
-    return this;
-  }
-
-  /**
-   * Encodes {@code value}.
-   *
-   * @param value a finite value. May not be {@link Double#isNaN() NaNs} or
-   *     {@link Double#isInfinite() infinities}.
-   * @return this writer.
-   */
-  public JsonWriter value(double value) throws IOException {
-    writeDeferredName();
-    if (!lenient && (Double.isNaN(value) || Double.isInfinite(value))) {
-      throw new IllegalArgumentException("Numeric values must be finite, but was " + value);
-    }
-    beforeValue();
-    out.append(Double.toString(value));
-    return this;
-  }
-
-  /**
-   * Encodes {@code value}.
-   *
-   * @return this writer.
-   */
-  public JsonWriter value(long value) throws IOException {
-    writeDeferredName();
-    beforeValue();
-    out.write(Long.toString(value));
-    return this;
-  }
-
-  /**
-   * Encodes {@code value}.
-   *
-   * @param value a finite value. May not be {@link Double#isNaN() NaNs} or
-   *     {@link Double#isInfinite() infinities}.
-   * @return this writer.
-   */
-  public JsonWriter value(Number value) throws IOException {
-    if (value == null) {
-      return nullValue();
-    }
-
-    writeDeferredName();
-    String string = value.toString();
-    if (!lenient
-        && (string.equals("-Infinity") || string.equals("Infinity") || string.equals("NaN"))) {
-      throw new IllegalArgumentException("Numeric values must be finite, but was " + value);
-    }
-    beforeValue();
-    out.append(string);
-    return this;
-  }
-
-  /**
-   * Ensures all buffered data is written to the underlying {@link Writer}
-   * and flushes that writer.
-   */
-  public void flush() throws IOException {
-    if (stackSize == 0) {
-      throw new IllegalStateException("JsonWriter is closed.");
-    }
-    out.flush();
-  }
-
-  /**
-   * Flushes and closes this writer and the underlying {@link Writer}.
-   *
-   * @throws IOException if the JSON document is incomplete.
-   */
-  public void close() throws IOException {
-    out.close();
-
-    int size = stackSize;
-    if (size > 1 || size == 1 && stack[size - 1] != NONEMPTY_DOCUMENT) {
-      throw new IOException("Incomplete document");
-    }
-    stackSize = 0;
-  }
-
-  private void string(String value) throws IOException {
-    String[] replacements = htmlSafe ? HTML_SAFE_REPLACEMENT_CHARS : REPLACEMENT_CHARS;
-    out.write('\"');
-    int last = 0;
-    int length = value.length();
-    for (int i = 0; i < length; i++) {
-      char c = value.charAt(i);
-      String replacement;
-      if (c < 128) {
-        replacement = replacements[c];
-        if (replacement == null) {
-          continue;
+    static {
+        REPLACEMENT_CHARS = new String[128];
+        for (int i = 0; i <= 0x1f; i++) {
+            REPLACEMENT_CHARS[i] = String.format("\\u%04x", (int) i);
         }
-      } else if (c == '\u2028') {
-        replacement = "\\u2028";
-      } else if (c == '\u2029') {
-        replacement = "\\u2029";
-      } else {
-        continue;
-      }
-      if (last < i) {
-        out.write(value, last, i - last);
-      }
-      out.write(replacement);
-      last = i + 1;
-    }
-    if (last < length) {
-      out.write(value, last, length - last);
-    }
-    out.write('\"');
-  }
-
-  private void newline() throws IOException {
-    if (indent == null) {
-      return;
+        REPLACEMENT_CHARS['"'] = "\\\"";
+        REPLACEMENT_CHARS['\\'] = "\\\\";
+        REPLACEMENT_CHARS['\t'] = "\\t";
+        REPLACEMENT_CHARS['\b'] = "\\b";
+        REPLACEMENT_CHARS['\n'] = "\\n";
+        REPLACEMENT_CHARS['\r'] = "\\r";
+        REPLACEMENT_CHARS['\f'] = "\\f";
+        HTML_SAFE_REPLACEMENT_CHARS = REPLACEMENT_CHARS.clone();
+        HTML_SAFE_REPLACEMENT_CHARS['<'] = "\\u003c";
+        HTML_SAFE_REPLACEMENT_CHARS['>'] = "\\u003e";
+        HTML_SAFE_REPLACEMENT_CHARS['&'] = "\\u0026";
+        HTML_SAFE_REPLACEMENT_CHARS['='] = "\\u003d";
+        HTML_SAFE_REPLACEMENT_CHARS['\''] = "\\u0027";
     }
 
-    out.write('\n');
-    for (int i = 1, size = stackSize; i < size; i++) {
-      out.write(indent);
+    /**
+     * The output data, containing at most one top-level array or object.
+     */
+    protected Writer out;
+
+    /**
+     * indicates, if the out should be closed, by closing this instance.
+     */
+    protected boolean closeWriterOnClose = true;
+
+    private int[] stack = new int[32];
+    private int stackSize = 0;
+//  {
+//    push(EMPTY_DOCUMENT);
+//  }
+
+    /**
+     * Initializes the instance, as {@code EMPTY_DOCUMENT}.
+     */
+    protected void _init() {
+        stackSize = 0;
+        Arrays.fill(stack, 0);
+        push(EMPTY_DOCUMENT);
     }
-  }
 
-  /**
-   * Inserts any necessary separators and whitespace before a name. Also
-   * adjusts the stack to expect the name's value.
-   */
-  private void beforeName() throws IOException {
-    int context = peek();
-    if (context == NONEMPTY_OBJECT) { // first in object
-      out.write(',');
-    } else if (context != EMPTY_OBJECT) { // not in an object!
-      throw new IllegalStateException("Nesting problem.");
+    protected void _reset(Writer arg_out, boolean arg_also_init) {
+        this.out = arg_out;
+        if (arg_also_init) {
+            _init();
+        }
     }
-    newline();
-    replaceTop(DANGLING_NAME);
-  }
 
-  /**
-   * Inserts any necessary separators and whitespace before a literal value,
-   * inline array, or inline object. Also adjusts the stack to expect either a
-   * closing bracket or another element.
-   */
-  @SuppressWarnings("fallthrough")
-  private void beforeValue() throws IOException {
-    switch (peek()) {
-    case NONEMPTY_DOCUMENT:
-      if (!lenient) {
-        throw new IllegalStateException(
-            "JSON must have only one top-level value.");
-      }
-      // fall-through
-    case EMPTY_DOCUMENT: // first in document
-      replaceTop(NONEMPTY_DOCUMENT);
-      break;
+    /**
+     * A string containing a full reset of spaces for a single level of
+     * indentation, or null for no pretty printing.
+     */
+    private String indent;
 
-    case EMPTY_ARRAY: // first in array
-      replaceTop(NONEMPTY_ARRAY);
-      newline();
-      break;
+    /**
+     * The name/value separator; either ":" or ": ".
+     */
+    private String separator = ":";
 
-    case NONEMPTY_ARRAY: // another in array
-      out.append(',');
-      newline();
-      break;
+    private boolean lenient;
 
-    case DANGLING_NAME: // value for name
-      out.append(separator);
-      replaceTop(NONEMPTY_OBJECT);
-      break;
+    private boolean htmlSafe;
 
-    default:
-      throw new IllegalStateException("Nesting problem.");
+    private String deferredName;
+
+    private boolean serializeNulls = true;
+
+    /**
+     * Creates a new instance that writes a JSON-encoded stream to {@code out}.
+     * For best performance, ensure {@link Writer} is buffered; wrapping in
+     * {@link java.io.BufferedWriter BufferedWriter} if necessary.
+     */
+    public JsonWriter(Writer out) {
+        if (out == null) {
+            throw new NullPointerException("out == null");
+        }
+        _reset(out, true);
     }
-  }
+
+    /**
+     * Creates a new instance, with an invalid state.
+     * <p>
+     * Before any write-call, make sure the {@link #out} has been reset,
+     * otherwise there will be exceptions.
+     * </p>
+     *
+     * @see #_reset(java.io.Writer, boolean)
+     * @see JsonWriterMutable
+     * @since +2.8.7-SNAPSHOT ?
+     */
+    protected JsonWriter() {
+
+    }
+
+    /**
+     * Sets the indentation string to be repeated for each level of indentation
+     * in the encoded document. If {@code indent.isEmpty()} the encoded document
+     * will be compact. Otherwise the encoded document will be more
+     * human-readable.
+     *
+     * @param indent a string containing only whitespace.
+     */
+    public final void setIndent(String indent) {
+        if (indent.length() == 0) {
+            this.indent = null;
+            this.separator = ":";
+        } else {
+            this.indent = indent;
+            this.separator = ": ";
+        }
+    }
+
+    /**
+     * Configure this writer to relax its syntax rules. By default, this writer
+     * only emits well-formed JSON as specified by <a
+     * href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>. Setting the
+     * writer to lenient permits the following:
+     * <ul>
+     * <li>Top-level values of any type. With strict writing, the top-level
+     * value must be an object or an array.
+     * <li>Numbers may be {@link Double#isNaN() NaNs} or {@link
+     *       Double#isInfinite() infinities}.
+     * </ul>
+     */
+    public final void setLenient(boolean lenient) {
+        this.lenient = lenient;
+    }
+
+    /**
+     * Returns true if this writer has relaxed syntax rules.
+     */
+    public boolean isLenient() {
+        return lenient;
+    }
+
+    /**
+     * Configure this writer to emit JSON that's safe for direct inclusion in
+     * HTML and XML documents. This escapes the HTML characters {@code <}, {@code >},
+     * {@code &} and {@code =} before writing them to the stream. Without this
+     * setting, your XML/HTML encoder should replace these characters with the
+     * corresponding escape sequences.
+     */
+    public final void setHtmlSafe(boolean htmlSafe) {
+        this.htmlSafe = htmlSafe;
+    }
+
+    /**
+     * Returns true if this writer writes JSON that's safe for inclusion in HTML
+     * and XML documents.
+     */
+    public final boolean isHtmlSafe() {
+        return htmlSafe;
+    }
+
+    /**
+     * Sets whether object members are serialized when their value is null. This
+     * has no impact on array elements. The default is true.
+     */
+    public final void setSerializeNulls(boolean serializeNulls) {
+        this.serializeNulls = serializeNulls;
+    }
+
+    /**
+     * Returns true if object members are serialized when their value is null.
+     * This has no impact on array elements. The default is true.
+     */
+    public final boolean getSerializeNulls() {
+        return serializeNulls;
+    }
+
+    /**
+     * Begins encoding a new array. Each call to this method must be paired with
+     * a call to {@link #endArray}.
+     *
+     * @return this writer.
+     */
+    public JsonWriter beginArray() throws IOException {
+        writeDeferredName();
+        return open(EMPTY_ARRAY, '[');
+    }
+
+    /**
+     * Ends encoding the current array.
+     *
+     * @return this writer.
+     */
+    public JsonWriter endArray() throws IOException {
+        return close(EMPTY_ARRAY, NONEMPTY_ARRAY, ']');
+    }
+
+    /**
+     * Begins encoding a new object. Each call to this method must be paired
+     * with a call to {@link #endObject}.
+     *
+     * @return this writer.
+     */
+    public JsonWriter beginObject() throws IOException {
+        writeDeferredName();
+        return open(EMPTY_OBJECT, '{');
+    }
+
+    /**
+     * Ends encoding the current object.
+     *
+     * @return this writer.
+     */
+    public JsonWriter endObject() throws IOException {
+        return close(EMPTY_OBJECT, NONEMPTY_OBJECT, '}');
+    }
+
+    /**
+     * Enters a new scope by appending any necessary whitespace and the given
+     * bracket.
+     */
+    private JsonWriter open(int empty, char openBracket) throws IOException {
+        beforeValue();
+        push(empty);
+        out.write(openBracket);
+        return this;
+    }
+
+    /**
+     * Closes the current scope by appending any necessary whitespace and the
+     * given bracket.
+     */
+    private JsonWriter close(int empty, int nonempty, char closeBracket)
+            throws IOException {
+        int context = peek();
+        if (context != nonempty && context != empty) {
+            throw new IllegalStateException("Nesting problem.");
+        }
+        if (deferredName != null) {
+            throw new IllegalStateException("Dangling name: " + deferredName);
+        }
+
+        stackSize--;
+        if (context == nonempty) {
+            newline();
+        }
+        out.write(closeBracket);
+        return this;
+    }
+
+    private void push(int newTop) {
+        if (stackSize == stack.length) {
+            stack = Arrays.copyOf(stack, stackSize * 2);
+        }
+        stack[stackSize++] = newTop;
+    }
+
+    /**
+     * Returns the value on the top of the stack.
+     */
+    private int peek() {
+        if (stackSize == 0) {
+            throw new IllegalStateException("JsonWriter is closed.");
+        }
+        return stack[stackSize - 1];
+    }
+
+    /**
+     * Replace the value on the top of the stack with the given value.
+     */
+    private void replaceTop(int topOfStack) {
+        stack[stackSize - 1] = topOfStack;
+    }
+
+    /**
+     * Encodes the property name.
+     *
+     * @param name the name of the forthcoming value. May not be null.
+     * @return this writer.
+     */
+    public JsonWriter name(String name) throws IOException {
+        if (name == null) {
+            throw new NullPointerException("name == null");
+        }
+        if (deferredName != null) {
+            throw new IllegalStateException();
+        }
+        if (stackSize == 0) {
+            throw new IllegalStateException("JsonWriter is closed.");
+        }
+        deferredName = name;
+        return this;
+    }
+
+    private void writeDeferredName() throws IOException {
+        if (deferredName != null) {
+            beforeName();
+            string(deferredName);
+            deferredName = null;
+        }
+    }
+
+    /**
+     * Encodes {@code value}.
+     *
+     * @param value the literal string value, or null to encode a null literal.
+     * @return this writer.
+     */
+    public JsonWriter value(String value) throws IOException {
+        if (value == null) {
+            return nullValue();
+        }
+        writeDeferredName();
+        beforeValue();
+        string(value);
+        return this;
+    }
+
+    /**
+     * Writes {@code value} directly to the writer without quoting or escaping.
+     *
+     * @param value the literal string value, or null to encode a null literal.
+     * @return this writer.
+     */
+    public JsonWriter jsonValue(String value) throws IOException {
+        if (value == null) {
+            return nullValue();
+        }
+        writeDeferredName();
+        beforeValue();
+        out.append(value);
+        return this;
+    }
+
+    /**
+     * Encodes {@code null}.
+     *
+     * @return this writer.
+     */
+    public JsonWriter nullValue() throws IOException {
+        if (deferredName != null) {
+            if (serializeNulls) {
+                writeDeferredName();
+            } else {
+                deferredName = null;
+                return this; // skip the name and the value
+            }
+        }
+        beforeValue();
+        out.write("null");
+        return this;
+    }
+
+    /**
+     * Encodes {@code value}.
+     *
+     * @return this writer.
+     */
+    public JsonWriter value(boolean value) throws IOException {
+        writeDeferredName();
+        beforeValue();
+        out.write(value ? "true" : "false");
+        return this;
+    }
+
+    /**
+     * Encodes {@code value}.
+     *
+     * @return this writer.
+     */
+    public JsonWriter value(Boolean value) throws IOException {
+        if (value == null) {
+            return nullValue();
+        }
+        writeDeferredName();
+        beforeValue();
+        out.write(value ? "true" : "false");
+        return this;
+    }
+
+    /**
+     * Encodes {@code value}.
+     *
+     * @param value a finite value. May not be {@link Double#isNaN() NaNs} or
+     * {@link Double#isInfinite() infinities}.
+     * @return this writer.
+     */
+    public JsonWriter value(double value) throws IOException {
+        writeDeferredName();
+        if (!lenient && (Double.isNaN(value) || Double.isInfinite(value))) {
+            throw new IllegalArgumentException("Numeric values must be finite, but was " + value);
+        }
+        beforeValue();
+        out.append(Double.toString(value));
+        return this;
+    }
+
+    /**
+     * Encodes {@code value}.
+     *
+     * @return this writer.
+     */
+    public JsonWriter value(long value) throws IOException {
+        writeDeferredName();
+        beforeValue();
+        out.write(Long.toString(value));
+        return this;
+    }
+
+    /**
+     * Encodes {@code value}.
+     *
+     * @param value a finite value. May not be {@link Double#isNaN() NaNs} or
+     * {@link Double#isInfinite() infinities}.
+     * @return this writer.
+     */
+    public JsonWriter value(Number value) throws IOException {
+        if (value == null) {
+            return nullValue();
+        }
+
+        writeDeferredName();
+        String string = value.toString();
+        if (!lenient
+                && (string.equals("-Infinity") || string.equals("Infinity") || string.equals("NaN"))) {
+            throw new IllegalArgumentException("Numeric values must be finite, but was " + value);
+        }
+        beforeValue();
+        out.append(string);
+        return this;
+    }
+
+    /**
+     * Ensures all buffered data is written to the underlying {@link Writer} and
+     * flushes that writer.
+     */
+    public void flush() throws IOException {
+        if (stackSize == 0) {
+            throw new IllegalStateException("JsonWriter is closed.");
+        }
+        out.flush();
+    }
+
+    /**
+     * Flushes and closes this writer and the underlying {@link Writer}.
+     *
+     * @throws IOException if the JSON document is incomplete.
+     */
+    public void close() throws IOException {
+        if (closeWriterOnClose) {
+            out.close();
+        }
+
+        int size = stackSize;
+        if (size > 1 || size == 1 && stack[size - 1] != NONEMPTY_DOCUMENT) {
+            throw new IOException("Incomplete document");
+        }
+        stackSize = 0;
+    }
+
+    private void string(String value) throws IOException {
+        String[] replacements = htmlSafe ? HTML_SAFE_REPLACEMENT_CHARS : REPLACEMENT_CHARS;
+        out.write('\"');
+        int last = 0;
+        int length = value.length();
+        for (int i = 0; i < length; i++) {
+            char c = value.charAt(i);
+            String replacement;
+            if (c < 128) {
+                replacement = replacements[c];
+                if (replacement == null) {
+                    continue;
+                }
+            } else if (c == '\u2028') {
+                replacement = "\\u2028";
+            } else if (c == '\u2029') {
+                replacement = "\\u2029";
+            } else {
+                continue;
+            }
+            if (last < i) {
+                out.write(value, last, i - last);
+            }
+            out.write(replacement);
+            last = i + 1;
+        }
+        if (last < length) {
+            out.write(value, last, length - last);
+        }
+        out.write('\"');
+    }
+
+    private void newline() throws IOException {
+        if (indent == null) {
+            return;
+        }
+
+        out.write('\n');
+        for (int i = 1, size = stackSize; i < size; i++) {
+            out.write(indent);
+        }
+    }
+
+    /**
+     * Inserts any necessary separators and whitespace before a name. Also
+     * adjusts the stack to expect the name's value.
+     */
+    private void beforeName() throws IOException {
+        int context = peek();
+        if (context == NONEMPTY_OBJECT) { // first in object
+            out.write(',');
+        } else if (context != EMPTY_OBJECT) { // not in an object!
+            throw new IllegalStateException("Nesting problem.");
+        }
+        newline();
+        replaceTop(DANGLING_NAME);
+    }
+
+    /**
+     * Inserts any necessary separators and whitespace before a literal value,
+     * inline array, or inline object. Also adjusts the stack to expect either a
+     * closing bracket or another element.
+     */
+    @SuppressWarnings("fallthrough")
+    private void beforeValue() throws IOException {
+        switch (peek()) {
+            case NONEMPTY_DOCUMENT:
+                if (!lenient) {
+                    throw new IllegalStateException(
+                            "JSON must have only one top-level value.");
+                }
+            // fall-through
+            case EMPTY_DOCUMENT: // first in document
+                replaceTop(NONEMPTY_DOCUMENT);
+                break;
+
+            case EMPTY_ARRAY: // first in array
+                replaceTop(NONEMPTY_ARRAY);
+                newline();
+                break;
+
+            case NONEMPTY_ARRAY: // another in array
+                out.append(',');
+                newline();
+                break;
+
+            case DANGLING_NAME: // value for name
+                out.append(separator);
+                replaceTop(NONEMPTY_OBJECT);
+                break;
+
+            default:
+                throw new IllegalStateException("Nesting problem.");
+        }
+    }
 }

--- a/gson/src/main/java/com/google/gson/stream/MutableJsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/MutableJsonReader.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2020 https://github.com/911992.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ /*
+gson
+File: MutableJsonReader.java
+Created on: Oct 10, 2020 6:03:38 AM
+    @author https://github.com/911992
+ 
+File History:
+    initial version: 0.1(20201010)
+ */
+package com.google.gson.stream;
+
+import java.io.Reader;
+
+/**
+ * A Mutable(and poolable) type of {@link JsonReader}.
+ * <p>
+ * This type has no any special business(functionality/alg) overriding, instead
+ * it allows the caller recycle/reuse this reader instance again without
+ * instancing another one.
+ * </p>
+ * <p>
+ * By default, the underlying {@link Reader} stream is closed by closing this
+ * type. This policy could be reset using {@link #setCloseReaderOnClose(boolean)
+ * }
+ * method.
+ * </p>
+ * <p>
+ * If mutability is not a consideration, then please use {@link JsonReader}
+ * </p>
+ * <p>
+ * Example usage:
+ * </p>
+ * <pre>
+ * Reader _in=...;
+ * //Getting a MutableJsonReader, either by new MutableJsonReader(), or whatever...
+ * MutableJsonReader _json_reader = ...
+ * //setting the in, and reset the state
+ * _json_reader.reset(_in);
+ * //using the _json_reader...
+ * ...
+ * //closing the _json_reader
+ * _json_reader.close();//could(by default) close the _in too
+ *
+ * Reader _in1=...;
+ * //using the same _json_reader instance to read another json too
+ * _json_reader.reset(_in1,true);//same as _json_reader.reset(_in1);
+ * //ignorring closing the _in1, by closing _json_reader
+ * _json_reader.setCloseReaderOnClose(false);
+ * //using the _json_reader...
+ * ...
+ * //closing the _json_reader
+ * _json_reader.close();//WILL NOT close the _out1, becasue of setCloseReaderOnClose(false)
+ * </pre>
+ *
+ * @author https://github.com/911992
+ * @since +2.8.7-SNAPSHOT ?
+ */
+public class MutableJsonReader extends JsonReader {
+
+    /**
+     * Calls the super {@link JsonReader#JsonReader(java.io.Reader) }, to create
+     * and initialize an instance of this type.
+     * <p>
+     * If associating the stream is not applicable during instancing, so use the
+     * default constructor({@link #MutableJsonReader()}), and then call the
+     * {@link #reset(java.io.Reader, boolean)} when required.
+     * </p>
+     *
+     * @param arg_in the underlying {@link Reader} stream needs to be associated
+     * (must be non-{@code null})
+     * @throws NullPointerException if the given {@code out} is {@code null}
+     * @see #MutableJsonReader()
+     * @see #reset(java.io.Reader, boolean)
+     */
+    public MutableJsonReader(Reader arg_in) {
+        super(arg_in);
+    }
+
+    /**
+     * Creates an state of this class with no-state.
+     * <p>
+     * After instancing, {@link #reset(java.io.Reader, boolean)} must be called
+     * in order to setting the underlying {@link Reader} stream, same
+     * initializing the state if needed.
+     * </p>
+     */
+    public MutableJsonReader() {
+    }
+
+    /**
+     * Returns the underlying {@link Reader} associated to this JSON writer.
+     * It's {@code null}, if there is no any associated {@link Reader} yet.
+     */
+    public Reader getIn() {
+        return in;
+    }
+
+    /**
+     * {@inheritDoc }
+     */
+    @Override
+    public void reset(Reader arg_in, boolean arg_reset_state) {
+        super.reset(arg_in, arg_reset_state); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    /**
+     * Calls the {@code reset(arg_in, true)}
+     *
+     * @param arg_in the non-{@code null} reader instance to be reset for in
+     * @see #reset(java.io.Reader, boolean)
+     */
+    public void reset(Reader arg_in) {
+        reset(arg_in, true);
+    }
+
+    /**
+     * Returns {@code true}, when underlying {@link Reader} should be closed by
+     * closing this instance, {@code false} otherwise.
+     */
+    public boolean isCloseReaderOnClose() {
+        return closeReaderOnClose;
+    }
+
+    /**
+     * Setting the policy, if the underlying {@link Reader} should be closed,
+     * once {@link #close()} is called, or not.
+     * <p>
+     * The default value is {@code true}
+     * </p>
+     *
+     * @param arg_closeReaderOnClose when {@code true} then underlying
+     * {@link Reader} should be closed by closing this instance, {@code false}
+     * otherwise
+     */
+    public void setCloseReaderOnClose(boolean arg_closeReaderOnClose) {
+        this.closeReaderOnClose = arg_closeReaderOnClose;
+    }
+
+}

--- a/gson/src/main/java/com/google/gson/stream/MutableJsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/MutableJsonWriter.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2020 https://github.com/911992.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ /*
+gson
+File: MutableJsonWriter.java
+Created on: Oct 9, 2020 12:33:49 PM
+    @author https://github.com/911992
+ 
+File History:
+    initial version: 0.1(20201009)
+ */
+package com.google.gson.stream;
+
+import java.io.Writer;
+
+/**
+ * A Mutable(and poolable) type of {@link JsonWriter}.
+ * <p>
+ * This type has no any special business(functionality/alg) overriding, instead
+ * it allows the caller recycle/reuse this writer instance again without
+ * instancing another one.
+ * </p>
+ * <p>
+ * By default, the underlying {@link Writer} stream is closed by closing this
+ * type. This policy could be reset using
+ * {@link #setCloseWriterOnClose(boolean)} method.
+ * </p>
+ * <p>
+ * If mutability is not a consideration, then please use {@link JsonWriter}
+ * </p>
+ * <p>
+ * Example usage:
+ * </p>
+ * <pre>
+ * Writer _out=...;
+ * //Getting a MutableJsonWriter, eitehr by new MutableJsonWriter(), or whatever...
+ * MutableJsonWriter _json_writer =...
+ * //setting the out, and reset the state
+ * _json_writer.reset(_out,true);// or  _json_writer.reset(_out);
+ * //using the _json_writer...
+ * ...
+ * //flushing, and closing the _json_writer
+ * _json_writer.flush();
+ * _json_writer.close();//could(by default) close the _out too
+ * //getting the json result
+ * String _json_res = _out.toString();
+ *
+ * Writer _out1=...;
+ * //using the same _json_writer instance to write another json too
+ * _json_writer.reset(_out1,true);
+ * //ignorring closing the _out1, by closing _json_writer
+ * _json_writer.setCloseWriterOnClose(false);
+ * //using the _json_writer...
+ * ...
+ * //flushing the _json_writer
+ * _json_writer.flush();
+ * //closing the _json_writer
+ * _json_writer.close();//WILL NOT close the _out1, because of setCloseWriterOnClose(false)
+ * </pre>
+ *
+ * @author https://github.com/911992
+ * @since +2.8.7-SNAPSHOT ?
+ */
+public class MutableJsonWriter extends JsonWriter {
+
+    /**
+     * Calls the super {@link JsonWriter#JsonWriter(java.io.Writer) }, to create
+     * and initialize an instance of this type.
+     * <p>
+     * If associating the stream is not applicable during instancing, so use the
+     * default constructor({@link #JsonWriterMutable() }), and then call the
+     * {@link #reset(java.io.Writer, boolean)} when required.
+     * </p>
+     *
+     * @param out the underlying {@link Writer} stream needs to be associated
+     * (must be non-{@code null})
+     * @throws NullPointerException if the given {@code out} is {@code null}
+     * @see #JsonWriterMutable()
+     * @see #reset(java.io.Writer, boolean)
+     */
+    public MutableJsonWriter(Writer out) {
+        super(out);
+    }
+
+    /**
+     * Creates an state of this class with no-state.
+     * <p>
+     * After instancing, {@link #reset(java.io.Writer, boolean) } must be called
+     * in order to setting the underlying {@link Writer} stream, same
+     * initializing the state if needed.
+     * </p>
+     */
+    public MutableJsonWriter() {
+        super();
+    }
+
+    /**
+     * Returns the underlying {@link Writer} associated to this JSON writer.
+     * It's {@code null}, if there is no any associated {@link Writer} yet.
+     */
+    public Writer getOut() {
+        return out;
+    }
+
+    /**
+     * Sets the working {@code out}({@link Writer}), also call for
+     * {@link #_init()} if appreciated.
+     * <p>
+     * It <b>does not</b> closes the current associated
+     * {@link Writer}({@code out}), neither flushes it.
+     * </p>
+     * <p>
+     * <b>Note:</b> It also does not resets the writing policies(such as
+     * lenient, or html-safe), and {@link #closeWriterOnClose} property.
+     * </p>
+     *
+     * @param arg_out the non-{@code null} writer instance to be reset for out
+     * @param arg_also_init when {@code true}, then {@link #_init()} will be
+     * called too
+     * @since +2.8.7-SNAPSHOT ?
+     * @see #close()
+     * @see #setCloseWriterOnClose(boolean)
+     */
+    public void reset(Writer arg_out, boolean arg_also_init) {
+        super._reset(arg_out, arg_also_init);
+    }
+
+    /**
+     * Calls the {@code reset(arg_out, true)}
+     *
+     * @param arg_out the non-{@code null} writer instance to be reset for out
+     * @see #reset(java.io.Writer, boolean)
+     */
+    public void reset(Writer arg_out) {
+        reset(arg_out, true);
+    }
+
+    /**
+     * Setting the policy, if the underlying {@link Writer} should be closed,
+     * once {@link #close()} is called, or not.
+     * <p>
+     * The default value is {@code true}
+     * </p>
+     *
+     * @param arg_closeOutOnClose when {@code true} then underlying
+     * {@link Writer} should be closed by closing this instance, {@code false}
+     * otherwise
+     */
+    public void setCloseWriterOnClose(boolean arg_closeOutOnClose) {
+        this.closeWriterOnClose = arg_closeOutOnClose;
+    }
+
+    /**
+     * Returns {@code true}, when underlying {@link Writer} should be closed by
+     * closing this instance, {@code false} otherwise.
+     */
+    public boolean isCloseWriterOnClose() {
+        return closeWriterOnClose;
+    }
+
+}

--- a/gson/src/test/java/com/google/gson/stream/MutableJsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/MutableJsonReaderTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 https://github.com/911992.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+gson
+File: MutableJsonReaderTest.java
+Created on: Oct 10, 2020 10:11:11 AM
+    @author https://github.com/911992
+ 
+History:
+    initial version: 0.1(20201010)
+*/
+
+package com.google.gson.stream;
+
+import junit.framework.TestCase;
+import java.io.StringReader;
+
+
+/**
+ * 
+ * @author https://github.com/911992
+ */
+public class MutableJsonReaderTest extends TestCase{
+
+    public void testMutability() throws Exception{
+        MutableJsonReader _shared_reader = new MutableJsonReader();
+        final String _a = "happy";
+        final String _b = "opensource";
+        
+        String _val = "911";
+        String _json=String.format("{\"%s\":\"%s\",\"%s\":\"%s\"}", _a,_val,_b,_val);
+        StringReader _str_reader = new StringReader(_json);
+        _shared_reader.reset(_str_reader);
+        String _a_name,_b_name;
+        String _a_val,_b_val;
+        _shared_reader.beginObject();
+        _a_name = _shared_reader.nextName();
+        assertEquals(_a_name, _a);
+        _a_val = _shared_reader.nextString();
+        assertEquals(_a_val, _val);
+        _b_name = _shared_reader.nextName();
+        assertEquals(_b_name, _b);
+        _b_val = _shared_reader.nextString();
+        assertEquals(_b_val, _val);
+        _shared_reader.endObject();
+        _shared_reader.close();
+        
+        _val ="992";
+        _json=String.format("{\"%s\":\"%s\",\"%s\":\"%s\"}", _a,_val,_b,_val);
+        _str_reader = new StringReader(_json);
+        _shared_reader.reset(_str_reader);
+        _shared_reader.beginObject();
+        _a_name = _shared_reader.nextName();
+        assertEquals(_a_name, _a);
+        _a_val = _shared_reader.nextString();
+        assertEquals(_a_val, _val);
+        _b_name = _shared_reader.nextName();
+        assertEquals(_b_name, _b);
+        _b_val = _shared_reader.nextString();
+        assertEquals(_b_val, _val);
+        _shared_reader.endObject();
+        _shared_reader.close();
+    }
+    
+}

--- a/gson/src/test/java/com/google/gson/stream/MutableJsonWriterTest.java
+++ b/gson/src/test/java/com/google/gson/stream/MutableJsonWriterTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 https://github.com/911992.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+gson
+File: MutableJsonWriterTest.java
+Created on: Oct 10, 2020 12:41:40 PM
+    @author https://github.com/911992
+ 
+History:
+    initial version: 0.1(20201010)
+*/
+
+package com.google.gson.stream;
+
+import java.io.StringWriter;
+import junit.framework.TestCase;
+
+/**
+ * 
+ * @author https://github.com/911992
+ */
+public class MutableJsonWriterTest extends TestCase{
+    
+    public void testMutability() throws Exception{
+        MutableJsonWriter _shared_writer = new MutableJsonWriter();
+        final String _a = "happy";
+        final String _b = "opensource";
+        
+        String _val = "911";
+        String _expected_json=String.format("{\"%s\":\"%s\",\"%s\":\"%s\"}", _a,_val,_b,_val);
+        StringWriter _str_writer = new StringWriter();
+        _shared_writer.reset(_str_writer);
+        _shared_writer.beginObject();
+        _shared_writer.name(_a);
+        _shared_writer.value(_val);
+        _shared_writer.name(_b);
+        _shared_writer.value(_val);
+        _shared_writer.endObject();
+        _shared_writer.flush();
+        _shared_writer.close();
+        String _gen_json = _str_writer.toString();
+//        System.out.printf("gen json: %s\n",_gen_json);
+        assertEquals(_expected_json, _gen_json);
+        
+        _val = "992";
+        _expected_json=String.format("{\"%s\":\"%s\",\"%s\":\"%s\"}", _a,_val,_b,_val);
+        _str_writer = new StringWriter();
+        _shared_writer.reset(_str_writer);
+        _shared_writer.beginObject();
+        _shared_writer.name(_a);
+        _shared_writer.value(_val);
+        _shared_writer.name(_b);
+        _shared_writer.value(_val);
+        _shared_writer.endObject();
+        _shared_writer.flush();
+        _shared_writer.close();
+        _gen_json = _str_writer.toString();
+//        System.out.printf("gen json: %s\n",_gen_json);
+        assertEquals(_expected_json, _gen_json);
+    }
+    
+}

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>1.6</java.version>
+    <java.version>1.7</java.version>
   </properties>
 
   <scm>
@@ -90,8 +90,8 @@
             <jdkToolchain>
               <version>[1.5,9)</version>
             </jdkToolchain>
-            <source>1.6</source>
-            <target>1.6</target>
+            <source>1.7</source>
+            <target>1.7</target>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Made the `JsonWriter` and `JsonReader` mutable/poolable as `MutableJsonWriter`, and `MutableJsonReader`

Added `_init` method in base `JsonWriter`, and `JsonReader` classes, to host the instance blocks using it.

The `reset(:Reader,:bool:=true)` / `reset(:Writer,:bool:=true)` methods now reset the instance of base `Json[Reader|Writer]` classes, by calling the `_init` method.

Both `MutableJson[Reader|Writer]` classes now allow the user to control if the underlying stream should be closed by closing the json reader/writer object or not. Th functionality lives in base classes.

A sample(and not well covered) test cases also added to the relative package, and those pass.
Sample usages could be found [here](https://gist.github.com/911992/61936ad985b7b39a6fd35224e8d37eb6) and [here](https://gist.github.com/911992/0d75e82a00ba0c57fa6008b7d9589487)

This change basically reflect my need, as mutable types are appreciated in most cases(in my case, pooling)

<hr/>

Commit desc:
Majors:
• Added `MutableJsonReader` as a mutable/recycable(poolable) instance of `JsonReader`
• Changes on `JsonReader` to let `MutableJsonReader` live
• Added `MutableJsonWriter` as a mutable/recycable(poolable) instance of `JsonWriter`
• Changes on `JsonWriter` to let `MutableJsonWriter` live