### PR TITLE
Add a currently-failing test for Java records and `@Ignore` it.

### DIFF
--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -247,6 +247,7 @@
       <properties>
         <javaVersion>17</javaVersion>
         <excludeTestCompilation></excludeTestCompilation>
+        <extraLintSuppressions>,-exports,-missing-explicit-ctor,-removal</extraLintSuppressions>
       </properties>
     </profile>
   </profiles>

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -17,6 +17,10 @@
     </license>
   </licenses>
 
+  <properties>
+    <excludeTestCompilation>**/Java17*</excludeTestCompilation>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
@@ -58,6 +62,18 @@
                 <!-- module-info.java is compiled using ModiTect -->
                 <exclude>module-info.java</exclude>
               </excludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <testExcludes>
+                <exclude>${excludeTestCompilation}</exclude>
+              </testExcludes>
             </configuration>
           </execution>
         </executions>
@@ -222,4 +238,16 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>JDK17</id>
+      <activation>
+        <jdk>[17,)</jdk>
+      </activation>
+      <properties>
+        <javaVersion>17</javaVersion>
+        <excludeTestCompilation></excludeTestCompilation>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -245,7 +245,7 @@
         <jdk>[17,)</jdk>
       </activation>
       <properties>
-        <javaVersion>17</javaVersion>
+        <maven.compiler.testRelease>17</maven.compiler.testRelease>
         <excludeTestCompilation></excludeTestCompilation>
         <extraLintSuppressions>,-exports,-missing-explicit-ctor,-removal</extraLintSuppressions>
       </properties>

--- a/gson/src/main/java/com/google/gson/ReflectionAccessFilter.java
+++ b/gson/src/main/java/com/google/gson/ReflectionAccessFilter.java
@@ -67,7 +67,7 @@ public interface ReflectionAccessFilter {
      * the used Java version would only log a warning, or is configured to open
      * packages for reflection using command line arguments.
      *
-     * @see AccessibleObject#canAccess(Object)
+     * @see java.lang.reflect.AccessibleObject#canAccess(Object)
      */
     BLOCK_INACCESSIBLE,
     /**

--- a/gson/src/main/java/com/google/gson/ReflectionAccessFilter.java
+++ b/gson/src/main/java/com/google/gson/ReflectionAccessFilter.java
@@ -67,8 +67,7 @@ public interface ReflectionAccessFilter {
      * the used Java version would only log a warning, or is configured to open
      * packages for reflection using command line arguments.
      *
-     * <p>See {@code AccessibleObject.canAccess(Object)}.
-     * <!-- This is not a @see because that API doesn't exist in Java 7. -->
+     * @see AccessibleObject#canAccess(Object)
      */
     BLOCK_INACCESSIBLE,
     /**

--- a/gson/src/main/java/com/google/gson/ReflectionAccessFilter.java
+++ b/gson/src/main/java/com/google/gson/ReflectionAccessFilter.java
@@ -67,7 +67,8 @@ public interface ReflectionAccessFilter {
      * the used Java version would only log a warning, or is configured to open
      * packages for reflection using command line arguments.
      *
-     * @see java.lang.reflect.AccessibleObject#canAccess(Object)
+     * <p>See {@code AccessibleObject.canAccess(Object)}.
+     * <!-- This is not a @see because that API doesn't exist in Java 7. -->
      */
     BLOCK_INACCESSIBLE,
     /**

--- a/gson/src/test/java/com/google/gson/functional/Java17RecordTest.java
+++ b/gson/src/test/java/com/google/gson/functional/Java17RecordTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gson.functional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+import java.util.Objects;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+@Ignore
+public final class Java17RecordTest {
+  private final Gson gson = new Gson();
+
+  @Test
+  public void testFirstNameIsChosenForSerialization() {
+    MyRecord target = new MyRecord("v1", "v2");
+    // Ensure name1 occurs exactly once, and name2 and name3 don't appear
+    assertEquals("{\"name\":\"v1\",\"name1\":\"v2\"}", gson.toJson(target));
+  }
+
+  @Test
+  public void testMultipleNamesDeserializedCorrectly() {
+    assertEquals("v1", gson.fromJson("{'name':'v1'}", MyRecord.class).a);
+
+    // Both name1 and name2 gets deserialized to b
+    assertEquals("v11", gson.fromJson("{'name1':'v11'}", MyRecord.class).b);
+    assertEquals("v2", gson.fromJson("{'name2':'v2'}", MyRecord.class).b);
+    assertEquals("v3", gson.fromJson("{'name3':'v3'}", MyRecord.class).b);
+  }
+
+  @Test
+  public void testMultipleNamesInTheSameString() {
+    // The last value takes precedence
+    assertEquals("v3", gson.fromJson("{'name1':'v1','name2':'v2','name3':'v3'}", MyRecord.class).b);
+  }
+
+  @Test
+  public void testConstructorRuns() {
+    assertThrows(NullPointerException.class,
+        () -> gson.fromJson("{'name1': null, 'name2': null", MyRecord.class));
+  }
+
+  private static record MyRecord(
+      @SerializedName("name") String a,
+      @SerializedName(value = "name1", alternate = {"name2", "name3"}) String b) {
+    MyRecord {
+      Objects.requireNonNull(a);
+    }
+  }
+}

--- a/gson/src/test/java/com/google/gson/functional/ReflectionAccessFilterTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ReflectionAccessFilterTest.java
@@ -2,6 +2,7 @@ package com.google.gson.functional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeNotNull;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -66,12 +67,11 @@ public class ReflectionAccessFilterTest {
       pointClass = Class.forName("java.awt.Point");
     } catch (ClassNotFoundException e) {
     }
-    if (pointClass != null) {
-      Constructor<?> pointConstructor = pointClass.getConstructor(int.class, int.class);
-      Object point = pointConstructor.newInstance(1, 2);
-      String json = gson.toJson(point);
-      assertEquals("{\"x\":1,\"y\":2}", json);
-    }
+    assumeNotNull(pointClass);
+    Constructor<?> pointConstructor = pointClass.getConstructor(int.class, int.class);
+    Object point = pointConstructor.newInstance(1, 2);
+    String json = gson.toJson(point);
+    assertEquals("{\"x\":1,\"y\":2}", json);
   }
 
   @Test

--- a/gson/src/test/java/com/google/gson/functional/ReflectionAccessTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ReflectionAccessTest.java
@@ -37,6 +37,7 @@ public class ReflectionAccessTest {
   }
 
   @Test
+  @SuppressWarnings("removal") // java.lang.SecurityManager
   public void testRestrictiveSecurityManager() throws Exception {
     // Must use separate class loader, otherwise permission is not checked, see Class.getDeclaredFields()
     Class<?> clazz = loadClassWithDifferentClassLoader(ClassWithPrivateMembers.class);

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,6 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.10.1</version>
           <configuration>
-            <release>${javaVersion}</release>
             <showWarnings>true</showWarnings>
             <showDeprecation>true</showDeprecation>
             <failOnWarning>true</failOnWarning>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <javaVersion>7</javaVersion>
+    <extraLintSuppressions></extraLintSuppressions>
   </properties>
 
   <scm>
@@ -77,7 +78,7 @@
             <compilerArgs>
               <!-- Enable all warnings, except for ones which cause issues when building with newer JDKs, see also
                 https://docs.oracle.com/en/java/javase/11/tools/javac.html -->
-              <compilerArg>-Xlint:all,-options</compilerArg>
+              <compilerArg>-Xlint:all,-options${extraLintSuppressions}</compilerArg>
             </compilerArgs>
             <jdkToolchain>
               <version>[11,)</version>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
             <jdkToolchain>
               <version>[11,)</version>
             </jdkToolchain>
+            <release>11</release>
             <!-- Exclude `missing` group because some tags have been omitted when they are redundant -->
             <doclint>all,-missing</doclint>
             <!-- Link against newer Java API Javadoc because most users likely 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <javaVersion>7</javaVersion>
+    <maven.compiler.release>7</maven.compiler.release>
     <extraLintSuppressions></extraLintSuppressions>
   </properties>
 


### PR DESCRIPTION
Also do the Maven gymastics required to ensure that this test only compiles on Java versions ≥17. (It would also work on Java 16, but 17 is all we have in the CI.)

Fix some compilation problems I saw when running locally, which for some reason don't show up in the CI.