### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,9 +16,11 @@ assignees: ''
 
 
 # Used tools
-<!-- List relevant build tools here which might affect Gson -->
-- [ ] ProGuard
-- ...
+<!-- List relevant build tools and plugins with version number here which might affect Gson -->
+- [ ] Maven; version: 
+- [ ] Gradle; version: 
+- [ ] ProGuard (attach the configuration file please); version: 
+- [ ] ...
 
 # Description
 <!-- Describe the bug you experienced -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,47 @@
+---
+name: Bug report
+about: Report a Gson bug.
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+# Gson version
+<!-- Gson version you are using, for example '2.8.8' -->
+
+
+# Java / Android version
+<!-- Version of the Java or Android platform on which the bug occurred -->
+
+
+# Used tools
+<!-- List relevant build tools here which might affect Gson -->
+- [ ] ProGuard
+- ...
+
+# Description
+<!-- Describe the bug you experienced -->
+
+
+## Expected behavior
+<!-- What behavior did you expect? -->
+
+
+## Actual behavior
+<!-- What happened instead? -->
+
+
+# Reproduction steps
+<!-- Provide exact reproduction steps for reproducing the bug -->
+<!-- Provide a short code snippet or link to a demo project -->
+
+1. ...
+2. ...
+
+# Exception stack trace
+<!-- In case an exception occurred, paste the COMPLETE exception stack trace in the code block below or attach it as file -->
+
+```
+
+```

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Usage question
+    url: https://stackoverflow.com/questions/tagged/gson
+    about: Ask usage questions on StackOverflow.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Request a feature. ⚠️ Gson is in maintenance mode; large feature requests might be rejected.
+title: ''
+labels: feature-request
+assignees: ''
+
+---
+
+# Problem solved by the feature
+<!-- Describe which problem the requested feature solves -->
+
+
+# Feature description
+<!-- Describe the feature -->
+
+
+# Alternatives / workarounds
+<!-- Describe alternatives or workarounds in case you are aware of any -->
+

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Maven:
   * [Change log](https://github.com/google/gson/blob/master/CHANGELOG.md): Changes in the recent versions
   * [Design document](https://github.com/google/gson/blob/master/GsonDesignDocument.md): This document discusses issues we faced while designing Gson. It also includes a comparison of Gson with other Java libraries that can be used for Json conversion
 
-Please use the 'gson' tag on StackOverflow or the [google-gson Google group](https://groups.google.com/group/google-gson) to discuss Gson or to post questions.
+Please use the ['gson' tag on StackOverflow](https://stackoverflow.com/questions/tagged/gson) or the [google-gson Google group](https://groups.google.com/group/google-gson) to discuss Gson or to post questions.
 
 ### Related Content Created by Third Parties
   * [Gson Tutorial](https://www.studytrails.com/java/json/java-google-json-introduction/) by `StudyTrails`


### PR DESCRIPTION
Adds [GitHub issue templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository). This helps making sure that bug reports contain all necessary information and automatically adds labels for bug reports and feature requests, making it easy to tell them apart.

This is a proof of concept implementation; please let me know what you think and if you want anything changed. You can also try them out here: https://github.com/Marcono1234/gson/issues/new/choose