### PR TITLE
Refactoring and reducing code duplication in JsonReader

### DIFF
--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -338,10 +338,7 @@ public class JsonReader implements Closeable {
    * beginning of a new array.
    */
   public void beginArray() throws IOException {
-    int p = peeked;
-    if (p == PEEKED_NONE) {
-      p = doPeek();
-    }
+    int p = peeked();
     if (p == PEEKED_BEGIN_ARRAY) {
       push(JsonScope.EMPTY_ARRAY);
       pathIndices[stackSize - 1] = 0;
@@ -356,10 +353,7 @@ public class JsonReader implements Closeable {
    * end of the current array.
    */
   public void endArray() throws IOException {
-    int p = peeked;
-    if (p == PEEKED_NONE) {
-      p = doPeek();
-    }
+    int p = peeked();
     if (p == PEEKED_END_ARRAY) {
       stackSize--;
       pathIndices[stackSize - 1]++;
@@ -374,10 +368,7 @@ public class JsonReader implements Closeable {
    * beginning of a new object.
    */
   public void beginObject() throws IOException {
-    int p = peeked;
-    if (p == PEEKED_NONE) {
-      p = doPeek();
-    }
+    int p = peeked();
     if (p == PEEKED_BEGIN_OBJECT) {
       push(JsonScope.EMPTY_OBJECT);
       peeked = PEEKED_NONE;
@@ -391,10 +382,7 @@ public class JsonReader implements Closeable {
    * end of the current object.
    */
   public void endObject() throws IOException {
-    int p = peeked;
-    if (p == PEEKED_NONE) {
-      p = doPeek();
-    }
+    int p = peeked();
     if (p == PEEKED_END_OBJECT) {
       stackSize--;
       pathNames[stackSize] = null; // Free the last path name so that it can be garbage collected!
@@ -406,13 +394,21 @@ public class JsonReader implements Closeable {
   }
 
   /**
+   * Returns peeked if not PEEKED_NONE, if PEEKED_NONE then doPeek() is returned instead
+   */
+  private int peeked() {
+    int p = peeked;
+    if (p == PEEKED_NONE) {
+         p = doPeek();
+    }
+    return p;
+  }
+
+  /**
    * Returns true if the current array or object has another element.
    */
   public boolean hasNext() throws IOException {
-    int p = peeked;
-    if (p == PEEKED_NONE) {
-      p = doPeek();
-    }
+    int p = peeked();
     return p != PEEKED_END_OBJECT && p != PEEKED_END_ARRAY && p != PEEKED_EOF;
   }
 
@@ -420,10 +416,7 @@ public class JsonReader implements Closeable {
    * Returns the type of the next token without consuming it.
    */
   public JsonToken peek() throws IOException {
-    int p = peeked;
-    if (p == PEEKED_NONE) {
-      p = doPeek();
-    }
+    int p = peeked();
 
     switch (p) {
     case PEEKED_BEGIN_OBJECT:
@@ -774,10 +767,7 @@ public class JsonReader implements Closeable {
    *     name.
    */
   public String nextName() throws IOException {
-    int p = peeked;
-    if (p == PEEKED_NONE) {
-      p = doPeek();
-    }
+    int p = peeked();
     String result;
     if (p == PEEKED_UNQUOTED_NAME) {
       result = nextUnquotedValue();
@@ -802,10 +792,7 @@ public class JsonReader implements Closeable {
    *     this reader is closed.
    */
   public String nextString() throws IOException {
-    int p = peeked;
-    if (p == PEEKED_NONE) {
-      p = doPeek();
-    }
+    int p = peeked();
     String result;
     if (p == PEEKED_UNQUOTED) {
       result = nextUnquotedValue();
@@ -837,10 +824,7 @@ public class JsonReader implements Closeable {
    *     this reader is closed.
    */
   public boolean nextBoolean() throws IOException {
-    int p = peeked;
-    if (p == PEEKED_NONE) {
-      p = doPeek();
-    }
+    int p = peeked();
     if (p == PEEKED_TRUE) {
       peeked = PEEKED_NONE;
       pathIndices[stackSize - 1]++;
@@ -861,10 +845,7 @@ public class JsonReader implements Closeable {
    *     reader is closed.
    */
   public void nextNull() throws IOException {
-    int p = peeked;
-    if (p == PEEKED_NONE) {
-      p = doPeek();
-    }
+    int p = peeked();
     if (p == PEEKED_NULL) {
       peeked = PEEKED_NONE;
       pathIndices[stackSize - 1]++;
@@ -883,10 +864,7 @@ public class JsonReader implements Closeable {
    *     as a double, or is non-finite.
    */
   public double nextDouble() throws IOException {
-    int p = peeked;
-    if (p == PEEKED_NONE) {
-      p = doPeek();
-    }
+    int p = peeked();
 
     if (p == PEEKED_LONG) {
       peeked = PEEKED_NONE;
@@ -928,10 +906,7 @@ public class JsonReader implements Closeable {
    *     as a number, or exactly represented as a long.
    */
   public long nextLong() throws IOException {
-    int p = peeked;
-    if (p == PEEKED_NONE) {
-      p = doPeek();
-    }
+    int p = peeked();
 
     if (p == PEEKED_LONG) {
       peeked = PEEKED_NONE;
@@ -1160,10 +1135,7 @@ public class JsonReader implements Closeable {
    *     as a number, or exactly represented as an int.
    */
   public int nextInt() throws IOException {
-    int p = peeked;
-    if (p == PEEKED_NONE) {
-      p = doPeek();
-    }
+    int p = peeked();
 
     int result;
     if (p == PEEKED_LONG) {
@@ -1227,10 +1199,7 @@ public class JsonReader implements Closeable {
   public void skipValue() throws IOException {
     int count = 0;
     do {
-      int p = peeked;
-      if (p == PEEKED_NONE) {
-        p = doPeek();
-      }
+      int p = peeked();
 
       if (p == PEEKED_BEGIN_ARRAY) {
         push(JsonScope.EMPTY_ARRAY);


### PR DESCRIPTION
Refactored code that was duplicated in several methods into its own method. Five of those methods(peek, nextDouble, nextInt, nextLong and nextString) have high cyclomatic complexity and this will help reducing that a bit.