### PR TITLE
Fix `Gson.newJsonWriter` ignoring lenient and HTML-safe setting

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -756,6 +756,13 @@ public final class Gson {
 
   /**
    * Returns a new JSON writer configured for the settings on this Gson instance.
+   *
+   * <p>The following settings are considered:
+   * <ul>
+   *   <li>{@link GsonBuilder#generateNonExecutableJson()}</li>
+   *   <li>{@link GsonBuilder#serializeNulls()}</li>
+   *   <li>{@link GsonBuilder#setPrettyPrinting()}</li>
+   * </ul>
    */
   public JsonWriter newJsonWriter(Writer writer) throws IOException {
     if (generateNonExecutableJson) {
@@ -771,6 +778,11 @@ public final class Gson {
 
   /**
    * Returns a new JSON reader configured for the settings on this Gson instance.
+   *
+   * <p>The following settings are considered:
+   * <ul>
+   *   <li>{@link GsonBuilder#setLenient()}</li>
+   * </ul>
    */
   public JsonReader newJsonReader(Reader reader) {
     JsonReader jsonReader = new JsonReader(reader);

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -759,8 +759,10 @@ public final class Gson {
    *
    * <p>The following settings are considered:
    * <ul>
+   *   <li>{@link GsonBuilder#disableHtmlEscaping()}</li>
    *   <li>{@link GsonBuilder#generateNonExecutableJson()}</li>
    *   <li>{@link GsonBuilder#serializeNulls()}</li>
+   *   <li>{@link GsonBuilder#setLenient()}</li>
    *   <li>{@link GsonBuilder#setPrettyPrinting()}</li>
    * </ul>
    */
@@ -772,6 +774,8 @@ public final class Gson {
     if (prettyPrinting) {
       jsonWriter.setIndent("  ");
     }
+    jsonWriter.setHtmlSafe(htmlSafe);
+    jsonWriter.setLenient(lenient);
     jsonWriter.setSerializeNulls(serializeNulls);
     return jsonWriter;
   }

--- a/gson/src/test/java/com/google/gson/GsonTest.java
+++ b/gson/src/test/java/com/google/gson/GsonTest.java
@@ -19,7 +19,11 @@ package com.google.gson;
 import com.google.gson.internal.Excluder;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import com.google.gson.stream.MalformedJsonException;
+
 import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.text.DateFormat;
@@ -81,5 +85,72 @@ public final class GsonTest extends TestCase {
       // Test stub.
     }
     @Override public Object read(JsonReader in) throws IOException { return null; }
+  }
+
+  public void testNewJsonWriter_Default() throws IOException {
+    StringWriter writer = new StringWriter();
+    JsonWriter jsonWriter = new Gson().newJsonWriter(writer);
+    jsonWriter.beginObject();
+    jsonWriter.name("test");
+    jsonWriter.nullValue();
+    jsonWriter.name("<test2");
+    jsonWriter.value(true);
+    jsonWriter.endObject();
+
+    try {
+      // Additional top-level value
+      jsonWriter.value(1);
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("JSON must have only one top-level value.", expected.getMessage());
+    }
+
+    jsonWriter.close();
+    assertEquals("{\"\\u003ctest2\":true}", writer.toString());
+  }
+
+  public void testNewJsonWriter_Custom() throws IOException {
+    StringWriter writer = new StringWriter();
+    JsonWriter jsonWriter = new GsonBuilder()
+      .disableHtmlEscaping()
+      .generateNonExecutableJson()
+      .setPrettyPrinting()
+      .serializeNulls()
+      .setLenient()
+      .create()
+      .newJsonWriter(writer);
+    jsonWriter.beginObject();
+    jsonWriter.name("test");
+    jsonWriter.nullValue();
+    jsonWriter.name("<test2");
+    jsonWriter.value(true);
+    jsonWriter.endObject();
+
+    // Additional top-level value
+    jsonWriter.value(1);
+
+    jsonWriter.close();
+    assertEquals(")]}'\n{\n  \"test\": null,\n  \"<test2\": true\n}1", writer.toString());
+  }
+
+  public void testNewJsonReader_Default() throws IOException {
+    String json = "test"; // String without quotes
+    JsonReader jsonReader = new Gson().newJsonReader(new StringReader(json));
+    try {
+      jsonReader.nextString();
+      fail();
+    } catch (MalformedJsonException expected) {
+    }
+    jsonReader.close();
+  }
+
+  public void testNewJsonReader_Custom() throws IOException {
+    String json = "test"; // String without quotes
+    JsonReader jsonReader = new GsonBuilder()
+      .setLenient()
+      .create()
+      .newJsonReader(new StringReader(json));
+    assertEquals("test", jsonReader.nextString());
+    jsonReader.close();
   }
 }

--- a/gson/src/test/java/com/google/gson/GsonTest.java
+++ b/gson/src/test/java/com/google/gson/GsonTest.java
@@ -20,7 +20,6 @@ import com.google.gson.internal.Excluder;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import com.google.gson.stream.MalformedJsonException;
-
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;


### PR DESCRIPTION
Resolves #1452
Supersedes #1451

:warning: This is a backward incompatible change because writers created by `newJsonWriter` will now by default produce HTML-safe output (because that is Gson's default setting). However, arguably the previous behavior was incorrect.