### PR TITLE
Fix missing bounds check for `JsonTreeReader.getPath()`

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
@@ -308,11 +308,11 @@ public final class JsonTreeReader extends JsonReader {
     StringBuilder result = new StringBuilder().append('$');
     for (int i = 0; i < stackSize; i++) {
       if (stack[i] instanceof JsonArray) {
-        if (stack[++i] instanceof Iterator) {
+        if (++i < stackSize && stack[i] instanceof Iterator) {
           result.append('[').append(pathIndices[i]).append(']');
         }
       } else if (stack[i] instanceof JsonObject) {
-        if (stack[++i] instanceof Iterator) {
+        if (++i < stackSize && stack[i] instanceof Iterator) {
           result.append('.');
           if (pathNames[i] != null) {
             result.append(pathNames[i]);


### PR DESCRIPTION
There are situations where the `stack` of JsonTreeReader contains a JsonArray or JsonObject without a subsequent Iterator, for example after calling `peek()` or `nextName()`.
When `JsonTreeReader.getPath()` is called afterwards it therefore must not assume that a JsonArray or JsonObject is always followed by an Iterator.

The only reason why this never caused an ArrayIndexOutOfBoundsException in the past is because the stack has an even default size (32) so it would just have read the next `null`.
However, if the stack had for example the default size 31, a user created a JsonTreeReader for 16 JSON arrays nested inside each other, then called 15 times `beginArray()`, followed by `peek()` and `getPath()` the exception would occur.
