### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
+os: linux
+arch:
+ - amd64
+ - ppc64le
 language: java
 
 jdk:
   - openjdk11
 
+addons:
+  apt:
+    packages:
+      - maven
 install: mvn -f gson install -DskipTests=true
 script: mvn -f gson test
 


### PR DESCRIPTION
Add support for architecture ppc64le.  
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
