### PR TITLE
Change target Java version to 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,25 @@ Maven:
 
 ![Build Status](https://github.com/google/gson/actions/workflows/build.yml/badge.svg)
 
+### Requirements
+#### Java version
+- Gson 2.9.0 and newer: Java 7
+- Gson 2.8.9 and older: Java 6
+
+Despite supporting older Java versions, Gson also provides a JPMS module descriptor (module name `com.google.gson`) for users of Java 9 or newer.
+
+#### JPMS dependencies (Java 9+)
+These are the optional Java Platform Module System (JPMS) JDK modules which Gson depends on.
+This only applies when running Java 9 or newer.
+
+- `java.sql` (optional since Gson 2.8.9)  
+When this module is present, Gson provides default adapters for some SQL date and time classes.
+
+- `jdk.unsupported`, respectively class `sun.misc.Unsafe` (optional)  
+When this module is present, Gson can use the `Unsafe` class to create instances of classes without no-args constructor.
+However, care should be taken when relying on this. `Unsafe` is not available in all environments and its usage has some pitfalls,
+see [`GsonBuilder.disableJdkUnsafe()`](https://javadoc.io/doc/com.google.code.gson/gson/latest/com.google.gson/com/google/gson/GsonBuilder.html#disableJdkUnsafe()).
+
 ### Documentation
   * [API Javadoc](https://www.javadoc.io/doc/com.google.code.gson/gson): Documentation for the current release
   * [User guide](https://github.com/google/gson/blob/master/UserGuide.md): This guide contains examples on how to use Gson in your code.

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -1,4 +1,4 @@
-# gson-codegen
+# codegen
 
 This Maven module contains the source code for automatically generating Gson type adapters.
 

--- a/gson/bnd.bnd
+++ b/gson/bnd.bnd
@@ -3,8 +3,8 @@ Bundle-Name: ${project.name}
 Bundle-Description: ${project.description}
 Bundle-Vendor: Google Gson Project
 Bundle-ContactAddress: ${project.parent.url}
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6, JavaSE-1.7, JavaSE-1.8
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.6))"
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7, JavaSE-1.8
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
 
 # Optional dependency for JDK's sun.misc.Unsafe
 # https://bnd.bndtools.org/chapters/920-faq.html#remove-unwanted-imports-

--- a/gson/build.gradle
+++ b/gson/build.gradle
@@ -4,8 +4,8 @@ apply plugin: 'maven'
 group = 'com.google.code.gson'
 version = '2.8.6-SNAPSHOT'
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
 
 sourceSets.main.java.exclude("**/module-info.java")
 dependencies {

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -58,8 +58,8 @@
           <jdkToolchain>
             <version>[1.5,9)</version>
           </jdkToolchain>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
       <plugin>
@@ -83,7 +83,7 @@
         <configuration>
           <excludePackageNames>com.google.gson.internal:com.google.gson.internal.bind</excludePackageNames>
           <links>
-            <link>https://docs.oracle.com/javase/6/docs/api/</link>
+            <link>https://docs.oracle.com/javase/7/docs/api/</link>
           </links>
         </configuration>
       </plugin>

--- a/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
+++ b/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
@@ -574,8 +574,9 @@ public final class $Gson$Types {
 
   /**
    * The WildcardType interface supports multiple upper bounds and multiple
-   * lower bounds. We only support what the Java 6 language needs - at most one
-   * bound. If a lower bound is set, the upper bound must be Object.class.
+   * lower bounds. We only support what the target Java version supports - at most one
+   * bound, see also https://bugs.openjdk.java.net/browse/JDK-8250660. If a lower bound
+   * is set, the upper bound must be Object.class.
    */
   private static final class WildcardTypeImpl implements WildcardType, Serializable {
     private final Type upperBound;

--- a/gson/src/main/java/com/google/gson/stream/MalformedJsonException.java
+++ b/gson/src/main/java/com/google/gson/stream/MalformedJsonException.java
@@ -30,15 +30,10 @@ public final class MalformedJsonException extends IOException {
   }
 
   public MalformedJsonException(String msg, Throwable throwable) {
-    super(msg);
-    // Using initCause() instead of calling super() because Java 1.5 didn't retrofit IOException
-    // with a constructor with Throwable. This was done in Java 1.6
-    initCause(throwable);
+    super(msg, throwable);
   }
 
   public MalformedJsonException(Throwable throwable) {
-    // Using initCause() instead of calling super() because Java 1.5 didn't retrofit IOException
-    // with a constructor with Throwable. This was done in Java 1.6
-    initCause(throwable);
+    super(throwable);
   }
 }

--- a/gson/src/main/java/com/google/gson/stream/package-info.java
+++ b/gson/src/main/java/com/google/gson/stream/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * This package provides classes for processing JSON in an efficient streaming way.
+ */
+package com.google.gson.stream;

--- a/gson/src/test/java/com/google/gson/internal/LinkedTreeMapTest.java
+++ b/gson/src/test/java/com/google/gson/internal/LinkedTreeMapTest.java
@@ -161,7 +161,7 @@ public final class LinkedTreeMapTest extends TestCase {
   }
 
   @SafeVarargs
-  private <T> void assertIterationOrder(Iterable<T> actual, T... expected) {
+  private final <T> void assertIterationOrder(Iterable<T> actual, T... expected) {
     ArrayList<T> actualList = new ArrayList<T>();
     for (T t : actual) {
       actualList.add(t);

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>1.6</java.version>
+    <java.version>1.7</java.version>
   </properties>
 
   <scm>


### PR DESCRIPTION
Resolves #2018

Also tries to add some documentation to the README regarding Java version and JPMS module requirements. I am not sure if the formatting and wording is ideal; feedback is appreciated.

Follow-up task:
Remove the Java version overwrite (and comment) in https://github.com/google/oss-fuzz/blob/master/projects/gson/build.sh