### PR TITLE
Avoid to crash with ConcurrentModificationException on serialization

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/CollectionTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/CollectionTypeAdapterFactory.java
@@ -96,7 +96,7 @@ public final class CollectionTypeAdapterFactory implements TypeAdapterFactory {
 
       final List<E> collectionSnapshot;
       synchronized (collection){ // Lock collection to do not mutate during shallow copy
-        collectionSnapshot = new ArrayList<>(collection);
+        collectionSnapshot = new ArrayList<E>(collection);
       }
 
       out.beginArray();

--- a/gson/src/main/java/com/google/gson/internal/bind/CollectionTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/CollectionTypeAdapterFactory.java
@@ -28,7 +28,9 @@ import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Adapt a homogeneous collection of objects.
@@ -92,8 +94,13 @@ public final class CollectionTypeAdapterFactory implements TypeAdapterFactory {
         return;
       }
 
+      final List<E> collectionSnapshot;
+      synchronized (collection){ // Lock collection to do not mutate during shallow copy
+        collectionSnapshot = new ArrayList<>(collection);
+      }
+
       out.beginArray();
-      for (E element : collection) {
+      for (E element : collectionSnapshot) {
         elementTypeAdapter.write(out, element);
       }
       out.endArray();

--- a/gson/src/test/java/com/google/gson/GsonMutableCollectionsTest.java
+++ b/gson/src/test/java/com/google/gson/GsonMutableCollectionsTest.java
@@ -1,0 +1,82 @@
+package com.google.gson;
+
+import com.google.gson.annotations.SerializedName;
+import junit.framework.TestCase;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.ConcurrentModificationException;
+import java.util.List;
+
+public class GsonMutableCollectionsTest extends TestCase {
+
+    public void testSerializationOfMutableCollectionWhenOtherThreadsAreMutatingIt() throws InterruptedException {
+        final List<ConcurrentModificationException> exceptionsBag = new ArrayList<>();
+
+        final Model model = new Model(4, "Model $it");
+        final List<Model> items = Collections.nCopies(1000, model);
+
+        final List<Model> mutableList = new ArrayList<>(items);
+        final Gson gson = new GsonBuilder().create();
+
+        final List<Thread> writers = new ArrayList<>();
+        for (int i=0; i<1000; ++i) {
+            writers.add(new Thread(){
+                @Override
+                public void run() {
+                    mutableList.addAll(items);
+                }
+            });
+        }
+        final List<Thread> readers= new ArrayList<>();
+        for (int i=0; i<10000; ++i) {
+            readers.add(new Thread() {
+                @Override
+                public void run() {
+                    try{
+                        gson.toJson(new ModelList(mutableList));
+                    }catch(ConcurrentModificationException ce){
+                        exceptionsBag.add(ce);
+                    }
+
+                }
+            });
+        }
+        for (Thread reader : readers) {
+            reader.start();
+        }
+        for (Thread writer : writers) {
+            writer.start();
+        }
+
+        // Wait threads to complete
+        for (Thread reader : readers) {
+            reader.join();
+        }
+        for (Thread writer : writers) {
+            writer.join();
+        }
+        assertEquals(0, exceptionsBag.size());
+    }
+
+    static class ModelList{
+        @SerializedName("list")
+        public List<Model> list;
+
+        public ModelList(List<Model> list) {
+            this.list = list;
+        }
+    }
+
+    static class Model {
+        @SerializedName("a")
+        public int a;
+        @SerializedName("b")
+        public String b;
+
+        public Model(int a, String b) {
+            this.a = a;
+            this.b = b;
+        }
+    }
+}

--- a/gson/src/test/java/com/google/gson/GsonMutableCollectionsTest.java
+++ b/gson/src/test/java/com/google/gson/GsonMutableCollectionsTest.java
@@ -11,15 +11,15 @@ import java.util.List;
 public class GsonMutableCollectionsTest extends TestCase {
 
     public void testSerializationOfMutableCollectionWhenOtherThreadsAreMutatingIt() throws InterruptedException {
-        final List<ConcurrentModificationException> exceptionsBag = new ArrayList<>();
+        final List<ConcurrentModificationException> exceptionsBag = new ArrayList<ConcurrentModificationException>();
 
         final Model model = new Model(4, "Model $it");
         final List<Model> items = Collections.nCopies(1000, model);
 
-        final List<Model> mutableList = new ArrayList<>(items);
+        final List<Model> mutableList = new ArrayList<Model>(items);
         final Gson gson = new GsonBuilder().create();
 
-        final List<Thread> writers = new ArrayList<>();
+        final List<Thread> writers = new ArrayList<Thread>();
         for (int i=0; i<1000; ++i) {
             writers.add(new Thread(){
                 @Override
@@ -28,7 +28,7 @@ public class GsonMutableCollectionsTest extends TestCase {
                 }
             });
         }
-        final List<Thread> readers= new ArrayList<>();
+        final List<Thread> readers= new ArrayList<Thread>();
         for (int i=0; i<10000; ++i) {
             readers.add(new Thread() {
                 @Override


### PR DESCRIPTION
Avoid crashing with ConcurrentModificationException during json serialization when Gson is serializing a Mutable collection 

Fixes: https://github.com/google/gson/issues/1812