### PR TITLE
Add test for JsonArray.isEmpty()

### DIFF
--- a/gson/src/test/java/com/google/gson/JsonArrayTest.java
+++ b/gson/src/test/java/com/google/gson/JsonArrayTest.java
@@ -105,6 +105,18 @@ public final class JsonArrayTest extends TestCase {
     assertEquals(1, original.get(0).getAsJsonArray().size());
     assertEquals(0, copy.get(0).getAsJsonArray().size());
   }
+  
+  public void testIsEmpty() {
+    JsonArray array = new JsonArray();
+    assertTrue(array.isEmpty());
+
+    JsonPrimitive a = new JsonPrimitive("a");
+    array.add(a);
+    assertFalse(array.isEmpty());
+
+    array.remove(0);
+    assertTrue(array.isEmpty());
+  }
 
   public void testFailedGetArrayValues() {
     JsonArray jsonArray = new JsonArray();


### PR DESCRIPTION
In commit https://github.com/google/gson/commit/fa947212e010e5757864fbebe9cdafde8faadabb the JsonArray.isEmpty() was added without any testing
I added a test which should cover the functionality of this method

Replaces https://github.com/google/gson/pull/1666