### PR TITLE
Fix overwriting type hierarchy factories not working for TypeAdapters

### DIFF
--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -82,7 +82,7 @@ public final class GsonBuilder {
   private final Map<Type, InstanceCreator<?>> instanceCreators
       = new HashMap<Type, InstanceCreator<?>>();
   private final List<TypeAdapterFactory> factories = new ArrayList<TypeAdapterFactory>();
-  /** tree-style hierarchy factories. These come after factories for backwards compatibility. */
+  /** Type hierarchy factories; these have lower precedence than {@link #factories}. */
   private final List<TypeAdapterFactory> hierarchyFactories = new ArrayList<TypeAdapterFactory>();
   private boolean serializeNulls = DEFAULT_SERIALIZE_NULLS;
   private String datePattern;
@@ -547,7 +547,7 @@ public final class GsonBuilder {
       hierarchyFactories.add(TreeTypeAdapter.newTypeHierarchyFactory(baseType, typeAdapter));
     }
     if (typeAdapter instanceof TypeAdapter<?>) {
-      factories.add(TypeAdapters.newTypeHierarchyFactory(baseType, (TypeAdapter)typeAdapter));
+      hierarchyFactories.add(TypeAdapters.newTypeHierarchyFactory(baseType, (TypeAdapter)typeAdapter));
     }
     return this;
   }


### PR DESCRIPTION
The `GsonBuilder.registerTypeHierarchyAdapter(...)` doc says:
> If a type adapter was previously registered for the specified type hierarchy, it is overridden. If a type adapter is registered for a specific type in the type hierarchy, it will be invoked instead of the one registered for the type hierarchy.

However both was not the case when a `TypeAdapter` was registered as type hierarchy adapter. Then it was not possible to overwrite that adapter using a JsonSerializer / JsonDeserializer, and type adapters for a specific type did not have higher precedence than the hierarchy adapter.