### PR TITLE
allow deserialize duplicate map key

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -109,6 +109,7 @@ public final class Gson {
   static final boolean DEFAULT_ESCAPE_HTML = true;
   static final boolean DEFAULT_SERIALIZE_NULLS = false;
   static final boolean DEFAULT_COMPLEX_MAP_KEYS = false;
+  static final boolean DEFAULT_DUPLICATE_MAP_KEYS = false;
   static final boolean DEFAULT_SPECIALIZE_FLOAT_VALUES = false;
 
   private static final TypeToken<?> NULL_KEY_SURROGATE = TypeToken.get(Object.class);
@@ -136,6 +137,7 @@ public final class Gson {
   final Map<Type, InstanceCreator<?>> instanceCreators;
   final boolean serializeNulls;
   final boolean complexMapKeySerialization;
+  final boolean duplicateMapKeyDeserialization;
   final boolean generateNonExecutableJson;
   final boolean htmlSafe;
   final boolean prettyPrinting;
@@ -185,7 +187,7 @@ public final class Gson {
   public Gson() {
     this(Excluder.DEFAULT, FieldNamingPolicy.IDENTITY,
         Collections.<Type, InstanceCreator<?>>emptyMap(), DEFAULT_SERIALIZE_NULLS,
-        DEFAULT_COMPLEX_MAP_KEYS, DEFAULT_JSON_NON_EXECUTABLE, DEFAULT_ESCAPE_HTML,
+        DEFAULT_COMPLEX_MAP_KEYS, DEFAULT_DUPLICATE_MAP_KEYS, DEFAULT_JSON_NON_EXECUTABLE, DEFAULT_ESCAPE_HTML,
         DEFAULT_PRETTY_PRINT, DEFAULT_LENIENT, DEFAULT_SPECIALIZE_FLOAT_VALUES,
         LongSerializationPolicy.DEFAULT, null, DateFormat.DEFAULT, DateFormat.DEFAULT,
         Collections.<TypeAdapterFactory>emptyList(), Collections.<TypeAdapterFactory>emptyList(),
@@ -194,7 +196,7 @@ public final class Gson {
 
   Gson(Excluder excluder, FieldNamingStrategy fieldNamingStrategy,
       Map<Type, InstanceCreator<?>> instanceCreators, boolean serializeNulls,
-      boolean complexMapKeySerialization, boolean generateNonExecutableGson, boolean htmlSafe,
+      boolean complexMapKeySerialization, boolean duplicateMapKeyDeserialization, boolean generateNonExecutableGson, boolean htmlSafe,
       boolean prettyPrinting, boolean lenient, boolean serializeSpecialFloatingPointValues,
       LongSerializationPolicy longSerializationPolicy, String datePattern, int dateStyle,
       int timeStyle, List<TypeAdapterFactory> builderFactories,
@@ -206,6 +208,7 @@ public final class Gson {
     this.constructorConstructor = new ConstructorConstructor(instanceCreators);
     this.serializeNulls = serializeNulls;
     this.complexMapKeySerialization = complexMapKeySerialization;
+    this.duplicateMapKeyDeserialization = duplicateMapKeyDeserialization;
     this.generateNonExecutableJson = generateNonExecutableGson;
     this.htmlSafe = htmlSafe;
     this.prettyPrinting = prettyPrinting;
@@ -270,7 +273,7 @@ public final class Gson {
 
     // type adapters for composite and user-defined types
     factories.add(new CollectionTypeAdapterFactory(constructorConstructor));
-    factories.add(new MapTypeAdapterFactory(constructorConstructor, complexMapKeySerialization));
+    factories.add(new MapTypeAdapterFactory(constructorConstructor, complexMapKeySerialization, duplicateMapKeyDeserialization));
     this.jsonAdapterFactory = new JsonAdapterAnnotationTypeAdapterFactory(constructorConstructor);
     factories.add(jsonAdapterFactory);
     factories.add(TypeAdapters.ENUM_FACTORY);

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -34,6 +34,7 @@ import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 
 import static com.google.gson.Gson.DEFAULT_COMPLEX_MAP_KEYS;
+import static com.google.gson.Gson.DEFAULT_DUPLICATE_MAP_KEYS;
 import static com.google.gson.Gson.DEFAULT_ESCAPE_HTML;
 import static com.google.gson.Gson.DEFAULT_JSON_NON_EXECUTABLE;
 import static com.google.gson.Gson.DEFAULT_LENIENT;
@@ -89,6 +90,7 @@ public final class GsonBuilder {
   private int dateStyle = DateFormat.DEFAULT;
   private int timeStyle = DateFormat.DEFAULT;
   private boolean complexMapKeySerialization = DEFAULT_COMPLEX_MAP_KEYS;
+  private boolean duplicateMapKeyDeserialization = DEFAULT_DUPLICATE_MAP_KEYS;
   private boolean serializeSpecialFloatingPointValues = DEFAULT_SPECIALIZE_FLOAT_VALUES;
   private boolean escapeHtmlChars = DEFAULT_ESCAPE_HTML;
   private boolean prettyPrinting = DEFAULT_PRETTY_PRINT;
@@ -116,6 +118,7 @@ public final class GsonBuilder {
     this.instanceCreators.putAll(gson.instanceCreators);
     this.serializeNulls = gson.serializeNulls;
     this.complexMapKeySerialization = gson.complexMapKeySerialization;
+    this.duplicateMapKeyDeserialization = gson.duplicateMapKeyDeserialization;
     this.generateNonExecutableJson = gson.generateNonExecutableJson;
     this.escapeHtmlChars = gson.htmlSafe;
     this.prettyPrinting = gson.prettyPrinting;
@@ -272,6 +275,18 @@ public final class GsonBuilder {
    */
   public GsonBuilder enableComplexMapKeySerialization() {
     complexMapKeySerialization = true;
+    return this;
+  }
+
+  /**
+   * Configure Gson to deserialize duplicate map key. By default, Gson throw a {@code JsonSyntaxException} when there are more than
+   * one same key.
+   *
+   * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
+   * @since 2.8
+   */
+  public GsonBuilder enableDuplicateMapKeyDeserialization() {
+    duplicateMapKeyDeserialization = true;
     return this;
   }
 
@@ -595,7 +610,7 @@ public final class GsonBuilder {
     addTypeAdaptersForDate(datePattern, dateStyle, timeStyle, factories);
 
     return new Gson(excluder, fieldNamingPolicy, instanceCreators,
-        serializeNulls, complexMapKeySerialization,
+        serializeNulls, complexMapKeySerialization, duplicateMapKeyDeserialization,
         generateNonExecutableJson, escapeHtmlChars, prettyPrinting, lenient,
         serializeSpecialFloatingPointValues, longSerializationPolicy,
         datePattern, dateStyle, timeStyle,

--- a/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
@@ -105,11 +105,13 @@ import java.util.Map;
 public final class MapTypeAdapterFactory implements TypeAdapterFactory {
   private final ConstructorConstructor constructorConstructor;
   final boolean complexMapKeySerialization;
+  final boolean duplicateMapKeyDeserialization;
 
   public MapTypeAdapterFactory(ConstructorConstructor constructorConstructor,
-      boolean complexMapKeySerialization) {
+      boolean complexMapKeySerialization, boolean duplicateMapKeyDeserialization) {
     this.constructorConstructor = constructorConstructor;
     this.complexMapKeySerialization = complexMapKeySerialization;
+    this.duplicateMapKeyDeserialization = duplicateMapKeyDeserialization;
   }
 
   @Override public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
@@ -173,7 +175,7 @@ public final class MapTypeAdapterFactory implements TypeAdapterFactory {
           K key = keyTypeAdapter.read(in);
           V value = valueTypeAdapter.read(in);
           V replaced = map.put(key, value);
-          if (replaced != null) {
+          if (!duplicateMapKeyDeserialization && replaced != null) {
             throw new JsonSyntaxException("duplicate key: " + key);
           }
           in.endArray();
@@ -186,7 +188,7 @@ public final class MapTypeAdapterFactory implements TypeAdapterFactory {
           K key = keyTypeAdapter.read(in);
           V value = valueTypeAdapter.read(in);
           V replaced = map.put(key, value);
-          if (replaced != null) {
+          if (!duplicateMapKeyDeserialization && replaced != null) {
             throw new JsonSyntaxException("duplicate key: " + key);
           }
         }

--- a/gson/src/test/java/com/google/gson/GsonTest.java
+++ b/gson/src/test/java/com/google/gson/GsonTest.java
@@ -46,7 +46,7 @@ public final class GsonTest extends TestCase {
 
   public void testOverridesDefaultExcluder() {
     Gson gson = new Gson(CUSTOM_EXCLUDER, CUSTOM_FIELD_NAMING_STRATEGY,
-        new HashMap<Type, InstanceCreator<?>>(), true, false, true, false,
+        new HashMap<Type, InstanceCreator<?>>(), true, false,false, true, false,
         true, true, false, LongSerializationPolicy.DEFAULT, null, DateFormat.DEFAULT,
         DateFormat.DEFAULT, new ArrayList<TypeAdapterFactory>(),
         new ArrayList<TypeAdapterFactory>(), new ArrayList<TypeAdapterFactory>());
@@ -59,7 +59,7 @@ public final class GsonTest extends TestCase {
 
   public void testClonedTypeAdapterFactoryListsAreIndependent() {
     Gson original = new Gson(CUSTOM_EXCLUDER, CUSTOM_FIELD_NAMING_STRATEGY,
-        new HashMap<Type, InstanceCreator<?>>(), true, false, true, false,
+        new HashMap<Type, InstanceCreator<?>>(), true, false,false, true, false,
         true, true, false, LongSerializationPolicy.DEFAULT, null, DateFormat.DEFAULT,
         DateFormat.DEFAULT, new ArrayList<TypeAdapterFactory>(),
         new ArrayList<TypeAdapterFactory>(), new ArrayList<TypeAdapterFactory>());

--- a/gson/src/test/java/com/google/gson/functional/MapTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MapTest.java
@@ -78,6 +78,17 @@ public class MapTest extends TestCase {
     assertEquals(2, target.get("b").intValue());
   }
 
+  public void testMapDuplicateKeyDeserialization() {
+    Gson gsonWithDuplicateKeys = new GsonBuilder()
+        .enableDuplicateMapKeyDeserialization()
+        .create();
+    Type typeOfMap = new TypeToken<Map<String,Integer>>(){}.getType();
+    String json = "{\"a\":1,\"b\":2,\"b\":3}";
+    Map<String,Integer> target = gsonWithDuplicateKeys.fromJson(json, typeOfMap);
+    assertEquals(1, target.get("a").intValue());
+    assertEquals(3, target.get("b").intValue());
+  }
+
   @SuppressWarnings({"unchecked", "rawtypes"})
   public void testRawMapSerialization() {
     Map map = new LinkedHashMap();


### PR DESCRIPTION
in my scenario， the json allow duplicate keys . We can just add a switch to enable the feature。  Pleas review it, thx.