### PR TITLE
Improve lenient mode documentation

### DIFF
--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -34,6 +34,7 @@ import com.google.gson.internal.bind.TypeAdapters;
 import com.google.gson.internal.sql.SqlTypesSupport;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 
 import static com.google.gson.Gson.DEFAULT_COMPLEX_MAP_KEYS;
 import static com.google.gson.Gson.DEFAULT_DATE_PATTERN;
@@ -425,12 +426,14 @@ public final class GsonBuilder {
   }
 
   /**
-   * By default, Gson is strict and only accepts JSON as specified by
-   * <a href="http://www.ietf.org/rfc/rfc4627.txt">RFC 4627</a>. This option makes the parser
-   * liberal in what it accepts.
+   * Configures Gson to allow JSON data which does not strictly comply with the JSON specification.
+   *
+   * <p>Note: Due to legacy reasons most methods of Gson are always lenient, regardless of
+   * whether this builder method is used.
    *
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
    * @see JsonReader#setLenient(boolean)
+   * @see JsonWriter#setLenient(boolean)
    */
   public GsonBuilder setLenient() {
     lenient = true;

--- a/gson/src/main/java/com/google/gson/JsonParser.java
+++ b/gson/src/main/java/com/google/gson/JsonParser.java
@@ -15,17 +15,16 @@
  */
 package com.google.gson;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
-
 import com.google.gson.internal.Streams;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.MalformedJsonException;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
 
 /**
- * A parser to parse Json into a parse tree of {@link JsonElement}s
+ * A parser to parse JSON into a parse tree of {@link JsonElement}s.
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
@@ -37,7 +36,11 @@ public final class JsonParser {
   public JsonParser() {}
 
   /**
-   * Parses the specified JSON string into a parse tree
+   * Parses the specified JSON string into a parse tree.
+   * An exception is thrown if the JSON string has multiple top-level JSON elements,
+   * or if there is trailing data.
+   *
+   * <p>The JSON string is parsed in {@linkplain JsonReader#setLenient(boolean) lenient mode}.
    *
    * @param json JSON text
    * @return a parse tree of {@link JsonElement}s corresponding to the specified JSON
@@ -48,11 +51,16 @@ public final class JsonParser {
   }
 
   /**
-   * Parses the specified JSON string into a parse tree
+   * Parses the complete JSON string provided by the reader into a parse tree.
+   * An exception is thrown if the JSON string has multiple top-level JSON elements,
+   * or if there is trailing data.
+   *
+   * <p>The JSON data is parsed in {@linkplain JsonReader#setLenient(boolean) lenient mode}.
    *
    * @param reader JSON text
    * @return a parse tree of {@link JsonElement}s corresponding to the specified JSON
-   * @throws JsonParseException if the specified text is not valid JSON
+   * @throws JsonParseException if there is an IOException or if the specified
+   *     text is not valid JSON
    */
   public static JsonElement parseReader(Reader reader) throws JsonIOException, JsonSyntaxException {
     try {
@@ -73,6 +81,12 @@ public final class JsonParser {
 
   /**
    * Returns the next value from the JSON stream as a parse tree.
+   * Unlike the other {@code parse} methods, no exception is thrown if the JSON data has
+   * multiple top-level JSON elements, or if there is trailing data.
+   *
+   * <p>The JSON data is parsed in {@linkplain JsonReader#setLenient(boolean) lenient mode},
+   * regardless of the lenient mode setting of the provided reader. The lenient mode setting
+   * of the reader is restored once this method returns.
    *
    * @throws JsonParseException if there is an IOException or if the specified
    *     text is not valid JSON

--- a/gson/src/main/java/com/google/gson/TypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/TypeAdapter.java
@@ -16,8 +16,8 @@
 
 package com.google.gson;
 
-import com.google.gson.internal.bind.JsonTreeWriter;
 import com.google.gson.internal.bind.JsonTreeReader;
+import com.google.gson.internal.bind.JsonTreeWriter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
@@ -252,6 +252,9 @@ public abstract class TypeAdapter<T> {
    * read is strict. Create a {@link JsonReader#setLenient(boolean) lenient}
    * {@code JsonReader} and call {@link #read(JsonReader)} for lenient reading.
    *
+   * <p>No exception is thrown if the JSON data has multiple top-level JSON elements,
+   * or if there is trailing data.
+   *
    * @return the converted Java object. May be null.
    * @since 2.2
    */
@@ -266,6 +269,9 @@ public abstract class TypeAdapter<T> {
    * strict. Create a {@link JsonReader#setLenient(boolean) lenient} {@code
    * JsonReader} and call {@link #read(JsonReader)} for lenient reading.
    *
+   * <p>No exception is thrown if the JSON data has multiple top-level JSON elements,
+   * or if there is trailing data.
+   *
    * @return the converted Java object. May be null.
    * @since 2.2
    */
@@ -276,7 +282,8 @@ public abstract class TypeAdapter<T> {
   /**
    * Converts {@code jsonTree} to a Java object.
    *
-   * @param jsonTree the Java object to convert. May be {@link JsonNull}.
+   * @param jsonTree the JSON element to convert. May be {@link JsonNull}.
+   * @return the converted Java object. May be null.
    * @since 2.2
    */
   public final T fromJsonTree(JsonElement jsonTree) {

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -304,8 +304,6 @@ public class JsonReader implements Closeable {
    *       prefix</a>, <code>")]}'\n"</code>.
    *   <li>Streams that include multiple top-level values. With strict parsing,
    *       each stream must contain exactly one top-level value.
-   *   <li>Top-level values of any type. With strict parsing, the top-level
-   *       value must be an object or an array.
    *   <li>Numbers may be {@link Double#isNaN() NaNs} or {@link
    *       Double#isInfinite() infinities}.
    *   <li>End of line comments starting with {@code //} or {@code #} and
@@ -320,6 +318,18 @@ public class JsonReader implements Closeable {
    *   <li>Names and values separated by {@code =} or {@code =>} instead of
    *       {@code :}.
    *   <li>Name/value pairs separated by {@code ;} instead of {@code ,}.
+   * </ul>
+   *
+   * <p>Note: Even in strict mode there are slight derivations from the JSON
+   * specification:
+   * <ul>
+   *   <li>JsonReader allows the literals {@code true}, {@code false} and {@code null}
+   *       to have any capitalization, for example {@code fAlSe}
+   *   <li>JsonReader supports the escape sequence {@code \'}, representing a {@code '}
+   *   <li>JsonReader supports the escape sequence <code>\<i>LF</i></code> (with {@code LF}
+   *       being the Unicode character U+000A), resulting in a {@code LF} within the
+   *       read JSON string
+   *   <li>JsonReader allows unescaped control characters (U+0000 through U+001F)
    * </ul>
    */
   public final void setLenient(boolean lenient) {

--- a/gson/src/test/java/com/google/gson/TypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/TypeAdapterTest.java
@@ -1,0 +1,52 @@
+package com.google.gson;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+import java.io.StringReader;
+import org.junit.Test;
+
+public class TypeAdapterTest {
+  @Test
+  public void testNullSafe() throws IOException {
+    TypeAdapter<String> adapter = new TypeAdapter<String>() {
+      @Override public void write(JsonWriter out, String value) {
+        throw new AssertionError("unexpected call");
+      }
+
+      @Override public String read(JsonReader in) {
+        throw new AssertionError("unexpected call");
+      }
+    }.nullSafe();
+
+    assertEquals("null", adapter.toJson(null));
+    assertNull(adapter.fromJson("null"));
+  }
+
+  private static final TypeAdapter<String> adapter = new TypeAdapter<String>() {
+    @Override public void write(JsonWriter out, String value) throws IOException {
+      out.value(value);
+    }
+
+    @Override public String read(JsonReader in) throws IOException {
+      return in.nextString();
+    }
+  };
+
+  // Note: This test just verifies the current behavior; it is a bit questionable
+  // whether that behavior is actually desired
+  @Test
+  public void testFromJson_Reader_TrailingData() throws IOException {
+    assertEquals("a", adapter.fromJson(new StringReader("\"a\"1")));
+  }
+
+  // Note: This test just verifies the current behavior; it is a bit questionable
+  // whether that behavior is actually desired
+  @Test
+  public void testFromJson_String_TrailingData() throws IOException {
+    assertEquals("a", adapter.fromJson("\"a\"1"));
+  }
+}


### PR DESCRIPTION
Fixes #1720
Resolves #1923

Relates to: #372, #763, #1208, #1609

Improves the documentation regarding lenient mode and trailing data handling. The current Gson behavior is still not ideal, but now at least the documentation (hopefully) matches the actual behavior.