### PR TITLE
Remove not needed .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-gson/docs/javadocs/* linguist-documentation


### PR DESCRIPTION
The `.gitattributes` file was added to prevent GitHub detecting Gson as HTML repository due to the included generated javadoc files. However, since #1654 has removed the javadoc files, the `.gitattributes` file is no longer needed.