### PR TITLE
Retain generic signature of TypeToken with R8 version 3.0 and higher

### DIFF
--- a/examples/android-proguard-example/proguard.cfg
+++ b/examples/android-proguard-example/proguard.cfg
@@ -25,4 +25,8 @@
   @com.google.gson.annotations.SerializedName <fields>;
 }
 
+# Retain generic signatures of TypeToken and its subclasses with R8 version 3.0 and higher.
+-keep,allowobfuscation,allowshrinking class com.google.gson.reflect.TypeToken
+-keep,allowobfuscation,allowshrinking class * extends com.google.gson.reflect.TypeToken
+
 ##---------------End: proguard configuration for Gson  ----------


### PR DESCRIPTION
R8 version 3.0 started to remove generic signatures from items that are not matched by a -keep rule in full mode (see also https://r8.googlesource.com/r8/+/744d742137a82656b8ee27513f975e0528aecd78). The motivation for this change is to avoid that all generic signatures are retained in programs, when only a few are typically required for reflection.

This change adds a rule that causes the generic signatures of com.google.gson.reflect.TypeToken and its subclasses to be retained. This is needed because [com.google.gson.reflect.TypeToken reflectively accesses its own generic signature](https://github.com/google/gson/blob/ceae88bd6667f4263bbe02e6b3710b8a683906a2/gson/src/main/java/com/google/gson/reflect/TypeToken.java#L62).

References:
* http://issuetracker.google.com/issues/188703877#comment28