### PR TITLE
Add Gson method for creating new instances (using `InstanceCreator`s)

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -1006,6 +1006,25 @@ public final class Gson {
     return (T) fromJson(new JsonTreeReader(json), typeOfT);
   }
 
+  /**
+   * Creates a new instance of the type using either one of the {@link InstanceCreator}s
+   * {@linkplain GsonBuilder#registerTypeAdapter(Type, Object) registered with the <code>GsonBuilder</code>}
+   * or a built-in creator.
+   *
+   * <p>This method is mainly intended for {@link TypeAdapterFactory} implementations of
+   * collection-like types which want to create an empty collection instance and then add
+   * the values read from JSON to it.
+   *
+   * @param <T> type to create
+   * @param type token representing the type to create
+   * @return the created instance
+   */
+  // TODO: Specify thrown exception type; but ConstructorConstructor currently uses
+  // RuntimeException instead of specific exception
+  public <T> T createInstance(TypeToken<? extends T> type) {
+    return constructorConstructor.get(type).construct();
+  }
+
   static class FutureTypeAdapter<T> extends TypeAdapter<T> {
     private TypeAdapter<T> delegate;
 


### PR DESCRIPTION
Adds the method `Gson.createInstance(TypeToken)` exposing `ConstructorConstructor`'s functionality.
This allows custom TypeAdapterFactories to easily create new instances which can be useful for example for custom collection-like types or for custom reflection based adapters which want to support `@JsonAdapter`, see https://github.com/google/gson/issues/1794#issuecomment-919890214.

Might relate to or resolve #537, though from its description it is not completely clear what that issue was proposing and the attached patch does not seem to be available anymore.