### PR TITLE
Mention in README that Gson is in maintenance mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Gson can work with arbitrary Java objects including pre-existing objects that yo
 
 There are a few open-source projects that can convert Java objects to JSON. However, most of them require that you place Java annotations in your classes; something that you can not do if you do not have access to the source-code. Most also do not fully support the use of Java Generics. Gson considers both of these as very important design goals.
 
+:information_source: Gson is currently in maintenance mode; existing bugs will be fixed, but large new features will likely not be added. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.
+
 ### Goals
   * Provide simple `toJson()` and `fromJson()` methods to convert Java objects to JSON and vice-versa
   * Allow pre-existing unmodifiable objects to be converted to and from JSON


### PR DESCRIPTION
Mention in README that Gson is in maintenance mode. Currently this is only mentioned in the [GitHub issue template](https://github.com/google/gson/blob/91256532788aeee39d67087936be9bb458022c7a/.github/ISSUE_TEMPLATE/feature_request.md?plain=1#L3) which might not be seen by users when they directly create a pull request.

I have prefixed the sentence with ":information_source:" to draw some attention to it. Please let me know if that should be removed or changed. Feedback regarding the wording is welcome as well.