### PR TITLE
Fail when parsing invalid local date

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/util/ISO8601Utils.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/util/ISO8601Utils.java
@@ -2,7 +2,11 @@ package com.google.gson.internal.bind.util;
 
 import java.text.ParseException;
 import java.text.ParsePosition;
-import java.util.*;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.Locale;
+import java.util.TimeZone;
 
 /**
  * Utilities methods for manipulating dates in iso8601 format. This is much much faster and GC friendly than using SimpleDateFormat so
@@ -147,9 +151,10 @@ public class ISO8601Utils
 
             // if the value has no time component (and no time zone), we are done
             boolean hasT = checkOffset(date, offset, 'T');
-            
+
             if (!hasT && (date.length() <= offset)) {
                 Calendar calendar = new GregorianCalendar(year, month - 1, day);
+                calendar.setLenient(false);
 
                 pos.setIndex(offset);
                 return calendar.getTime();

--- a/gson/src/test/java/com/google/gson/internal/bind/util/ISO8601UtilsTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/util/ISO8601UtilsTest.java
@@ -1,13 +1,18 @@
 package com.google.gson.internal.bind.util;
 
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
-import java.text.ParseException;
-import java.text.ParsePosition;
-import java.util.*;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
+
+import java.text.ParseException;
+import java.text.ParsePosition;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.Locale;
+import java.util.TimeZone;
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 
 public class ISO8601UtilsTest {
 
@@ -59,6 +64,16 @@ public class ISO8601UtilsTest {
         Date date = ISO8601Utils.parse(dateStr, new ParsePosition(0));
         Date expectedDate = new GregorianCalendar(2018, Calendar.JUNE, 25).getTime();
         assertEquals(expectedDate, date);
+    }
+
+    @Test
+    public void testDateParseInvalid() {
+      String dateStr = "2022-15-01";
+      try {
+        ISO8601Utils.parse(dateStr, new ParsePosition(0));
+        fail();
+      } catch (ParseException e) {
+      }
     }
 
     @Test

--- a/gson/src/test/java/com/google/gson/internal/bind/util/ISO8601UtilsTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/util/ISO8601UtilsTest.java
@@ -67,12 +67,22 @@ public class ISO8601UtilsTest {
     }
 
     @Test
-    public void testDateParseInvalid() {
-      String dateStr = "2022-15-01";
+    public void testDateParseInvalidDay() {
+      String dateStr = "2022-12-33";
       try {
         ISO8601Utils.parse(dateStr, new ParsePosition(0));
-        fail();
-      } catch (ParseException e) {
+        fail("Expected parsing to fail");
+      } catch (ParseException expected) {
+      }
+    }
+
+    @Test
+    public void testDateParseInvalidMonth() {
+      String dateStr = "2022-14-30";
+      try {
+        ISO8601Utils.parse(dateStr, new ParsePosition(0));
+        fail("Expected parsing to fail");
+      } catch (ParseException expected) {
       }
     }
 


### PR DESCRIPTION
Fixes #2133

To me this looks like an oversight because by when time information is provided, `setLenient(false)` is called a few lines below.