### PR TITLE
Improve TreeTypeAdapter thread-safety

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/TreeTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TreeTypeAdapter.java
@@ -47,7 +47,7 @@ public final class TreeTypeAdapter<T> extends TypeAdapter<T> {
   private final GsonContextImpl context = new GsonContextImpl();
 
   /** The delegate is lazily created because it may not be needed, and creating it may fail. */
-  private TypeAdapter<T> delegate;
+  private volatile TypeAdapter<T> delegate;
 
   public TreeTypeAdapter(JsonSerializer<T> serializer, JsonDeserializer<T> deserializer,
       Gson gson, TypeToken<T> typeToken, TypeAdapterFactory skipPast) {
@@ -83,6 +83,7 @@ public final class TreeTypeAdapter<T> extends TypeAdapter<T> {
   }
 
   private TypeAdapter<T> delegate() {
+    // Allows racy initialization of `delegate` by multiple threads
     TypeAdapter<T> d = delegate;
     return d != null
         ? d

--- a/gson/src/main/java/com/google/gson/internal/bind/TreeTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TreeTypeAdapter.java
@@ -83,7 +83,7 @@ public final class TreeTypeAdapter<T> extends TypeAdapter<T> {
   }
 
   private TypeAdapter<T> delegate() {
-    // Allows racy initialization of `delegate` by multiple threads
+    // A race might lead to `delegate` being assigned by multiple threads but the last assignment will stick
     TypeAdapter<T> d = delegate;
     return d != null
         ? d


### PR DESCRIPTION
Gson [claims to be thread-safe](https://github.com/google/gson/blob/3b7835a18b7ce999fe79ad12cd85014642f30968/gson/src/main/java/com/google/gson/Gson.java#L63) so `TreeTypeAdapter.delegate()` might be called by multiple threads. To guarantee that each thread sees a fully constructed `delegate`, the field has to be `volatile`.

Otherwise when a user-defined type adapter with non-`final` fields (even though it is stateless) is being used as delegate a thread might see an incomplete constructed instance. See [Safe Publication and Safe Initialization in Java](https://shipilev.net/blog/2014/safe-public-construction/#_correctness); the current case of `TreeTypeAdapter.delegate()` would be similar to the "Unsafe Local DCL & Unsafe Singleton" case shown in that blog post.