### PR TITLE
Add visitor support for traversing json tree.

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonArray.java
+++ b/gson/src/main/java/com/google/gson/JsonArray.java
@@ -16,6 +16,8 @@
 
 package com.google.gson;
 
+import com.google.gson.visitor.JsonElementVisitor;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -389,5 +391,18 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
   @Override
   public int hashCode() {
     return elements.hashCode();
+  }
+
+  /**
+   * This method accepts a JsonElementVisitor visitor and calls
+   * the visit method on it by passing itself.
+   *
+   * @param visitor JsonElementVisitor for traversing the json tree.
+   * @param data    Buffer to hold the result of processed node.
+   * @return Returns the processed data.
+   */
+  @Override
+  public <T> T accept(JsonElementVisitor visitor, T data) {
+    return (T)visitor.visitJsonArray(this, data);
   }
 }

--- a/gson/src/main/java/com/google/gson/JsonElement.java
+++ b/gson/src/main/java/com/google/gson/JsonElement.java
@@ -18,6 +18,8 @@ package com.google.gson;
 
 import com.google.gson.internal.Streams;
 import com.google.gson.stream.JsonWriter;
+import com.google.gson.visitor.VisitableJsonElement;
+
 import java.io.IOException;
 import java.io.StringWriter;
 import java.math.BigDecimal;
@@ -30,7 +32,7 @@ import java.math.BigInteger;
  * @author Inderjeet Singh
  * @author Joel Leitch
  */
-public abstract class JsonElement {
+public abstract class JsonElement implements VisitableJsonElement {
   /**
    * Returns a deep copy of this element. Immutable elements like primitives
    * and nulls are not copied.

--- a/gson/src/main/java/com/google/gson/JsonNull.java
+++ b/gson/src/main/java/com/google/gson/JsonNull.java
@@ -16,6 +16,8 @@
 
 package com.google.gson;
 
+import com.google.gson.visitor.JsonElementVisitor;
+
 /**
  * A class representing a Json {@code null} value.
  *
@@ -63,5 +65,18 @@ public final class JsonNull extends JsonElement {
   @Override
   public boolean equals(Object other) {
     return this == other || other instanceof JsonNull;
+  }
+
+  /**
+   * This method accepts a JsonElementVisitor and calls
+   * the visit method on it passing itself.
+   *
+   * @param visitor JsonElementVisitor for traversing the json tree.
+   * @param data    Buffer to hold the result of processed node.
+   * @return Returns the processed data.
+   */
+  @Override
+  public <T> T accept(JsonElementVisitor visitor, T data) {
+    return (T)visitor.visitJsonNull(this, data);
   }
 }

--- a/gson/src/main/java/com/google/gson/JsonObject.java
+++ b/gson/src/main/java/com/google/gson/JsonObject.java
@@ -17,6 +17,7 @@
 package com.google.gson;
 
 import com.google.gson.internal.LinkedTreeMap;
+import com.google.gson.visitor.JsonElementVisitor;
 
 import java.util.Map;
 import java.util.Set;
@@ -201,5 +202,18 @@ public final class JsonObject extends JsonElement {
   @Override
   public int hashCode() {
     return members.hashCode();
+  }
+
+  /**
+   * This method accepts a JsonElementVisitor and calls
+   * the visit method on it by passing itself.
+   *
+   * @param visitor JsonElementVisitor for traversing the json tree.
+   * @param data    Buffer to hold the result of processed node.
+   * @return Returns the processed data.
+   */
+  @Override
+  public <T> T accept(JsonElementVisitor visitor, T data) {
+    return (T)visitor.visitJsonObject(this, data);
   }
 }

--- a/gson/src/main/java/com/google/gson/JsonPrimitive.java
+++ b/gson/src/main/java/com/google/gson/JsonPrimitive.java
@@ -21,6 +21,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 
 import com.google.gson.internal.LazilyParsedNumber;
+import com.google.gson.visitor.JsonElementVisitor;
 
 /**
  * A class representing a Json primitive value. A primitive value
@@ -291,5 +292,18 @@ public final class JsonPrimitive extends JsonElement {
           || number instanceof Short || number instanceof Byte;
     }
     return false;
+  }
+
+  /**
+   * This method accepts a JsonElementVisitor and calls
+   * the visit method on it by passing itself.
+   *
+   * @param visitor JsonElementVisitor for traversing the json tree.
+   * @param data    Buffer to hold the result of processed node.
+   * @return Returns the processed data.
+   */
+  @Override
+  public <T> T accept(JsonElementVisitor visitor, T data) {
+    return (T)visitor.visitJsonPrimitive(this, data);
   }
 }

--- a/gson/src/main/java/com/google/gson/visitor/JsonElementVisitor.java
+++ b/gson/src/main/java/com/google/gson/visitor/JsonElementVisitor.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson.visitor;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+/**
+ * Interface for traversing the json
+ * tree using visitor design pattern.
+ *
+ * @author sjaiswal on 8/2/21
+ */
+public interface JsonElementVisitor <T> {
+    /**
+     * Handles the processing of JsonObject.
+     *
+     * @param jsonObject
+     *          holds json object.
+     * @param data
+     *          Buffer for storing processed data.
+     * @return
+     *          Data of processed json object.
+     */
+    public T visitJsonObject(JsonObject jsonObject, T data);
+
+
+    /**
+     * Handles the processing of JsonArray.
+     *
+     * @param jsonArray
+     *          holds json array.
+     * @param data
+     *          Buffer for storing processed data.
+     * @return
+     *          Data of processed json array.
+     */
+    public T visitJsonArray(JsonArray jsonArray, T data);
+
+    /**
+     * Handles the processing of JsonPrimitive.
+     *
+     * @param jsonPrimitive
+     *          holds json primitive.
+     * @param data
+     *          Buffer for storing processed data.
+     * @return
+     *          Data of processed json primitive.
+     */
+    public T visitJsonPrimitive(JsonPrimitive jsonPrimitive, T data);
+
+
+    /**
+     * Handles the processing of JsonNull.
+     *
+     * @param jsonNull
+     *          holds json null.
+     * @param data
+     *          Buffer for storing processed data.
+     * @return
+     *          Data of processed json null.
+     */
+    public T visitJsonNull(JsonNull jsonNull, T data);
+}

--- a/gson/src/main/java/com/google/gson/visitor/VisitableJsonElement.java
+++ b/gson/src/main/java/com/google/gson/visitor/VisitableJsonElement.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson.visitor;
+
+/**
+ * Interface for all visitable JsonElement types.
+ *
+ * @author sjaiswal on 8/2/21
+ */
+public interface VisitableJsonElement {
+
+    /**
+     * This method accepts a JsonElementVisitor. All JsonElement types
+     * should implement this and call the visitor by passing itself.
+     * @param visitor
+     *        JsonElementVisitor for traversing the json tree.
+     * @param data
+     *        Buffer to hold the result of processed node.
+     * @param <T>
+     * @return
+     *        Returns the processed data.
+     */
+    public<T> T accept(JsonElementVisitor visitor, T data);
+}


### PR DESCRIPTION
This PR adds the visitor support for traversing the JSON tree. See below example of custom visitor.

**CustomJsonElementVisitor**
```
public class CustomJsonElementVisitor implements JsonElementVisitor<String> {
    /**
     * Handles the processing of JsonObject.
     *
     * @param jsonObject holds json object.
     * @param data       Buffer for storing processed data.
     * @return Data of processed json object.
     */
    @Override
    public String visitJsonObject(JsonObject jsonObject, String data) {
        return jsonObject.accept(this,"");
    }

    /**
     * Handles the processing of JsonArray.
     *
     * @param jsonArray holds json array.
     * @param data      Buffer for storing processed data.
     * @return Data of processed json array.
     */
    @Override
    public String visitJsonArray(JsonArray jsonArray, String data) {
        jsonArray.iterator().forEachRemaining(element -> {
            element.accept(this, data);
        });
        return data;
    }

    /**
     * Handles the processing of JsonPrimitive.
     *
     * @param jsonPrimitive holds json primitive.
     * @param data          Buffer for storing processed data.
     * @return Data of processed json primitive.
     */
    @Override
    public String visitJsonPrimitive(JsonPrimitive jsonPrimitive, String data) {
        return data + jsonPrimitive.getAsString();
    }

    /**
     * Handles the processing of JsonNull.
     *
     * @param jsonNull holds json null.
     * @param data     Buffer for storing processed data.
     * @return Data of processed json null.
     */
    @Override
    public String visitJsonNull(JsonNull jsonNull, String data) {
        return data;
    }
}
```