### PR TITLE
Adjust some minor details of #1391.

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
+++ b/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
@@ -339,13 +339,13 @@ public final class $Gson$Types {
   }
 
   public static Type resolve(Type context, Class<?> contextRawType, Type toResolve) {
-    return resolve(context, contextRawType, toResolve, new HashMap<TypeVariable, Type>());
+    return resolve(context, contextRawType, toResolve, new HashMap<TypeVariable<?>, Type>());
   }
 
   private static Type resolve(Type context, Class<?> contextRawType, Type toResolve,
-                              Map<TypeVariable, Type> visitedTypeVariables) {
+                              Map<TypeVariable<?>, Type> visitedTypeVariables) {
     // this implementation is made a little more complicated in an attempt to avoid object-creation
-    TypeVariable resolving = null;
+    TypeVariable<?> resolving = null;
     while (true) {
       if (toResolve instanceof TypeVariable) {
         TypeVariable<?> typeVariable = (TypeVariable<?>) toResolve;

--- a/gson/src/test/java/com/google/gson/functional/ReusedTypeVariablesFullyResolveTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ReusedTypeVariablesFullyResolveTest.java
@@ -1,15 +1,16 @@
 package com.google.gson.functional;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.junit.Before;
 import org.junit.Test;
-
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
-
-import static org.junit.Assert.*;
 
 /**
  * This test covers the scenario described in #1390 where a type variable needs to be used
@@ -18,37 +19,37 @@ import static org.junit.Assert.*;
  */
 public class ReusedTypeVariablesFullyResolveTest {
 
-    private Gson gson;
+  private Gson gson;
 
-    @Before
-    public void setUp() {
-        gson = new GsonBuilder().create();
-    }
+  @Before
+  public void setUp() {
+    gson = new GsonBuilder().create();
+  }
 
-    @SuppressWarnings("ConstantConditions") // The instances were being unmarshaled as Strings instead of TestEnums
-    @Test
-    public void testGenericsPreservation() {
-        TestEnumSetCollection withSet = gson.fromJson("{\"collection\":[\"ONE\",\"THREE\"]}", TestEnumSetCollection.class);
-        Iterator<TestEnum> iterator = withSet.collection.iterator();
-        assertNotNull(withSet);
-        assertNotNull(withSet.collection);
-        assertEquals(2, withSet.collection.size());
-        TestEnum first = iterator.next();
-        TestEnum second = iterator.next();
+  @SuppressWarnings("ConstantConditions") // The instances were being unmarshaled as Strings instead of TestEnums
+  @Test
+  public void testGenericsPreservation() {
+    TestEnumSetCollection withSet = gson.fromJson("{\"collection\":[\"ONE\",\"THREE\"]}", TestEnumSetCollection.class);
+    Iterator<TestEnum> iterator = withSet.collection.iterator();
+    assertNotNull(withSet);
+    assertNotNull(withSet.collection);
+    assertEquals(2, withSet.collection.size());
+    TestEnum first = iterator.next();
+    TestEnum second = iterator.next();
 
-        assertTrue(first instanceof TestEnum);
-        assertTrue(second instanceof TestEnum);
-    }
+    assertTrue(first instanceof TestEnum);
+    assertTrue(second instanceof TestEnum);
+  }
 
-    enum TestEnum { ONE, TWO, THREE }
+  enum TestEnum { ONE, TWO, THREE }
 
-    private static class TestEnumSetCollection extends SetCollection<TestEnum> {}
+  private static class TestEnumSetCollection extends SetCollection<TestEnum> {}
 
-    private static class SetCollection<T> extends BaseCollection<T, Set<T>> {}
+  private static class SetCollection<T> extends BaseCollection<T, Set<T>> {}
 
-    private static class BaseCollection<U, C extends Collection<U>>
-    {
-        public C collection;
-    }
+  private static class BaseCollection<U, C extends Collection<U>>
+  {
+    public C collection;
+  }
 
 }


### PR DESCRIPTION
Use two-space indentation for the new test.
Use standard Google import style.
Supply missing type argument for `TypeVariable`.