### PR TITLE
Inline declaration of Java compatibility

### DIFF
--- a/gson/build.gradle
+++ b/gson/build.gradle
@@ -4,8 +4,7 @@ apply plugin: 'maven'
 group = 'com.google.code.gson'
 version = '2.8.6-SNAPSHOT'
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = targetCompatibility = 1.6
 
 sourceSets.main.java.exclude("**/module-info.java")
 dependencies {


### PR DESCRIPTION
There is no need to write two lines to declare the source and the target Java compatibility.