### PR TITLE
Refactored three test methods in CustomSerializerTest, and two test methods in ThrowableFunctionalTest

### DIFF
--- a/gson/src/test/java/com/google/gson/functional/CustomSerializerTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CustomSerializerTest.java
@@ -16,6 +16,7 @@
 
 package com.google.gson.functional;
 
+import com.google.gson.common.TestTypes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
@@ -47,10 +48,7 @@ public class CustomSerializerTest extends TestCase {
          .registerTypeAdapter(Base.class, new BaseSerializer())
          .registerTypeAdapter(Sub.class, new SubSerializer())
          .create();
-     ClassWithBaseField target = new ClassWithBaseField(new Base());
-     JsonObject json = (JsonObject) gson.toJsonTree(target);
-     JsonObject base = json.get("base").getAsJsonObject();
-     assertEquals(BaseSerializer.NAME, base.get(Base.SERIALIZER_KEY).getAsString());
+     this.testSerializerInvokedForBaseClassFieldsTemplate(gson, TestTypes.Base.class, BaseSerializer.NAME);
    }
 
    public void testSubClassSerializerInvokedForBaseClassFieldsHoldingSubClassInstances() {
@@ -58,10 +56,7 @@ public class CustomSerializerTest extends TestCase {
          .registerTypeAdapter(Base.class, new BaseSerializer())
          .registerTypeAdapter(Sub.class, new SubSerializer())
          .create();
-     ClassWithBaseField target = new ClassWithBaseField(new Sub());
-     JsonObject json = (JsonObject) gson.toJsonTree(target);
-     JsonObject base = json.get("base").getAsJsonObject();
-     assertEquals(SubSerializer.NAME, base.get(Base.SERIALIZER_KEY).getAsString());
+     this.testSerializerInvokedForBaseClassFieldsTemplate(gson, TestTypes.Sub.class, SubSerializer.NAME);
    }
 
    public void testSubClassSerializerInvokedForBaseClassFieldsHoldingArrayOfSubClassInstances() {
@@ -82,10 +77,7 @@ public class CustomSerializerTest extends TestCase {
      Gson gson = new GsonBuilder()
          .registerTypeAdapter(Base.class, new BaseSerializer())
          .create();
-     ClassWithBaseField target = new ClassWithBaseField(new Sub());
-     JsonObject json = (JsonObject) gson.toJsonTree(target);
-     JsonObject base = json.get("base").getAsJsonObject();
-     assertEquals(BaseSerializer.NAME, base.get(Base.SERIALIZER_KEY).getAsString());
+     this.testSerializerInvokedForBaseClassFieldsTemplate(gson, TestTypes.Sub.class, BaseSerializer.NAME);
    }
 
    public void testSerializerReturnsNull() {
@@ -98,5 +90,17 @@ public class CustomSerializerTest extends TestCase {
        .create();
        JsonElement json = gson.toJsonTree(new Base());
        assertTrue(json.isJsonNull());
+   }
+
+   public <TBase> void testSerializerInvokedForBaseClassFieldsTemplate(Gson gson, Class<TBase> clazzTBase, String string1) {
+     try {
+       ClassWithBaseField target = new ClassWithBaseField((TestTypes.Base) clazzTBase.newInstance());
+       JsonObject json = (JsonObject) gson.toJsonTree(target);
+       JsonObject base = json.get("base").getAsJsonObject();
+       assertEquals(string1, base.get(Base.SERIALIZER_KEY).getAsString());
+     } catch (Exception e) {
+       e.printStackTrace();
+       throw new RuntimeException();
+     }
    }
 }

--- a/gson/src/test/java/com/google/gson/functional/ThrowableFunctionalTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ThrowableFunctionalTest.java
@@ -13,12 +13,7 @@ public final class ThrowableFunctionalTest extends TestCase {
   private final Gson gson = new Gson();
 
   public void testExceptionWithoutCause() {
-    RuntimeException e = new RuntimeException("hello");
-    String json = gson.toJson(e);
-    assertTrue(json.contains("hello"));
-
-    e = gson.fromJson("{'detailMessage':'hello'}", RuntimeException.class);
-    assertEquals("hello", e.getMessage());
+    this.testThrowableWithoutCauseTemplate(RuntimeException.class, "hello", "{'detailMessage':'hello'}");
   }
 
   public void testExceptionWithCause() {
@@ -39,12 +34,7 @@ public final class ThrowableFunctionalTest extends TestCase {
   }
 
   public void testErrorWithoutCause() {
-    OutOfMemoryError e = new OutOfMemoryError("hello");
-    String json = gson.toJson(e);
-    assertTrue(json.contains("hello"));
-
-    e = gson.fromJson("{'detailMessage':'hello'}", OutOfMemoryError.class);
-    assertEquals("hello", e.getMessage());
+    this.testThrowableWithoutCauseTemplate(OutOfMemoryError.class, "hello", "{'detailMessage':'hello'}");
   }
 
   public void testErrornWithCause() {
@@ -61,5 +51,18 @@ public final class ThrowableFunctionalTest extends TestCase {
 
   private static final class MyException extends Throwable {
     @SerializedName("my_custom_name") String myCustomMessage = "myCustomMessageValue";
+  }
+
+  public <TThrowable extends Throwable> void testThrowableWithoutCauseTemplate(Class<TThrowable> clazzTThrowable, String msg, String jsonString) {
+    try {
+      TThrowable e = clazzTThrowable.getDeclaredConstructor(String.class).newInstance(msg);
+      String json = gson.toJson(e);
+      assertTrue(json.contains(msg));
+      e = (TThrowable) gson.fromJson(jsonString, clazzTThrowable);
+      assertEquals(msg, e.getMessage());
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw new RuntimeException();
+    }
   }
 }


### PR DESCRIPTION
As part of a research project at the University of Waterloo, we are exploring automatic test refactoring tools and submitting vetted proposed refactorings upstream. These refactorings make it easier to add additional related test methods and should help with the maintainability of the tests. In this pull request, we have two refactoring cases that refactors five test methods. We've checked both cases and ensured that all the test runs pass successfully.

If it helps, we can also propose a test case that uses these five refactored test methods. We explained each of the two refactoring cases below.

1. In CustomSerializerTest, after declaration of gson, the only difference between the three test methods "testBaseClassSerializerInvokedForBaseClassFields() ", "testSubClassSerializerInvokedForBaseClassFieldsHoldingSubClassInstances", and "testSubClassSerializerInvokedForBaseClassFieldsHoldingArrayOfSubClassInstances" is in a class type (new Base() vs new Sub()) and a string (BaseSerializer.NAME vs SubSerializer.NAME). We create "testSerializerInvokedForBaseClassFieldsTemplate(Gson gson, Class<TBase> clazzTBase, String string1)" parametrized method, which allows you to add similar test cases with different arguments gson, clazzTBase and string1.

2. In ThrowableFunctionalTest, the only difference between the two test methods "testExceptionWithoutCause()" and "testErrorWithoutCause()" is in a class type (RuntimeException.class vs OutOfMemoryError.class). We create "testThrowableWithoutCauseTemplate(Class<TThrowable> clazzTThrowable, String msg, String jsonString)" parametrized method, which allows you to add similar test cases with different arguments clazzTThrowable, msg, and jsonString.
