### PR TITLE
Adjust Record adapter and extend test coverage

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
+++ b/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
@@ -261,14 +261,17 @@ public final class ConstructorConstructor {
           @SuppressWarnings("unchecked") // T is the same raw type as is requested
           T newInstance = (T) constructor.newInstance();
           return newInstance;
-        } catch (InstantiationException e) {
-          // TODO: JsonParseException ?
-          throw new RuntimeException("Failed to invoke " + constructor + " with no args", e);
+        }
+        // Note: InstantiationException should be impossible because check at start of method made sure
+        //   that class is not abstract
+        catch (InstantiationException e) {
+          throw new RuntimeException("Failed to invoke constructor '" + ReflectionHelper.constructorToString(constructor) + "'"
+              + " with no args", e);
         } catch (InvocationTargetException e) {
-          // TODO: don't wrap if cause is unchecked!
+          // TODO: don't wrap if cause is unchecked?
           // TODO: JsonParseException ?
-          throw new RuntimeException("Failed to invoke " + constructor + " with no args",
-              e.getTargetException());
+          throw new RuntimeException("Failed to invoke constructor '" + ReflectionHelper.constructorToString(constructor) + "'"
+              + " with no args", e.getCause());
         } catch (IllegalAccessException e) {
           throw ReflectionHelper.createExceptionForUnexpectedIllegalAccess(e);
         }

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -480,7 +480,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
       Integer componentIndex = componentIndices.get(field.fieldName);
       if (componentIndex == null) {
         throw new IllegalStateException(
-            "Could not find the index in the constructor " + constructor
+            "Could not find the index in the constructor " + ReflectionHelper.constructorToString(constructor)
                 + " for field with name " + field.fieldName + ","
                 + " unable to determine which argument in the constructor the field corresponds"
                 + " to. This is unexpected behavior, as we expect the RecordComponents to have the"
@@ -496,7 +496,8 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
         return constructor.newInstance(accumulator);
       } catch (ReflectiveOperationException e) {
         throw new RuntimeException(
-            "Failed to invoke " + constructor + " with args " + Arrays.toString(accumulator), e);
+            "Failed to invoke constructor " + ReflectionHelper.constructorToString(constructor)
+            + " with args " + Arrays.toString(accumulator), e);
       }
     }
   }

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -111,8 +111,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
         ReflectionAccessFilterHelper.getFilterResult(reflectionFilters, raw);
     if (filterResult == FilterResult.BLOCK_ALL) {
       throw new JsonIOException(
-          "ReflectionAccessFilter does not permit using reflection for "
-              + raw
+          "ReflectionAccessFilter does not permit using reflection for " + raw
               + ". Register a TypeAdapter for this type or adjust the access filter.");
     }
     boolean blockInaccessible = filterResult == FilterResult.BLOCK_INACCESSIBLE;
@@ -133,9 +132,9 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
   private static <M extends AccessibleObject & Member> void checkAccessible(Object object, M member) {
     if (!ReflectionAccessFilterHelper.canAccess(member, Modifier.isStatic(member.getModifiers()) ? null : object)) {
       String memberDescription = ReflectionHelper.getAccessibleObjectDescription(member, true);
-      throw new JsonIOException(memberDescription + " is not accessible and ReflectionAccessFilter does not "
-          + "permit making it accessible. Register a TypeAdapter for the declaring type, adjust the "
-          + "access filter or increase the visibility of the element and its declaring type.");
+      throw new JsonIOException(memberDescription + " is not accessible and ReflectionAccessFilter does not"
+          + " permit making it accessible. Register a TypeAdapter for the declaring type, adjust the"
+          + " access filter or increase the visibility of the element and its declaring type.");
     }
   }
 
@@ -187,8 +186,8 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
       void readIntoArray(JsonReader reader, int index, Object[] target) throws IOException, JsonParseException {
         Object fieldValue = typeAdapter.read(reader);
         if (fieldValue == null && isPrimitive) {
-          throw new JsonParseException("null is not allowed as value for record component '" + fieldName + "' "
-              + "of primitive type; at path " + reader.getPath());
+          throw new JsonParseException("null is not allowed as value for record component '" + fieldName + "'"
+              + " of primitive type; at path " + reader.getPath());
         }
         target[index] = fieldValue;
       }
@@ -223,9 +222,9 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
       if (raw != originalRaw && fields.length > 0) {
         FilterResult filterResult = ReflectionAccessFilterHelper.getFilterResult(reflectionFilters, raw);
         if (filterResult == FilterResult.BLOCK_ALL) {
-          throw new JsonIOException("ReflectionAccessFilter does not permit using reflection for "
-              + raw + " (supertype of " + originalRaw + "). Register a TypeAdapter for this type "
-              + "or adjust the access filter.");
+          throw new JsonIOException("ReflectionAccessFilter does not permit using reflection for " + raw
+              + " (supertype of " + originalRaw + "). Register a TypeAdapter for this type"
+              + " or adjust the access filter.");
         }
         blockInaccessible = filterResult == FilterResult.BLOCK_INACCESSIBLE;
       }
@@ -241,7 +240,8 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
         Method accessor = null;
         if (isRecord) {
           // If there is a static field on a record, there will not be an accessor. Instead we will use the default
-          // field logic for dealing with statics. For deserialization the field is ignored.
+          // field serialization logic, but for deserialization the field is excluded for simplicity. Note that Gson
+          // ignores static fields by default, but GsonBuilder.excludeFieldsWithModifiers can overwrite this.
           if (Modifier.isStatic(field.getModifiers())) {
             deserialize = false;
           } else {
@@ -326,7 +326,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
    * @param <T> type of objects that this Adapter creates.
    * @param <A> type of accumulator used to build the deserialization result.
    */
-  // This class is public because external projects check for this class (even though it is internal)
+  // This class is public because external projects check for this class with `instanceof` (even though it is internal)
   public static abstract class Adapter<T, A> extends TypeAdapter<T> {
     final Map<String, BoundField> boundFields;
 
@@ -480,11 +480,9 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
       Integer componentIndex = componentIndices.get(field.fieldName);
       if (componentIndex == null) {
         throw new IllegalStateException(
-            "Could not find the index in the constructor "
-                + constructor
-                + " for field with name "
-                + field.fieldName
-                + ", unable to determine which argument in the constructor the field corresponds"
+            "Could not find the index in the constructor " + constructor
+                + " for field with name " + field.fieldName + ","
+                + " unable to determine which argument in the constructor the field corresponds"
                 + " to. This is unexpected behavior, as we expect the RecordComponents to have the"
                 + " same names as the fields in the Java class, and that the order of the"
                 + " RecordComponents is the same as the order of the canonical constructor parameters.");

--- a/gson/src/main/java/com/google/gson/internal/reflect/ReflectionHelper.java
+++ b/gson/src/main/java/com/google/gson/internal/reflect/ReflectionHelper.java
@@ -42,6 +42,9 @@ public class ReflectionHelper {
 
   /**
    * Returns a short string describing the {@link AccessibleObject} in a human-readable way.
+   * The result is normally shorter than {@link AccessibleObject#toString()} because it omits
+   * modifiers (e.g. {@code final}) and uses simple names for constructor and method parameter
+   * types.
    *
    * @param object object to describe
    * @param uppercaseFirstLetter whether the first letter of the description should be uppercased
@@ -74,12 +77,10 @@ public class ReflectionHelper {
 
   /**
    * Creates a string representation for a constructor.
-   * E.g.: {@code java.lang.String#String(char[], int, int)}
+   * E.g.: {@code java.lang.String(char[], int, int)}
    */
-  private static String constructorToString(Constructor<?> constructor) {
-    StringBuilder stringBuilder = new StringBuilder(constructor.getDeclaringClass().getName())
-      .append('#')
-      .append(constructor.getDeclaringClass().getSimpleName());
+  public static String constructorToString(Constructor<?> constructor) {
+    StringBuilder stringBuilder = new StringBuilder(constructor.getDeclaringClass().getName());
     appendExecutableParameters(constructor, stringBuilder);
 
     return stringBuilder.toString();

--- a/gson/src/main/java/com/google/gson/internal/reflect/ReflectionHelper.java
+++ b/gson/src/main/java/com/google/gson/internal/reflect/ReflectionHelper.java
@@ -35,8 +35,8 @@ public class ReflectionHelper {
       object.setAccessible(true);
     } catch (Exception exception) {
       String description = getAccessibleObjectDescription(object, false);
-      throw new JsonIOException("Failed making " + description + " accessible; either increase its visibility "
-              + "or write a custom TypeAdapter for its declaring type.", exception);
+      throw new JsonIOException("Failed making " + description + " accessible; either increase its visibility"
+              + " or write a custom TypeAdapter for its declaring type.", exception);
     }
   }
 
@@ -89,7 +89,8 @@ public class ReflectionHelper {
   private static void appendExecutableParameters(AccessibleObject executable, StringBuilder stringBuilder) {
     stringBuilder.append('(');
 
-    Class<?>[] parameters = (executable instanceof Method) ? ((Method) executable).getParameterTypes()
+    Class<?>[] parameters = (executable instanceof Method)
+        ? ((Method) executable).getParameterTypes()
         : ((Constructor<?>) executable).getParameterTypes();
     for (int i = 0; i < parameters.length; i++) {
       if (i > 0) {
@@ -114,10 +115,10 @@ public class ReflectionHelper {
       constructor.setAccessible(true);
       return null;
     } catch (Exception exception) {
-      return "Failed making constructor '" + constructorToString(constructor) + "' accessible; "
-          + "either increase its visibility or write a custom InstanceCreator or TypeAdapter for its declaring type: "
+      return "Failed making constructor '" + constructorToString(constructor) + "' accessible;"
+          + " either increase its visibility or write a custom InstanceCreator or TypeAdapter for"
           // Include the message since it might contain more detailed information
-          + exception.getMessage();
+          + " its declaring type: " + exception.getMessage();
     }
   }
 
@@ -141,20 +142,20 @@ public class ReflectionHelper {
 
   public static RuntimeException createExceptionForUnexpectedIllegalAccess(
       IllegalAccessException exception) {
-    throw new RuntimeException("Unexpected IllegalAccessException occurred (Gson " + GsonBuildConfig.VERSION + "). "
-        + "Certain ReflectionAccessFilter features require Java >= 9 to work correctly. If you are not using "
-        + "ReflectionAccessFilter, report this to the Gson maintainers.",
+    throw new RuntimeException("Unexpected IllegalAccessException occurred (Gson " + GsonBuildConfig.VERSION + ")."
+        + " Certain ReflectionAccessFilter features require Java >= 9 to work correctly. If you are not using"
+        + " ReflectionAccessFilter, report this to the Gson maintainers.",
         exception);
   }
 
 
   public static RuntimeException createExceptionForRecordReflectionException(
           ReflectiveOperationException exception) {
-    throw new RuntimeException("Unexpected ReflectiveOperationException occurred "
-            + "(Gson " + GsonBuildConfig.VERSION + "). "
-            + "To support Java records, reflection is utilized to read out information "
-            + "about records. All these invocations happens after it is established "
-            + "that records exist in the JVM. This exception is unexpected behavior.",
+    throw new RuntimeException("Unexpected ReflectiveOperationException occurred"
+            + " (Gson " + GsonBuildConfig.VERSION + ")."
+            + " To support Java records, reflection is utilized to read out information"
+            + " about records. All these invocations happens after it is established"
+            + " that records exist in the JVM. This exception is unexpected behavior.",
             exception);
   }
 

--- a/gson/src/main/java/com/google/gson/internal/reflect/ReflectionHelper.java
+++ b/gson/src/main/java/com/google/gson/internal/reflect/ReflectionHelper.java
@@ -150,7 +150,7 @@ public class ReflectionHelper {
   }
 
 
-  public static RuntimeException createExceptionForRecordReflectionException(
+  private static RuntimeException createExceptionForRecordReflectionException(
           ReflectiveOperationException exception) {
     throw new RuntimeException("Unexpected ReflectiveOperationException occurred"
             + " (Gson " + GsonBuildConfig.VERSION + ")."

--- a/gson/src/test/java/com/google/gson/functional/Java17RecordTest.java
+++ b/gson/src/test/java/com/google/gson/functional/Java17RecordTest.java
@@ -136,6 +136,30 @@ public final class Java17RecordTest {
     assertEquals("custom-null", deserialized.s());
   }
 
+  /** Tests behavior when the canonical constructor throws an exception */
+  @Test
+  public void testThrowingConstructor() {
+    record LocalRecord(String s) {
+      static final RuntimeException thrownException = new RuntimeException("Custom exception");
+
+      @SuppressWarnings("unused")
+      LocalRecord {
+        throw thrownException;
+      }
+    }
+
+    try {
+      gson.fromJson("{\"s\":\"value\"}", LocalRecord.class);
+      fail();
+    }
+    // TODO: Adjust this once Gson throws more specific exception type
+    catch (RuntimeException e) {
+      assertEquals("Failed to invoke constructor '" + LocalRecord.class.getName() + "(String)' with args [value]",
+          e.getMessage());
+      assertSame(LocalRecord.thrownException, e.getCause());
+    }
+  }
+
   @Test
   public void testAccessorIsCalled() {
     record LocalRecord(String s) {

--- a/gson/src/test/java/com/google/gson/functional/Java17RecordTest.java
+++ b/gson/src/test/java/com/google/gson/functional/Java17RecordTest.java
@@ -18,7 +18,9 @@ package com.google.gson.functional;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
 
 import com.google.gson.ExclusionStrategy;
 import com.google.gson.FieldAttributes;
@@ -144,6 +146,28 @@ public final class Java17RecordTest {
     }
 
     assertEquals("{\"s\":\"accessor-value\"}", gson.toJson(new LocalRecord(null)));
+  }
+
+  /** Tests behavior when a record accessor method throws an exception */
+  @Test
+  public void testThrowingAccessor() {
+    record LocalRecord(String s) {
+      static final RuntimeException thrownException = new RuntimeException("Custom exception");
+
+      @Override
+      public String s() {
+        throw thrownException;
+      }
+    }
+
+    try {
+      gson.toJson(new LocalRecord("a"));
+      fail();
+    } catch (JsonIOException e) {
+      assertEquals("Accessor method '" + LocalRecord.class.getName() + "#s()' threw exception",
+          e.getMessage());
+      assertSame(LocalRecord.thrownException, e.getCause());
+    }
   }
 
   /** Tests behavior for a record without components */

--- a/gson/src/test/java/com/google/gson/functional/Java17RecordTest.java
+++ b/gson/src/test/java/com/google/gson/functional/Java17RecordTest.java
@@ -227,6 +227,9 @@ public final class Java17RecordTest {
    */
   @Test
   public void testStaticFieldSerialization() {
+    // By default Gson should ignore static fields
+    assertEquals("{}", gson.toJson(new RecordWithStaticField()));
+
     Gson gson = new GsonBuilder()
         // Include static fields
         .excludeFieldsWithModifiers(0)
@@ -244,6 +247,10 @@ public final class Java17RecordTest {
    */
   @Test
   public void testStaticFieldDeserialization() {
+    // By default Gson should ignore static fields
+    gson.fromJson("{\"s\":\"custom\"}", RecordWithStaticField.class);
+    assertEquals("initial", RecordWithStaticField.s);
+
     Gson gson = new GsonBuilder()
         // Include static fields
         .excludeFieldsWithModifiers(0)

--- a/gson/src/test/java/com/google/gson/functional/Java17RecordTest.java
+++ b/gson/src/test/java/com/google/gson/functional/Java17RecordTest.java
@@ -339,13 +339,13 @@ public final class Java17RecordTest {
         .create();
 
     var exception = assertThrows(JsonIOException.class, () -> gson.toJson(new PrivateRecord(1)));
-    assertEquals("Constructor '" + PrivateRecord.class.getName() + "#PrivateRecord(int)' is not accessible and"
+    assertEquals("Constructor 'com.google.gson.functional.Java17RecordTest$PrivateRecord(int)' is not accessible and"
         + " ReflectionAccessFilter does not permit making it accessible. Register a TypeAdapter for the declaring"
         + " type, adjust the access filter or increase the visibility of the element and its declaring type.",
         exception.getMessage());
 
     exception = assertThrows(JsonIOException.class, () -> gson.fromJson("{}", PrivateRecord.class));
-    assertEquals("Constructor '" + PrivateRecord.class.getName() + "#PrivateRecord(int)' is not accessible and"
+    assertEquals("Constructor 'com.google.gson.functional.Java17RecordTest$PrivateRecord(int)' is not accessible and"
         + " ReflectionAccessFilter does not permit making it accessible. Register a TypeAdapter for the declaring"
         + " type, adjust the access filter or increase the visibility of the element and its declaring type.",
         exception.getMessage());

--- a/gson/src/test/java/com/google/gson/functional/Java17RecordTest.java
+++ b/gson/src/test/java/com/google/gson/functional/Java17RecordTest.java
@@ -339,15 +339,15 @@ public final class Java17RecordTest {
         .create();
 
     var exception = assertThrows(JsonIOException.class, () -> gson.toJson(new PrivateRecord(1)));
-    assertEquals("Constructor '" + PrivateRecord.class.getName() + "#PrivateRecord(int)' is not accessible and "
-        + "ReflectionAccessFilter does not permit making it accessible. Register a TypeAdapter for the declaring "
-        + "type, adjust the access filter or increase the visibility of the element and its declaring type.",
+    assertEquals("Constructor '" + PrivateRecord.class.getName() + "#PrivateRecord(int)' is not accessible and"
+        + " ReflectionAccessFilter does not permit making it accessible. Register a TypeAdapter for the declaring"
+        + " type, adjust the access filter or increase the visibility of the element and its declaring type.",
         exception.getMessage());
 
     exception = assertThrows(JsonIOException.class, () -> gson.fromJson("{}", PrivateRecord.class));
-    assertEquals("Constructor '" + PrivateRecord.class.getName() + "#PrivateRecord(int)' is not accessible and "
-        + "ReflectionAccessFilter does not permit making it accessible. Register a TypeAdapter for the declaring "
-        + "type, adjust the access filter or increase the visibility of the element and its declaring type.",
+    assertEquals("Constructor '" + PrivateRecord.class.getName() + "#PrivateRecord(int)' is not accessible and"
+        + " ReflectionAccessFilter does not permit making it accessible. Register a TypeAdapter for the declaring"
+        + " type, adjust the access filter or increase the visibility of the element and its declaring type.",
         exception.getMessage());
 
     assertEquals("{\"i\":1}", gson.toJson(new PublicRecord(1)));
@@ -368,8 +368,8 @@ public final class Java17RecordTest {
     assertEquals("{}", gson.toJson(new LocalRecord(1), Record.class));
 
     var exception = assertThrows(JsonIOException.class, () -> gson.fromJson("{}", Record.class));
-    assertEquals("Abstract classes can't be instantiated! Register an InstanceCreator or a TypeAdapter for "
-        + "this type. Class name: java.lang.Record",
+    assertEquals("Abstract classes can't be instantiated! Register an InstanceCreator or a TypeAdapter for"
+        + " this type. Class name: java.lang.Record",
         exception.getMessage());
   }
 }

--- a/gson/src/test/java/com/google/gson/functional/Java17RecordTest.java
+++ b/gson/src/test/java/com/google/gson/functional/Java17RecordTest.java
@@ -17,11 +17,30 @@ package com.google.gson.functional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.ReflectionAccessFilter.FilterResult;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
-import java.util.Objects;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+import java.lang.reflect.Type;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -32,32 +51,121 @@ public final class Java17RecordTest {
 
   @Test
   public void testFirstNameIsChosenForSerialization() {
-    MyRecord target = new MyRecord("v1", "v2");
+    RecordWithCustomNames target = new RecordWithCustomNames("v1", "v2");
     // Ensure name1 occurs exactly once, and name2 and name3 don't appear
-    assertEquals("{\"name\":\"modified-v1\",\"name1\":\"v2\"}", gson.toJson(target));
+    assertEquals("{\"name\":\"v1\",\"name1\":\"v2\"}", gson.toJson(target));
   }
 
   @Test
   public void testMultipleNamesDeserializedCorrectly() {
-    assertEquals("modified-v1", gson.fromJson("{'name':'v1'}", MyRecord.class).a);
+    assertEquals("v1", gson.fromJson("{'name':'v1'}", RecordWithCustomNames.class).a);
 
     // Both name1 and name2 gets deserialized to b
-    assertEquals("v11", gson.fromJson("{'name': 'v1', 'name1':'v11'}", MyRecord.class).b);
-    assertEquals("v2", gson.fromJson("{'name': 'v1', 'name2':'v2'}", MyRecord.class).b);
-    assertEquals("v3", gson.fromJson("{'name': 'v1', 'name3':'v3'}", MyRecord.class).b);
+    assertEquals("v11", gson.fromJson("{'name': 'v1', 'name1':'v11'}", RecordWithCustomNames.class).b);
+    assertEquals("v2", gson.fromJson("{'name': 'v1', 'name2':'v2'}", RecordWithCustomNames.class).b);
+    assertEquals("v3", gson.fromJson("{'name': 'v1', 'name3':'v3'}", RecordWithCustomNames.class).b);
   }
 
   @Test
   public void testMultipleNamesInTheSameString() {
     // The last value takes precedence
     assertEquals("v3",
-        gson.fromJson("{'name': 'foo', 'name1':'v1','name2':'v2','name3':'v3'}", MyRecord.class).b);
+        gson.fromJson("{'name': 'foo', 'name1':'v1','name2':'v2','name3':'v3'}", RecordWithCustomNames.class).b);
+  }
+
+  private record RecordWithCustomNames(
+      @SerializedName("name") String a,
+      @SerializedName(value = "name1", alternate = {"name2", "name3"}) String b) {}
+
+  @Test
+  public void testSerializedNameOnAccessor() {
+    record LocalRecord(int i) {
+      @SerializedName("a")
+      @Override
+      public int i() {
+        return i;
+      }
+    }
+
+    var exception = assertThrows(JsonIOException.class, () -> gson.getAdapter(LocalRecord.class));
+    assertEquals("@SerializedName on method '" + LocalRecord.class.getName() + "#i()' is not supported",
+        exception.getMessage());
+  }
+
+  @Test
+  public void testFieldNamingStrategy() {
+    record LocalRecord(int i) {}
+
+    Gson gson = new GsonBuilder()
+        .setFieldNamingStrategy(f -> f.getName() + "-custom")
+        .create();
+
+    assertEquals("{\"i-custom\":1}", gson.toJson(new LocalRecord(1)));
+    assertEquals(new LocalRecord(2), gson.fromJson("{\"i-custom\":2}", LocalRecord.class));
+  }
+
+  @Test
+  public void testUnknownJsonProperty() {
+    record LocalRecord(int i) {}
+
+    // Unknown property 'x' should be ignored
+    assertEquals(new LocalRecord(1), gson.fromJson("{\"i\":1,\"x\":2}", LocalRecord.class));
+  }
+
+  @Test
+  public void testDuplicateJsonProperties() {
+    record LocalRecord(Integer a, Integer b) {}
+
+    String json = "{\"a\":null,\"a\":2,\"b\":1,\"b\":null}";
+    // Should use value of last occurrence
+    assertEquals(new LocalRecord(2, null), gson.fromJson(json, LocalRecord.class));
   }
 
   @Test
   public void testConstructorRuns() {
-    assertEquals(new MyRecord(null, null),
-        gson.fromJson("{'name1': null, 'name2': null}", MyRecord.class));
+    record LocalRecord(String s) {
+      LocalRecord {
+        s = "custom-" + s;
+      }
+    }
+
+    LocalRecord deserialized = gson.fromJson("{\"s\": null}", LocalRecord.class);
+    assertEquals(new LocalRecord(null), deserialized);
+    assertEquals("custom-null", deserialized.s());
+  }
+
+  @Test
+  public void testAccessorIsCalled() {
+    record LocalRecord(String s) {
+      @Override
+      public String s() {
+        return "accessor-value";
+      }
+    }
+
+    assertEquals("{\"s\":\"accessor-value\"}", gson.toJson(new LocalRecord(null)));
+  }
+
+  /** Tests behavior for a record without components */
+  @Test
+  public void testEmptyRecord() {
+    record EmptyRecord() {}
+
+    assertEquals("{}", gson.toJson(new EmptyRecord()));
+    assertEquals(new EmptyRecord(), gson.fromJson("{}", EmptyRecord.class));
+  }
+
+  /**
+   * Tests behavior when {@code null} is serialized / deserialized as record value;
+   * basically makes sure the adapter is 'null-safe'
+   */
+  @Test
+  public void testRecordNull() throws IOException {
+    record LocalRecord(int i) {}
+
+    TypeAdapter<LocalRecord> adapter = gson.getAdapter(LocalRecord.class);
+    assertEquals("null", adapter.toJson(null));
+    assertNull(adapter.fromJson("null"));
   }
 
   @Test
@@ -67,21 +175,201 @@ public final class Java17RecordTest {
   }
 
   @Test
-  public void testPrimitiveNullValues() {
-    RecordWithPrimitives expected = new RecordWithPrimitives("s", (byte) 0, (short) 0, 0, 0, 0, 0, '\0', false);
-    // TODO(eamonnmcmanus): consider forbidding null for primitives
-    String s = "{'aString': 's', 'aByte': null, 'aShort': null, 'anInt': null, 'aLong': null, 'aFloat': null, 'aDouble': null, 'aChar': null, 'aBoolean': null}";
-    assertEquals(expected, gson.fromJson(s, RecordWithPrimitives.class));
+  public void testPrimitiveJsonNullValue() {
+    String s = "{'aString': 's', 'aByte': null, 'aShort': 0}";
+    var e = assertThrows(JsonParseException.class, () -> gson.fromJson(s, RecordWithPrimitives.class));
+    assertEquals("null is not allowed as value for record component 'aByte' of primitive type; at path $.aByte",
+        e.getMessage());
   }
 
-  public record MyRecord(
-      @SerializedName("name") String a,
-      @SerializedName(value = "name1", alternate = {"name2", "name3"}) String b) {
-    public MyRecord {
-      a = "modified-" + a;
+  /**
+   * Tests behavior when JSON contains non-null value, but custom adapter returns null
+   * for primitive component
+   */
+  @Test
+  public void testPrimitiveAdapterNullValue() {
+    Gson gson = new GsonBuilder()
+        .registerTypeAdapter(byte.class, new TypeAdapter<Byte>() {
+          @Override public Byte read(JsonReader in) throws IOException {
+            in.skipValue();
+            // Always return null
+            return null;
+          }
+
+          @Override public void write(JsonWriter out, Byte value) {
+            throw new AssertionError("not needed for test");
+          }
+        })
+        .create();
+
+    String s = "{'aString': 's', 'aByte': 0}";
+    var exception = assertThrows(JsonParseException.class, () -> gson.fromJson(s, RecordWithPrimitives.class));
+    assertEquals("null is not allowed as value for record component 'aByte' of primitive type; at path $.aByte",
+        exception.getMessage());
+  }
+
+  private record RecordWithPrimitives(
+      String aString, byte aByte, short aShort, int anInt, long aLong, float aFloat, double aDouble, char aChar, boolean aBoolean) {}
+
+  /** Tests behavior when value of Object component is missing; should default to null */
+  @Test
+  public void testObjectDefaultValue() {
+    record LocalRecord(String s, int i) {}
+
+    assertEquals(new LocalRecord(null, 1), gson.fromJson("{\"i\":1}", LocalRecord.class));
+  }
+
+  /**
+   * Tests serialization of a record with {@code static} field.
+   *
+   * <p>Important: It is not documented that this is officially supported; this
+   * test just checks the current behavior.
+   */
+  @Test
+  public void testStaticFieldSerialization() {
+    Gson gson = new GsonBuilder()
+        // Include static fields
+        .excludeFieldsWithModifiers(0)
+        .create();
+
+    String json = gson.toJson(new RecordWithStaticField());
+    assertEquals("{\"s\":\"initial\"}", json);
+  }
+
+  /**
+   * Tests deserialization of a record with {@code static} field.
+   *
+   * <p>Important: It is not documented that this is officially supported; this
+   * test just checks the current behavior.
+   */
+  @Test
+  public void testStaticFieldDeserialization() {
+    Gson gson = new GsonBuilder()
+        // Include static fields
+        .excludeFieldsWithModifiers(0)
+        .create();
+
+    String oldValue = RecordWithStaticField.s;
+    try {
+      RecordWithStaticField obj = gson.fromJson("{\"s\":\"custom\"}", RecordWithStaticField.class);
+      assertNotNull(obj);
+      // Currently record deserialization always ignores static fields
+      assertEquals("initial", RecordWithStaticField.s);
+    } finally {
+      RecordWithStaticField.s = oldValue;
     }
   }
 
-  public record RecordWithPrimitives(
-      String aString, byte aByte, short aShort, int anInt, long aLong, float aFloat, double aDouble, char aChar, boolean aBoolean) {}
+  private record RecordWithStaticField() {
+    static String s = "initial";
+  }
+
+  @Test
+  public void testExposeAnnotation() {
+    record RecordWithExpose(
+        @Expose int a,
+        int b
+    ) {}
+
+    Gson gson = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
+    String json = gson.toJson(new RecordWithExpose(1, 2));
+    assertEquals("{\"a\":1}", json);
+  }
+
+  @Test
+  public void testFieldExclusionStrategy() {
+    record LocalRecord(int a, int b, double c) {}
+
+    Gson gson = new GsonBuilder()
+        .setExclusionStrategies(new ExclusionStrategy() {
+          @Override public boolean shouldSkipField(FieldAttributes f) {
+            return f.getName().equals("a");
+          }
+
+          @Override public boolean shouldSkipClass(Class<?> clazz) {
+            return clazz == double.class;
+          }
+        })
+        .create();
+
+    assertEquals("{\"b\":2}", gson.toJson(new LocalRecord(1, 2, 3.0)));
+  }
+
+  @Test
+  public void testJsonAdapterAnnotation() {
+    record Adapter() implements JsonSerializer<String>, JsonDeserializer<String> {
+      @Override public String deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
+        return "deserializer-" + json.getAsString();
+      }
+
+      @Override public JsonElement serialize(String src, Type typeOfSrc, JsonSerializationContext context) {
+        return new JsonPrimitive("serializer-" + src);
+      }
+    }
+    record LocalRecord(
+        @JsonAdapter(Adapter.class) String s
+    ) {}
+
+    assertEquals("{\"s\":\"serializer-a\"}", gson.toJson(new LocalRecord("a")));
+    assertEquals(new LocalRecord("deserializer-a"), gson.fromJson("{\"s\":\"a\"}", LocalRecord.class));
+  }
+
+  @Test
+  public void testClassReflectionFilter() {
+    record Allowed(int a) {}
+    record Blocked(int b) {}
+
+    Gson gson = new GsonBuilder()
+        .addReflectionAccessFilter(c -> c == Allowed.class ? FilterResult.ALLOW : FilterResult.BLOCK_ALL)
+        .create();
+
+    String json = gson.toJson(new Allowed(1));
+    assertEquals("{\"a\":1}", json);
+
+    var exception = assertThrows(JsonIOException.class, () -> gson.toJson(new Blocked(1)));
+    assertEquals("ReflectionAccessFilter does not permit using reflection for class " + Blocked.class.getName() +
+        ". Register a TypeAdapter for this type or adjust the access filter.",
+        exception.getMessage());
+  }
+
+  @Test
+  public void testReflectionFilterBlockInaccessible() {
+    Gson gson = new GsonBuilder()
+        .addReflectionAccessFilter(c -> FilterResult.BLOCK_INACCESSIBLE)
+        .create();
+
+    var exception = assertThrows(JsonIOException.class, () -> gson.toJson(new PrivateRecord(1)));
+    assertEquals("Constructor '" + PrivateRecord.class.getName() + "#PrivateRecord(int)' is not accessible and "
+        + "ReflectionAccessFilter does not permit making it accessible. Register a TypeAdapter for the declaring "
+        + "type, adjust the access filter or increase the visibility of the element and its declaring type.",
+        exception.getMessage());
+
+    exception = assertThrows(JsonIOException.class, () -> gson.fromJson("{}", PrivateRecord.class));
+    assertEquals("Constructor '" + PrivateRecord.class.getName() + "#PrivateRecord(int)' is not accessible and "
+        + "ReflectionAccessFilter does not permit making it accessible. Register a TypeAdapter for the declaring "
+        + "type, adjust the access filter or increase the visibility of the element and its declaring type.",
+        exception.getMessage());
+
+    assertEquals("{\"i\":1}", gson.toJson(new PublicRecord(1)));
+    assertEquals(new PublicRecord(2), gson.fromJson("{\"i\":2}", PublicRecord.class));
+  }
+
+  private record PrivateRecord(int i) {}
+  public record PublicRecord(int i) {}
+
+  /**
+   * Tests behavior when {@code java.lang.Record} is used as type for serialization
+   * and deserialization.
+   */
+  @Test
+  public void testRecordBaseClass() {
+    record LocalRecord(int i) {}
+
+    assertEquals("{}", gson.toJson(new LocalRecord(1), Record.class));
+
+    var exception = assertThrows(JsonIOException.class, () -> gson.fromJson("{}", Record.class));
+    assertEquals("Abstract classes can't be instantiated! Register an InstanceCreator or a TypeAdapter for "
+        + "this type. Class name: java.lang.Record",
+        exception.getMessage());
+  }
 }

--- a/gson/src/test/java/com/google/gson/functional/ObjectTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ObjectTest.java
@@ -20,6 +20,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.InstanceCreator;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonIOException;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializationContext;
@@ -524,6 +525,9 @@ public class ObjectTest extends TestCase {
 
     String json = gson.toJson(new ClassWithStaticField());
     assertEquals("{\"s\":\"initial\"}", json);
+
+    json = gson.toJson(new ClassWithStaticFinalField());
+    assertEquals("{\"s\":\"initial\"}", json);
   }
 
   /**
@@ -550,9 +554,21 @@ public class ObjectTest extends TestCase {
     } finally {
       ClassWithStaticField.s = oldValue;
     }
+
+    try {
+      gson.fromJson("{\"s\":\"custom\"}", ClassWithStaticFinalField.class);
+      fail();
+    } catch (JsonIOException e) {
+      assertEquals("Cannot set value of 'static final' field 'com.google.gson.functional.ObjectTest$ClassWithStaticFinalField#s'",
+          e.getMessage());
+    }
   }
 
   static class ClassWithStaticField {
     static String s = "initial";
+  }
+
+  static class ClassWithStaticFinalField {
+    static final String s = "initial";
   }
 }

--- a/gson/src/test/java/com/google/gson/functional/ObjectTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ObjectTest.java
@@ -514,6 +514,9 @@ public class ObjectTest extends TestCase {
    * test just checks the current behavior.
    */
   public void testStaticFieldSerialization() {
+    // By default Gson should ignore static fields
+    assertEquals("{}", gson.toJson(new ClassWithStaticField()));
+
     Gson gson = new GsonBuilder()
         // Include static fields
         .excludeFieldsWithModifiers(0)
@@ -530,6 +533,10 @@ public class ObjectTest extends TestCase {
    * test just checks the current behavior.
    */
   public void testStaticFieldDeserialization() {
+    // By default Gson should ignore static fields
+    gson.fromJson("{\"s\":\"custom\"}", ClassWithStaticField.class);
+    assertEquals("initial", ClassWithStaticField.s);
+
     Gson gson = new GsonBuilder()
         // Include static fields
         .excludeFieldsWithModifiers(0)

--- a/gson/src/test/java/com/google/gson/functional/ObjectTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ObjectTest.java
@@ -571,4 +571,25 @@ public class ObjectTest extends TestCase {
   static class ClassWithStaticFinalField {
     static final String s = "initial";
   }
+
+  public void testThrowingDefaultConstructor() {
+    try {
+      gson.fromJson("{}", ClassWithThrowingConstructor.class);
+      fail();
+    }
+    // TODO: Adjust this once Gson throws more specific exception type
+    catch (RuntimeException e) {
+      assertEquals("Failed to invoke constructor 'com.google.gson.functional.ObjectTest$ClassWithThrowingConstructor()' with no args",
+          e.getMessage());
+      assertSame(ClassWithThrowingConstructor.thrownException, e.getCause());
+    }
+  }
+
+  static class ClassWithThrowingConstructor {
+    static final RuntimeException thrownException = new RuntimeException("Custom exception");
+
+    public ClassWithThrowingConstructor() {
+      throw thrownException;
+    }
+  }
 }

--- a/gson/src/test/java/com/google/gson/functional/ObjectTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ObjectTest.java
@@ -482,6 +482,16 @@ public class ObjectTest extends TestCase {
     gson.fromJson(gson.toJson(product), Product.class);
   }
 
+  static final class Department {
+    public String name = "abc";
+    public String code = "123";
+  }
+
+  static final class Product {
+    private List<String> attributes = new ArrayList<>();
+    private List<Department> departments = new ArrayList<>();
+  }
+
   // http://code.google.com/p/google-gson/issues/detail?id=270
   public void testDateAsMapObjectField() {
     HasObjectMap a = new HasObjectMap();
@@ -493,17 +503,49 @@ public class ObjectTest extends TestCase {
     }
   }
 
-  public class HasObjectMap {
+  static class HasObjectMap {
     Map<String, Object> map = new HashMap<>();
   }
 
-  static final class Department {
-    public String name = "abc";
-    public String code = "123";
+  /**
+   * Tests serialization of a class with {@code static} field.
+   *
+   * <p>Important: It is not documented that this is officially supported; this
+   * test just checks the current behavior.
+   */
+  public void testStaticFieldSerialization() {
+    Gson gson = new GsonBuilder()
+        // Include static fields
+        .excludeFieldsWithModifiers(0)
+        .create();
+
+    String json = gson.toJson(new ClassWithStaticField());
+    assertEquals("{\"s\":\"initial\"}", json);
   }
 
-  static final class Product {
-    private List<String> attributes = new ArrayList<>();
-    private List<Department> departments = new ArrayList<>();
+  /**
+   * Tests deserialization of a class with {@code static} field.
+   *
+   * <p>Important: It is not documented that this is officially supported; this
+   * test just checks the current behavior.
+   */
+  public void testStaticFieldDeserialization() {
+    Gson gson = new GsonBuilder()
+        // Include static fields
+        .excludeFieldsWithModifiers(0)
+        .create();
+
+    String oldValue = ClassWithStaticField.s;
+    try {
+      ClassWithStaticField obj = gson.fromJson("{\"s\":\"custom\"}", ClassWithStaticField.class);
+      assertNotNull(obj);
+      assertEquals("custom", ClassWithStaticField.s);
+    } finally {
+      ClassWithStaticField.s = oldValue;
+    }
+  }
+
+  static class ClassWithStaticField {
+    static String s = "initial";
   }
 }

--- a/gson/src/test/java/com/google/gson/functional/ReflectionAccessFilterTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ReflectionAccessFilterTest.java
@@ -53,9 +53,9 @@ public class ReflectionAccessFilterTest {
     } catch (JsonIOException expected) {
       // Note: This test is rather brittle and depends on the JDK implementation
       assertEquals(
-        "Field 'java.io.File#path' is not accessible and ReflectionAccessFilter does not permit "
-        + "making it accessible. Register a TypeAdapter for the declaring type, adjust the access "
-        + "filter or increase the visibility of the element and its declaring type.",
+        "Field 'java.io.File#path' is not accessible and ReflectionAccessFilter does not permit"
+        + " making it accessible. Register a TypeAdapter for the declaring type, adjust the access"
+        + " filter or increase the visibility of the element and its declaring type.",
         expected.getMessage()
       );
     }
@@ -86,9 +86,9 @@ public class ReflectionAccessFilterTest {
       fail("Expected exception; test needs to be run with Java >= 9");
     } catch (JsonIOException expected) {
       assertEquals(
-        "Field 'java.io.Reader#lock' is not accessible and ReflectionAccessFilter does not permit "
-        + "making it accessible. Register a TypeAdapter for the declaring type, adjust the access "
-        + "filter or increase the visibility of the element and its declaring type.",
+        "Field 'java.io.Reader#lock' is not accessible and ReflectionAccessFilter does not permit"
+        + " making it accessible. Register a TypeAdapter for the declaring type, adjust the access"
+        + " filter or increase the visibility of the element and its declaring type.",
         expected.getMessage()
       );
     }
@@ -106,8 +106,8 @@ public class ReflectionAccessFilterTest {
       fail();
     } catch (JsonIOException expected) {
       assertEquals(
-        "ReflectionAccessFilter does not permit using reflection for class java.lang.Thread. "
-        + "Register a TypeAdapter for this type or adjust the access filter.",
+        "ReflectionAccessFilter does not permit using reflection for class java.lang.Thread."
+        + " Register a TypeAdapter for this type or adjust the access filter.",
         expected.getMessage()
       );
     }
@@ -124,9 +124,9 @@ public class ReflectionAccessFilterTest {
       fail();
     } catch (JsonIOException expected) {
       assertEquals(
-        "ReflectionAccessFilter does not permit using reflection for class java.io.Reader "
-        + "(supertype of class com.google.gson.functional.ReflectionAccessFilterTest$ClassExtendingJdkClass). "
-        + "Register a TypeAdapter for this type or adjust the access filter.",
+        "ReflectionAccessFilter does not permit using reflection for class java.io.Reader"
+        + " (supertype of class com.google.gson.functional.ReflectionAccessFilterTest$ClassExtendingJdkClass)."
+        + " Register a TypeAdapter for this type or adjust the access filter.",
         expected.getMessage()
       );
     }
@@ -154,10 +154,10 @@ public class ReflectionAccessFilterTest {
         fail("Expected exception; test needs to be run with Java >= 9");
       } catch (JsonIOException expected) {
         assertEquals(
-          "Field 'com.google.gson.functional.ReflectionAccessFilterTest$ClassWithStaticField#i' "
-          + "is not accessible and ReflectionAccessFilter does not permit making it accessible. "
-          + "Register a TypeAdapter for the declaring type, adjust the access filter or increase "
-          + "the visibility of the element and its declaring type.",
+          "Field 'com.google.gson.functional.ReflectionAccessFilterTest$ClassWithStaticField#i'"
+          + " is not accessible and ReflectionAccessFilter does not permit making it accessible."
+          + " Register a TypeAdapter for the declaring type, adjust the access filter or increase"
+          + " the visibility of the element and its declaring type.",
           expected.getMessage()
         );
       }
@@ -197,9 +197,9 @@ public class ReflectionAccessFilterTest {
       fail();
     } catch (JsonIOException expected) {
       assertEquals(
-        "ReflectionAccessFilter does not permit using reflection for class "
-        + "com.google.gson.functional.ReflectionAccessFilterTest$SuperTestClass. "
-        + "Register a TypeAdapter for this type or adjust the access filter.",
+        "ReflectionAccessFilter does not permit using reflection for class"
+        + " com.google.gson.functional.ReflectionAccessFilterTest$SuperTestClass."
+        + " Register a TypeAdapter for this type or adjust the access filter.",
         expected.getMessage()
       );
     }
@@ -236,10 +236,10 @@ public class ReflectionAccessFilterTest {
       fail("Expected exception; test needs to be run with Java >= 9");
     } catch (JsonIOException expected) {
       assertEquals(
-        "Field 'com.google.gson.functional.ReflectionAccessFilterTest$ClassWithPrivateField#i' "
-        + "is not accessible and ReflectionAccessFilter does not permit making it accessible. "
-        + "Register a TypeAdapter for the declaring type, adjust the access filter or increase "
-        + "the visibility of the element and its declaring type.",
+        "Field 'com.google.gson.functional.ReflectionAccessFilterTest$ClassWithPrivateField#i'"
+        + " is not accessible and ReflectionAccessFilter does not permit making it accessible."
+        + " Register a TypeAdapter for the declaring type, adjust the access filter or increase"
+        + " the visibility of the element and its declaring type.",
         expected.getMessage()
       );
     }
@@ -278,9 +278,9 @@ public class ReflectionAccessFilterTest {
       fail("Expected exception; test needs to be run with Java >= 9");
     } catch (JsonIOException expected) {
       assertEquals(
-        "Unable to invoke no-args constructor of class com.google.gson.functional.ReflectionAccessFilterTest$ClassWithPrivateNoArgsConstructor; "
-        + "constructor is not accessible and ReflectionAccessFilter does not permit making it accessible. Register an "
-        + "InstanceCreator or a TypeAdapter for this type, change the visibility of the constructor or adjust the access filter.",
+        "Unable to invoke no-args constructor of class com.google.gson.functional.ReflectionAccessFilterTest$ClassWithPrivateNoArgsConstructor;"
+        + " constructor is not accessible and ReflectionAccessFilter does not permit making it accessible. Register an"
+        + " InstanceCreator or a TypeAdapter for this type, change the visibility of the constructor or adjust the access filter.",
         expected.getMessage()
       );
     }
@@ -310,9 +310,9 @@ public class ReflectionAccessFilterTest {
       fail();
     } catch (JsonIOException expected) {
       assertEquals(
-        "Unable to create instance of class com.google.gson.functional.ReflectionAccessFilterTest$ClassWithoutNoArgsConstructor; "
-        + "ReflectionAccessFilter does not permit using reflection or Unsafe. Register an InstanceCreator "
-        + "or a TypeAdapter for this type or adjust the access filter to allow using reflection.",
+        "Unable to create instance of class com.google.gson.functional.ReflectionAccessFilterTest$ClassWithoutNoArgsConstructor;"
+        + " ReflectionAccessFilter does not permit using reflection or Unsafe. Register an InstanceCreator"
+        + " or a TypeAdapter for this type or adjust the access filter to allow using reflection.",
         expected.getMessage()
       );
     }
@@ -372,8 +372,8 @@ public class ReflectionAccessFilterTest {
       fail();
     } catch (JsonIOException expected) {
       assertEquals(
-        "ReflectionAccessFilter does not permit using reflection for class com.google.gson.functional.ReflectionAccessFilterTest$OtherClass. "
-        + "Register a TypeAdapter for this type or adjust the access filter.",
+        "ReflectionAccessFilter does not permit using reflection for class com.google.gson.functional.ReflectionAccessFilterTest$OtherClass."
+        + " Register a TypeAdapter for this type or adjust the access filter.",
         expected.getMessage()
       );
     }
@@ -432,8 +432,8 @@ public class ReflectionAccessFilterTest {
       fail();
     } catch (JsonIOException expected) {
       assertEquals(
-        "Interfaces can't be instantiated! Register an InstanceCreator or a TypeAdapter for "
-        + "this type. Interface name: java.lang.Runnable",
+        "Interfaces can't be instantiated! Register an InstanceCreator or a TypeAdapter for"
+        + " this type. Interface name: java.lang.Runnable",
         expected.getMessage()
       );
     }

--- a/gson/src/test/java/com/google/gson/functional/ReflectionAccessFilterTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ReflectionAccessFilterTest.java
@@ -54,7 +54,8 @@ public class ReflectionAccessFilterTest {
       // Note: This test is rather brittle and depends on the JDK implementation
       assertEquals(
         "Field 'java.io.File#path' is not accessible and ReflectionAccessFilter does not permit "
-        + "making it accessible. Register a TypeAdapter for the declaring type or adjust the access filter.",
+        + "making it accessible. Register a TypeAdapter for the declaring type, adjust the access "
+        + "filter or increase the visibility of the element and its declaring type.",
         expected.getMessage()
       );
     }
@@ -86,7 +87,8 @@ public class ReflectionAccessFilterTest {
     } catch (JsonIOException expected) {
       assertEquals(
         "Field 'java.io.Reader#lock' is not accessible and ReflectionAccessFilter does not permit "
-        + "making it accessible. Register a TypeAdapter for the declaring type or adjust the access filter.",
+        + "making it accessible. Register a TypeAdapter for the declaring type, adjust the access "
+        + "filter or increase the visibility of the element and its declaring type.",
         expected.getMessage()
       );
     }
@@ -154,7 +156,8 @@ public class ReflectionAccessFilterTest {
         assertEquals(
           "Field 'com.google.gson.functional.ReflectionAccessFilterTest$ClassWithStaticField#i' "
           + "is not accessible and ReflectionAccessFilter does not permit making it accessible. "
-          + "Register a TypeAdapter for the declaring type or adjust the access filter.",
+          + "Register a TypeAdapter for the declaring type, adjust the access filter or increase "
+          + "the visibility of the element and its declaring type.",
           expected.getMessage()
         );
       }
@@ -235,7 +238,8 @@ public class ReflectionAccessFilterTest {
       assertEquals(
         "Field 'com.google.gson.functional.ReflectionAccessFilterTest$ClassWithPrivateField#i' "
         + "is not accessible and ReflectionAccessFilter does not permit making it accessible. "
-        + "Register a TypeAdapter for the declaring type or adjust the access filter.",
+        + "Register a TypeAdapter for the declaring type, adjust the access filter or increase "
+        + "the visibility of the element and its declaring type.",
         expected.getMessage()
       );
     }
@@ -322,7 +326,7 @@ public class ReflectionAccessFilterTest {
         }
         @Override public void write(JsonWriter out, ClassWithoutNoArgsConstructor value) throws IOException {
           throw new AssertionError("Not needed for test");
-        };
+        }
       })
       .create();
     ClassWithoutNoArgsConstructor deserialized = gson.fromJson("{}", ClassWithoutNoArgsConstructor.class);

--- a/gson/src/test/java/com/google/gson/functional/ReflectionAccessTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ReflectionAccessTest.java
@@ -119,8 +119,8 @@ public class ReflectionAccessTest {
       fail("Unexpected exception; test has to be run with `--illegal-access=deny`");
     } catch (JsonIOException expected) {
       assertTrue(expected.getMessage().startsWith(
-          "Failed making constructor 'java.util.Collections$EmptyList#EmptyList()' accessible; "
-          + "either increase its visibility or write a custom InstanceCreator or TypeAdapter for its declaring type: "
+          "Failed making constructor 'java.util.Collections$EmptyList#EmptyList()' accessible;"
+          + " either increase its visibility or write a custom InstanceCreator or TypeAdapter for its declaring type: "
       ));
     }
   }

--- a/gson/src/test/java/com/google/gson/functional/ReflectionAccessTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ReflectionAccessTest.java
@@ -119,7 +119,7 @@ public class ReflectionAccessTest {
       fail("Unexpected exception; test has to be run with `--illegal-access=deny`");
     } catch (JsonIOException expected) {
       assertTrue(expected.getMessage().startsWith(
-          "Failed making constructor 'java.util.Collections$EmptyList#EmptyList()' accessible;"
+          "Failed making constructor 'java.util.Collections$EmptyList()' accessible;"
           + " either increase its visibility or write a custom InstanceCreator or TypeAdapter for its declaring type: "
       ));
     }

--- a/gson/src/test/java/com/google/gson/functional/ReflectionAccessTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ReflectionAccessTest.java
@@ -120,7 +120,7 @@ public class ReflectionAccessTest {
     } catch (JsonIOException expected) {
       assertTrue(expected.getMessage().startsWith(
           "Failed making constructor 'java.util.Collections$EmptyList#EmptyList()' accessible; "
-          + "either change its visibility or write a custom InstanceCreator or TypeAdapter for its declaring type"
+          + "either increase its visibility or write a custom InstanceCreator or TypeAdapter for its declaring type: "
       ));
     }
   }

--- a/gson/src/test/java/com/google/gson/internal/bind/Java17ReflectiveTypeAdapterFactoryTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/Java17ReflectiveTypeAdapterFactoryTest.java
@@ -6,42 +6,39 @@ import static org.junit.Assert.assertNotEquals;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.TypeAdapter;
-import com.google.gson.internal.reflect.ReflectionHelperTest;
+import com.google.gson.internal.reflect.Java17ReflectionHelperTest;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.nio.file.attribute.GroupPrincipal;
 import java.nio.file.attribute.UserPrincipal;
 import java.security.Principal;
-import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ReflectiveTypeAdapterFactoryTest {
+public class Java17ReflectiveTypeAdapterFactoryTest {
 
-  // The class jdk.net.UnixDomainPrincipal is one of the few Record types that are included in the
-  // JDK.
+  // The class jdk.net.UnixDomainPrincipal is one of the few Record types that are included in the JDK.
   // We use this to test serialization and deserialization of Record classes, so we do not need to
-  // have
-  // record support at the language level for these tests. This class was added in JDK 16.
+  // have record support at the language level for these tests. This class was added in JDK 16.
   Class<?> unixDomainPrincipalClass;
 
   @Before
   public void setUp() throws Exception {
-    try {
-      Class.forName("java.lang.Record");
-      unixDomainPrincipalClass = Class.forName("jdk.net.UnixDomainPrincipal");
-    } catch (ClassNotFoundException e) {
-      // Records not supported, ignore
-      throw new AssumptionViolatedException("java.lang.Record not supported");
-    }
+    unixDomainPrincipalClass = Class.forName("jdk.net.UnixDomainPrincipal");
+  }
+
+  // Class for which the normal reflection based adapter is used
+  private static class DummyClass {
+    @SuppressWarnings("unused")
+    public String s;
   }
 
   @Test
   public void testCustomAdapterForRecords() {
     Gson gson = new Gson();
     TypeAdapter<?> recordAdapter = gson.getAdapter(unixDomainPrincipalClass);
-    TypeAdapter<?> defaultReflectionAdapter = gson.getAdapter(UserPrincipal.class);
+    TypeAdapter<?> defaultReflectionAdapter = gson.getAdapter(DummyClass.class);
     assertNotEquals(recordAdapter.getClass(), defaultReflectionAdapter.getClass());
   }
 
@@ -77,7 +74,7 @@ public class ReflectiveTypeAdapterFactoryTest {
       final String name = in.nextString();
       // This type adapter is only used for Group and User Principal, both of which are implemented by PrincipalImpl.
       @SuppressWarnings("unchecked")
-      T principal = (T) new ReflectionHelperTest.PrincipalImpl(name);
+      T principal = (T) new Java17ReflectionHelperTest.PrincipalImpl(name);
       return principal;
     }
   }

--- a/gson/src/test/java/com/google/gson/internal/reflect/Java17ReflectionHelperTest.java
+++ b/gson/src/test/java/com/google/gson/internal/reflect/Java17ReflectionHelperTest.java
@@ -11,22 +11,9 @@ import java.lang.reflect.Method;
 import java.nio.file.attribute.GroupPrincipal;
 import java.nio.file.attribute.UserPrincipal;
 import java.util.Objects;
-import org.junit.AssumptionViolatedException;
-import org.junit.Before;
 import org.junit.Test;
 
-public class ReflectionHelperTest {
-
-  @Before
-  public void setUp() throws Exception {
-    try {
-      Class.forName("java.lang.Record");
-    } catch (ClassNotFoundException e) {
-      // Records not supported, ignore
-      throw new AssumptionViolatedException("java.lang.Record not supported");
-    }
-  }
-
+public class Java17ReflectionHelperTest {
   @Test
   public void testJava17Record() throws ClassNotFoundException {
     Class<?> unixDomainPrincipalClass = Class.forName("jdk.net.UnixDomainPrincipal");
@@ -54,8 +41,11 @@ public class ReflectionHelperTest {
     Object unixDomainPrincipal =
         ReflectionHelper.getCanonicalRecordConstructor(unixDomainPrincipalClass)
             .newInstance(new PrincipalImpl("user"), new PrincipalImpl("group"));
-    for (String componentName :
-        ReflectionHelper.getRecordComponentNames(unixDomainPrincipalClass)) {
+
+    String[] componentNames = ReflectionHelper.getRecordComponentNames(unixDomainPrincipalClass);
+    assertTrue(componentNames.length > 0);
+
+    for (String componentName : componentNames) {
       Field componentField = unixDomainPrincipalClass.getDeclaredField(componentName);
       Method accessor = ReflectionHelper.getAccessor(unixDomainPrincipalClass, componentField);
       Object principal = accessor.invoke(unixDomainPrincipal);


### PR DESCRIPTION
Changes:
- Make record constructor and accessor accessible (unless reflection access filter prevents it)
- Disallow `null` for primitive component, see https://github.com/google/gson/pull/2219#discussion_r992866260
- Skip `static` fields when deserializing records
Would not work without special casing and I am not sure if serializing or deserializing `static` fields was ever officially documented as supported (just happens to work by using `GsonBuilder.excludeFieldsWithModifiers`). For serialization there might be legit use cases (e.g. to encode a version number), but deserialization it rather questionable.
- Disallow `@SerializedName` placed only on accessor method
Implemented this because we have the accessor method available for this check anyway, and because for records the accessor method is actually called on serialization so users might expect `@SerializedName` to work on them.
- Adjust `ReflectionHelper.makeAccessible` to create description of object only when exception is thrown instead of eagerly
- Prefix names of test classes `ReflectiveTypeAdapterFactoryTest` and `ReflectionHelperTest` with `Java17`
This makes sure that we notice when the checked JDK class `UnixDomainPrincipal` is missing for some reason even though the test runs on Java >= 17. Otherwise these tests might just be silently skipped without us noticing.
Arguably these tests could also be rewritten to use custom record classes now that the tests are only compiled on Java 17 or newer, but on the other hand it might also be valuable that they test against a record class which is not part of Gson's tests.
- ... for further changes see messages of subsequent commits
