### PR TITLE
Disable Maven transfer progress for GitHub workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,4 +20,4 @@ jobs:
           cache: 'maven'
       - name: Build with Maven
         # This also runs javadoc:jar to detect any issues with the Javadoc generated during release
-        run: mvn --batch-mode --update-snapshots verify javadoc:jar
+        run: mvn --batch-mode --update-snapshots --no-transfer-progress verify javadoc:jar

--- a/.github/workflows/check-api-compatibility.yml
+++ b/.github/workflows/check-api-compatibility.yml
@@ -24,9 +24,9 @@ jobs:
         run: |
           cd gson-old-japicmp
           # Set dummy version
-          mvn --batch-mode org.codehaus.mojo:versions-maven-plugin:2.11.0:set -DnewVersion=JAPICMP-OLD
+          mvn --batch-mode --no-transfer-progress org.codehaus.mojo:versions-maven-plugin:2.11.0:set -DnewVersion=JAPICMP-OLD
           # Install artifacts with dummy version in local repository; used later by Maven plugin for comparison
-          mvn --batch-mode install -DskipTests
+          mvn --batch-mode --no-transfer-progress install -DskipTests
 
       - name: Checkout new version
         uses: actions/checkout@v3
@@ -34,7 +34,7 @@ jobs:
       - name: Check API compatibility
         id: check-compatibility
         run: |
-          mvn --batch-mode --fail-at-end package japicmp:cmp -DskipTests
+          mvn --batch-mode --fail-at-end --no-transfer-progress package japicmp:cmp -DskipTests
 
       - name: Upload API differences artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,7 +48,7 @@ jobs:
     # Can replace this with github/codeql-action/autobuild action to run complete build
     - name: Compile sources
       run: |
-        mvn compile --batch-mode
+        mvn compile --batch-mode --no-transfer-progress
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
Disables the download transfer progress which is shown when Maven downloads (or uploads) artifacts which are not available in the local repository. This download progress can be quite verbose and is normally not that relevant.

This is mainly noticable when changing the `pom.xml` files which causes the GitHub workflow cache containing the local repository to be discarded.