### PR TITLE
Make `RuntimeTypeAdapterFactory` recognize subclasses only conditionally

### DIFF
--- a/extras/src/test/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactoryTest.java
+++ b/extras/src/test/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactoryTest.java
@@ -34,8 +34,27 @@ public final class RuntimeTypeAdapterFactoryTest extends TestCase {
 
     CreditCard original = new CreditCard("Jesse", 234);
     assertEquals("{\"type\":\"CreditCard\",\"cvv\":234,\"ownerName\":\"Jesse\"}",
-        //do not give the explicit typeOfSrc, because if this would be in a list
-        //or an attribute, there would also be no hint. See #712
+        gson.toJson(original, BillingInstrument.class));
+    BillingInstrument deserialized = gson.fromJson(
+        "{type:'CreditCard',cvv:234,ownerName:'Jesse'}", BillingInstrument.class);
+    assertEquals("Jesse", deserialized.ownerName);
+    assertTrue(deserialized instanceof CreditCard);
+  }
+
+  public void testRuntimeTypeAdapterRecognizeSubtypes() {
+    // We don't have an explicit factory for CreditCard.class, but we do have one for
+    // BillingInstrument.class that has recognizeSubtypes(). So it should recognize CreditCard, and
+    // when we call gson.toJson(original) below, without an explicit type, it should be invoked.
+    RuntimeTypeAdapterFactory<BillingInstrument> rta = RuntimeTypeAdapterFactory.of(
+        BillingInstrument.class)
+        .recognizeSubtypes()
+        .registerSubtype(CreditCard.class);
+    Gson gson = new GsonBuilder()
+        .registerTypeAdapterFactory(rta)
+        .create();
+
+    CreditCard original = new CreditCard("Jesse", 234);
+    assertEquals("{\"type\":\"CreditCard\",\"cvv\":234,\"ownerName\":\"Jesse\"}",
         gson.toJson(original));
     BillingInstrument deserialized = gson.fromJson(
         "{type:'CreditCard',cvv:234,ownerName:'Jesse'}", BillingInstrument.class);


### PR DESCRIPTION
PR #2139 changed this factory so that if given a certain `baseType`, it will also
recognize any subtype of that type. That is often the right thing to do, but it
is a change in behaviour, and does in fact break at least one current client of
this code. So instead we introduce a new `recognizeSubclasses()` method that
triggers this behaviour. When the method is not called, we revert to the old
behaviour of only recognizing instances of the exact class `baseType`.