### PR TITLE
Prevent Java deserialization of internal classes

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/LazilyParsedNumber.java
+++ b/gson/src/main/java/com/google/gson/internal/LazilyParsedNumber.java
@@ -15,6 +15,9 @@
  */
 package com.google.gson.internal;
 
+import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
 import java.io.ObjectStreamException;
 import java.math.BigDecimal;
 
@@ -75,6 +78,11 @@ public final class LazilyParsedNumber extends Number {
    */
   private Object writeReplace() throws ObjectStreamException {
     return new BigDecimal(value);
+  }
+
+  private void readObject(ObjectInputStream in) throws IOException {
+    // Don't permit directly deserializing this class; writeReplace() should have written a replacement
+    throw new InvalidObjectException("Deserialization is unsupported");
   }
 
   @Override

--- a/gson/src/main/java/com/google/gson/internal/LinkedHashTreeMap.java
+++ b/gson/src/main/java/com/google/gson/internal/LinkedHashTreeMap.java
@@ -17,6 +17,9 @@
 
 package com.google.gson.internal;
 
+import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.util.AbstractMap;
@@ -860,5 +863,10 @@ public final class LinkedHashTreeMap<K, V> extends AbstractMap<K, V> implements 
    */
   private Object writeReplace() throws ObjectStreamException {
     return new LinkedHashMap<K, V>(this);
+  }
+
+  private void readObject(ObjectInputStream in) throws IOException {
+    // Don't permit directly deserializing this class; writeReplace() should have written a replacement
+    throw new InvalidObjectException("Deserialization is unsupported");
   }
 }

--- a/gson/src/main/java/com/google/gson/internal/LinkedTreeMap.java
+++ b/gson/src/main/java/com/google/gson/internal/LinkedTreeMap.java
@@ -17,6 +17,9 @@
 
 package com.google.gson.internal;
 
+import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.util.AbstractMap;
@@ -626,5 +629,10 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
    */
   private Object writeReplace() throws ObjectStreamException {
     return new LinkedHashMap<K, V>(this);
+  }
+
+  private void readObject(ObjectInputStream in) throws IOException {
+    // Don't permit directly deserializing this class; writeReplace() should have written a replacement
+    throw new InvalidObjectException("Deserialization is unsupported");
   }
 }

--- a/gson/src/test/java/com/google/gson/internal/LazilyParsedNumberTest.java
+++ b/gson/src/test/java/com/google/gson/internal/LazilyParsedNumberTest.java
@@ -15,6 +15,13 @@
  */
 package com.google.gson.internal;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.math.BigDecimal;
+
 import junit.framework.TestCase;
 
 public class LazilyParsedNumberTest extends TestCase {
@@ -28,5 +35,16 @@ public class LazilyParsedNumberTest extends TestCase {
     LazilyParsedNumber n1 = new LazilyParsedNumber("1");
     LazilyParsedNumber n1Another = new LazilyParsedNumber("1");
     assertTrue(n1.equals(n1Another));
+  }
+
+  public void testJavaSerialization() throws IOException, ClassNotFoundException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    ObjectOutputStream objOut = new ObjectOutputStream(out);
+    objOut.writeObject(new LazilyParsedNumber("123"));
+    objOut.close();
+
+    ObjectInputStream objIn = new ObjectInputStream(new ByteArrayInputStream(out.toByteArray()));
+    Number deserialized = (Number) objIn.readObject();
+    assertEquals(new BigDecimal("123"), deserialized);
   }
 }

--- a/gson/src/test/java/com/google/gson/internal/LinkedHashTreeMapTest.java
+++ b/gson/src/test/java/com/google/gson/internal/LinkedHashTreeMapTest.java
@@ -20,8 +20,15 @@ import com.google.gson.common.MoreAsserts;
 import com.google.gson.internal.LinkedHashTreeMap.AvlBuilder;
 import com.google.gson.internal.LinkedHashTreeMap.AvlIterator;
 import com.google.gson.internal.LinkedHashTreeMap.Node;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Random;
@@ -222,6 +229,20 @@ public final class LinkedHashTreeMapTest extends TestCase {
         assertConsistent(node);
       }
     }
+  }
+
+  public void testJavaSerialization() throws IOException, ClassNotFoundException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    ObjectOutputStream objOut = new ObjectOutputStream(out);
+    Map<String, Integer> map = new LinkedHashTreeMap<String, Integer>();
+    map.put("a", 1);
+    objOut.writeObject(map);
+    objOut.close();
+
+    ObjectInputStream objIn = new ObjectInputStream(new ByteArrayInputStream(out.toByteArray()));
+    @SuppressWarnings("unchecked")
+    Map<String, Integer> deserialized = (Map<String, Integer>) objIn.readObject();
+    assertEquals(Collections.singletonMap("a", 1), deserialized);
   }
 
   private static final Node<String, String> head = new Node<String, String>();

--- a/gson/src/test/java/com/google/gson/internal/LinkedTreeMapTest.java
+++ b/gson/src/test/java/com/google/gson/internal/LinkedTreeMapTest.java
@@ -16,8 +16,14 @@
 
 package com.google.gson.internal;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Random;
@@ -138,6 +144,20 @@ public final class LinkedTreeMapTest extends TestCase {
     map2.put("A", 1);
 
     MoreAsserts.assertEqualsAndHashCode(map1, map2);
+  }
+
+  public void testJavaSerialization() throws IOException, ClassNotFoundException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    ObjectOutputStream objOut = new ObjectOutputStream(out);
+    Map<String, Integer> map = new LinkedTreeMap<String, Integer>();
+    map.put("a", 1);
+    objOut.writeObject(map);
+    objOut.close();
+
+    ObjectInputStream objIn = new ObjectInputStream(new ByteArrayInputStream(out.toByteArray()));
+    @SuppressWarnings("unchecked")
+    Map<String, Integer> deserialized = (Map<String, Integer>) objIn.readObject();
+    assertEquals(Collections.singletonMap("a", 1), deserialized);
   }
 
   @SafeVarargs


### PR DESCRIPTION
Adversaries might be able to forge data which can be abused for DoS attacks.
These classes are already writing a replacement JDK object during serialization for a long time, so this change should not cause any issues.

I have not added tests for the prevented deserialization because it would require hardcoding the binary deserialization data which would decrease transparency of this project.