### PR TITLE
Kotlin support for index access operators

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonObject.java
+++ b/gson/src/main/java/com/google/gson/JsonObject.java
@@ -67,7 +67,7 @@ public final class JsonObject extends JsonElement {
    * @param value the member object.
    */
   public void set(String property, JsonElement value) {
-    set(property, value);
+    add(property, value);
   }
 
   /**
@@ -130,7 +130,7 @@ public final class JsonObject extends JsonElement {
    * JsonPrimitive of Boolean.
    *
    * @param property name of the member.
-   * @param value the number value associated with the member.
+   * @param value the boolean value associated with the member.
    */
   public void addProperty(String property, Boolean value) {
     add(property, value == null ? JsonNull.INSTANCE : new JsonPrimitive(value));
@@ -141,7 +141,7 @@ public final class JsonObject extends JsonElement {
    * JsonPrimitive of Boolean.
    *
    * @param property name of the member.
-   * @param value the number value associated with the member.
+   * @param value the boolean value associated with the member.
    */
   public void set(String property, Boolean value) {
     addProperty(property, value);
@@ -152,7 +152,7 @@ public final class JsonObject extends JsonElement {
    * JsonPrimitive of Character.
    *
    * @param property name of the member.
-   * @param value the number value associated with the member.
+   * @param value the char value associated with the member.
    */
   public void addProperty(String property, Character value) {
     add(property, value == null ? JsonNull.INSTANCE : new JsonPrimitive(value));
@@ -163,7 +163,7 @@ public final class JsonObject extends JsonElement {
    * JsonPrimitive of Character.
    *
    * @param property name of the member.
-   * @param value the number value associated with the member.
+   * @param value the char value associated with the member.
    */
   public void set(String property, Character value) {
     addProperty(property, value);

--- a/gson/src/main/java/com/google/gson/JsonObject.java
+++ b/gson/src/main/java/com/google/gson/JsonObject.java
@@ -59,6 +59,18 @@ public final class JsonObject extends JsonElement {
   }
 
   /**
+   * Adds a member, which is a name-value pair, to self. The name must be a String, but the value
+   * can be an arbitrary JsonElement, thereby allowing you to build a full tree of JsonElements
+   * rooted at this node.
+   *
+   * @param property name of the member.
+   * @param value the member object.
+   */
+  public void set(String property, JsonElement value) {
+    set(property, value);
+  }
+
+  /**
    * Removes the {@code property} from this {@link JsonObject}.
    *
    * @param property name of the member that should be removed.
@@ -82,6 +94,17 @@ public final class JsonObject extends JsonElement {
 
   /**
    * Convenience method to add a primitive member. The specified value is converted to a
+   * JsonPrimitive of String.
+   *
+   * @param property name of the member.
+   * @param value the string value associated with the member.
+   */
+  public void set(String property, String value) {
+    addProperty(property, value);
+  }
+
+  /**
+   * Convenience method to add a primitive member. The specified value is converted to a
    * JsonPrimitive of Number.
    *
    * @param property name of the member.
@@ -89,6 +112,17 @@ public final class JsonObject extends JsonElement {
    */
   public void addProperty(String property, Number value) {
     add(property, value == null ? JsonNull.INSTANCE : new JsonPrimitive(value));
+  }
+
+  /**
+   * Convenience method to add a primitive member. The specified value is converted to a
+   * JsonPrimitive of Number.
+   *
+   * @param property name of the member.
+   * @param value the number value associated with the member.
+   */
+  public void set(String property, Number value) {
+    addProperty(property, value);
   }
 
   /**
@@ -103,6 +137,17 @@ public final class JsonObject extends JsonElement {
   }
 
   /**
+   * Convenience method to add a boolean member. The specified value is converted to a
+   * JsonPrimitive of Boolean.
+   *
+   * @param property name of the member.
+   * @param value the number value associated with the member.
+   */
+  public void set(String property, Boolean value) {
+    addProperty(property, value);
+  }
+
+  /**
    * Convenience method to add a char member. The specified value is converted to a
    * JsonPrimitive of Character.
    *
@@ -111,6 +156,17 @@ public final class JsonObject extends JsonElement {
    */
   public void addProperty(String property, Character value) {
     add(property, value == null ? JsonNull.INSTANCE : new JsonPrimitive(value));
+  }
+
+  /**
+   * Convenience method to add a char member. The specified value is converted to a
+   * JsonPrimitive of Character.
+   *
+   * @param property name of the member.
+   * @param value the number value associated with the member.
+   */
+  public void set(String property, Character value) {
+    addProperty(property, value);
   }
 
   /**

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -1486,11 +1486,10 @@ public class JsonReader implements Closeable {
   }
 
   /**
-   * Return she current position of the input string
+   * Return the current position of the JSON reader
    *
-   * @return Position of the json reader
+   * @return Position of the JSON reader
    */
-
   public int getPosition() {
       return this.pos - this.lineStart + 1;
   }

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -1485,7 +1485,8 @@ public class JsonReader implements Closeable {
     return result.toString();
   }
 
-  /** Return she current position of the input string
+  /**
+   * Return she current position of the input string
    *
    * @return Position of the json reader
    */

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -1485,6 +1485,15 @@ public class JsonReader implements Closeable {
     return result.toString();
   }
 
+  /** Return she current position of the input string
+   *
+   * @return Position of the json reader
+   */
+
+  public int getPosition() {
+      return this.pos - this.lineStart + 1;
+  }
+
   /**
    * Unescapes the character identified by the character or characters that
    * immediately follow a backslash. The backslash '\' should have already


### PR DESCRIPTION
In Kotlin you can define your own operators. You can use the ::set Method to add a object. See https://kotlinlang.org/docs/reference/keyword-reference.html for more.

I added the set method in JsonObject. It is a simple alias to add or addProperty.

Also I need the current String position in JsonReader. E.g I have a command as a string and the next argument is a JsonObject. I just want to know how many chars were read from the input string to determinate the next argument. Currently this looks like this:
```java

    private static final Field JSON_READER_POS_FIELD;
    private static final Field JSON_READER_LINE_START_FIELD;

        new JsonReader(new StringReader(""));
        Class<?> jsonReadClass = JsonReader.class;
        try {
            JSON_READER_POS_FIELD = jsonReadClass.getDeclaredField("pos");
            JSON_READER_POS_FIELD.setAccessible(true);
            JSON_READER_LINE_START_FIELD = jsonReadClass.getDeclaredField("lineStart");
            JSON_READER_LINE_START_FIELD.setAccessible(true);
        } catch (NoSuchFieldException e) {
            e.printStackTrace();
            throw new RuntimeException(e);
        }

        try {
            return JSON_READER_POS_FIELD.getInt(jsonReader) - JSON_READER_LINE_START_FIELD.getInt(jsonReader) + 1;
        } catch (IllegalAccessException e) {
            throw new IllegalStateException();
        }
```