### PR TITLE
Improve settings propagation for temporary `JsonTreeReader` and `JsonTreeWriter`

### DIFF
--- a/extras/src/main/java/com/google/gson/graph/GraphAdapterBuilder.java
+++ b/extras/src/main/java/com/google/gson/graph/GraphAdapterBuilder.java
@@ -194,7 +194,7 @@ public final class GraphAdapterBuilder {
             // now that we know the typeAdapter for this name, go from JsonElement to 'T'
             if (element.value == null) {
               element.typeAdapter = typeAdapter;
-              element.read(graph);
+              element.read(graph, in);
             }
             return element.value;
           } finally {
@@ -299,12 +299,12 @@ public final class GraphAdapterBuilder {
       typeAdapter.write(out, value);
     }
 
-    void read(Graph graph) throws IOException {
+    void read(Graph graph, JsonReader originalReader) throws IOException {
       if (graph.nextCreate != null) {
         throw new IllegalStateException("Unexpected recursive call to read() for " + id);
       }
       graph.nextCreate = this;
-      value = typeAdapter.fromJsonTree(element);
+      value = typeAdapter.fromJsonTreeWithSettingsFrom(element, originalReader);
       if (value == null) {
         throw new IllegalStateException("non-null value deserialized to null: " + element);
       }

--- a/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
@@ -282,8 +282,9 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
          * JsonObject here, make it as permissive as possible.
          *
          * This has no effect if adapter did not change settings. Then JsonObject was written
-         * with same settings as `out` and the following temporary setting changes won't make
-         * a difference.
+         * with same settings as `out` and the following temporary settings changes won't make
+         * a difference (assuming JsonTreeWriter and JsonWriter both handle the settings in the
+         * same way).
          *
          * Unfortunately this workaround won't work for HTML-safe and indentation settings,
          * though at least they do not affect the JSON data, only the formatting.

--- a/extras/src/test/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactoryTest.java
+++ b/extras/src/test/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactoryTest.java
@@ -383,31 +383,35 @@ public final class RuntimeTypeAdapterFactoryTest extends TestCase {
     String expectedJson = "{\"type\":\"d\",\"c1\":NaN,\"c2\":null}";
 
     // First create a permissive writer
-    StringWriter writer = new StringWriter();
-    JsonWriter jsonWriter = new JsonWriter(writer);
-    jsonWriter.setSerializeNulls(true);
-    jsonWriter.setLenient(true);
+    {
+      StringWriter writer = new StringWriter();
+      JsonWriter jsonWriter = new JsonWriter(writer);
+      jsonWriter.setSerializeNulls(true);
+      jsonWriter.setLenient(true);
 
-    adapter.write(jsonWriter, new DoubleContainer(0.0));
-    assertEquals(expectedJson, writer.toString());
+      adapter.write(jsonWriter, new DoubleContainer(0.0));
+      assertEquals(expectedJson, writer.toString());
 
-    // Should still have original settings values
-    assertEquals(true, jsonWriter.getSerializeNulls());
-    assertEquals(true, jsonWriter.isLenient());
+      // Should still have original settings values
+      assertEquals(true, jsonWriter.getSerializeNulls());
+      assertEquals(true, jsonWriter.isLenient());
+    }
 
     // Then try non-permissive writer; should have same result because custom
     // adapter temporarily changed writer settings
-    writer = new StringWriter();
-    jsonWriter = new JsonWriter(writer);
-    jsonWriter.setSerializeNulls(false);
-    jsonWriter.setLenient(false);
+    {
+      StringWriter writer = new StringWriter();
+      JsonWriter jsonWriter = new JsonWriter(writer);
+      jsonWriter.setSerializeNulls(false);
+      jsonWriter.setLenient(false);
 
-    adapter.write(jsonWriter, new DoubleContainer(0.0));
-    assertEquals(expectedJson, writer.toString());
+      adapter.write(jsonWriter, new DoubleContainer(0.0));
+      assertEquals(expectedJson, writer.toString());
 
-    // Should still have original settings values
-    assertEquals(false, jsonWriter.getSerializeNulls());
-    assertEquals(false, jsonWriter.isLenient());
+      // Should still have original settings values
+      assertEquals(false, jsonWriter.getSerializeNulls());
+      assertEquals(false, jsonWriter.isLenient());
+    }
   }
 
   static class DummyBaseClass {

--- a/gson/src/main/java/com/google/gson/TypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/TypeAdapter.java
@@ -245,10 +245,15 @@ public abstract class TypeAdapter<T> {
    * {@linkplain JsonWriter#setLenient(boolean) lenient mode} applied from
    * the given writer.
    *
-   * <p>Note: In case the result of this method is afterwards written
+   * <p>Note: The {@link #write(JsonWriter, Object)} implementation of this
+   * type adapter might temporarily change the settings of the internally
+   * used writer during serialization, for example to make it lenient. In
+   * case the {@code JsonElement} result of this method is afterwards written
    * to {@code otherWriter}, possibly after some modifications to the
    * {@code JsonElement}, it might be necessary to temporarily reconfigure
-   * {@code otherWriter}:
+   * {@code otherWriter} to make sure the result is fully preserved (e.g.
+   * no fields with {@code null} value are omitted) and no exceptions are
+   * thrown due to lenient mode mismatch:
    * <pre>{@code
    *boolean oldLenient = otherWriter.isLenient();
    *boolean oldSerializeNulls = otherWriter.getSerializeNulls();
@@ -263,12 +268,9 @@ public abstract class TypeAdapter<T> {
    *  otherWriter.setSerializeNulls(oldSerializeNulls);
    *}
    * }</pre>
-   * This is necessary because this type adapter might have temporarily
-   * changed the settings of the internally used writer during serialization,
-   * for example to make it lenient.
    *
    * @param value the Java object to convert. May be null.
-   * @param otherWriter whose settings should be used for serialization
+   * @param otherWriter whose settings should be used for serialization.
    * @return the converted JSON tree. May be {@link JsonNull}.
    */
   public final JsonElement toJsonTreeWithSettingsFrom(T value, JsonWriter otherWriter) {
@@ -346,7 +348,7 @@ public abstract class TypeAdapter<T> {
    * the given reader.
    *
    * @param jsonTree the JSON element to convert. May be {@link JsonNull}.
-   * @param otherReader whose settings should be used for deserialization
+   * @param otherReader whose settings should be used for deserialization.
    * @return the converted Java object. May be null.
    */
   public final T fromJsonTreeWithSettingsFrom(JsonElement jsonTree, JsonReader otherReader) {

--- a/gson/src/main/java/com/google/gson/TypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/TypeAdapter.java
@@ -245,6 +245,28 @@ public abstract class TypeAdapter<T> {
    * {@linkplain JsonWriter#setLenient(boolean) lenient mode} applied from
    * the given writer.
    *
+   * <p>Note: In case the result of this method is afterwards written
+   * to {@code otherWriter}, possibly after some modifications to the
+   * {@code JsonElement}, it might be necessary to temporarily reconfigure
+   * {@code otherWriter}:
+   * <pre>{@code
+   *boolean oldLenient = otherWriter.isLenient();
+   *boolean oldSerializeNulls = otherWriter.getSerializeNulls();
+   *try {
+   *  otherWriter.setLenient(true);
+   *  otherWriter.setSerializeNulls(true);
+   *
+   *  ... // write JsonElement result to otherWriter
+   *
+   *} finally {
+   *  otherWriter.setLenient(oldLenient);
+   *  otherWriter.setSerializeNulls(oldSerializeNulls);
+   *}
+   * }</pre>
+   * This is necessary because this type adapter might have temporarily
+   * changed the settings of the internally used writer during serialization,
+   * for example to make it lenient.
+   *
    * @param value the Java object to convert. May be null.
    * @param otherWriter whose settings should be used for serialization
    * @return the converted JSON tree. May be {@link JsonNull}.

--- a/gson/src/main/java/com/google/gson/TypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/TypeAdapter.java
@@ -222,7 +222,9 @@ public abstract class TypeAdapter<T> {
   }
 
   /**
-   * Converts {@code value} to a JSON tree.
+   * Converts {@code value} to a JSON tree. The internally used writer is
+   * {@linkplain JsonWriter#setLenient(boolean) strict} and
+   * {@linkplain JsonWriter#setSerializeNulls(boolean) serializes <code>null</code>}.
    *
    * @param value the Java object to convert. May be null.
    * @return the converted JSON tree. May be {@link JsonNull}.
@@ -231,6 +233,26 @@ public abstract class TypeAdapter<T> {
   public final JsonElement toJsonTree(T value) {
     try {
       JsonTreeWriter jsonWriter = new JsonTreeWriter();
+      write(jsonWriter, value);
+      return jsonWriter.get();
+    } catch (IOException e) {
+      throw new JsonIOException(e);
+    }
+  }
+
+  /**
+   * Converts {@code value} to a JSON tree, with the settings such as the
+   * {@linkplain JsonWriter#setLenient(boolean) lenient mode} applied from
+   * the given writer.
+   *
+   * @param value the Java object to convert. May be null.
+   * @param otherWriter whose settings should be used for serialization
+   * @return the converted JSON tree. May be {@link JsonNull}.
+   */
+  public final JsonElement toJsonTreeWithSettingsFrom(T value, JsonWriter otherWriter) {
+    try {
+      JsonTreeWriter jsonWriter = new JsonTreeWriter();
+      jsonWriter.applySettingsFrom(otherWriter);
       write(jsonWriter, value);
       return jsonWriter.get();
     } catch (IOException e) {
@@ -280,7 +302,8 @@ public abstract class TypeAdapter<T> {
   }
 
   /**
-   * Converts {@code jsonTree} to a Java object.
+   * Converts {@code jsonTree} to a Java object. The internally used reader is
+   * strict and does not allow non-finite floating point values.
    *
    * @param jsonTree the JSON element to convert. May be {@link JsonNull}.
    * @return the converted Java object. May be null.
@@ -288,7 +311,26 @@ public abstract class TypeAdapter<T> {
    */
   public final T fromJsonTree(JsonElement jsonTree) {
     try {
-      JsonReader jsonReader = new JsonTreeReader(jsonTree);
+      JsonTreeReader jsonReader = new JsonTreeReader(jsonTree);
+      return read(jsonReader);
+    } catch (IOException e) {
+      throw new JsonIOException(e);
+    }
+  }
+
+  /**
+   * Converts {@code jsonTree} to a Java object, with the settings such as the
+   * {@linkplain JsonReader#setLenient(boolean) lenient mode} applied from
+   * the given reader.
+   *
+   * @param jsonTree the JSON element to convert. May be {@link JsonNull}.
+   * @param otherReader whose settings should be used for deserialization
+   * @return the converted Java object. May be null.
+   */
+  public final T fromJsonTreeWithSettingsFrom(JsonElement jsonTree, JsonReader otherReader) {
+    try {
+      JsonTreeReader jsonReader = new JsonTreeReader(jsonTree);
+      jsonReader.applySettingsFrom(otherReader);
       return read(jsonReader);
     } catch (IOException e) {
       throw new JsonIOException(e);

--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
@@ -25,9 +25,9 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import java.io.IOException;
 import java.io.Reader;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Arrays;
 
 /**
  * This reader walks the elements of a JsonElement as if it was coming from a
@@ -66,6 +66,10 @@ public final class JsonTreeReader extends JsonReader {
   public JsonTreeReader(JsonElement element) {
     super(UNREADABLE_READER);
     push(element);
+  }
+
+  public void applySettingsFrom(JsonReader reader) {
+    setLenient(reader.isLenient());
   }
 
   @Override public void beginArray() throws IOException {

--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
@@ -68,6 +68,9 @@ public final class JsonTreeReader extends JsonReader {
     push(element);
   }
 
+  /**
+   * Applies all settings relevant for {@code JsonTreeReader} from the given reader.
+   */
   public void applySettingsFrom(JsonReader reader) {
     setLenient(reader.isLenient());
   }

--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeWriter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeWriter.java
@@ -59,6 +59,14 @@ public final class JsonTreeWriter extends JsonWriter {
   }
 
   /**
+   * Applies all settings relevant for {@code JsonTreeWriter} from the given writer.
+   */
+  public void applySettingsFrom(JsonWriter writer) {
+    setLenient(writer.isLenient());
+    setSerializeNulls(writer.getSerializeNulls());
+  }
+
+  /**
    * Returns the top level object produced by this writer.
    */
   public JsonElement get() {

--- a/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
@@ -215,7 +215,7 @@ public final class MapTypeAdapterFactory implements TypeAdapterFactory {
 
       List<V> values = new ArrayList<>(map.size());
       for (Map.Entry<K, V> entry : map.entrySet()) {
-        JsonElement keyElement = keyTypeAdapter.toJsonTree(entry.getKey());
+        JsonElement keyElement = keyTypeAdapter.toJsonTreeWithSettingsFrom(entry.getKey(), out);
         keys.add(keyElement);
         values.add(entry.getValue());
         hasComplexKeys |= keyElement.isJsonArray() || keyElement.isJsonObject();

--- a/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
@@ -232,8 +232,9 @@ public final class MapTypeAdapterFactory implements TypeAdapterFactory {
            * JsonElement here, make it as permissive as possible.
            *
            * This has no effect if adapter did not change settings. Then JsonElement was written
-           * with same settings as `out` and the following temporary setting changes won't make
-           * a difference.
+           * with same settings as `out` and the following temporary settings changes won't make
+           * a difference (assuming JsonTreeWriter and JsonWriter both handle the settings in the
+           * same way).
            *
            * Unfortunately this workaround won't work for HTML-safe and indentation settings,
            * though at least they do not affect the JSON data, only the formatting.

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -228,6 +228,8 @@ public class JsonReader implements Closeable {
   /** True to accept non-spec compliant JSON */
   private boolean lenient = false;
 
+  //Important: When adding more settings, adjust JsonTreeReader.applySettingsFrom, if necessary
+
   static final int BUFFER_SIZE = 1024;
   /**
    * Use a manual buffer to easily read and unread upcoming characters, and

--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -16,6 +16,14 @@
 
 package com.google.gson.stream;
 
+import static com.google.gson.stream.JsonScope.DANGLING_NAME;
+import static com.google.gson.stream.JsonScope.EMPTY_ARRAY;
+import static com.google.gson.stream.JsonScope.EMPTY_DOCUMENT;
+import static com.google.gson.stream.JsonScope.EMPTY_OBJECT;
+import static com.google.gson.stream.JsonScope.NONEMPTY_ARRAY;
+import static com.google.gson.stream.JsonScope.NONEMPTY_DOCUMENT;
+import static com.google.gson.stream.JsonScope.NONEMPTY_OBJECT;
+
 import java.io.Closeable;
 import java.io.Flushable;
 import java.io.IOException;
@@ -26,14 +34,6 @@ import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
-
-import static com.google.gson.stream.JsonScope.DANGLING_NAME;
-import static com.google.gson.stream.JsonScope.EMPTY_ARRAY;
-import static com.google.gson.stream.JsonScope.EMPTY_DOCUMENT;
-import static com.google.gson.stream.JsonScope.EMPTY_OBJECT;
-import static com.google.gson.stream.JsonScope.NONEMPTY_ARRAY;
-import static com.google.gson.stream.JsonScope.NONEMPTY_DOCUMENT;
-import static com.google.gson.stream.JsonScope.NONEMPTY_OBJECT;
 
 /**
  * Writes a JSON (<a href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>)
@@ -198,6 +198,8 @@ public class JsonWriter implements Closeable, Flushable {
 
   private boolean serializeNulls = true;
 
+  // Important: When adding more settings, adjust JsonTreeWriter.applySettingsFrom, if necessary
+
   /**
    * Creates a new instance that writes a JSON-encoded stream to {@code out}.
    * For best performance, ensure {@link Writer} is buffered; wrapping in
@@ -213,8 +215,8 @@ public class JsonWriter implements Closeable, Flushable {
   /**
    * Sets the indentation string to be repeated for each level of indentation
    * in the encoded document. If {@code indent.isEmpty()} the encoded document
-   * will be compact. Otherwise the encoded document will be more
-   * human-readable.
+   * will be compact, this is the default. Otherwise the encoded document will
+   * be more human-readable.
    *
    * @param indent a string containing only whitespace.
    */
@@ -256,7 +258,7 @@ public class JsonWriter implements Closeable, Flushable {
    * and XML documents. This escapes the HTML characters {@code <}, {@code >},
    * {@code &} and {@code =} before writing them to the stream. Without this
    * setting, your XML/HTML encoder should replace these characters with the
-   * corresponding escape sequences.
+   * corresponding escape sequences. By default this writer is not HTML-safe.
    */
   public final void setHtmlSafe(boolean htmlSafe) {
     this.htmlSafe = htmlSafe;

--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -258,7 +258,8 @@ public class JsonWriter implements Closeable, Flushable {
    * and XML documents. This escapes the HTML characters {@code <}, {@code >},
    * {@code &} and {@code =} before writing them to the stream. Without this
    * setting, your XML/HTML encoder should replace these characters with the
-   * corresponding escape sequences. By default this writer is not HTML-safe.
+   * corresponding escape sequences. By default this writer does not emit
+   * HTML-safe JSON.
    */
   public final void setHtmlSafe(boolean htmlSafe) {
     this.htmlSafe = htmlSafe;

--- a/gson/src/test/java/com/google/gson/TypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/TypeAdapterTest.java
@@ -68,10 +68,19 @@ public class TypeAdapterTest {
 
   @Test
   public void testToJsonTree() {
-    JsonObject expectedJson = new JsonObject();
-    expectedJson.add("d", JsonNull.INSTANCE);
+    {
+      JsonObject expectedJson = new JsonObject();
+      expectedJson.addProperty("d", 1.0);
 
-    assertEquals(expectedJson, customDoubleAdapter.toJsonTree(null));
+      assertEquals(expectedJson, customDoubleAdapter.toJsonTree(1.0));
+    }
+
+    {
+      JsonObject expectedJson = new JsonObject();
+      expectedJson.add("d", JsonNull.INSTANCE);
+
+      assertEquals(expectedJson, customDoubleAdapter.toJsonTree(null));
+    }
 
     try {
       customDoubleAdapter.toJsonTree(Double.NaN);
@@ -85,10 +94,12 @@ public class TypeAdapterTest {
   public void testToJsonTreeWithSettingsFrom() {
     JsonWriter customWriter = new JsonWriter(new StringWriter());
 
-    JsonObject expectedJson = new JsonObject();
-    expectedJson.add("d", JsonNull.INSTANCE);
+    {
+      JsonObject expectedJson = new JsonObject();
+      expectedJson.add("d", JsonNull.INSTANCE);
 
-    assertEquals(expectedJson, customDoubleAdapter.toJsonTreeWithSettingsFrom(null, customWriter));
+      assertEquals(expectedJson, customDoubleAdapter.toJsonTreeWithSettingsFrom(null, customWriter));
+    }
 
     try {
       customDoubleAdapter.toJsonTreeWithSettingsFrom(Double.NaN, customWriter);
@@ -103,13 +114,17 @@ public class TypeAdapterTest {
     // Should be empty JSON object
     assertEquals(new JsonObject(), customDoubleAdapter.toJsonTreeWithSettingsFrom(null, customWriter));
 
-    expectedJson = new JsonObject();
-    expectedJson.addProperty("d", Double.NaN);
-    assertEquals(expectedJson, customDoubleAdapter.toJsonTreeWithSettingsFrom(Double.NaN, customWriter));
+    {
+      JsonObject expectedJson = new JsonObject();
+      expectedJson.addProperty("d", Double.NaN);
+      assertEquals(expectedJson, customDoubleAdapter.toJsonTreeWithSettingsFrom(Double.NaN, customWriter));
+    }
   }
 
   @Test
   public void testFromJsonTree() {
+    assertEquals((Double) 1.0, customDoubleAdapter.fromJsonTree(new JsonPrimitive(1.0)));
+
     try {
       customDoubleAdapter.fromJsonTree(new JsonPrimitive(Double.NaN));
       fail();

--- a/gson/src/test/java/com/google/gson/TypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/TypeAdapterTest.java
@@ -2,11 +2,13 @@ package com.google.gson;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.io.StringReader;
+import java.io.StringWriter;
 import org.junit.Test;
 
 public class TypeAdapterTest {
@@ -48,5 +50,88 @@ public class TypeAdapterTest {
   @Test
   public void testFromJson_String_TrailingData() throws IOException {
     assertEquals("a", adapter.fromJson("\"a\"1"));
+  }
+
+  private static final TypeAdapter<Double> customDoubleAdapter = new TypeAdapter<Double>() {
+    @Override public void write(JsonWriter out, Double value) throws IOException {
+      out.beginObject();
+      out.name("d");
+      out.value(value);
+      out.endObject();
+    }
+
+    @Override public Double read(JsonReader in) throws IOException {
+      // Note: Does not match `write` method above because tests don't require that
+      return in.nextDouble();
+    }
+  };
+
+  @Test
+  public void testToJsonTree() {
+    JsonObject expectedJson = new JsonObject();
+    expectedJson.add("d", JsonNull.INSTANCE);
+
+    assertEquals(expectedJson, customDoubleAdapter.toJsonTree(null));
+
+    try {
+      customDoubleAdapter.toJsonTree(Double.NaN);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("JSON forbids NaN and infinities: NaN", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testToJsonTreeWithSettingsFrom() {
+    JsonWriter customWriter = new JsonWriter(new StringWriter());
+
+    JsonObject expectedJson = new JsonObject();
+    expectedJson.add("d", JsonNull.INSTANCE);
+
+    assertEquals(expectedJson, customDoubleAdapter.toJsonTreeWithSettingsFrom(null, customWriter));
+
+    try {
+      customDoubleAdapter.toJsonTreeWithSettingsFrom(Double.NaN, customWriter);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("JSON forbids NaN and infinities: NaN", e.getMessage());
+    }
+
+    customWriter.setLenient(true);
+    customWriter.setSerializeNulls(false);
+
+    // Should be empty JSON object
+    assertEquals(new JsonObject(), customDoubleAdapter.toJsonTreeWithSettingsFrom(null, customWriter));
+
+    expectedJson = new JsonObject();
+    expectedJson.addProperty("d", Double.NaN);
+    assertEquals(expectedJson, customDoubleAdapter.toJsonTreeWithSettingsFrom(Double.NaN, customWriter));
+  }
+
+  @Test
+  public void testFromJsonTree() {
+    try {
+      customDoubleAdapter.fromJsonTree(new JsonPrimitive(Double.NaN));
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("JSON forbids NaN and infinities: NaN", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testFromJsonTreeWithSettingsFrom() {
+    JsonReader customReader = new JsonReader(new StringReader(""));
+
+    try {
+      customDoubleAdapter.fromJsonTreeWithSettingsFrom(new JsonPrimitive(Double.NaN), customReader);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("JSON forbids NaN and infinities: NaN", e.getMessage());
+    }
+
+    customReader.setLenient(true);
+
+    Double deserialized = customDoubleAdapter.fromJsonTreeWithSettingsFrom(new JsonPrimitive(Double.NaN), customReader);
+    assertEquals((Double) Double.NaN, deserialized);
   }
 }


### PR DESCRIPTION
Fixes #676
Supersedes #677 (this PR here does not contain the same test code, but have verified that the test code there passed with these changes too)

### Description of the issue
In some situations adapters need to:
- first parse the JSON as `JsonElement`, perform modifications to it and then parse the `JsonElement` as desired target type
- first write the JSON to a `JsonElement`, perform modifications to it and then write the `JsonElement` to the final `JsonWriter`

In these situations a temporary `JsonTreeReader` respectively `JsonTreeWriter` is used. The issue was that these readers and writers were not created with the same settings (lenientness, serialize null) as the original reader or writer. This could cause behavior mismatch or unexpected exceptions during deserialization or serialization.

### Implementation notes for this PR
This PR introduces two new `TypeAdapter` methods: `fromJsonTreeWithSettingsFrom` and `toJsonTreeWithSettingsFrom`. Both apply the settings from an existing reader / writer to the temporary `JsonTreeReader` / `JsonTreeWriter`.
This might not be the cleanest solution, so any feedback is appreciated. However, it appears a solution similar to this is necessary because `JsonTreeReader` and `JsonTreeWriter` are internal classes and therefore cannot be used from outside of Gson (not even from the `extras` module at the moment), which was the proposed solution in #677.
