### PR TITLE
Fix LongSerializationPolicy null handling being inconsistent with Gson

### DIFF
--- a/gson/src/main/java/com/google/gson/LongSerializationPolicy.java
+++ b/gson/src/main/java/com/google/gson/LongSerializationPolicy.java
@@ -17,7 +17,7 @@
 package com.google.gson;
 
 /**
- * Defines the expected format for a {@code long} or {@code Long} type when its serialized.
+ * Defines the expected format for a {@code long} or {@code Long} type when it is serialized.
  *
  * @since 1.3
  *
@@ -26,13 +26,18 @@ package com.google.gson;
  */
 public enum LongSerializationPolicy {
   /**
-   * This is the "default" serialization policy that will output a {@code long} object as a JSON
+   * This is the "default" serialization policy that will output a {@code Long} object as a JSON
    * number. For example, assume an object has a long field named "f" then the serialized output
    * would be:
-   * {@code {"f":123}}.
+   * {@code {"f":123}}
+   *
+   * <p>A {@code null} value is serialized as {@link JsonNull}.
    */
   DEFAULT() {
     @Override public JsonElement serialize(Long value) {
+      if (value == null) {
+        return JsonNull.INSTANCE;
+      }
       return new JsonPrimitive(value);
     }
   },
@@ -40,11 +45,16 @@ public enum LongSerializationPolicy {
   /**
    * Serializes a long value as a quoted string. For example, assume an object has a long field 
    * named "f" then the serialized output would be:
-   * {@code {"f":"123"}}.
+   * {@code {"f":"123"}}
+   *
+   * <p>A {@code null} value is serialized as {@link JsonNull}.
    */
   STRING() {
     @Override public JsonElement serialize(Long value) {
-      return new JsonPrimitive(String.valueOf(value));
+      if (value == null) {
+        return JsonNull.INSTANCE;
+      }
+      return new JsonPrimitive(value.toString());
     }
   };
   

--- a/gson/src/test/java/com/google/gson/LongSerializationPolicyTest.java
+++ b/gson/src/test/java/com/google/gson/LongSerializationPolicyTest.java
@@ -29,19 +29,29 @@ public class LongSerializationPolicyTest extends TestCase {
   public void testDefaultLongSerialization() throws Exception {
     JsonElement element = LongSerializationPolicy.DEFAULT.serialize(1556L);
     assertTrue(element.isJsonPrimitive());
-    
+
     JsonPrimitive jsonPrimitive = element.getAsJsonPrimitive();
     assertFalse(jsonPrimitive.isString());
     assertTrue(jsonPrimitive.isNumber());
     assertEquals(1556L, element.getAsLong());
   }
-  
+
   public void testDefaultLongSerializationIntegration() {
     Gson gson = new GsonBuilder()
-        .setLongSerializationPolicy(LongSerializationPolicy.DEFAULT)
-        .create();
+      .setLongSerializationPolicy(LongSerializationPolicy.DEFAULT)
+      .create();
     assertEquals("[1]", gson.toJson(new long[] { 1L }, long[].class));
     assertEquals("[1]", gson.toJson(new Long[] { 1L }, Long[].class));
+  }
+
+  public void testDefaultLongSerializationNull() {
+    LongSerializationPolicy policy = LongSerializationPolicy.DEFAULT;
+    assertTrue(policy.serialize(null).isJsonNull());
+
+    Gson gson = new GsonBuilder()
+      .setLongSerializationPolicy(policy)
+      .create();
+    assertEquals("null", gson.toJson(null, Long.class));
   }
 
   public void testStringLongSerialization() throws Exception {
@@ -56,9 +66,19 @@ public class LongSerializationPolicyTest extends TestCase {
 
   public void testStringLongSerializationIntegration() {
     Gson gson = new GsonBuilder()
-        .setLongSerializationPolicy(LongSerializationPolicy.STRING)
-        .create();
+      .setLongSerializationPolicy(LongSerializationPolicy.STRING)
+      .create();
     assertEquals("[\"1\"]", gson.toJson(new long[] { 1L }, long[].class));
     assertEquals("[\"1\"]", gson.toJson(new Long[] { 1L }, Long[].class));
+  }
+
+  public void testStringLongSerializationNull() {
+    LongSerializationPolicy policy = LongSerializationPolicy.STRING;
+    assertTrue(policy.serialize(null).isJsonNull());
+
+    Gson gson = new GsonBuilder()
+      .setLongSerializationPolicy(policy)
+      .create();
+    assertEquals("null", gson.toJson(null, Long.class));
   }
 }


### PR DESCRIPTION
Gson does not actually use the specified `LongSerializationPolicy` but instead uses type adapters which emulate the behavior. However, previously Gson's implementation did not match LongSerializationPolicy regarding `null` handling.

Because it is rather unlikely that LongSerializationPolicy has been used on its own, this pull request adjusts its implementation to match Gson's behavior (instead of the other way around).