### PR TITLE
Fix incorrect HTML headings in Javadoc

### DIFF
--- a/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
@@ -119,7 +119,7 @@ import java.util.Map;
  *       .registerSubtype(Diamond.class);
  * }</pre>
  *
- * <h3>Serialization and deserialization</h3>
+ * <h2>Serialization and deserialization</h2>
  * In order to serialize and deserialize a polymorphic object,
  * you must specify the base type explicitly.
  * <pre>   {@code
@@ -158,7 +158,7 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
   public static <T> RuntimeTypeAdapterFactory<T> of(Class<T> baseType, String typeFieldName, boolean maintainType) {
     return new RuntimeTypeAdapterFactory<>(baseType, typeFieldName, maintainType);
   }
-  
+
   /**
    * Creates a new runtime type adapter using for {@code baseType} using {@code
    * typeFieldName} as the type field name. Type field names are case sensitive.
@@ -244,7 +244,7 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
         } else {
             labelJsonElement = jsonElement.getAsJsonObject().remove(typeFieldName);
         }
-        
+
         if (labelJsonElement == null) {
           throw new JsonParseException("cannot deserialize " + baseType
               + " because it does not define a field named " + typeFieldName);
@@ -282,7 +282,7 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
               + " because it already defines a field named " + typeFieldName);
         }
         clone.add(typeFieldName, new JsonPrimitive(label));
-        
+
         for (Map.Entry<String, JsonElement> e : jsonObject.entrySet()) {
           clone.add(e.getKey(), e.getValue());
         }

--- a/gson/src/main/java/com/google/gson/TypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/TypeAdapter.java
@@ -96,7 +96,7 @@ import java.io.Writer;
  */
 // non-Javadoc:
 //
-// <h3>JSON Conversion</h3>
+// <h2>JSON Conversion</h2>
 // <p>A type adapter registered with Gson is automatically invoked while serializing
 // or deserializing JSON. However, you can also use type adapters directly to serialize
 // and deserialize JSON. Here is an example for deserialization: <pre>   {@code

--- a/gson/src/main/java/com/google/gson/TypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/TypeAdapterFactory.java
@@ -22,7 +22,8 @@ import com.google.gson.reflect.TypeToken;
  * Creates type adapters for set of related types. Type adapter factories are
  * most useful when several types share similar structure in their JSON form.
  *
- * <h2>Example: Converting enums to lowercase</h2>
+ * <h2>Examples</h2>
+ * <h3>Example: Converting enums to lowercase</h3>
  * In this example, we implement a factory that creates type adapters for all
  * enums. The type adapters will write enums in lowercase, despite the fact
  * that they're defined in {@code CONSTANT_CASE} in the corresponding Java
@@ -90,7 +91,7 @@ import com.google.gson.reflect.TypeToken;
  * If multiple factories support the same type, the factory registered earlier
  * takes precedence.
  *
- * <h3>Example: composing other type adapters</h3>
+ * <h3>Example: Composing other type adapters</h3>
  * In this example we implement a factory for Guava's {@code Multiset}
  * collection type. The factory can be used to create type adapters for
  * multisets of any element type: the type adapter for {@code

--- a/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
@@ -40,7 +40,7 @@ import java.util.Map;
 /**
  * Adapts maps to either JSON objects or JSON arrays.
  *
- * <h3>Maps as JSON objects</h3>
+ * <h2>Maps as JSON objects</h2>
  * For primitive keys or when complex map key serialization is not enabled, this
  * converts Java {@link Map Maps} to JSON Objects. This requires that map keys
  * can be serialized as strings; this is insufficient for some key types. For
@@ -65,7 +65,7 @@ import java.util.Map;
  *   at com.google.gson.ObjectNavigator.navigateClassFields
  *   ...</pre>
  *
- * <h3>Maps as JSON arrays</h3>
+ * <h2>Maps as JSON arrays</h2>
  * An alternative approach taken by this type adapter when it is required and
  * complex map key serialization is enabled is to encode maps as arrays of map
  * entries. Each map entry is a two element array containing a key and a value.

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -62,7 +62,7 @@ import java.util.Objects;
  * Null literals can be consumed using either {@link #nextNull()} or {@link
  * #skipValue()}.
  *
- * <h3>Example</h3>
+ * <h2>Example</h2>
  * Suppose we'd like to parse a stream of messages such as the following: <pre> {@code
  * [
  *   {
@@ -161,7 +161,7 @@ import java.util.Objects;
  *     return new User(username, followersCount);
  *   }}</pre>
  *
- * <h3>Number Handling</h3>
+ * <h2>Number Handling</h2>
  * This reader permits numeric values to be read as strings and string values to
  * be read as numbers. For example, both elements of the JSON array {@code
  * [1, "1"]} may be read using either {@link #nextInt} or {@link #nextString}.
@@ -171,7 +171,7 @@ import java.util.Objects;
  * precision loss, extremely large values should be written and read as strings
  * in JSON.
  *
- * <h3 id="nonexecuteprefix">Non-Execute Prefix</h3>
+ * <h2 id="nonexecuteprefix">Non-Execute Prefix</h2>
  * Web servers that serve private data using JSON may be vulnerable to <a
  * href="http://en.wikipedia.org/wiki/JSON#Cross-site_request_forgery">Cross-site
  * request forgery</a> attacks. In such an attack, a malicious site gains access

--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -58,7 +58,7 @@ import java.util.regex.Pattern;
  *       Finally close the object using {@link #endObject()}.
  * </ul>
  *
- * <h3>Example</h3>
+ * <h2>Example</h2>
  * Suppose we'd like to encode a stream of messages such as the following: <pre> {@code
  * [
  *   {


### PR DESCRIPTION
Follow-up for #2198

It looks like in that pull request only the first incorrect heading was updated, but headings which should be at the same level were not updated, causing them to become sub-headings.