### PR TITLE
Add explicit support for floats in JsonTreeWriter.

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeWriter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeWriter.java
@@ -170,6 +170,14 @@ public final class JsonTreeWriter extends JsonWriter {
     return this;
   }
 
+  @Override public JsonWriter value(float value) throws IOException {
+    if (!isLenient() && (Float.isNaN(value) || Float.isInfinite(value))) {
+      throw new IllegalArgumentException("JSON forbids NaN and infinities: " + value);
+    }
+    put(new JsonPrimitive(value));
+    return this;
+  }
+
   @Override public JsonWriter value(double value) throws IOException {
     if (!isLenient() && (Double.isNaN(value) || Double.isInfinite(value))) {
       throw new IllegalArgumentException("JSON forbids NaN and infinities: " + value);

--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -493,8 +493,9 @@ public class JsonWriter implements Closeable, Flushable {
   /**
    * Encodes {@code value}.
    *
-   * @param value a finite value. May not be {@link Float#isNaN() NaNs} or {@link Float#isInfinite()
-   *     infinities}.
+   * @param value a finite value, or if {@link #setLenient(boolean) lenient},
+   *     also {@link Float#isNaN() NaN} or {@link Float#isInfinite()
+   *     infinity}.
    * @return this writer.
    * @throws IllegalArgumentException if the value is NaN or Infinity and this writer is not {@link
    *     #setLenient(boolean) lenient}.
@@ -512,8 +513,8 @@ public class JsonWriter implements Closeable, Flushable {
   /**
    * Encodes {@code value}.
    *
-   * @param value a finite value. May not be {@link Double#isNaN() NaNs} or
-   *     {@link Double#isInfinite() infinities}.
+   * @param value a finite value, or if {@link #setLenient(boolean) lenient},
+   *     also {@link Double#isNaN() NaN} or {@link Double#isInfinite() infinity}.
    * @return this writer.
    * @throws IllegalArgumentException if the value is NaN or Infinity and this writer is
    *     not {@link #setLenient(boolean) lenient}.
@@ -555,8 +556,8 @@ public class JsonWriter implements Closeable, Flushable {
    * Encodes {@code value}. The value is written by directly writing the {@link Number#toString()}
    * result to JSON. Implementations must make sure that the result represents a valid JSON number.
    *
-   * @param value a finite value. May not be {@link Double#isNaN() NaNs} or
-   *     {@link Double#isInfinite() infinities}.
+   * @param value a finite value, or if {@link #setLenient(boolean) lenient},
+   *     also {@link Double#isNaN() NaN} or {@link Double#isInfinite() infinity}.
    * @return this writer.
    * @throws IllegalArgumentException if the value is NaN or Infinity and this writer is
    *     not {@link #setLenient(boolean) lenient}; or if the {@code toString()} result is not a

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
@@ -152,17 +152,35 @@ public final class JsonTreeWriterTest extends TestCase {
     JsonTreeWriter writer = new JsonTreeWriter();
     writer.setLenient(true);
     writer.beginArray();
+    writer.value(Float.NaN);
+    writer.value(Float.NEGATIVE_INFINITY);
+    writer.value(Float.POSITIVE_INFINITY);
     writer.value(Double.NaN);
     writer.value(Double.NEGATIVE_INFINITY);
     writer.value(Double.POSITIVE_INFINITY);
     writer.endArray();
-    assertEquals("[NaN,-Infinity,Infinity]", writer.get().toString());
+    assertEquals("[NaN,-Infinity,Infinity,NaN,-Infinity,Infinity]", writer.get().toString());
   }
 
   public void testStrictNansAndInfinities() throws IOException {
     JsonTreeWriter writer = new JsonTreeWriter();
     writer.setLenient(false);
     writer.beginArray();
+    try {
+      writer.value(Float.NaN);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+    try {
+      writer.value(Float.NEGATIVE_INFINITY);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+    try {
+      writer.value(Float.POSITIVE_INFINITY);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
     try {
       writer.value(Double.NaN);
       fail();
@@ -184,6 +202,21 @@ public final class JsonTreeWriterTest extends TestCase {
     JsonTreeWriter writer = new JsonTreeWriter();
     writer.setLenient(false);
     writer.beginArray();
+    try {
+      writer.value(Float.valueOf(Float.NaN));
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+    try {
+      writer.value(Float.valueOf(Float.NEGATIVE_INFINITY));
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+    try {
+      writer.value(Float.valueOf(Float.POSITIVE_INFINITY));
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
     try {
       writer.value(Double.valueOf(Double.NaN));
       fail();


### PR DESCRIPTION
Follow-up to comments on #2130, which introduced a new override which was not overridden by `JsonTreeWriter`. Also tweaks the doccomments for the `float`, `double`, and `Number` variants of `JsonWriter.value`.

Supplement to the fix for #1127.