### PR TITLE
Revise the version regex in `GsonVersionDiagnosticsTest`.

### DIFF
--- a/gson/src/test/java/com/google/gson/functional/GsonVersionDiagnosticsTest.java
+++ b/gson/src/test/java/com/google/gson/functional/GsonVersionDiagnosticsTest.java
@@ -35,7 +35,7 @@ import junit.framework.TestCase;
  * @author Inderjeet Singh
  */
 public class GsonVersionDiagnosticsTest extends TestCase {
-  private static final Pattern GSON_VERSION_PATTERN = Pattern.compile("(\\(GSON \\d\\.\\d\\.\\d)(?:[-.][A-Z]+)?\\)$");
+  private static final Pattern GSON_VERSION_PATTERN = Pattern.compile("(\\(GSON \\d\\.\\d+(\\.\\d)?)(?:[-.][A-Z]+)?\\)$");
 
   private Gson gson;
 


### PR DESCRIPTION
Before we can release 2.10 we must support two-digit components. Additionally, there's no reason to require a patch number (2.10.0 rather than 2.10).