### PR TITLE
Added JsonObject method isEmpty()

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonObject.java
+++ b/gson/src/main/java/com/google/gson/JsonObject.java
@@ -148,11 +148,21 @@ public final class JsonObject extends JsonElement {
   /**
    * Returns the number of key/value pairs in the object.
    *
-   * @return the number of key/value pairs in the object.
+   * @return the number of key/value pairs in the objezct.
    * @since 2.7
    */
   public int size() {
     return members.size();
+  }
+
+  /**
+   * Returns true if the number of key/value pairs in the object is zero.
+   *
+   * @return true if the number of key/value pairs in the object is zero.
+   * @since $next-version$
+   */
+  public boolean isEmpty() {
+    return members.size() == 0;
   }
 
   /**

--- a/gson/src/main/java/com/google/gson/JsonObject.java
+++ b/gson/src/main/java/com/google/gson/JsonObject.java
@@ -148,7 +148,7 @@ public final class JsonObject extends JsonElement {
   /**
    * Returns the number of key/value pairs in the object.
    *
-   * @return the number of key/value pairs in the objezct.
+   * @return the number of key/value pairs in the object.
    * @since 2.7
    */
   public int size() {

--- a/gson/src/test/java/com/google/gson/JsonObjectTest.java
+++ b/gson/src/test/java/com/google/gson/JsonObjectTest.java
@@ -225,13 +225,13 @@ public class JsonObjectTest {
   @Test
   public void testIsEmpty() {
     JsonObject o = new JsonObject();
-    assertEquals(true, o.isEmpty());
+    assertTrue(o.isEmpty());
 
     o.add("Hello", new JsonPrimitive(1));
-    assertEquals(false, o.isEmpty());
+    assertFalse(o.isEmpty());
 
     o.remove("Hello");
-    assertEquals(true, o.isEmpty());
+    assertTrue(o.isEmpty());
   }
 
   @Test

--- a/gson/src/test/java/com/google/gson/JsonObjectTest.java
+++ b/gson/src/test/java/com/google/gson/JsonObjectTest.java
@@ -223,6 +223,18 @@ public class JsonObjectTest {
   }
 
   @Test
+  public void testIsEmpty() {
+    JsonObject o = new JsonObject();
+    assertEquals(true, o.isEmpty());
+
+    o.add("Hello", new JsonPrimitive(1));
+    assertEquals(false, o.isEmpty());
+
+    o.remove("Hello");
+    assertEquals(true, o.isEmpty());
+  }
+
+  @Test
   public void testDeepCopy() {
     JsonObject original = new JsonObject();
     JsonArray firstEntry = new JsonArray();


### PR DESCRIPTION
**Code change**

Added JsonObject method `isEmpty()`.

**Rationale**

There are scenarios where there is a need to check whether a `JsonObject` contains any key/value pairs.

This mirrors the existing functionality of `JsonArray.isEmpty()`