### PR TITLE
Add license note to GSON POM file.

### DIFF
--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -10,6 +10,13 @@
   <artifactId>gson</artifactId>
   <name>Gson</name>
 
+  <licenses>
+    <license>
+      <name>Apache 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+  
   <dependencies>
     <dependency>
       <groupId>junit</groupId>

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -12,7 +12,7 @@
 
   <licenses>
     <license>
-      <name>Apache 2.0</name>
+      <name>Apache-2.0</name>
       <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>


### PR DESCRIPTION
I use [gradle-license-plugin](https://github.com/jaredsburrows/gradle-license-plugin) to keep information about licenses for my project's dependencies up-to-date. This Gradle plugin heavily relies on POM file to get information about license for `.jar` or `.aar` artifacts.

Unfortunately, for the latest GSON artifact from Maven Central it is impossible to retrieve information about license from [POM file](https://repo1.maven.org/maven2/com/google/code/gson/gson/2.8.8/gson-2.8.8.pom). This PR adds such information to GSON POM file.