### PR TITLE
Some code suggestion from CodeGuru

### DIFF
--- a/codegen/src/main/java/com/google/gson/codegen/GeneratedTypeAdapterProcessor.java
+++ b/codegen/src/main/java/com/google/gson/codegen/GeneratedTypeAdapterProcessor.java
@@ -53,9 +53,12 @@ public final class GeneratedTypeAdapterProcessor extends AbstractProcessor {
     System.out.println("Generating type adapter: " + typeAdapterName + " in " + sourceFile.getName());
 
     JavaWriter writer = new JavaWriter(sourceFile.openWriter());
-    writer.addPackage(CodeGen.getPackage(type).getQualifiedName().toString());
-    writer.beginType(typeAdapterName, "class", FINAL, null);
-    writer.endType();
-    writer.close();
+    try {
+      writer.addPackage(CodeGen.getPackage(type).getQualifiedName().toString());
+      writer.beginType(typeAdapterName, "class", FINAL, null);
+      writer.endType();
+    } finally {
+      writer.close();
+    }
   }
 }

--- a/proto/src/main/java/com/google/gson/protobuf/ProtoTypeAdapter.java
+++ b/proto/src/main/java/com/google/gson/protobuf/ProtoTypeAdapter.java
@@ -389,7 +389,7 @@ public class ProtoTypeAdapter
       EnumValueDescriptor fieldValue = desc.findValueByNumber(jsonElement.getAsInt());
       if (fieldValue == null) {
         throw new IllegalArgumentException(
-            String.format("Unrecognized enum value: %s", jsonElement.getAsInt()));
+            String.format("Unrecognized enum value: %d", jsonElement.getAsInt()));
       }
       return fieldValue;
     }


### PR DESCRIPTION
- Some code uses '%s' to format int: 'size' expression. Use %d, not %s, for integers. This ensures locale-sensitive formatting.
- Some lines of code contain a resource that might not have closed properly. closing the _write_ resource in a try-finally block.