### PR TITLE
Fix `TypeAdapter.toJson` throwing AssertionError for custom IOException

### DIFF
--- a/gson/src/main/java/com/google/gson/TypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/TypeAdapter.java
@@ -216,7 +216,7 @@ public abstract class TypeAdapter<T> {
     try {
       toJson(stringWriter, value);
     } catch (IOException e) {
-      throw new AssertionError(e); // No I/O writing to a StringWriter.
+      throw new JsonIOException(e);
     }
     return stringWriter.toString();
   }

--- a/gson/src/main/java/com/google/gson/TypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/TypeAdapter.java
@@ -131,8 +131,7 @@ public abstract class TypeAdapter<T> {
    * Unlike Gson's similar {@link Gson#toJson(JsonElement, Appendable) toJson}
    * method, this write is strict. Create a {@link
    * JsonWriter#setLenient(boolean) lenient} {@code JsonWriter} and call
-   * {@link #write(com.google.gson.stream.JsonWriter, Object)} for lenient
-   * writing.
+   * {@link #write(JsonWriter, Object)} for lenient writing.
    *
    * @param value the Java object to convert. May be null.
    * @since 2.2
@@ -205,9 +204,9 @@ public abstract class TypeAdapter<T> {
    * Converts {@code value} to a JSON document. Unlike Gson's similar {@link
    * Gson#toJson(Object) toJson} method, this write is strict. Create a {@link
    * JsonWriter#setLenient(boolean) lenient} {@code JsonWriter} and call
-   * {@link #write(com.google.gson.stream.JsonWriter, Object)} for lenient
-   * writing.
+   * {@link #write(JsonWriter, Object)} for lenient writing.
    *
+   * @throws JsonIOException wrapping {@code IOException}s thrown by {@link #write(JsonWriter, Object)}
    * @param value the Java object to convert. May be null.
    * @since 2.2
    */
@@ -226,6 +225,7 @@ public abstract class TypeAdapter<T> {
    *
    * @param value the Java object to convert. May be null.
    * @return the converted JSON tree. May be {@link JsonNull}.
+   * @throws JsonIOException wrapping {@code IOException}s thrown by {@link #write(JsonWriter, Object)}
    * @since 2.2
    */
   public final JsonElement toJsonTree(T value) {
@@ -248,7 +248,7 @@ public abstract class TypeAdapter<T> {
 
   /**
    * Converts the JSON document in {@code in} to a Java object. Unlike Gson's
-   * similar {@link Gson#fromJson(java.io.Reader, Class) fromJson} method, this
+   * similar {@link Gson#fromJson(Reader, Class) fromJson} method, this
    * read is strict. Create a {@link JsonReader#setLenient(boolean) lenient}
    * {@code JsonReader} and call {@link #read(JsonReader)} for lenient reading.
    *
@@ -284,6 +284,7 @@ public abstract class TypeAdapter<T> {
    *
    * @param jsonTree the JSON element to convert. May be {@link JsonNull}.
    * @return the converted Java object. May be null.
+   * @throws JsonIOException wrapping {@code IOException}s thrown by {@link #read(JsonReader)}
    * @since 2.2
    */
   public final T fromJsonTree(JsonElement jsonTree) {

--- a/gson/src/test/java/com/google/gson/TypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/TypeAdapterTest.java
@@ -2,6 +2,7 @@ package com.google.gson;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
@@ -24,6 +25,38 @@ public class TypeAdapterTest {
 
     assertEquals("null", adapter.toJson(null));
     assertNull(adapter.fromJson("null"));
+  }
+
+  /**
+   * Tests behavior when {@link TypeAdapter#write(JsonWriter, Object)} manually throws
+   * {@link IOException} which is not caused by writer usage.
+   */
+  @Test
+  public void testToJson_ThrowingIOException() {
+    final IOException exception = new IOException("test");
+    TypeAdapter<Integer> adapter = new TypeAdapter<Integer>() {
+      @Override public void write(JsonWriter out, Integer value) throws IOException {
+        throw exception;
+      }
+
+      @Override public Integer read(JsonReader in) throws IOException {
+        throw new AssertionError("not needed by this test");
+      }
+    };
+
+    try {
+      adapter.toJson(1);
+      fail();
+    } catch (JsonIOException e) {
+      assertEquals(exception, e.getCause());
+    }
+
+    try {
+      adapter.toJsonTree(1);
+      fail();
+    } catch (JsonIOException e) {
+      assertEquals(exception, e.getCause());
+    }
   }
 
   private static final TypeAdapter<String> adapter = new TypeAdapter<String>() {


### PR DESCRIPTION
Currently `TypeAdapter.toJson` assumes that no `IOException` can occur because a `StringWriter` is used. However, this assumption is incorrect because the implementation of `write` may manually throw an `IOException`, unrelated to usage of the writer.