### PR TITLE
Missing `getType()` in Maps Examples

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -263,7 +263,7 @@ For deserialization Gson uses the `read` method of the `TypeAdapter` registered 
 
 ```java
 Gson gson = new Gson();
-TypeToken<Map<String, String>> mapType = new TypeToken<Map<String, String>>(){};
+TypeToken<Map<String, String>> mapType = new TypeToken<Map<String, String>>(){}.getType();
 String json = "{\"key\": \"value\"}";
 
 // Deserialization


### PR DESCRIPTION
The code as-written does not compile! :(