### PR TITLE
Fix warnings

### DIFF
--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -35,7 +35,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <includePackageNames>com.google.gson</includePackageNames>
           <excludePackageNames>com.google.gson.internal:com.google.gson.internal.bind</excludePackageNames>
           <links>
             <link>https://docs.oracle.com/javase/6/docs/api/</link>

--- a/gson/src/main/java/com/google/gson/JsonArray.java
+++ b/gson/src/main/java/com/google/gson/JsonArray.java
@@ -344,7 +344,10 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
   @Override
   public char getAsCharacter() {
     if (elements.size() == 1) {
-      return elements.get(0).getAsCharacter();
+      JsonElement element = elements.get(0);
+      @SuppressWarnings("deprecation")
+      char result = element.getAsCharacter();
+      return result;
     }
     throw new IllegalStateException();
   }

--- a/gson/src/test/java/com/google/gson/InnerClassExclusionStrategyTest.java
+++ b/gson/src/test/java/com/google/gson/InnerClassExclusionStrategyTest.java
@@ -26,8 +26,8 @@ import junit.framework.TestCase;
  * @author Joel Leitch
  */
 public class InnerClassExclusionStrategyTest extends TestCase {
-  public InnerClass innerClass = new InnerClass();
-  public StaticNestedClass staticNestedClass = new StaticNestedClass();
+  private InnerClass innerClass = new InnerClass();
+  private StaticNestedClass staticNestedClass = new StaticNestedClass();
   private Excluder excluder = Excluder.DEFAULT.disableInnerClassSerialization();
 
   public void testExcludeInnerClassObject() throws Exception {
@@ -36,7 +36,7 @@ public class InnerClassExclusionStrategyTest extends TestCase {
   }
 
   public void testExcludeInnerClassField() throws Exception {
-    Field f = getClass().getField("innerClass");
+    Field f = getClass().getDeclaredField("innerClass");
     assertTrue(excluder.excludeField(f, true));
   }
 
@@ -46,7 +46,7 @@ public class InnerClassExclusionStrategyTest extends TestCase {
   }
 
   public void testIncludeStaticNestedClassField() throws Exception {
-    Field f = getClass().getField("staticNestedClass");
+    Field f = getClass().getDeclaredField("staticNestedClass");
     assertFalse(excluder.excludeField(f, true));
   }
 

--- a/gson/src/test/java/com/google/gson/InnerClassExclusionStrategyTest.java
+++ b/gson/src/test/java/com/google/gson/InnerClassExclusionStrategyTest.java
@@ -26,8 +26,8 @@ import junit.framework.TestCase;
  * @author Joel Leitch
  */
 public class InnerClassExclusionStrategyTest extends TestCase {
-  private InnerClass innerClass = new InnerClass();
-  private StaticNestedClass staticNestedClass = new StaticNestedClass();
+  public InnerClass innerClass = new InnerClass();
+  public StaticNestedClass staticNestedClass = new StaticNestedClass();
   private Excluder excluder = Excluder.DEFAULT.disableInnerClassSerialization();
 
   public void testExcludeInnerClassObject() throws Exception {
@@ -36,7 +36,7 @@ public class InnerClassExclusionStrategyTest extends TestCase {
   }
 
   public void testExcludeInnerClassField() throws Exception {
-    Field f = getClass().getDeclaredField("innerClass");
+    Field f = getClass().getField("innerClass");
     assertTrue(excluder.excludeField(f, true));
   }
 
@@ -46,7 +46,7 @@ public class InnerClassExclusionStrategyTest extends TestCase {
   }
 
   public void testIncludeStaticNestedClassField() throws Exception {
-    Field f = getClass().getDeclaredField("staticNestedClass");
+    Field f = getClass().getField("staticNestedClass");
     assertFalse(excluder.excludeField(f, true));
   }
 

--- a/gson/src/test/java/com/google/gson/JsonObjectTest.java
+++ b/gson/src/test/java/com/google/gson/JsonObjectTest.java
@@ -92,7 +92,6 @@ public class JsonObjectTest extends TestCase {
     assertEquals(value, jsonElement.getAsString());
   }
 
-  @SuppressWarnings("deprecation")
   public void testAddingCharacterProperties() throws Exception {
     String propertyName = "property";
     char value = 'a';
@@ -105,7 +104,10 @@ public class JsonObjectTest extends TestCase {
     JsonElement jsonElement = jsonObj.get(propertyName);
     assertNotNull(jsonElement);
     assertEquals(String.valueOf(value), jsonElement.getAsString());
-    assertEquals(value, jsonElement.getAsCharacter());
+
+    @SuppressWarnings("deprecation")
+    char character = jsonElement.getAsCharacter();
+    assertEquals(value, character);
   }
 
   /**

--- a/gson/src/test/java/com/google/gson/JsonObjectTest.java
+++ b/gson/src/test/java/com/google/gson/JsonObjectTest.java
@@ -92,6 +92,7 @@ public class JsonObjectTest extends TestCase {
     assertEquals(value, jsonElement.getAsString());
   }
 
+  @SuppressWarnings("deprecation")
   public void testAddingCharacterProperties() throws Exception {
     String propertyName = "property";
     char value = 'a';

--- a/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
@@ -39,7 +39,6 @@ import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URL;
-import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/gson/src/test/java/com/google/gson/internal/JavaVersionTest.java
+++ b/gson/src/test/java/com/google/gson/internal/JavaVersionTest.java
@@ -19,8 +19,6 @@ import static org.junit.Assert.*;
 
 import org.junit.Test;
 
-import com.google.gson.internal.JavaVersion;
-
 /**
  * Unit and functional tests for {@link JavaVersion}
  *

--- a/gson/src/test/java/com/google/gson/internal/bind/DefaultDateTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/DefaultDateTypeAdapterTest.java
@@ -27,7 +27,6 @@ import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
 import com.google.gson.internal.JavaVersion;
-import com.google.gson.internal.bind.DefaultDateTypeAdapter;
 import com.google.gson.internal.bind.DefaultDateTypeAdapter.DateType;
 import com.google.gson.reflect.TypeToken;
 

--- a/gson/src/test/java/com/google/gson/internal/bind/util/ISO8601UtilsTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/util/ISO8601UtilsTest.java
@@ -1,19 +1,15 @@
 package com.google.gson.internal.bind.util;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
+import org.junit.function.ThrowingRunnable;
 import java.text.ParseException;
 import java.text.ParsePosition;
 import java.util.*;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class ISO8601UtilsTest {
-
-    @Rule
-    public final ExpectedException exception = ExpectedException.none();
 
     private static TimeZone utcTimeZone() {
         return TimeZone.getTimeZone("UTC");
@@ -87,8 +83,12 @@ public class ISO8601UtilsTest {
 
     @Test
     public void testDateParseInvalidTime() throws ParseException {
-        String dateStr = "2018-06-25T61:60:62-03:00";
-        exception.expect(ParseException.class);
-        ISO8601Utils.parse(dateStr, new ParsePosition(0));
+        final String dateStr = "2018-06-25T61:60:62-03:00";
+        assertThrows(ParseException.class, new ThrowingRunnable() {
+          @Override
+          public void run() throws Throwable {
+            ISO8601Utils.parse(dateStr, new ParsePosition(0));
+          }
+        });
     }
 }

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderPathTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderPathTest.java
@@ -307,7 +307,7 @@ public class JsonReaderPathTest {
     assertEquals("$", reader.getPath());
   }
 
-  enum Factory {
+  public enum Factory {
     STRING_READER {
       @Override public JsonReader create(String data) {
         return new JsonReader(new StringReader(data));


### PR DESCRIPTION
Note: The visibility changes in the test classes are not strictly necessary. Eclipse IDE complained that the exposed types had lower visibility than the exposing field.