### PR TITLE
BUILD files to build Gson with Bazel and easily depend on it in Bazel projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ build
 .DS_Store
 
 examples/android-proguard-example/gen
+
+bazel-*

--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ Maven:
 </dependency>
 ```
 
+<!-- TODO(pawelz): replace branch="master" with tag="gson-parent-X.Y.Z" once the bazel BUILD files make it to a release. -->
+Bazel:
+```bzl
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+git_repository(
+    name="gson",
+    remote="https://github.com/google/gson.git",
+    branch="master",
+)
+```
+
 [Gson jar downloads](https://maven-badges.herokuapp.com/maven-central/com.google.code.gson/gson) are available from Maven Central.
 
 ![Build Status](https://github.com/google/gson/actions/workflows/build.yml/badge.svg)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "com_google_gson")

--- a/gson/src/main/java-templates/com/google/gson/internal/BUILD
+++ b/gson/src/main/java-templates/com/google/gson/internal/BUILD
@@ -1,0 +1,9 @@
+java_library(
+    name = "gson_build_config",
+    srcs = [
+        "GsonBuildConfig.java",
+    ],
+    visibility = [
+        "//gson/src/main/java/com/google/gson:__subpackages__",
+    ],
+)

--- a/gson/src/main/java/com/google/gson/BUILD
+++ b/gson/src/main/java/com/google/gson/BUILD
@@ -1,0 +1,8 @@
+java_library(
+    name = "gson",
+    srcs = glob(["*.java", "**/*.java"]),
+    deps = [
+        "//gson/src/main/java-templates/com/google/gson/internal:gson_build_config",
+    ],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Gson builds cleanly without any external dependencies, so Bazel BUILD files are very simple. I believe this won't add much maintanance burden, but will make it very easy to use Gson in Bazel projects.