### PR TITLE
Add GitHub workflow for checking API compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '11'

--- a/.github/workflows/check-api-compatibility.yml
+++ b/.github/workflows/check-api-compatibility.yml
@@ -1,0 +1,50 @@
+name: Check API compatibility
+
+on: pull_request
+
+jobs:
+  check-api-compatibility:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout old version
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: 'gson-old-japicmp'
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'maven'
+
+      - name: Build old version
+        run: |
+          cd gson-old-japicmp
+          # Set dummy version
+          mvn --batch-mode org.codehaus.mojo:versions-maven-plugin:2.11.0:set -DnewVersion=JAPICMP-OLD
+          # Install artifacts with dummy version in local repository; used later by Maven plugin for comparison
+          mvn --batch-mode install -DskipTests
+
+      - name: Checkout new version
+        uses: actions/checkout@v3
+
+      - name: Check API compatibility
+        id: check-compatibility
+        run: |
+          mvn --batch-mode --fail-at-end package japicmp:cmp -DskipTests
+
+      - name: Upload API differences artifacts
+        uses: actions/upload-artifact@v3
+        # Run on workflow success (in that case differences report might include added methods and classes)
+        # or when API compatibility check failed
+        if: success() || ( failure() && steps.check-compatibility.outcome == 'failure' )
+        with:
+          name: api-differences
+          path: |
+            **/japicmp/default-cli.html
+            **/japicmp/default-cli.diff
+          # Plugin should always have created report files (though they might be empty)
+          if-no-files-found: error

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning
     - name: Initialize CodeQL

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -45,6 +45,15 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>com.github.siom79.japicmp</groupId>
+          <artifactId>japicmp-maven-plugin</artifactId>
+          <version>0.15.7</version>
+          <configuration>
+            <!-- This module is not supposed to be consumed as library, so no need to check API -->
+            <skip>true</skip>
+          </configuration>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
           <version>3.0.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <modules>
     <module>gson</module>
-    <module>extras</module> 
+    <module>extras</module>
     <module>metrics</module>
     <module>proto</module>
   </modules>
@@ -102,6 +102,37 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <version>3.2.2</version>
+        </plugin>
+        <!-- Plugin for checking source and binary compatibility; used by GitHub workflow -->
+        <plugin>
+          <groupId>com.github.siom79.japicmp</groupId>
+          <artifactId>japicmp-maven-plugin</artifactId>
+          <version>0.15.7</version>
+          <configuration>
+            <oldVersion>
+              <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>${project.artifactId}</artifactId>
+                <!-- This is set by the GitHub workflow -->
+                <version>JAPICMP-OLD</version>
+              </dependency>
+            </oldVersion>
+            <newVersion>
+              <file>
+                <path>${project.build.directory}/${project.build.finalName}.${project.packaging}</path>
+              </file>
+            </newVersion>
+            <parameter>
+              <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
+              <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
+              <excludes>
+                <exclude>com.google.gson.internal</exclude>
+              </excludes>
+              <onlyModified>true</onlyModified>
+              <skipXmlReport>true</skipXmlReport>
+              <reportOnlyFilename>true</reportOnlyFilename>
+            </parameter>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Resolves #2171

This currently only runs as GitHub workflow but not as part of a regular Maven build. It first checks out the pull request base, builds the project and installs the artifacts into the local Maven repository. Then it checks out the pull request head builds it and compares the artifacts with the previous ones.

The API differences report is uploaded as GitHub artifact, an example can be seen here: https://github.com/google/gson/actions/runs/2905297668
Note that the artifact is produced even when there are non-breaking changes, or no changes. Though in these cases the workflow won't fail.

This is mainly a proof-of-concept, I don't know how well this approach will work for real pull requests.

This uses https://github.com/siom79/japicmp. I don't know whether it covers all cases, so it would be good to not rely on it exclusively.
