### PR TITLE
Verify that JsonTreeReader and JsonTreeWriter override all methods

### DIFF
--- a/gson/src/test/java/com/google/gson/common/MoreAsserts.java
+++ b/gson/src/test/java/com/google/gson/common/MoreAsserts.java
@@ -63,12 +63,10 @@ public class MoreAsserts {
     StringBuilder builder = new StringBuilder(method.getName());
     builder.append('(');
 
-    Class<?>[] paramTypes = method.getParameterTypes();
-    for (int i = 0; i < paramTypes.length; i++) {
-      if (i > 0) {
-        builder.append(',');
-      }
-      builder.append(paramTypes[i].getName());
+    String sep = "";
+    for (Class<?> paramType : method.getParameterTypes()) {
+      builder.append(sep).append(paramType.getName());
+      sep = ",";
     }
 
     builder.append(')');

--- a/gson/src/test/java/com/google/gson/common/MoreAsserts.java
+++ b/gson/src/test/java/com/google/gson/common/MoreAsserts.java
@@ -16,9 +16,13 @@
 
 package com.google.gson.common;
 
-import org.junit.Assert;
-
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.Assert;
 
 /**
  * Handy asserts that we wish were present in {@link Assert}
@@ -48,5 +52,56 @@ public class MoreAsserts {
     Assert.assertEquals(a.hashCode(), b.hashCode());
     Assert.assertFalse(a.equals(null));
     Assert.assertFalse(a.equals(new Object()));
+  }
+
+  private static boolean isProtectedOrPublic(Method method) {
+    int modifiers = method.getModifiers();
+    return Modifier.isProtected(modifiers) || Modifier.isPublic(modifiers);
+  }
+
+  private static String getMethodSignature(Method method) {
+    StringBuilder builder = new StringBuilder(method.getName());
+    builder.append('(');
+
+    Class<?>[] paramTypes = method.getParameterTypes();
+    for (int i = 0; i < paramTypes.length; i++) {
+      if (i > 0) {
+        builder.append(',');
+      }
+      builder.append(paramTypes[i].getName());
+    }
+
+    builder.append(')');
+    return builder.toString();
+  }
+
+  /**
+   * Asserts that {@code subClass} overrides all protected and public methods declared by
+   * {@code baseClass} except for the ones whose signatures are in {@code ignoredMethods}.
+   */
+  public static void assertOverridesMethods(Class<?> baseClass, Class<?> subClass, List<String> ignoredMethods) {
+    Set<String> requiredOverriddenMethods = new LinkedHashSet<>();
+    for (Method method : baseClass.getDeclaredMethods()) {
+      // Note: Do not filter out `final` methods; maybe they should not be `final` and subclass needs
+      // to override them
+      if (isProtectedOrPublic(method)) {
+        requiredOverriddenMethods.add(getMethodSignature(method));
+      }
+    }
+
+    for (Method method : subClass.getDeclaredMethods()) {
+      requiredOverriddenMethods.remove(getMethodSignature(method));
+    }
+
+    for (String ignoredMethod : ignoredMethods) {
+      boolean foundIgnored = requiredOverriddenMethods.remove(ignoredMethod);
+      if (!foundIgnored) {
+        throw new IllegalArgumentException("Method '" + ignoredMethod + "' does not exist or is already overridden");
+      }
+    }
+
+    if (!requiredOverriddenMethods.isEmpty()) {
+      Assert.fail(subClass.getSimpleName() + " must override these methods: " + requiredOverriddenMethods);
+    }
   }
 }

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeReaderTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeReaderTest.java
@@ -19,9 +19,14 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
+import com.google.gson.common.MoreAsserts;
+import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.MalformedJsonException;
 import java.io.IOException;
+import java.io.Reader;
+import java.util.Arrays;
+import java.util.List;
 import junit.framework.TestCase;
 
 @SuppressWarnings("resource")
@@ -79,5 +84,15 @@ public class JsonTreeReaderTest extends TestCase {
       assertEquals("Custom JsonElement subclass " + CustomSubclass.class.getName() + " is not supported",
           expected.getMessage());
     }
+  }
+
+  /**
+   * {@link JsonTreeReader} effectively replaces the complete reading logic of {@link JsonReader} to
+   * read from a {@link JsonElement} instead of a {@link Reader}. Therefore all relevant methods of
+   * {@code JsonReader} must be overridden.
+   */
+  public void testOverrides() {
+    List<String> ignoredMethods = Arrays.asList("setLenient(boolean)", "isLenient()");
+    MoreAsserts.assertOverridesMethods(JsonReader.class, JsonTreeReader.class, ignoredMethods);
   }
 }

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
@@ -16,8 +16,14 @@
 
 package com.google.gson.internal.bind;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
+import com.google.gson.common.MoreAsserts;
+import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
+import java.io.Writer;
+import java.util.Arrays;
+import java.util.List;
 import junit.framework.TestCase;
 
 @SuppressWarnings("resource")
@@ -242,5 +248,16 @@ public final class JsonTreeWriterTest extends TestCase {
       fail();
     } catch (UnsupportedOperationException expected) {
     }
+  }
+
+  /**
+   * {@link JsonTreeWriter} effectively replaces the complete writing logic of {@link JsonWriter} to
+   * create a {@link JsonElement} tree instead of writing to a {@link Writer}. Therefore all relevant
+   * methods of {@code JsonWriter} must be overridden.
+   */
+  public void testOverrides() {
+    List<String> ignoredMethods = Arrays.asList("setLenient(boolean)", "isLenient()", "setIndent(java.lang.String)",
+        "setHtmlSafe(boolean)", "isHtmlSafe()", "setSerializeNulls(boolean)", "getSerializeNulls()");
+    MoreAsserts.assertOverridesMethods(JsonWriter.class, JsonTreeWriter.class, ignoredMethods);
   }
 }


### PR DESCRIPTION
If those classes do not override one of the `JsonReader` or `JsonWriter` methods the user might encounter an `AssertionError`.

This was originally suggested in https://github.com/google/gson/pull/2132#issuecomment-1154194193.

Related issues:
- #1651
- #2132