### PR TITLE
Improve the speed of the JSON_ELEMENT TypeAdapter when the object graph has already been turned into a JsonElement

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
@@ -250,8 +250,14 @@ public final class JsonTreeReader extends JsonReader {
   }
 
   JsonElement nextJsonElement() throws IOException {
-    if (peek() == JsonToken.NAME) {
-      throw new IllegalStateException("Can't turn a name into a JsonElement");
+    final JsonToken peeked = peek();
+    if (
+      peeked == JsonToken.NAME
+      || peeked == JsonToken.END_ARRAY
+      || peeked == JsonToken.END_OBJECT
+      || peeked == JsonToken.END_DOCUMENT
+    ) {
+      throw new IllegalStateException("Unexpected " + peeked + " when reading a JsonElement.");
     }
     final JsonElement element = (JsonElement) peekStack();
     skipValue();

--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
@@ -251,12 +251,10 @@ public final class JsonTreeReader extends JsonReader {
 
   JsonElement nextJsonElement() throws IOException {
     final JsonToken peeked = peek();
-    if (
-      peeked == JsonToken.NAME
-      || peeked == JsonToken.END_ARRAY
-      || peeked == JsonToken.END_OBJECT
-      || peeked == JsonToken.END_DOCUMENT
-    ) {
+    if (peeked == JsonToken.NAME
+        || peeked == JsonToken.END_ARRAY
+        || peeked == JsonToken.END_OBJECT
+        || peeked == JsonToken.END_DOCUMENT) {
       throw new IllegalStateException("Unexpected " + peeked + " when reading a JsonElement.");
     }
     final JsonElement element = (JsonElement) peekStack();

--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
@@ -249,6 +249,15 @@ public final class JsonTreeReader extends JsonReader {
     return result;
   }
 
+  JsonElement nextJsonElement() throws IOException {
+    if (peek() == JsonToken.NAME) {
+      throw new IllegalStateException("Can't turn a name into a JsonElement");
+    }
+    final JsonElement element = (JsonElement) peekStack();
+    skipValue();
+    return element;
+  }
+
   @Override public void close() throws IOException {
     stack = new Object[] { SENTINEL_CLOSED };
     stackSize = 1;

--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -700,6 +700,10 @@ public final class TypeAdapters {
 
   public static final TypeAdapter<JsonElement> JSON_ELEMENT = new TypeAdapter<JsonElement>() {
     @Override public JsonElement read(JsonReader in) throws IOException {
+      if (in instanceof JsonTreeReader) {
+        return ((JsonTreeReader) in).nextJsonElement();
+      }
+
       switch (in.peek()) {
       case STRING:
         return new JsonPrimitive(in.nextString());

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonElementReaderTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonElementReaderTest.java
@@ -18,6 +18,7 @@ package com.google.gson.internal.bind;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
 import com.google.gson.stream.JsonToken;
 import java.io.IOException;
 import junit.framework.TestCase;
@@ -296,6 +297,41 @@ public final class JsonElementReaderTest extends TestCase {
     }
     assertEquals("A", reader.nextString());
     reader.endArray();
+  }
+
+  public void testNextJsonElement() throws IOException {
+    final JsonElement element = JsonParser.parseString("{\"A\": 1, \"B\" : {}, \"C\" : []}");
+    JsonTreeReader reader = new JsonTreeReader(element);
+    reader.beginObject();
+    try {
+      reader.nextJsonElement();
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+    reader.nextName();
+    assertEquals(reader.nextJsonElement(), new JsonPrimitive(1));
+    reader.nextName();
+    reader.beginObject();
+    try {
+      reader.nextJsonElement();
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+    reader.endObject();
+    reader.nextName();
+    reader.beginArray();
+    try {
+      reader.nextJsonElement();
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+    reader.endArray();
+    reader.endObject();
+    try {
+      reader.nextJsonElement();
+      fail();
+    } catch (IllegalStateException expected) {
+    }
   }
 
   public void testEarlyClose() throws IOException {


### PR DESCRIPTION
Following up th #1942 conversation, here is a small change, which improves the speed of processing a lot in cases where accessing the `JsonElement` is required.

Note - I'm working on providing flame graphs and examples without company-specific data.