### PR TITLE
Removed java.sql.Timestamp import

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/sql/SqlTypesSupport.java
+++ b/gson/src/main/java/com/google/gson/internal/sql/SqlTypesSupport.java
@@ -1,6 +1,5 @@
 package com.google.gson.internal.sql;
 
-import java.sql.Timestamp;
 import java.util.Date;
 
 import com.google.gson.TypeAdapterFactory;
@@ -47,9 +46,9 @@ public final class SqlTypesSupport {
           return new java.sql.Date(date.getTime());
         }
       };
-      TIMESTAMP_DATE_TYPE = new DateType<Timestamp>(Timestamp.class) {
-        @Override protected Timestamp deserialize(Date date) {
-          return new Timestamp(date.getTime());
+      TIMESTAMP_DATE_TYPE = new DateType<java.sql.Timestamp>(java.sql.Timestamp.class) {
+        @Override protected java.sql.Timestamp deserialize(Date date) {
+          return new java.sql.Timestamp(date.getTime());
         }
       };
 


### PR DESCRIPTION
With an import to java.sql package is not possible to use in JREs without java.sql module.