### PR TITLE
Reduce Maven console output for CodeQL analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,12 +35,20 @@ jobs:
         # Run all security queries and maintainability and reliability queries
         queries: +security-and-quality
 
+    - name: Cache local Maven repository
+      uses: actions/cache@v3
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+
     # Only compile main sources, but ignore test sources because findings for them might not
     # be that relevant (though GitHub security view also allows filtering by source type)
     # Can replace this with github/codeql-action/autobuild action to run complete build
     - name: Compile sources
       run: |
-        mvn compile
+        mvn compile --batch-mode
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
Without `--batch-mode` Maven prints the download progress of artifacts in a verbose way (was an oversight by me to not add this initially).