### PR TITLE
Add `JsonWriter` methods `setEscapeNonAsciiChars` and `setEscapeAllControlChars`

### DIFF
--- a/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
@@ -645,4 +645,39 @@ public final class JsonWriterTest extends TestCase {
     writer.close();
     writer.close();
   }
+
+  public void testEscapeNonAsciiChars() throws IOException {
+    StringWriter stringWriter = new StringWriter();
+    JsonWriter writer = new JsonWriter(stringWriter);
+    // false by default
+    assertFalse(writer.isEscapeNonAsciiChars());
+
+    String str = "\0ab\u007F\u0080\uFFFF unpaired \uDC00 paired \uD83D\uDE00";
+    writer.beginObject();
+
+    writer.name(str);
+    writer.value(str);
+
+    writer.setEscapeNonAsciiChars(true);
+    assertTrue(writer.isEscapeNonAsciiChars());
+    writer.name(str);
+    writer.value(str);
+
+    writer.setEscapeNonAsciiChars(false);
+    assertFalse(writer.isEscapeNonAsciiChars());
+    writer.name(str);
+    writer.value(str);
+
+    writer.endObject();
+    writer.close();
+
+    assertEquals(
+      "{"
+      + "\"\\u0000ab\u007F\u0080\uFFFF unpaired \uDC00 paired \uD83D\uDE00\":\"\\u0000ab\u007F\u0080\uFFFF unpaired \uDC00 paired \uD83D\uDE00\","
+      + "\"\\u0000ab\u007F\\u0080\\uffff unpaired \\udc00 paired \\ud83d\\ude00\":\"\\u0000ab\u007F\\u0080\\uffff unpaired \\udc00 paired \\ud83d\\ude00\","
+      + "\"\\u0000ab\u007F\u0080\uFFFF unpaired \uDC00 paired \uD83D\uDE00\":\"\\u0000ab\u007F\u0080\uFFFF unpaired \uDC00 paired \uD83D\uDE00\""
+      + "}",
+      stringWriter.toString()
+    );
+  }
 }

--- a/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
@@ -680,4 +680,39 @@ public final class JsonWriterTest extends TestCase {
       stringWriter.toString()
     );
   }
+
+  public void testEscapeAllControlChars() throws IOException {
+    StringWriter stringWriter = new StringWriter();
+    JsonWriter writer = new JsonWriter(stringWriter);
+    // false by default
+    assertFalse(writer.isEscapeAllControlChars());
+
+    String str = "\0ab\u007F\u0080\u009F\u00A0\uFFFF unpaired \uDC00 paired \uD83D\uDE00";
+    writer.beginObject();
+
+    writer.name(str);
+    writer.value(str);
+
+    writer.setEscapeAllControlChars(true);
+    assertTrue(writer.isEscapeAllControlChars());
+    writer.name(str);
+    writer.value(str);
+
+    writer.setEscapeAllControlChars(false);
+    assertFalse(writer.isEscapeAllControlChars());
+    writer.name(str);
+    writer.value(str);
+
+    writer.endObject();
+    writer.close();
+
+    assertEquals(
+      "{"
+      + "\"\\u0000ab\u007F\u0080\u009F\u00A0\uFFFF unpaired \uDC00 paired \uD83D\uDE00\":\"\\u0000ab\u007F\u0080\u009F\u00A0\uFFFF unpaired \uDC00 paired \uD83D\uDE00\","
+      + "\"\\u0000ab\\u007f\\u0080\\u009f\u00A0\uFFFF unpaired \uDC00 paired \uD83D\uDE00\":\"\\u0000ab\\u007f\\u0080\\u009f\u00A0\uFFFF unpaired \uDC00 paired \uD83D\uDE00\","
+      + "\"\\u0000ab\u007F\u0080\u009F\u00A0\uFFFF unpaired \uDC00 paired \uD83D\uDE00\":\"\\u0000ab\u007F\u0080\u009F\u00A0\uFFFF unpaired \uDC00 paired \uD83D\uDE00\""
+      + "}",
+      stringWriter.toString()
+    );
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -91,8 +91,8 @@
             <jdkToolchain>
               <version>[1.5,9)</version>
             </jdkToolchain>
-            <source>1.6</source>
-            <target>1.6</target>
+            <source>${java.version}</source>
+            <target>${java.version}</target>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Resolves #388

Adds convenience methods to `JsonWriter` to give the user more control over which characters should be escaped. This can be useful when interacting with legacy systems which do not support UTF-8 text.

An existing workaround is to provide a custom `java.io.Writer` to `JsonWriter` which performs the escaping, see https://github.com/google/gson/issues/388#issuecomment-83704872.
So feel free to close this pull request if you think these changes are not worth it.