### PR TITLE
Fix `RuntimeTypeAdapterFactory` depending on internal `Streams` class

### DIFF
--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -1,47 +1,37 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>com.google.code.gson</groupId>
+  <parent>
+    <groupId>com.google.code.gson</groupId>
+    <artifactId>gson-parent</artifactId>
+    <version>2.8.9-SNAPSHOT</version>
+  </parent>
+
   <artifactId>gson-extras</artifactId>
   <packaging>jar</packaging>
   <version>1.0-SNAPSHOT</version>
   <inceptionYear>2008</inceptionYear>
   <name>Gson Extras</name>
-  <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>9</version>
-  </parent>
-  <url>http://code.google.com/p/google-gson/</url>
   <description>Google Gson grab bag of utilities, type adapters, etc.</description>
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
+
   <licenses>
     <license>
-      <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-      <distribution>repo</distribution>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>
-  <scm>
-    <connection>scm:svn:http://google-gson.googlecode.com/svn/trunk/extras</connection>
-    <developerConnection>scm:svn:https://google-gson.googlecode.com/svn/trunk/extras</developerConnection>
-    <url>http://google-gson.codegoogle.com/svn/trunk/extras</url>
-  </scm>
-  <issueManagement>
-    <system>Google Code Issue Tracking</system>
-    <url>http://code.google.com/p/google-gson/issues/list</url>
-  </issueManagement>
+
   <organization>
     <name>Google, Inc.</name>
-    <url>http://www.google.com</url>
+    <url>https://www.google.com</url>
   </organization>
+
   <dependencies>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.7</version>
-      <scope>compile</scope>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.annotation</groupId>
@@ -51,130 +41,26 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <profiles>
-    <!-- Activate PGP signing only when performing a release -->
-    <profile>
-      <id>release-sign-artifacts</id>
-      <activation>
-        <property>
-          <name>performRelease</name>
-          <value>true</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.5</version>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>  
+
   <build>
-    <defaultGoal>package</defaultGoal>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
-        <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>3.0.2</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <archive>
-            <addMavenDescriptor>false</addMavenDescriptor>
-          </archive>
-        </configuration>
-      </plugin>
-      <plugin>
-         <groupId>org.apache.maven.plugins</groupId>
-         <artifactId>maven-source-plugin</artifactId>
-         <version>3.0.1</version>
-         <executions>
-           <execution>
-             <id>attach-sources</id>
-             <phase>verify</phase>
-             <goals>
-               <goal>jar</goal>
-             </goals>
-           </execution>
-         </executions>
-       </plugin>
-       <plugin>
-         <groupId>org.apache.maven.plugins</groupId>
-         <artifactId>maven-javadoc-plugin</artifactId>
-         <version>2.10.4</version>
-         <executions>
-           <execution>
-             <id>attach-javadocs</id>
-             <goals>
-               <goal>jar</goal>
-             </goals>
-           </execution>
-         </executions>
-         <configuration>
-           <links>
-             <link>http://download.oracle.com/javase/1.5.0/docs/api/</link>
-           </links>
-           <version>true</version>
-           <show>public</show>
-         </configuration>
-       </plugin>
-       <plugin>
-         <groupId>org.apache.maven.plugins</groupId>
-         <artifactId>maven-eclipse-plugin</artifactId>
-         <version>2.10</version>
-         <configuration>
-           <downloadSources>true</downloadSources>
-           <downloadJavadocs>true</downloadJavadocs>
-           <workspace>
-             ../eclipse-ws/
-           </workspace>
-           <workspaceCodeStylesURL>
-             file:///${basedir}/../lib/gson-formatting-styles.xml
-           </workspaceCodeStylesURL>
-         </configuration>
-       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-release-plugin</artifactId>
-        <!--  version>2.3.2</version -->
-        <configuration>
-          <arguments>-DenableCiProfile=true</arguments>
-          <tagBase>https://google-gson.googlecode.com/svn/tags/</tagBase>
-        </configuration>
-      </plugin>
-    </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>3.0.0-M1</version>
+          <configuration>
+            <!-- Currently not deployed -->
+            <skip>true</skip>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
+
   <developers>
     <developer>
       <name>Inderjeet Singh</name>

--- a/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
@@ -204,7 +204,7 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
   }
 
   @Override
-public <R> TypeAdapter<R> create(Gson gson, TypeToken<R> type) {
+  public <R> TypeAdapter<R> create(Gson gson, TypeToken<R> type) {
     if (type.getRawType() != baseType) {
       return null;
     }

--- a/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
@@ -27,7 +27,6 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
-import com.google.gson.internal.Streams;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
@@ -204,11 +203,13 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
     return registerSubtype(type, type.getSimpleName());
   }
 
-  public <R> TypeAdapter<R> create(Gson gson, TypeToken<R> type) {
+  @Override
+public <R> TypeAdapter<R> create(Gson gson, TypeToken<R> type) {
     if (type.getRawType() != baseType) {
       return null;
     }
 
+    final TypeAdapter<JsonElement> jsonElementAdapter = gson.getAdapter(JsonElement.class);
     final Map<String, TypeAdapter<?>> labelToDelegate
         = new LinkedHashMap<String, TypeAdapter<?>>();
     final Map<Class<?>, TypeAdapter<?>> subtypeToDelegate
@@ -221,7 +222,7 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
 
     return new TypeAdapter<R>() {
       @Override public R read(JsonReader in) throws IOException {
-        JsonElement jsonElement = Streams.parse(in);
+        JsonElement jsonElement = jsonElementAdapter.read(in);
         JsonElement labelJsonElement;
         if (maintainType) {
             labelJsonElement = jsonElement.getAsJsonObject().get(typeFieldName);
@@ -255,7 +256,7 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
         JsonObject jsonObject = delegate.toJsonTree(value).getAsJsonObject();
 
         if (maintainType) {
-          Streams.write(jsonObject, out);
+          jsonElementAdapter.write(out, jsonObject);
           return;
         }
 
@@ -270,7 +271,7 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
         for (Map.Entry<String, JsonElement> e : jsonObject.entrySet()) {
           clone.add(e.getKey(), e.getValue());
         }
-        Streams.write(clone, out);
+        jsonElementAdapter.write(out, clone);
       }
     }.nullSafe();
   }

--- a/extras/src/test/java/com/google/gson/graph/GraphAdapterBuilderTest.java
+++ b/extras/src/test/java/com/google/gson/graph/GraphAdapterBuilderTest.java
@@ -16,16 +16,23 @@
 
 package com.google.gson.graph;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.reflect.TypeToken;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import junit.framework.TestCase;
 
-public final class GraphAdapterBuilderTest extends TestCase {
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+
+public final class GraphAdapterBuilderTest {
+  @Test
   public void testSerialization() {
     Roshambo rock = new Roshambo("ROCK");
     Roshambo scissors = new Roshambo("SCISSORS");
@@ -46,6 +53,7 @@ public final class GraphAdapterBuilderTest extends TestCase {
         gson.toJson(rock).replace('"', '\''));
   }
 
+  @Test
   public void testDeserialization() {
     String json = "{'0x1':{'name':'ROCK','beats':'0x2'}," +
         "'0x2':{'name':'SCISSORS','beats':'0x3'}," +
@@ -66,6 +74,8 @@ public final class GraphAdapterBuilderTest extends TestCase {
     assertSame(rock, paper.beats);
   }
 
+  @Ignore("Does not work anymore due to ReflectiveTypeAdapterFactory ignoring self references")
+  @Test
   public void testSerializationDirectSelfReference() {
     Roshambo suicide = new Roshambo("SUICIDE");
     suicide.beats = suicide;
@@ -80,6 +90,7 @@ public final class GraphAdapterBuilderTest extends TestCase {
         gson.toJson(suicide).replace('"', '\''));
   }
 
+  @Test
   public void testDeserializationDirectSelfReference() {
     String json = "{'0x1':{'name':'SUICIDE','beats':'0x1'}}";
 
@@ -94,6 +105,7 @@ public final class GraphAdapterBuilderTest extends TestCase {
     assertSame(suicide, suicide.beats);
   }
 
+  @Test
   public void testSerializeListOfLists() {
     Type listOfListsType = new TypeToken<List<List<?>>>() {}.getType();
     Type listOfAnyType = new TypeToken<List<?>>() {}.getType();
@@ -113,6 +125,7 @@ public final class GraphAdapterBuilderTest extends TestCase {
     assertEquals("{'0x1':['0x1','0x2'],'0x2':[]}", json.replace('"', '\''));
   }
 
+  @Test
   public void testDeserializeListOfLists() {
     Type listOfAnyType = new TypeToken<List<?>>() {}.getType();
     Type listOfListsType = new TypeToken<List<List<?>>>() {}.getType();
@@ -130,6 +143,7 @@ public final class GraphAdapterBuilderTest extends TestCase {
     assertEquals(Collections.emptyList(), listOfLists.get(1));
   }
 
+  @Test
   public void testSerializationWithMultipleTypes() {
     Company google = new Company("Google");
     new Employee("Jesse", google);
@@ -148,6 +162,7 @@ public final class GraphAdapterBuilderTest extends TestCase {
         gson.toJson(google).replace('"', '\''));
   }
 
+  @Test
   public void testDeserializationWithMultipleTypes() {
     GsonBuilder gsonBuilder = new GsonBuilder();
     new GraphAdapterBuilder()

--- a/extras/src/test/java/com/google/gson/graph/GraphAdapterBuilderTest.java
+++ b/extras/src/test/java/com/google/gson/graph/GraphAdapterBuilderTest.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -72,22 +71,6 @@ public final class GraphAdapterBuilderTest {
     Roshambo paper = scissors.beats;
     assertEquals("PAPER", paper.name);
     assertSame(rock, paper.beats);
-  }
-
-  @Ignore("Does not work anymore due to ReflectiveTypeAdapterFactory ignoring self references")
-  @Test
-  public void testSerializationDirectSelfReference() {
-    Roshambo suicide = new Roshambo("SUICIDE");
-    suicide.beats = suicide;
-
-    GsonBuilder gsonBuilder = new GsonBuilder();
-    new GraphAdapterBuilder()
-        .addType(Roshambo.class)
-        .registerOn(gsonBuilder);
-    Gson gson = gsonBuilder.create();
-
-    assertEquals("{'0x1':{'name':'SUICIDE','beats':'0x1'}}",
-        gson.toJson(suicide).replace('"', '\''));
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
 
   <modules>
     <module>gson</module>
+    <module>extras</module>
   </modules>
 
   <properties>
@@ -41,7 +42,7 @@
 
   <licenses>
     <license>
-      <name>Apache 2.0</name>
+      <name>Apache-2.0</name>
       <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>


### PR DESCRIPTION
Fixes #1931

Additionally makes gson-extras a Maven module of gson-parent and cleans up its POM.
Deploying for gson-extras is disabled, hopefully this is respected by the Maven Release Plugin.