### PR TITLE
Add `GsonBuilder.disallowDuplicateProperties()`

### DIFF
--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -35,6 +35,7 @@ import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 
 import static com.google.gson.Gson.DEFAULT_COMPLEX_MAP_KEYS;
+import static com.google.gson.Gson.DEFAULT_DISALLOW_DUPLICATE_PROPERTIES;
 import static com.google.gson.Gson.DEFAULT_ESCAPE_HTML;
 import static com.google.gson.Gson.DEFAULT_JSON_NON_EXECUTABLE;
 import static com.google.gson.Gson.DEFAULT_LENIENT;
@@ -90,6 +91,7 @@ public final class GsonBuilder {
   private int dateStyle = DateFormat.DEFAULT;
   private int timeStyle = DateFormat.DEFAULT;
   private boolean complexMapKeySerialization = DEFAULT_COMPLEX_MAP_KEYS;
+  private boolean disallowDuplicateProperties = DEFAULT_DISALLOW_DUPLICATE_PROPERTIES;
   private boolean serializeSpecialFloatingPointValues = DEFAULT_SPECIALIZE_FLOAT_VALUES;
   private boolean escapeHtmlChars = DEFAULT_ESCAPE_HTML;
   private boolean prettyPrinting = DEFAULT_PRETTY_PRINT;
@@ -117,6 +119,7 @@ public final class GsonBuilder {
     this.instanceCreators.putAll(gson.instanceCreators);
     this.serializeNulls = gson.serializeNulls;
     this.complexMapKeySerialization = gson.complexMapKeySerialization;
+    this.disallowDuplicateProperties = gson.disallowDuplicateProperties;
     this.generateNonExecutableJson = gson.generateNonExecutableJson;
     this.escapeHtmlChars = gson.htmlSafe;
     this.prettyPrinting = gson.prettyPrinting;
@@ -323,6 +326,26 @@ public final class GsonBuilder {
    */
   public GsonBuilder setFieldNamingStrategy(FieldNamingStrategy fieldNamingStrategy) {
     this.fieldNamingPolicy = fieldNamingStrategy;
+    return this;
+  }
+
+  /**
+   * Disallows duplicate JSON object properties during deserialization. When the JSON
+   * data contains multiple properties with the same name a {@link JsonSyntaxException}
+   * will be thrown. This affects the built-in adapters for {@code Object}, {@code Map}
+   * and {@link JsonObject} as well as the reflection based adapter.
+   *
+   * <p>By default Gson permits duplicate properties and only uses the value of the
+   * last property with the same name.<br>
+   * When an application interacts with other components using different JSON libraries,
+   * they might treat duplicate properties differently, allowing an attacker to circumvent
+   * security checks. It is therefore recommended to disable duplicate properties to
+   * make the application more secure.
+   *
+   * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
+   */
+  public GsonBuilder disallowDuplicatePropertyDeserialization() {
+    this.disallowDuplicateProperties = true;
     return this;
   }
 
@@ -598,7 +621,7 @@ public final class GsonBuilder {
     return new Gson(excluder, fieldNamingPolicy, instanceCreators,
         serializeNulls, complexMapKeySerialization,
         generateNonExecutableJson, escapeHtmlChars, prettyPrinting, lenient,
-        serializeSpecialFloatingPointValues, longSerializationPolicy,
+        serializeSpecialFloatingPointValues, disallowDuplicateProperties, longSerializationPolicy,
         datePattern, dateStyle, timeStyle,
         this.factories, this.hierarchyFactories, factories);
   }

--- a/gson/src/main/java/com/google/gson/JsonParser.java
+++ b/gson/src/main/java/com/google/gson/JsonParser.java
@@ -25,7 +25,10 @@ import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.MalformedJsonException;
 
 /**
- * A parser to parse Json into a parse tree of {@link JsonElement}s
+ * A parser to parse Json into a parse tree of {@link JsonElement}s.
+ *
+ * <p>In case the JSON data contains properties with duplicate names only the
+ * value of the last property is used.
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
@@ -37,7 +40,7 @@ public final class JsonParser {
   public JsonParser() {}
 
   /**
-   * Parses the specified JSON string into a parse tree
+   * Parses the specified JSON string into a parse tree.
    *
    * @param json JSON text
    * @return a parse tree of {@link JsonElement}s corresponding to the specified JSON
@@ -48,7 +51,7 @@ public final class JsonParser {
   }
 
   /**
-   * Parses the specified JSON string into a parse tree
+   * Parses the specified JSON string into a parse tree.
    *
    * @param reader JSON text
    * @return a parse tree of {@link JsonElement}s corresponding to the specified JSON

--- a/gson/src/main/java/com/google/gson/JsonStreamParser.java
+++ b/gson/src/main/java/com/google/gson/JsonStreamParser.java
@@ -35,7 +35,7 @@ import com.google.gson.stream.MalformedJsonException;
  * <p>This class is conditionally thread-safe (see Item 70, Effective Java second edition). To
  * properly use this class across multiple threads, you will need to add some external
  * synchronization. For example:
- * 
+ *
  * <pre>
  * JsonStreamParser parser = new JsonStreamParser("['first'] {'second':10} 'third'");
  * JsonElement element;
@@ -45,6 +45,9 @@ import com.google.gson.stream.MalformedJsonException;
  *   }
  * }
  * </pre>
+ *
+ * <p>In case the JSON data contains properties with duplicate names only the
+ * value of the last property is used.
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
@@ -59,9 +62,9 @@ public final class JsonStreamParser implements Iterator<JsonElement> {
    * @since 1.4
    */
   public JsonStreamParser(String json) {
-    this(new StringReader(json));      
+    this(new StringReader(json));
   }
-  
+
   /**
    * @param reader The data stream containing JSON elements concatenated to each other.
    * @since 1.4
@@ -71,7 +74,7 @@ public final class JsonStreamParser implements Iterator<JsonElement> {
     parser.setLenient(true);
     lock = new Object();
   }
-  
+
   /**
    * Returns the next available {@link JsonElement} on the reader. Throws a
    * {@link NoSuchElementException} if no element is available.
@@ -85,7 +88,7 @@ public final class JsonStreamParser implements Iterator<JsonElement> {
     if (!hasNext()) {
       throw new NoSuchElementException();
     }
-    
+
     try {
       return Streams.parse(parser);
     } catch (StackOverflowError e) {

--- a/gson/src/main/java/com/google/gson/internal/Streams.java
+++ b/gson/src/main/java/com/google/gson/internal/Streams.java
@@ -39,6 +39,8 @@ public final class Streams {
 
   /**
    * Takes a reader in any state and returns the next value as a JsonElement.
+   * In case the JSON data contains properties with duplicate names only the
+   * value of the last property is used.
    */
   public static JsonElement parse(JsonReader reader) throws JsonParseException {
     boolean isEmpty = true;

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -23,6 +23,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.Arrays;
+import java.util.Map;
 
 /**
  * Reads a JSON (<a href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>)
@@ -768,6 +769,12 @@ public class JsonReader implements Closeable {
   /**
    * Returns the next token, a {@link com.google.gson.stream.JsonToken#NAME property name}, and
    * consumes it.
+   *
+   * <p>This method does not detect or prevent multiple properties with the same name.
+   * Security sensitive applications should manually verify that no duplicate properties
+   * exist, also considering {@code null} values (checking the result of {@link Map#put}
+   * is therefore not sufficient), to protect against malicious JSON data which tries
+   * to circumvent security checks.
    *
    * @throws java.io.IOException if the next token in the stream is not a property
    *     name.

--- a/gson/src/test/java/com/google/gson/GsonTest.java
+++ b/gson/src/test/java/com/google/gson/GsonTest.java
@@ -47,7 +47,7 @@ public final class GsonTest extends TestCase {
   public void testOverridesDefaultExcluder() {
     Gson gson = new Gson(CUSTOM_EXCLUDER, CUSTOM_FIELD_NAMING_STRATEGY,
         new HashMap<Type, InstanceCreator<?>>(), true, false, true, false,
-        true, true, false, LongSerializationPolicy.DEFAULT, null, DateFormat.DEFAULT,
+        true, true, false, false, LongSerializationPolicy.DEFAULT, null, DateFormat.DEFAULT,
         DateFormat.DEFAULT, new ArrayList<TypeAdapterFactory>(),
         new ArrayList<TypeAdapterFactory>(), new ArrayList<TypeAdapterFactory>());
 
@@ -60,7 +60,7 @@ public final class GsonTest extends TestCase {
   public void testClonedTypeAdapterFactoryListsAreIndependent() {
     Gson original = new Gson(CUSTOM_EXCLUDER, CUSTOM_FIELD_NAMING_STRATEGY,
         new HashMap<Type, InstanceCreator<?>>(), true, false, true, false,
-        true, true, false, LongSerializationPolicy.DEFAULT, null, DateFormat.DEFAULT,
+        true, true, false, false, LongSerializationPolicy.DEFAULT, null, DateFormat.DEFAULT,
         DateFormat.DEFAULT, new ArrayList<TypeAdapterFactory>(),
         new ArrayList<TypeAdapterFactory>(), new ArrayList<TypeAdapterFactory>());
 

--- a/gson/src/test/java/com/google/gson/JsonObjectTest.java
+++ b/gson/src/test/java/com/google/gson/JsonObjectTest.java
@@ -127,11 +127,6 @@ public class JsonObjectTest extends TestCase {
 
   }
 
-  public void testReadPropertyWithEmptyStringName() {
-    JsonObject jsonObj = JsonParser.parseString("{\"\":true}").getAsJsonObject();
-    assertEquals(true, jsonObj.get("").getAsBoolean());
-  }
-
   public void testEqualsOnEmptyObject() {
     MoreAsserts.assertEqualsAndHashCode(new JsonObject(), new JsonObject());
   }

--- a/gson/src/test/java/com/google/gson/ObjectTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/ObjectTypeAdapterTest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+
 import junit.framework.TestCase;
 
 public final class ObjectTypeAdapterTest extends TestCase {
@@ -38,7 +39,7 @@ public final class ObjectTypeAdapterTest extends TestCase {
     Object object = new RuntimeType();
     assertEquals("{'a':5,'b':[1,2,null]}", adapter.toJson(object).replace("\"", "'"));
   }
-  
+
   public void testSerializeNullValue() throws Exception {
     Map<String, Object> map = new LinkedHashMap<String, Object>();
     map.put("a", null);
@@ -53,6 +54,35 @@ public final class ObjectTypeAdapterTest extends TestCase {
 
   public void testSerializeObject() throws Exception {
     assertEquals("{}", adapter.toJson(new Object()));
+  }
+
+  public void testDeserializeDuplicateProperties() throws Exception {
+    String json = "{\"a\":1,\"a\":2}";
+    assertEquals(Collections.singletonMap("a", 2.0), adapter.fromJson(json));
+  }
+
+  public void testDeserializeDuplicatePropertiesDisallowed() throws Exception {
+    Gson gson = new GsonBuilder().disallowDuplicatePropertyDeserialization().create();
+
+    {
+      String json = "{\"a\":1,\"a\":2}";
+      try {
+        gson.getAdapter(Object.class).fromJson(json);
+        fail();
+      } catch (JsonSyntaxException e) {
+        assertEquals("Duplicate property 'a'", e.getMessage());
+      }
+    }
+
+    {
+      String json = "{\"a\":null,\"a\":null}";
+      try {
+        gson.getAdapter(Object.class).fromJson(json);
+        fail();
+      } catch (JsonSyntaxException e) {
+        assertEquals("Duplicate property 'a'", e.getMessage());
+      }
+    }
   }
 
   @SuppressWarnings("unused")

--- a/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
@@ -409,6 +409,17 @@ public class DefaultTypeAdaptersTest extends TestCase {
     assertEquals(23, cal.get(Calendar.SECOND));
   }
 
+  public void testDefaultCalendarDeserializationDuplicatePropertiesDisallowed() throws Exception {
+    Gson gson = new GsonBuilder().disallowDuplicatePropertyDeserialization().create();
+    String json = "{year:2009,year:2010,month:2,dayOfMonth:11,hourOfDay:14,minute:29,second:23}";
+    try {
+      gson.fromJson(json, Calendar.class);
+      fail();
+    } catch (JsonSyntaxException e) {
+      assertEquals("Duplicate property 'year'", e.getMessage());
+    }
+  }
+
   public void testDefaultGregorianCalendarSerialization() throws Exception {
     Gson gson = new GsonBuilder().create();
     GregorianCalendar cal = new GregorianCalendar();
@@ -431,6 +442,17 @@ public class DefaultTypeAdaptersTest extends TestCase {
     assertEquals(14, cal.get(Calendar.HOUR_OF_DAY));
     assertEquals(29, cal.get(Calendar.MINUTE));
     assertEquals(23, cal.get(Calendar.SECOND));
+  }
+
+  public void testDefaultGregorianCalendarDeserializationDuplicatePropertiesDisallowed() throws Exception {
+    Gson gson = new GsonBuilder().disallowDuplicatePropertyDeserialization().create();
+    String json = "{year:2009,month:2,month:7,dayOfMonth:11,hourOfDay:14,minute:29,second:23}";
+    try {
+      gson.fromJson(json, GregorianCalendar.class);
+      fail();
+    } catch (JsonSyntaxException e) {
+      assertEquals("Duplicate property 'month'", e.getMessage());
+    }
   }
 
   public void testDateSerializationWithPattern() throws Exception {

--- a/gson/src/test/java/com/google/gson/functional/MapAsArrayTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MapAsArrayTypeAdapterTest.java
@@ -21,6 +21,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -114,6 +115,26 @@ public class MapAsArrayTypeAdapterTest extends TestCase {
     Point value = map.map.values().iterator().next();
     assertEquals(new Point(2, 3), key);
     assertEquals(new Point(4, 5), value);
+  }
+
+  public void testMapDeserializationWithDuplicateNullProperties() {
+    Gson gson = new GsonBuilder().enableComplexMapKeySerialization().create();
+    String json = "[['a', null], ['a', null]]";
+    Type type = new TypeToken<Map<String, String>>(){}.getType();
+    Map<String, String> map = gson.fromJson(json, type);
+    assertEquals(Collections.singletonMap("a", null), map);
+  }
+
+  public void testMapDeserializationWithDuplicateNullPropertiesDisallowed() {
+    Gson gson = new GsonBuilder().enableComplexMapKeySerialization().disallowDuplicatePropertyDeserialization().create();
+    String json = "[['a', null], ['a', null]]";
+    Type type = new TypeToken<Map<String, String>>(){}.getType();
+    try {
+      gson.fromJson(json, type);
+      fail();
+    } catch (JsonSyntaxException e) {
+      assertEquals("duplicate key: a", e.getMessage());
+    }
   }
 
   static class Point {

--- a/gson/src/test/java/com/google/gson/functional/MapTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MapTest.java
@@ -18,6 +18,7 @@ package com.google.gson.functional;
 
 import java.lang.reflect.Type;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -576,6 +577,21 @@ public class MapTest extends TestCase {
       gson.fromJson("{'a':1,'a':2}", new TypeToken<Map<String, Integer>>() {}.getType());
       fail();
     } catch (JsonSyntaxException expected) {
+    }
+  }
+
+  public void testMapDeserializationWithDuplicateNullKeys() {
+    Map<String, String> map = gson.fromJson("{'a':null,'a':null}", new TypeToken<Map<String, String>>() {}.getType());
+    assertEquals(Collections.singletonMap("a", null), map);
+  }
+
+  public void testMapDeserializationWithDuplicateNullKeysDisallowed() {
+    Gson gson = new GsonBuilder().disallowDuplicatePropertyDeserialization().create();
+    try {
+      gson.fromJson("{'a':null,'a':null}", new TypeToken<Map<String, String>>() {}.getType());
+      fail();
+    } catch (JsonSyntaxException e) {
+      assertEquals("duplicate key: a", e.getMessage());
     }
   }
 

--- a/gson/src/test/java/com/google/gson/functional/ReflectionDeserializationDuplicatePropertyTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ReflectionDeserializationDuplicatePropertyTest.java
@@ -1,0 +1,55 @@
+package com.google.gson.functional;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+
+import junit.framework.TestCase;
+
+public class ReflectionDeserializationDuplicatePropertyTest extends TestCase {
+  static class MyClass {
+    public String s;
+  }
+
+  public void testDuplicateProperty() {
+    Gson gson = new Gson();
+    String json = "{\"s\":\"1\",\"s\":\"2\"}";
+    MyClass obj = gson.fromJson(json, MyClass.class);
+    assertEquals("2", obj.s);
+  }
+
+  public void testDuplicatePropertyDisallowed() {
+    Gson gson = new GsonBuilder().disallowDuplicatePropertyDeserialization().create();
+
+    {
+      String json = "{\"s\":\"1\",\"s\":\"2\"}";
+      try {
+        gson.fromJson(json, MyClass.class);
+        fail();
+      } catch (JsonSyntaxException e) {
+        assertEquals("Duplicate property 's'", e.getMessage());
+      }
+    }
+
+    {
+      String json = "{\"s\":null,\"s\":null}";
+      try {
+        gson.fromJson(json, MyClass.class);
+        fail();
+      } catch (JsonSyntaxException e) {
+        assertEquals("Duplicate property 's'", e.getMessage());
+      }
+    }
+
+    {
+      // Refers to non-existent field
+      String json = "{\"other\":null,\"other\":null}";
+      try {
+        gson.fromJson(json, MyClass.class);
+        fail();
+      } catch (JsonSyntaxException e) {
+        assertEquals("Duplicate property 'other'", e.getMessage());
+      }
+    }
+  }
+}


### PR DESCRIPTION
Resolves  #386
Relates to #1884

Adds the method `GsonBuilder.disallowDuplicateProperties()` to disallow multiple properties with the same name. Security sensitive applications can use this to protect against malicious JSON data which tries to circumvent security checks.