### PR TITLE
Specify optional dependency on `sun.misc.Unsafe`

### DIFF
--- a/gson/bnd.bnd
+++ b/gson/bnd.bnd
@@ -6,6 +6,10 @@ Bundle-ContactAddress: ${project.parent.url}
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6, JavaSE-1.7, JavaSE-1.8
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.6))"
 
+# Optional dependency for JDK's sun.misc.Unsafe
+# https://bnd.bndtools.org/chapters/920-faq.html#remove-unwanted-imports-
+Import-Package: sun.misc;resolution:=optional, *
+
 -removeheaders: Private-Package
 
 -exportcontents:\

--- a/gson/src/main/java/module-info.java
+++ b/gson/src/main/java/module-info.java
@@ -10,4 +10,7 @@ module com.google.gson {
 
 	// Optional dependency on java.sql
 	requires static java.sql;
+
+	// Optional dependency on jdk.unsupported for JDK's sun.misc.Unsafe
+	requires static jdk.unsupported;
 }


### PR DESCRIPTION
Resolves #1695 (though maybe Gson documentation could be improved to mention usage of `Unsafe`)
(Hopefully) resolves #1981

I have marked this as draft because I am not very familiar with OSGi. To be tested:
- [ ] works for OGSi deployments without `Unsafe`
- [ ] works for OSGi deployments with `Unsafe` and Gson is able to construct instances of class without default constructor (by using `Unsafe`)
   - With System property `org.osgi.framework.bootdelegation=sun.misc.*`
   - With System property `org.osgi.framework.system.packages.extra=sun.misc`
   - Using extension bundle from https://github.com/diffplug/osgiX (?)

See also [this StackOverflow answer](https://stackoverflow.com/a/21867850) and [diffplug/osgiX README](https://github.com/diffplug/osgiX#alternatives-to-extension-bundles).

Ideally a test as proposed by #1993 should be added as well (with some adjustments), but the class from #1993 cannot be reused because the CLA is not signed.
