### PR TITLE
Make ISO8601UtilsTest run successfully in any time zone

### DIFF
--- a/gson/src/test/java/com/google/gson/internal/bind/util/ISO8601UtilsTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/util/ISO8601UtilsTest.java
@@ -17,6 +17,7 @@ public class ISO8601UtilsTest {
 
     @Test
     public void testDateFormatString() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
         Date date = new GregorianCalendar(2018, Calendar.JUNE, 25).getTime();
         String dateStr = ISO8601Utils.format(date);
         String expectedDate = "2018-06-25";


### PR DESCRIPTION
In some timezones, ISO8601UtilsTest fails with:

```
Failed tests:   testDateFormatString(com.google.gson.internal.bind.util.ISO8601UtilsTest):
      expected:<2018-06-2[5]> but was:<2018-06-2[4]>
```
This PR simply forced the timezone to always be UTC so that the test passes regardless of the timezone of the person running the test.