### PR TITLE
Improve Maven build and GitHub Maven workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,4 +15,5 @@ jobs:
           java-version: '11'
           cache: 'maven'
       - name: Build with Maven
-        run: mvn --batch-mode --update-snapshots verify
+        # This also runs javadoc:javadoc to detect any issues with the Javadoc
+        run: mvn --batch-mode --update-snapshots verify javadoc:javadoc

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -86,6 +86,8 @@
               <module>
                 <moduleInfoFile>${project.build.sourceDirectory}/module-info.java</moduleInfoFile>
               </module>
+              <!-- Overwrite the previously generated JAR file, if any -->
+              <overwriteExistingFiles>true</overwriteExistingFiles>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Two minor changes to improve the Maven build:

- Fix consecutive Maven builds failing without performing `clean`
By default moditect-maven-plugin refuses to overwrite the JAR file it generated in a previous run. See also https://github.com/moditect/moditect/issues/161.
- Make GitHub Maven build workflow detect Javadoc issues
