### PR TITLE
fix error when using GraphAdapterBuilder with RuntimeTypeAdapterFactory

### DIFF
--- a/extras/src/main/java/com/google/gson/graph/GraphAdapterBuilder.java
+++ b/extras/src/main/java/com/google/gson/graph/GraphAdapterBuilder.java
@@ -303,6 +303,10 @@ public final class GraphAdapterBuilder {
       if (value == null) {
         throw new IllegalStateException("non-null value deserialized to null: " + element);
       }
+      if (graph.nextCreate != null) {
+        graph.nextCreate.value = value;
+        graph.nextCreate = null;
+      }
     }
   }
 }


### PR DESCRIPTION
I made a proper fix for Issue #542 where the object graph fails to deserialize when a RuntimeTypeAdapterFactory is registered.
The problem is that if a custom TypeAdapter is registered for a Type the custom InstanceCreator in GraphAdapterBuilder:215 is not called and thus graph.nextCreate will not have a value set and the nextCreate field will not be cleared. If Element.read is called after that the it throws an Exception "Unexpected recursive call to read() for %". My addition to read just checks if the deserialized result wasn't populated yet (which only happens if T has a custom TypeAdapter registered) and makes sure that 'value' is set and nextCreate is set.

The Test attached in #542 still perfectly show the issue.  