### PR TITLE
Add Javadoc `@since` tags for previously added elements

### DIFF
--- a/gson/src/main/java/com/google/gson/FieldNamingPolicy.java
+++ b/gson/src/main/java/com/google/gson/FieldNamingPolicy.java
@@ -86,6 +86,8 @@ public enum FieldNamingPolicy implements FieldNamingStrategy {
    *   <li>aStringField ---&gt; A_STRING_FIELD</li>
    *   <li>aURL ---&gt; A_U_R_L</li>
    * </ul>
+   *
+   * @since 2.9.0
    */
   UPPER_CASE_WITH_UNDERSCORES() {
     @Override public String translateName(Field f) {
@@ -125,7 +127,8 @@ public enum FieldNamingPolicy implements FieldNamingStrategy {
    * Using dashes in JavaScript is not recommended since dash is also used for a minus sign in
    * expressions. This requires that a field named with dashes is always accessed as a quoted
    * property like {@code myobject['my-field']}. Accessing it as an object field
-   * {@code myobject.my-field} will result in an unintended javascript expression.
+   * {@code myobject.my-field} will result in an unintended JavaScript expression.
+   *
    * @since 1.4
    */
   LOWER_CASE_WITH_DASHES() {
@@ -148,8 +151,9 @@ public enum FieldNamingPolicy implements FieldNamingStrategy {
    * Using dots in JavaScript is not recommended since dot is also used for a member sign in
    * expressions. This requires that a field named with dots is always accessed as a quoted
    * property like {@code myobject['my.field']}. Accessing it as an object field
-   * {@code myobject.my.field} will result in an unintended javascript expression.
-   * @since 2.8
+   * {@code myobject.my.field} will result in an unintended JavaScript expression.
+   *
+   * @since 2.8.4
    */
   LOWER_CASE_WITH_DOTS() {
     @Override public String translateName(Field f) {

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -343,6 +343,7 @@ public final class Gson {
    * instance.
    *
    * @return a GsonBuilder instance.
+   * @since 2.8.3
    */
   public GsonBuilder newBuilder() {
     return new GsonBuilder(this);

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -364,6 +364,7 @@ public final class GsonBuilder {
    * @param objectToNumberStrategy the actual object-to-number strategy
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
    * @see ToNumberPolicy#DOUBLE The default object-to-number strategy
+   * @since 2.8.9
    */
   public GsonBuilder setObjectToNumberStrategy(ToNumberStrategy objectToNumberStrategy) {
     this.objectToNumberStrategy = Objects.requireNonNull(objectToNumberStrategy);
@@ -376,6 +377,7 @@ public final class GsonBuilder {
    * @param numberToNumberStrategy the actual number-to-number strategy
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
    * @see ToNumberPolicy#LAZILY_PARSED_NUMBER The default number-to-number strategy
+   * @since 2.8.9
    */
   public GsonBuilder setNumberToNumberStrategy(ToNumberStrategy numberToNumberStrategy) {
     this.numberToNumberStrategy = Objects.requireNonNull(numberToNumberStrategy);
@@ -682,6 +684,7 @@ public final class GsonBuilder {
    * disabling usage of {@code Unsafe}.
    *
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
+   * @since 2.9.0
    */
   public GsonBuilder disableJdkUnsafe() {
     this.useJdkUnsafe = false;
@@ -702,6 +705,7 @@ public final class GsonBuilder {
    *
    * @param filter filter to add
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
+   * @since 2.9.1
    */
   public GsonBuilder addReflectionAccessFilter(ReflectionAccessFilter filter) {
     Objects.requireNonNull(filter);

--- a/gson/src/main/java/com/google/gson/JsonArray.java
+++ b/gson/src/main/java/com/google/gson/JsonArray.java
@@ -48,6 +48,7 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
    * @param capacity initial capacity.
    * @throws IllegalArgumentException if the {@code capacity} is
    *   negative
+   * @since 2.8.1
    */
   @SuppressWarnings("deprecation") // superclass constructor
   public JsonArray(int capacity) {
@@ -75,6 +76,7 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
    * Adds the specified boolean to self.
    *
    * @param bool the boolean that needs to be added to the array.
+   * @since 2.4
    */
   public void add(Boolean bool) {
     elements.add(bool == null ? JsonNull.INSTANCE : new JsonPrimitive(bool));
@@ -84,6 +86,7 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
    * Adds the specified character to self.
    *
    * @param character the character that needs to be added to the array.
+   * @since 2.4
    */
   public void add(Character character) {
     elements.add(character == null ? JsonNull.INSTANCE : new JsonPrimitive(character));
@@ -93,6 +96,7 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
    * Adds the specified number to self.
    *
    * @param number the number that needs to be added to the array.
+   * @since 2.4
    */
   public void add(Number number) {
     elements.add(number == null ? JsonNull.INSTANCE : new JsonPrimitive(number));
@@ -102,6 +106,7 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
    * Adds the specified string to self.
    *
    * @param string the string that needs to be added to the array.
+   * @since 2.4
    */
   public void add(String string) {
     elements.add(string == null ? JsonNull.INSTANCE : new JsonPrimitive(string));
@@ -190,6 +195,7 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
    * Returns true if the array is empty.
    *
    * @return true if the array is empty.
+   * @since 2.8.7
    */
   public boolean isEmpty() {
     return elements.isEmpty();

--- a/gson/src/main/java/com/google/gson/JsonObject.java
+++ b/gson/src/main/java/com/google/gson/JsonObject.java
@@ -146,6 +146,7 @@ public final class JsonObject extends JsonElement {
    * Returns the number of key/value pairs in the object.
    *
    * @return the number of key/value pairs in the object.
+   * @since 2.7
    */
   public int size() {
     return members.size();

--- a/gson/src/main/java/com/google/gson/JsonParser.java
+++ b/gson/src/main/java/com/google/gson/JsonParser.java
@@ -45,6 +45,7 @@ public final class JsonParser {
    * @param json JSON text
    * @return a parse tree of {@link JsonElement}s corresponding to the specified JSON
    * @throws JsonParseException if the specified text is not valid JSON
+   * @since 2.8.6
    */
   public static JsonElement parseString(String json) throws JsonSyntaxException {
     return parseReader(new StringReader(json));
@@ -61,6 +62,7 @@ public final class JsonParser {
    * @return a parse tree of {@link JsonElement}s corresponding to the specified JSON
    * @throws JsonParseException if there is an IOException or if the specified
    *     text is not valid JSON
+   * @since 2.8.6
    */
   public static JsonElement parseReader(Reader reader) throws JsonIOException, JsonSyntaxException {
     try {
@@ -90,6 +92,7 @@ public final class JsonParser {
    *
    * @throws JsonParseException if there is an IOException or if the specified
    *     text is not valid JSON
+   * @since 2.8.6
    */
   public static JsonElement parseReader(JsonReader reader)
       throws JsonIOException, JsonSyntaxException {

--- a/gson/src/main/java/com/google/gson/ReflectionAccessFilter.java
+++ b/gson/src/main/java/com/google/gson/ReflectionAccessFilter.java
@@ -1,8 +1,7 @@
 package com.google.gson;
 
-import java.lang.reflect.AccessibleObject;
-
 import com.google.gson.internal.ReflectionAccessFilterHelper;
+import java.lang.reflect.AccessibleObject;
 
 /**
  * Filter for determining whether reflection based serialization and
@@ -28,10 +27,13 @@ import com.google.gson.internal.ReflectionAccessFilterHelper;
  * fields and classes.
  *
  * @see GsonBuilder#addReflectionAccessFilter(ReflectionAccessFilter)
+ * @since 2.9.1
  */
 public interface ReflectionAccessFilter {
   /**
    * Result of a filter check.
+   *
+   * @since 2.9.1
    */
   enum FilterResult {
     /**

--- a/gson/src/main/java/com/google/gson/ToNumberPolicy.java
+++ b/gson/src/main/java/com/google/gson/ToNumberPolicy.java
@@ -16,12 +16,11 @@
 
 package com.google.gson;
 
-import java.io.IOException;
-import java.math.BigDecimal;
-
 import com.google.gson.internal.LazilyParsedNumber;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.MalformedJsonException;
+import java.io.IOException;
+import java.math.BigDecimal;
 
 /**
  * An enumeration that defines two standard number reading strategies and a couple of
@@ -29,6 +28,7 @@ import com.google.gson.stream.MalformedJsonException;
  * {@link Object} and {@link Number}.
  *
  * @see ToNumberStrategy
+ * @since 2.8.9
  */
 public enum ToNumberPolicy implements ToNumberStrategy {
 

--- a/gson/src/main/java/com/google/gson/ToNumberStrategy.java
+++ b/gson/src/main/java/com/google/gson/ToNumberStrategy.java
@@ -16,9 +16,8 @@
 
 package com.google.gson;
 
-import java.io.IOException;
-
 import com.google.gson.stream.JsonReader;
+import java.io.IOException;
 
 /**
  * A strategy that is used to control how numbers should be deserialized for {@link Object} and {@link Number}
@@ -56,6 +55,7 @@ import com.google.gson.stream.JsonReader;
  * @see ToNumberPolicy
  * @see GsonBuilder#setObjectToNumberStrategy(ToNumberStrategy)
  * @see GsonBuilder#setNumberToNumberStrategy(ToNumberStrategy)
+ * @since 2.8.9
  */
 public interface ToNumberStrategy {
 

--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -429,6 +429,7 @@ public class JsonWriter implements Closeable, Flushable {
    * @return this writer.
    * @throws UnsupportedOperationException if this writer does not support
    *    writing raw JSON values.
+   * @since 2.4
    */
   public JsonWriter jsonValue(String value) throws IOException {
     if (value == null) {
@@ -475,6 +476,7 @@ public class JsonWriter implements Closeable, Flushable {
    * Encodes {@code value}.
    *
    * @return this writer.
+   * @since 2.7
    */
   public JsonWriter value(Boolean value) throws IOException {
     if (value == null) {
@@ -495,6 +497,7 @@ public class JsonWriter implements Closeable, Flushable {
    * @return this writer.
    * @throws IllegalArgumentException if the value is NaN or Infinity and this writer is not {@link
    *     #setLenient(boolean) lenient}.
+   * @since 2.9.1
    */
   public JsonWriter value(float value) throws IOException {
     writeDeferredName();


### PR DESCRIPTION
Adds Javadoc `@since` tags for elements which were added in previous releases and do not have this tag yet. I have also added review comments below referring to the relevant commits where these elements were added.