### PR TITLE
Small adjustments to the new record code.

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -43,7 +43,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
-import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -93,9 +92,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
 
     List<String> fieldNames = new ArrayList<>(alternates.length + 1);
     fieldNames.add(serializedName);
-    for (String alternate : alternates) {
-      fieldNames.add(alternate);
-    }
+    Collections.addAll(fieldNames, alternates);
     return fieldNames;
   }
 
@@ -394,6 +391,8 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
   }
 
   private static final class RecordAdapter<T> extends Adapter<T, Object[]> {
+    static Map<Class<?>, Object> ZEROES = primitiveZeroes();
+
     // The actual record constructor.
     private final Constructor<? super T> constructor;
     // Array of arguments to the constructor, initialized with default values for primitives
@@ -417,14 +416,22 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
       // we create an Object[] where all primitives are initialized to non-null values.
       constructorArgsDefaults = new Object[parameterTypes.length];
       for (int i = 0; i < parameterTypes.length; i++) {
-        if (parameterTypes[i].isPrimitive()) {
-          // Voodoo magic, we create a new instance of this primitive type using reflection via an
-          // array. The array has 1 element, that of course will be initialized to the primitives
-          // default value. We then retrieve this value back from the array to get the properly
-          // initialized default value for the primitve type.
-          constructorArgsDefaults[i] = Array.get(Array.newInstance(parameterTypes[i], 1), 0);
-        }
+        constructorArgsDefaults[i] = ZEROES.get(parameterTypes[i]);
+        // This will correctly be null for non-primitive types.
       }
+    }
+
+    private static Map<Class<?>, Object> primitiveZeroes() {
+      Map<Class<?>, Object> zeroes = new HashMap<>();
+      zeroes.put(byte.class, (byte) 0);
+      zeroes.put(short.class, (short) 0);
+      zeroes.put(int.class, 0);
+      zeroes.put(long.class, 0L);
+      zeroes.put(float.class, 0F);
+      zeroes.put(double.class, 0D);
+      zeroes.put(char.class, '\0');
+      zeroes.put(boolean.class, false);
+      return zeroes;
     }
 
     @Override

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -391,7 +391,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
   }
 
   private static final class RecordAdapter<T> extends Adapter<T, Object[]> {
-    static Map<Class<?>, Object> ZEROES = primitiveZeroes();
+    static Map<Class<?>, Object> PRIMITIVE_DEFAULTS = primitiveDefaults();
 
     // The actual record constructor.
     private final Constructor<? super T> constructor;
@@ -416,12 +416,12 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
       // we create an Object[] where all primitives are initialized to non-null values.
       constructorArgsDefaults = new Object[parameterTypes.length];
       for (int i = 0; i < parameterTypes.length; i++) {
-        constructorArgsDefaults[i] = ZEROES.get(parameterTypes[i]);
-        // This will correctly be null for non-primitive types.
+        // This will correctly be null for non-primitive types:
+        constructorArgsDefaults[i] = PRIMITIVE_DEFAULTS.get(parameterTypes[i]);
       }
     }
 
-    private static Map<Class<?>, Object> primitiveZeroes() {
+    private static Map<Class<?>, Object> primitiveDefaults() {
       Map<Class<?>, Object> zeroes = new HashMap<>();
       zeroes.put(byte.class, (byte) 0);
       zeroes.put(short.class, (short) 0);

--- a/gson/src/main/java/com/google/gson/internal/reflect/ReflectionHelper.java
+++ b/gson/src/main/java/com/google/gson/internal/reflect/ReflectionHelper.java
@@ -2,8 +2,10 @@ package com.google.gson.internal.reflect;
 
 import com.google.gson.JsonIOException;
 import com.google.gson.internal.GsonBuildConfig;
-
-import java.lang.reflect.*;
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 
 public class ReflectionHelper {
 
@@ -158,7 +160,6 @@ public class ReflectionHelper {
     private final Method getRecordComponents;
     private final Method getName;
     private final Method getType;
-    private final Method getAccessor;
 
     private RecordSupportedHelper() throws NoSuchMethodException {
       isRecord = Class.class.getMethod("isRecord");
@@ -166,13 +167,12 @@ public class ReflectionHelper {
       Class<?> recordComponentType = getRecordComponents.getReturnType().getComponentType();
       getName = recordComponentType.getMethod("getName");
       getType = recordComponentType.getMethod("getType");
-      getAccessor = recordComponentType.getMethod("getAccessor");
     }
 
     @Override
     boolean isRecord(Class<?> raw) {
       try {
-        return Boolean.class.cast(isRecord.invoke(raw)).booleanValue();
+        return (boolean) isRecord.invoke(raw);
       } catch (ReflectiveOperationException e) {
         throw createExceptionForRecordReflectionException(e);
       }

--- a/gson/src/test/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactoryTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactoryTest.java
@@ -1,6 +1,7 @@
 package com.google.gson.internal.bind;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;

--- a/gson/src/test/java/com/google/gson/internal/reflect/ReflectionHelperTest.java
+++ b/gson/src/test/java/com/google/gson/internal/reflect/ReflectionHelperTest.java
@@ -1,6 +1,9 @@
 package com.google.gson.internal.reflect;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -76,10 +79,10 @@ public class ReflectionHelperTest {
 
     @Override
     public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-      PrincipalImpl principal = (PrincipalImpl) o;
-      return Objects.equals(name, principal.name);
+      if (o instanceof PrincipalImpl) {
+        return Objects.equals(name, ((PrincipalImpl) o).name);
+      }
+      return false;
     }
 
     @Override


### PR DESCRIPTION
* Replace wildcard imports with single imports.
* Enable `Java17RecordTest` and fix its many previously-hidden problems.
* Use a `Map` to get primitive zero values rather than a potentially-expensive reflective trick.
* Apply some automated code fixes.