### PR TITLE
Clarify that `GsonBuilder.setExclusionStrategies` does not replace existing ones

### DIFF
--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -368,6 +368,8 @@ public final class GsonBuilder {
    * deserialization. Each of the {@code strategies} will be applied as a disjunction rule.
    * This means that if one of the {@code strategies} suggests that a field (or class) should be
    * skipped then that field (or object) is skipped during serialization/deserialization.
+   * The strategies are added to the existing strategies (if any), the existing strategies
+   * are not replaced.
    *
    * @param strategies the set of strategy object to apply during object (de)serialization.
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -368,7 +368,7 @@ public final class GsonBuilder {
    * deserialization. Each of the {@code strategies} will be applied as a disjunction rule.
    * This means that if one of the {@code strategies} suggests that a field (or class) should be
    * skipped then that field (or object) is skipped during serialization/deserialization.
-   * The strategies are added to the existing strategies (if any), the existing strategies
+   * The strategies are added to the existing strategies (if any); the existing strategies
    * are not replaced.
    *
    * @param strategies the set of strategy object to apply during object (de)serialization.


### PR DESCRIPTION
Normally `set...` methods on builders make it sound like the previously specified value is overwritten, especially when there also exist `add...` methods. However, this is not the case here so the documentation should explicitly mention this.

Feedback regarding the wording is appreciated.