### PR TITLE
Don't exclude static local classes

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/Excluder.java
+++ b/gson/src/main/java/com/google/gson/internal/Excluder.java
@@ -173,7 +173,7 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
       return true;
     }
 
-    if (isAnonymousOrLocal(field.getType())) {
+    if (isAnonymousOrNonStaticLocal(field.getType())) {
       return true;
     }
 
@@ -199,7 +199,7 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
           return true;
       }
 
-      if (isAnonymousOrLocal(clazz)) {
+      if (isAnonymousOrNonStaticLocal(clazz)) {
           return true;
       }
 
@@ -221,8 +221,8 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
       return false;
   }
 
-  private boolean isAnonymousOrLocal(Class<?> clazz) {
-    return !Enum.class.isAssignableFrom(clazz)
+  private boolean isAnonymousOrNonStaticLocal(Class<?> clazz) {
+    return !Enum.class.isAssignableFrom(clazz) && !isStatic(clazz)
         && (clazz.isAnonymousClass() || clazz.isLocalClass());
   }
 


### PR DESCRIPTION
Java 16 added Records, which can be declared locally but are always `static`. It also allows interfaces to be declared locally.

This pull request makes makes `Excluder` allow such static local classes. Despite Gson not having a built-in adapter for Record types yet, it at least makes it easier for users to write their own, see https://github.com/google/gson/issues/1794#issuecomment-803611447.
The reason why local classes were previously not permitted seems to be that they can capture enclosing references which cannot be serialized and deserialized properly, see #298. However for `static` classes this won't be an issue.

I have not added a test for this because Gson currently uses Java 6 to compile, so it would require adjustments to the Maven build to support compiling and running one test with Java 16. With Maven this is slightly more cumbersome than with Gradle because users need to manually set up a toolchain to specify a Java 16 JDK, whereas Gradle can handle that on its own.
But you can test this manually by running:
```java
public void test() {
  record R(int i) {}
  record C(R r) {}
  // Without the change this prints "null"
  System.out.println(new Gson().toJson(new C(new R(1))));
}
```

Relates to #1510