### PR TITLE
Upgrade to oss-parent 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.sonatype.oss</groupId>
     <artifactId>oss-parent</artifactId>
-    <version>7</version>
+    <version>9</version>
   </parent>
 
   <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
org.sonatype.oss:oss-parent:7 is unsigned (missing .asc files), which forces users of gson library
that enforce signature verification to explicitly allowlist oss-parent. Luckily oss-parent 9 is signed,
thus fixing this issue.

See:
https://repo1.maven.org/maven2/org/sonatype/oss/oss-parent/7/
vs
https://repo1.maven.org/maven2/org/sonatype/oss/oss-parent/9/