### PR TITLE
Improve CharSequence support

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -254,6 +254,7 @@ public final class Gson {
     factories.add(TypeAdapters.newFactory(AtomicLongArray.class, atomicLongArrayAdapter(longAdapter)));
     factories.add(TypeAdapters.ATOMIC_INTEGER_ARRAY_FACTORY);
     factories.add(TypeAdapters.CHARACTER_FACTORY);
+    factories.add(TypeAdapters.CHAR_SEQUENCE_FACTORY);
     factories.add(TypeAdapters.STRING_BUILDER_FACTORY);
     factories.add(TypeAdapters.STRING_BUFFER_FACTORY);
     factories.add(TypeAdapters.newFactory(BigDecimal.class, TypeAdapters.BIG_DECIMAL));

--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeWriter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeWriter.java
@@ -152,6 +152,13 @@ public final class JsonTreeWriter extends JsonWriter {
     return this;
   }
 
+  @Override public JsonWriter value(CharSequence value) throws IOException {
+    if (value == null) {
+      return nullValue();
+    }
+    return value(value.toString());
+  }
+
   @Override public JsonWriter nullValue() throws IOException {
     put(JsonNull.INSTANCE);
     return this;

--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -377,6 +377,23 @@ public final class TypeAdapters {
   public static final TypeAdapterFactory CHARACTER_FACTORY
       = newFactory(char.class, Character.class, CHARACTER);
 
+  public static final TypeAdapter<CharSequence> CHAR_SEQUENCE = new TypeAdapter<CharSequence>() {
+    @Override
+    public CharSequence read(JsonReader in) throws IOException {
+      JsonToken peek = in.peek();
+      if (peek == JsonToken.NULL) {
+        in.nextNull();
+        return null;
+      }
+      return in.nextString();
+    }
+    @Override
+    public void write(JsonWriter out, CharSequence value) throws IOException {
+      out.value(value);
+    }
+  };
+  public static final TypeAdapterFactory CHAR_SEQUENCE_FACTORY = newFactory(CharSequence.class, CHAR_SEQUENCE);
+
   public static final TypeAdapter<String> STRING = new TypeAdapter<String>() {
     @Override
     public String read(JsonReader in) throws IOException {
@@ -396,6 +413,7 @@ public final class TypeAdapters {
       out.value(value);
     }
   };
+  public static final TypeAdapterFactory STRING_FACTORY = newFactory(String.class, STRING);
 
   public static final TypeAdapter<BigDecimal> BIG_DECIMAL = new TypeAdapter<BigDecimal>() {
     @Override public BigDecimal read(JsonReader in) throws IOException {
@@ -434,8 +452,6 @@ public final class TypeAdapters {
       out.value(value);
     }
   };
-
-  public static final TypeAdapterFactory STRING_FACTORY = newFactory(String.class, STRING);
 
   public static final TypeAdapter<StringBuilder> STRING_BUILDER = new TypeAdapter<StringBuilder>() {
     @Override

--- a/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
@@ -39,7 +39,7 @@ import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URL;
-import java.sql.Timestamp;
+import java.nio.CharBuffer;
 import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -632,6 +632,19 @@ public class DefaultTypeAdaptersTest extends TestCase {
     Type type = new TypeToken<TreeSet<String>>() {}.getType();
     TreeSet<String> treeSet = gson.fromJson(json, type);
     assertTrue(treeSet.contains("Value1"));
+  }
+
+  public void testCharSequenceSerialization() {
+    CharSequence charSeq = CharBuffer.wrap("abc".toCharArray());
+    String json = gson.toJson(charSeq, CharSequence.class);
+    assertEquals("\"abc\"", json);
+  }
+
+  public void testCharSequenceDeserialization() {
+    // Only require that result implements CharSequence; the fact that it returns String
+    // is an implementation detail
+    CharSequence charSeq = gson.fromJson("'abc'", CharSequence.class);
+    assertEquals("abc", charSeq.toString());
   }
 
   public void testStringBuilderSerialization() {

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
@@ -16,8 +16,13 @@
 
 package com.google.gson.internal.bind;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.CharBuffer;
 import junit.framework.TestCase;
 
 @SuppressWarnings("resource")
@@ -120,32 +125,87 @@ public final class JsonTreeWriterTest extends TestCase {
     assertEquals(JsonNull.INSTANCE, writer.get());
   }
 
-  public void testBeginArray() throws Exception {
+  public void testBeginEndArray() throws Exception {
     JsonTreeWriter writer = new JsonTreeWriter();
-    assertEquals(writer, writer.beginArray());
+    assertSame(writer, writer.beginArray());
+    assertSame(writer, writer.endArray());
+
+    assertEquals(new JsonArray(), writer.get());
   }
 
-  public void testBeginObject() throws Exception {
+  public void testBeginEndObject() throws Exception {
     JsonTreeWriter writer = new JsonTreeWriter();
-    assertEquals(writer, writer.beginObject());
+    assertSame(writer, writer.beginObject());
+    assertSame(writer, writer.name("a"));
+    assertSame(writer, writer.value(1));
+    assertSame(writer, writer.endObject());
+
+    JsonObject expected = new JsonObject();
+    expected.addProperty("a", 1);
+    assertEquals(expected, writer.get());
   }
 
   public void testValueString() throws Exception {
     JsonTreeWriter writer = new JsonTreeWriter();
     String n = "as";
-    assertEquals(writer, writer.value(n));
+    assertSame(writer, writer.value(n));
+
+    assertEquals(new JsonPrimitive(n), writer.get());
   }
 
-  public void testBoolValue() throws Exception {
+  public void testValueCharSequence() throws Exception {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    String n = "as";
+    assertSame(writer, writer.value(CharBuffer.wrap(n.toCharArray())));
+
+    assertEquals(new JsonPrimitive(n), writer.get());
+  }
+
+  public void testBooleanValue() throws Exception {
     JsonTreeWriter writer = new JsonTreeWriter();
     boolean bool = true;
-    assertEquals(writer, writer.value(bool));
+    assertSame(writer, writer.value(bool));
+
+    assertEquals(new JsonPrimitive(bool), writer.get());
   }
 
-  public void testBoolMaisValue() throws Exception {
+  public void testBooleanWrappedValue() throws Exception {
     JsonTreeWriter writer = new JsonTreeWriter();
     Boolean bool = true;
-    assertEquals(writer, writer.value(bool));
+    assertSame(writer, writer.value(bool));
+
+    assertEquals(new JsonPrimitive(bool), writer.get());
+  }
+
+  public void testDoubleValue() throws Exception {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    double value = 123.45;
+    assertSame(writer, writer.value(value));
+
+    assertEquals(new JsonPrimitive(value), writer.get());
+  }
+
+  public void testLongValue() throws Exception {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    long value = 1234L;
+    assertSame(writer, writer.value(value));
+
+    assertEquals(new JsonPrimitive(value), writer.get());
+  }
+
+  public void testNumberValue() throws Exception {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    BigInteger value = new BigInteger("1234");
+    assertSame(writer, writer.value(value));
+
+    assertEquals(new JsonPrimitive(value), writer.get());
+  }
+
+  public void testNullValue() throws Exception {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    assertSame(writer, writer.nullValue());
+
+    assertEquals(JsonNull.INSTANCE, writer.get());
   }
 
   public void testLenientNansAndInfinities() throws IOException {

--- a/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.CharBuffer;
 
 @SuppressWarnings("resource")
 public final class JsonWriterTest extends TestCase {
@@ -52,10 +53,16 @@ public final class JsonWriterTest extends TestCase {
     assertEquals("123.4", string4.toString());
 
     StringWriter string5 = new StringWriter();
-    JsonWriter writert = new JsonWriter(string5);
-    writert.value("a");
-    writert.close();
+    JsonWriter writer5 = new JsonWriter(string5);
+    writer5.value("a");
+    writer5.close();
     assertEquals("\"a\"", string5.toString());
+
+    StringWriter string6 = new StringWriter();
+    JsonWriter writer6 = new JsonWriter(string6);
+    writer6.value(CharBuffer.wrap("test".toCharArray()));
+    writer6.close();
+    assertEquals("\"test\"", string6.toString());
   }
 
   public void testInvalidTopLevelTypes() throws IOException {


### PR DESCRIPTION
Changes:
- Adds `JsonWriter.value(CharSequence)`
This allows writing a non-String CharSequence more efficiently without having to create a temporary String first.
- Adds a default adapter for `CharSequence`

Note that the addition of a default adapter for `CharSequence` is a potentially backward incompatible change in case someone currently relies on the reflective adapter being used for a compile-time type of `CharSequence` where the runtime type is a custom subclass. Due to the way Gson's `TypeAdapterRuntimeTypeWrapper` works, it would now prefer the non-reflective adapter for `CharSequence` over the reflective adapter for the custom runtime subclass.

Possibly relates to #1229; not sure why the user there wants to use `jsonValue(...)` (to write raw JSON) instead of `value(...)`. For the use case of zeroization one could with the changes of this pull request use `CharBuffer` to wrap a `char[]`.