### PR TITLE
JsonWriter make indent accessible

### DIFF
--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -219,7 +219,15 @@ public class JsonWriter implements Closeable, Flushable {
       this.separator = ": ";
     }
   }
-
+  
+  /**
+   * Returns the indentation string to be repeated for each level of indentation
+   * in the encoded document.
+   */
+  public String getIndent() {
+    return indent;
+  }
+  
   /**
    * Configure this writer to relax its syntax rules. By default, this writer
    * only emits well-formed JSON as specified by <a


### PR DESCRIPTION
Motivation for this change.
When using indents in the JsonWriter usually spam newlines for arrays.
I wrote a custom JsonWriter on top of this one which just implements a nicer Pretty Printing style.
Said Style disables newlines & indents when a Array is started, but enables them if a object is started within the array.
It uses a List<Boolean> to keep track of the blockage state.

The only thing that I couldn't override without adding a extra Method is the "indent". Which is set to final for reasons I assume,
but a getter should be present to aid people who want to improve their "Human Readable" JsonFile.

The idea is that you can seamlessly override the JsonWriter without the need of requiring extra functions to make original behavior work.

Thanks for reading and your time.