### PR TITLE
Remove explicit ProGuard plugin dependencies

### DIFF
--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -12,10 +12,6 @@
   <artifactId>gson</artifactId>
   <name>Gson</name>
 
-  <properties>
-    <proguardVersion>7.1.1</proguardVersion>
-  </properties>
-
   <licenses>
     <license>
       <name>Apache-2.0</name>
@@ -168,7 +164,6 @@
           </execution>
         </executions>
         <configuration>
-          <proguardVersion>${proguardVersion}</proguardVersion>
           <obfuscate>true</obfuscate>
           <injar>test-classes-obfuscated-injar</injar>
           <outjar>test-classes-obfuscated-outjar</outjar>
@@ -179,20 +174,6 @@
             <lib>${java.home}/jmods/java.base.jmod</lib>
           </libs>
         </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>com.guardsquare</groupId>
-            <artifactId>proguard-core</artifactId>
-            <version>${proguardVersion}</version>
-            <scope>runtime</scope>
-          </dependency>
-          <dependency>
-            <groupId>com.guardsquare</groupId>
-            <artifactId>proguard-base</artifactId>
-            <version>${proguardVersion}</version>
-            <scope>runtime</scope>
-          </dependency>
-        </dependencies>
       </plugin>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>


### PR DESCRIPTION
Explicitly specifying dependencies only seems to be necessary when using `<proguardVersion>` config element to override version (and even that might not be necessary; only adding explicit dependencies might suffice). However, when omitting it, plugin uses a recent ProGuard version on its own.

So it was most likely redundant by me to include the explicit ProGuard dependencies and the `<proguardVersion>` in #1964 in the first place, sorry.