### PR TITLE
Update CodeQL action in GitHub workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,7 +29,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # Run all security queries and maintainability and reliability queries
@@ -51,4 +51,4 @@ jobs:
         mvn compile --batch-mode
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
v1 is deprecated and currently a warning is logged; see also [Code scanning: deprecation of CodeQL Action v1](https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/)