### PR TITLE
Support Java Records when present in JVM.

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -300,7 +300,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
    * @param <T> type of objects that this Adapter creates.
    * @param <A> type of accumulator used to build the deserialization result.
    */
-  abstract static class Adapter<T, A> extends TypeAdapter<T> {
+  public static abstract class Adapter<T, A> extends TypeAdapter<T> {
     protected final Map<String, BoundField> boundFields;
 
     protected Adapter(Map<String, BoundField> boundFields) {

--- a/gson/src/main/java/com/google/gson/internal/reflect/ReflectionHelper.java
+++ b/gson/src/main/java/com/google/gson/internal/reflect/ReflectionHelper.java
@@ -2,15 +2,32 @@ package com.google.gson.internal.reflect;
 
 import com.google.gson.JsonIOException;
 import com.google.gson.internal.GsonBuildConfig;
+import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 public class ReflectionHelper {
-  private ReflectionHelper() { }
+
+  private static final RecordHelper RECORD_HELPER;
+
+  static {
+    RecordHelper instance;
+    try {
+      // Try to construct the RecordSupportedHelper, if this fails, records are not supported on this JVM.
+      instance = new RecordSupportedHelper();
+    } catch (NoSuchMethodException e) {
+      instance = new RecordNotSupportedHelper();
+    }
+    RECORD_HELPER = instance;
+  }
+
+  private ReflectionHelper() {}
 
   /**
-   * Tries making the field accessible, wrapping any thrown exception in a
-   * {@link JsonIOException} with descriptive message.
+   * Tries making the field accessible, wrapping any thrown exception in a {@link JsonIOException}
+   * with descriptive message.
    *
    * @param field field to make accessible
    * @throws JsonIOException if making the field accessible fails
@@ -65,10 +82,131 @@ public class ReflectionHelper {
     }
   }
 
-  public static RuntimeException createExceptionForUnexpectedIllegalAccess(IllegalAccessException exception) {
+  public static boolean isRecord(Class<?> raw) {
+    return RECORD_HELPER.isRecord(raw);
+  }
+
+  public static String[] recordFields(Class<?> raw) {
+    return RECORD_HELPER.recordFields(raw);
+  }
+
+  public static RuntimeException createExceptionForUnexpectedIllegalAccess(
+      IllegalAccessException exception) {
     throw new RuntimeException("Unexpected IllegalAccessException occurred (Gson " + GsonBuildConfig.VERSION + "). "
         + "Certain ReflectionAccessFilter features require Java >= 9 to work correctly. If you are not using "
         + "ReflectionAccessFilter, report this to the Gson maintainers.",
         exception);
+  }
+
+  public static <T> Constructor<T> getCanonicalRecordConstructor(Class<T> raw) {
+    return RECORD_HELPER.getCanonicalRecordConstructor(raw);
+  }
+
+  /**
+   * Internal abstraction over reflection when Records are supported.
+   */
+  private abstract static class RecordHelper {
+    abstract boolean isRecord(Class<?> clazz);
+
+    abstract String[] recordFields(Class<?> clazz);
+
+    abstract <T> Constructor<T> getCanonicalRecordConstructor(Class<T> raw);
+  }
+
+  private static class RecordSupportedHelper extends RecordHelper {
+    private final Method isRecord;
+    private final Method getRecordComponents;
+    private final Method getName;
+    private final Method getType;
+
+    private RecordSupportedHelper() throws NoSuchMethodException {
+      isRecord = Class.class.getMethod("isRecord");
+      getRecordComponents = Class.class.getDeclaredMethod("getRecordComponents");
+      Class<?> recordComponentType = getRecordComponents.getReturnType().getComponentType();
+      getName = recordComponentType.getDeclaredMethod("getName");
+      getType = recordComponentType.getDeclaredMethod("getType");
+    }
+
+    @Override
+    boolean isRecord(Class<?> raw) {
+      try {
+        return boolean.class.cast(isRecord.invoke(raw));
+      } catch (IllegalAccessException e) {
+        throw createExceptionForUnexpectedIllegalAccess(e);
+      } catch (InvocationTargetException e) {
+        throw new RuntimeException("Failed to reflect into record components on"
+                + " class [" + raw + "], this is unexpected behaviour, as these methods should"
+                + " not throw when they are defined on Class",
+                e
+        );
+      }
+    }
+
+    @Override
+    String[] recordFields(Class<?> raw) {
+      try {
+        Object recordComponents = getRecordComponents.invoke(raw);
+        int componentCount = Array.getLength(recordComponents);
+        String[] recordFields = new String[componentCount];
+        for (int i = 0; i < componentCount; i++) {
+          recordFields[i] =
+                  String.class.cast(getName.invoke(Array.get(recordComponents, i)));
+        }
+        return recordFields;
+      } catch (IllegalAccessException e) {
+        throw createExceptionForUnexpectedIllegalAccess(e);
+      } catch (ReflectiveOperationException e) {
+        throw new RuntimeException("Failed to reflect into record components on"
+                + " class [" + raw + "], this is unexpected behaviour, as these methods should"
+                + " not throw when they are defined on Class",
+                e
+        );
+      }
+    }
+
+    @Override
+    public <T> Constructor<T> getCanonicalRecordConstructor(Class<T> raw) {
+      try {
+        Object recordComponents = getRecordComponents.invoke(raw);
+        int componentCount = Array.getLength(recordComponents);
+        Class[] recordFields = new Class[componentCount];
+        for (int i = 0; i < componentCount; i++) {
+          recordFields[i] =
+                  Class.class.cast(getType.invoke(Array.get(recordComponents, i)));
+        }
+        return raw.getConstructor(recordFields);
+      } catch (IllegalAccessException e) {
+        throw createExceptionForUnexpectedIllegalAccess(e);
+      } catch (ReflectiveOperationException e) {
+        throw new RuntimeException("Failed to reflect into record components on"
+                + " class [" + raw + "], this is unexpected behaviour, as these methods should"
+                + " not throw when they are defined on Class",
+                e
+        );
+      }
+    }
+  }
+
+  /**
+   * Instance used when records are not supported
+   */
+  private static class RecordNotSupportedHelper extends RecordHelper {
+
+    @Override
+    boolean isRecord(Class<?> clazz) {
+      return false;
+    }
+
+    @Override
+    String[] recordFields(Class<?> clazz) {
+      throw new UnsupportedOperationException(
+              "Records are not supported on this JVM, this method should not be called");
+    }
+
+    @Override
+    <T> Constructor<T> getCanonicalRecordConstructor(Class<T> raw) {
+      throw new UnsupportedOperationException(
+              "Records are not supported on this JVM, this method should not be called");
+    }
   }
 }

--- a/gson/src/test/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactoryTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactoryTest.java
@@ -1,0 +1,132 @@
+package com.google.gson.internal.bind;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import org.junit.AssumptionViolatedException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.attribute.GroupPrincipal;
+import java.nio.file.attribute.UserPrincipal;
+import java.util.Objects;
+
+import static org.junit.Assert.*;
+
+public class ReflectiveTypeAdapterFactoryTest {
+
+
+    @Before
+    public void setUp() throws Exception {
+        try {
+            Class.forName("java.lang.Record");
+        } catch (ClassNotFoundException e) {
+            // Records not supported, ignore
+            throw new AssumptionViolatedException("java.lang.Record not supported");
+        }
+    }
+
+    @Test
+    public void testCustomAdapterForRecords() throws ClassNotFoundException {
+        Class<?> unixDomainPrincipalClass = Class.forName("jdk.net.UnixDomainPrincipal");
+
+        Gson gson = new Gson();
+        TypeAdapter<?> recordAdapter = gson.getAdapter(unixDomainPrincipalClass);
+        TypeAdapter<?> defaultReflectionAdapter = gson.getAdapter(GroupPrincipalImpl.class);
+        assertNotEquals(recordAdapter.getClass(), defaultReflectionAdapter.getClass());
+    }
+
+    @Test
+    public void testSerializeRecords() throws ReflectiveOperationException {
+        Class<?> unixDomainPrincipalClass = Class.forName("jdk.net.UnixDomainPrincipal");
+        Gson gson = new GsonBuilder()
+                .registerTypeAdapter(UserPrincipal.class, new TypeAdapter<UserPrincipal>() {
+                    @Override
+                    public void write(JsonWriter out, UserPrincipal principal) throws IOException {
+                        out.value(principal.getName());
+                    }
+
+                    @Override
+                    public UserPrincipal read(JsonReader in) throws IOException {
+                        final String name = in.nextString();
+                        return new UserPrincipalImpl(name);
+                    }
+                })
+                .registerTypeAdapter(GroupPrincipal.class, new TypeAdapter<GroupPrincipal>() {
+                    @Override
+                    public void write(JsonWriter out, GroupPrincipal value) throws IOException {
+                        out.value(value.getName());
+                    }
+
+                    @Override
+                    public GroupPrincipal read(JsonReader in) throws IOException {
+                        final String name = in.nextString();
+                        return new GroupPrincipalImpl(name);
+                    }
+                })
+                .create();
+        UserPrincipal userPrincipal = gson.fromJson("\"user\"", UserPrincipal.class);
+        GroupPrincipal groupPrincipal = gson.fromJson("\"group\"", GroupPrincipal.class);
+        Object recordInstance = unixDomainPrincipalClass.getDeclaredConstructor(UserPrincipal.class, GroupPrincipal.class)
+                .newInstance(userPrincipal, groupPrincipal);
+        String serialized = gson.toJson(recordInstance);
+        Object deserializedRecordInstance = gson.fromJson(serialized, unixDomainPrincipalClass);
+
+        assertEquals(recordInstance, deserializedRecordInstance);
+    }
+
+    private static class GroupPrincipalImpl implements GroupPrincipal {
+        private final String _name;
+
+        public GroupPrincipalImpl(String name) {
+            _name = name;
+        }
+
+        @Override
+        public String getName() {
+            return _name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            GroupPrincipalImpl that = (GroupPrincipalImpl) o;
+            return Objects.equals(_name, that._name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(_name);
+        }
+    }
+
+    private static class UserPrincipalImpl implements UserPrincipal {
+        private final String _name;
+
+        public UserPrincipalImpl(String name) {
+            _name = name;
+        }
+
+        @Override
+        public String getName() {
+            return _name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            UserPrincipalImpl that = (UserPrincipalImpl) o;
+            return Objects.equals(_name, that._name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(_name);
+        }
+    }
+}

--- a/gson/src/test/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactoryTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactoryTest.java
@@ -1,132 +1,83 @@
 package com.google.gson.internal.bind;
 
+import static org.junit.Assert.*;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.TypeAdapter;
+import com.google.gson.internal.reflect.ReflectionHelperTest;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+import java.nio.file.attribute.GroupPrincipal;
+import java.nio.file.attribute.UserPrincipal;
+import java.security.Principal;
 import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.nio.file.attribute.GroupPrincipal;
-import java.nio.file.attribute.UserPrincipal;
-import java.util.Objects;
-
-import static org.junit.Assert.*;
-
 public class ReflectiveTypeAdapterFactoryTest {
 
+  // The class jdk.net.UnixDomainPrincipal is one of the few Record types that are included in the
+  // JDK.
+  // We use this to test serialization and deserialization of Record classes, so we do not need to
+  // have
+  // record support at the language level for these tests. This class was added in JDK 16.
+  Class<?> unixDomainPrincipalClass;
 
-    @Before
-    public void setUp() throws Exception {
-        try {
-            Class.forName("java.lang.Record");
-        } catch (ClassNotFoundException e) {
-            // Records not supported, ignore
-            throw new AssumptionViolatedException("java.lang.Record not supported");
-        }
+  @Before
+  public void setUp() throws Exception {
+    try {
+      Class.forName("java.lang.Record");
+      unixDomainPrincipalClass = Class.forName("jdk.net.UnixDomainPrincipal");
+    } catch (ClassNotFoundException e) {
+      // Records not supported, ignore
+      throw new AssumptionViolatedException("java.lang.Record not supported");
+    }
+  }
+
+  @Test
+  public void testCustomAdapterForRecords() {
+    Gson gson = new Gson();
+    TypeAdapter<?> recordAdapter = gson.getAdapter(unixDomainPrincipalClass);
+    TypeAdapter<?> defaultReflectionAdapter = gson.getAdapter(UserPrincipal.class);
+    assertNotEquals(recordAdapter.getClass(), defaultReflectionAdapter.getClass());
+  }
+
+  @Test
+  public void testSerializeRecords() throws ReflectiveOperationException {
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(UserPrincipal.class, new PrincipalTypeAdapter<>())
+            .registerTypeAdapter(GroupPrincipal.class, new PrincipalTypeAdapter<>())
+            .create();
+
+    UserPrincipal userPrincipal = gson.fromJson("\"user\"", UserPrincipal.class);
+    GroupPrincipal groupPrincipal = gson.fromJson("\"group\"", GroupPrincipal.class);
+    Object recordInstance =
+        unixDomainPrincipalClass
+            .getDeclaredConstructor(UserPrincipal.class, GroupPrincipal.class)
+            .newInstance(userPrincipal, groupPrincipal);
+    String serialized = gson.toJson(recordInstance);
+    Object deserializedRecordInstance = gson.fromJson(serialized, unixDomainPrincipalClass);
+
+    assertEquals(recordInstance, deserializedRecordInstance);
+    assertEquals("{\"user\":\"user\",\"group\":\"group\"}", serialized);
+  }
+
+  private static class PrincipalTypeAdapter<T extends Principal> extends TypeAdapter<T> {
+    @Override
+    public void write(JsonWriter out, T principal) throws IOException {
+      out.value(principal.getName());
     }
 
-    @Test
-    public void testCustomAdapterForRecords() throws ClassNotFoundException {
-        Class<?> unixDomainPrincipalClass = Class.forName("jdk.net.UnixDomainPrincipal");
-
-        Gson gson = new Gson();
-        TypeAdapter<?> recordAdapter = gson.getAdapter(unixDomainPrincipalClass);
-        TypeAdapter<?> defaultReflectionAdapter = gson.getAdapter(GroupPrincipalImpl.class);
-        assertNotEquals(recordAdapter.getClass(), defaultReflectionAdapter.getClass());
+    @Override
+    public T read(JsonReader in) throws IOException {
+      final String name = in.nextString();
+      // This type adapter is only used for Group and User Principal, both of which are implemented by PrincipalImpl.
+      @SuppressWarnings("unchecked")
+      T principal = (T) new ReflectionHelperTest.PrincipalImpl(name);
+      return principal;
     }
-
-    @Test
-    public void testSerializeRecords() throws ReflectiveOperationException {
-        Class<?> unixDomainPrincipalClass = Class.forName("jdk.net.UnixDomainPrincipal");
-        Gson gson = new GsonBuilder()
-                .registerTypeAdapter(UserPrincipal.class, new TypeAdapter<UserPrincipal>() {
-                    @Override
-                    public void write(JsonWriter out, UserPrincipal principal) throws IOException {
-                        out.value(principal.getName());
-                    }
-
-                    @Override
-                    public UserPrincipal read(JsonReader in) throws IOException {
-                        final String name = in.nextString();
-                        return new UserPrincipalImpl(name);
-                    }
-                })
-                .registerTypeAdapter(GroupPrincipal.class, new TypeAdapter<GroupPrincipal>() {
-                    @Override
-                    public void write(JsonWriter out, GroupPrincipal value) throws IOException {
-                        out.value(value.getName());
-                    }
-
-                    @Override
-                    public GroupPrincipal read(JsonReader in) throws IOException {
-                        final String name = in.nextString();
-                        return new GroupPrincipalImpl(name);
-                    }
-                })
-                .create();
-        UserPrincipal userPrincipal = gson.fromJson("\"user\"", UserPrincipal.class);
-        GroupPrincipal groupPrincipal = gson.fromJson("\"group\"", GroupPrincipal.class);
-        Object recordInstance = unixDomainPrincipalClass.getDeclaredConstructor(UserPrincipal.class, GroupPrincipal.class)
-                .newInstance(userPrincipal, groupPrincipal);
-        String serialized = gson.toJson(recordInstance);
-        Object deserializedRecordInstance = gson.fromJson(serialized, unixDomainPrincipalClass);
-
-        assertEquals(recordInstance, deserializedRecordInstance);
-    }
-
-    private static class GroupPrincipalImpl implements GroupPrincipal {
-        private final String _name;
-
-        public GroupPrincipalImpl(String name) {
-            _name = name;
-        }
-
-        @Override
-        public String getName() {
-            return _name;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            GroupPrincipalImpl that = (GroupPrincipalImpl) o;
-            return Objects.equals(_name, that._name);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(_name);
-        }
-    }
-
-    private static class UserPrincipalImpl implements UserPrincipal {
-        private final String _name;
-
-        public UserPrincipalImpl(String name) {
-            _name = name;
-        }
-
-        @Override
-        public String getName() {
-            return _name;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            UserPrincipalImpl that = (UserPrincipalImpl) o;
-            return Objects.equals(_name, that._name);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(_name);
-        }
-    }
+  }
 }

--- a/gson/src/test/java/com/google/gson/internal/reflect/ReflectionHelperTest.java
+++ b/gson/src/test/java/com/google/gson/internal/reflect/ReflectionHelperTest.java
@@ -1,0 +1,39 @@
+package com.google.gson.internal.reflect;
+
+import org.junit.*;
+
+import java.lang.reflect.Constructor;
+import java.nio.file.attribute.GroupPrincipal;
+import java.nio.file.attribute.UserPrincipal;
+
+import static org.junit.Assert.*;
+
+public class ReflectionHelperTest {
+
+    @Before
+    public void setUp() throws Exception {
+        try {
+            Class.forName("java.lang.Record");
+        } catch (ClassNotFoundException e) {
+            // Records not supported, ignore
+            throw new AssumptionViolatedException("java.lang.Record not supported");
+        }
+    }
+
+    @Test
+    public void testJava17Record() throws ClassNotFoundException {
+        Class<?> unixDomainPrincipalClass = Class.forName("jdk.net.UnixDomainPrincipal");
+        // UnixDomainPrincipal is a record
+        assertTrue(ReflectionHelper.isRecord(unixDomainPrincipalClass));
+        // with 2 fields
+        assertArrayEquals(new String[] {"user", "group"}, ReflectionHelper.getRecordComponentNames(unixDomainPrincipalClass));
+        // Check canonical constructor
+        Constructor<?> constructor = ReflectionHelper.getCanonicalRecordConstructor(unixDomainPrincipalClass);
+        assertNotNull(constructor);
+        assertArrayEquals(
+                new Class<?>[] { UserPrincipal.class, GroupPrincipal.class },
+                constructor.getParameterTypes());
+    }
+
+
+}

--- a/gson/src/test/java/com/google/gson/internal/reflect/ReflectionHelperTest.java
+++ b/gson/src/test/java/com/google/gson/internal/reflect/ReflectionHelperTest.java
@@ -1,39 +1,90 @@
 package com.google.gson.internal.reflect;
 
-import org.junit.*;
+import static org.junit.Assert.*;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.nio.file.attribute.GroupPrincipal;
 import java.nio.file.attribute.UserPrincipal;
-
-import static org.junit.Assert.*;
+import java.util.Objects;
+import org.junit.AssumptionViolatedException;
+import org.junit.Before;
+import org.junit.Test;
 
 public class ReflectionHelperTest {
 
-    @Before
-    public void setUp() throws Exception {
-        try {
-            Class.forName("java.lang.Record");
-        } catch (ClassNotFoundException e) {
-            // Records not supported, ignore
-            throw new AssumptionViolatedException("java.lang.Record not supported");
-        }
+  @Before
+  public void setUp() throws Exception {
+    try {
+      Class.forName("java.lang.Record");
+    } catch (ClassNotFoundException e) {
+      // Records not supported, ignore
+      throw new AssumptionViolatedException("java.lang.Record not supported");
+    }
+  }
+
+  @Test
+  public void testJava17Record() throws ClassNotFoundException {
+    Class<?> unixDomainPrincipalClass = Class.forName("jdk.net.UnixDomainPrincipal");
+    // UnixDomainPrincipal is a record
+    assertTrue(ReflectionHelper.isRecord(unixDomainPrincipalClass));
+    // with 2 components
+    assertArrayEquals(
+        new String[] {"user", "group"},
+        ReflectionHelper.getRecordComponentNames(unixDomainPrincipalClass));
+    // Check canonical constructor
+    Constructor<?> constructor =
+        ReflectionHelper.getCanonicalRecordConstructor(unixDomainPrincipalClass);
+    assertNotNull(constructor);
+    assertArrayEquals(
+        new Class<?>[] {UserPrincipal.class, GroupPrincipal.class},
+        constructor.getParameterTypes());
+  }
+
+  @Test
+  public void testJava17RecordAccessors() throws ReflectiveOperationException {
+    // Create an instance of UnixDomainPrincipal, using our custom implementation of UserPrincipal,
+    // and GroupPrincipal. Then attempt to access each component of the record using our accessor
+    // methods.
+    Class<?> unixDomainPrincipalClass = Class.forName("jdk.net.UnixDomainPrincipal");
+    Object unixDomainPrincipal =
+        ReflectionHelper.getCanonicalRecordConstructor(unixDomainPrincipalClass)
+            .newInstance(new PrincipalImpl("user"), new PrincipalImpl("group"));
+    for (String componentName :
+        ReflectionHelper.getRecordComponentNames(unixDomainPrincipalClass)) {
+      Field componentField = unixDomainPrincipalClass.getDeclaredField(componentName);
+      Method accessor = ReflectionHelper.getAccessor(unixDomainPrincipalClass, componentField);
+      Object principal = accessor.invoke(unixDomainPrincipal);
+
+      assertEquals(new PrincipalImpl(componentName), principal);
+    }
+  }
+
+  /** Implementation of {@link UserPrincipal} and {@link GroupPrincipal} just for record tests. */
+  public static class PrincipalImpl implements UserPrincipal, GroupPrincipal {
+    private final String name;
+
+    public PrincipalImpl(String name) {
+      this.name = name;
     }
 
-    @Test
-    public void testJava17Record() throws ClassNotFoundException {
-        Class<?> unixDomainPrincipalClass = Class.forName("jdk.net.UnixDomainPrincipal");
-        // UnixDomainPrincipal is a record
-        assertTrue(ReflectionHelper.isRecord(unixDomainPrincipalClass));
-        // with 2 fields
-        assertArrayEquals(new String[] {"user", "group"}, ReflectionHelper.getRecordComponentNames(unixDomainPrincipalClass));
-        // Check canonical constructor
-        Constructor<?> constructor = ReflectionHelper.getCanonicalRecordConstructor(unixDomainPrincipalClass);
-        assertNotNull(constructor);
-        assertArrayEquals(
-                new Class<?>[] { UserPrincipal.class, GroupPrincipal.class },
-                constructor.getParameterTypes());
+    @Override
+    public String getName() {
+      return name;
     }
 
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      PrincipalImpl principal = (PrincipalImpl) o;
+      return Objects.equals(name, principal.name);
+    }
 
+    @Override
+    public int hashCode() {
+      return Objects.hash(name);
+    }
+  }
 }


### PR DESCRIPTION
Fixes google/gson#1794

Added support in the ReflectionHelper to detect if a class is a record on the JVM (via reflection), and if so, we will create a special RecordAdapter to deserialize records, using the canoncial constructor.

The ReflectionTypeAdapterFactory had to be refactored a bit to support this. The Adapter class inside the factory is now abstract, with concrete implementations for normal field reflection and for Records. The common code is in the Adapter, with each implementation deserializing values into an intermediary object.

For the FieldReflectionAdapter, the intermediary is actually the final result, and field access is used to write to fields as before. For the RecordAdapter the intermediary is the Object[] to pass to the Record constructor.