### PR TITLE
Adjust version numbers and a test to conform to the SemVer spec.

### DIFF
--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.google.code.gson</groupId>
     <artifactId>gson-parent</artifactId>
-    <version>2.10.1-SNAPSHOT</version>
+    <version>2.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gson-extras</artifactId>

--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.google.code.gson</groupId>
     <artifactId>gson-parent</artifactId>
-    <version>2.11-SNAPSHOT</version>
+    <version>2.10.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>gson-extras</artifactId>

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.code.gson</groupId>
     <artifactId>gson-parent</artifactId>
-    <version>2.11-SNAPSHOT</version>
+    <version>2.10.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>gson</artifactId>

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.code.gson</groupId>
     <artifactId>gson-parent</artifactId>
-    <version>2.10.1-SNAPSHOT</version>
+    <version>2.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gson</artifactId>

--- a/gson/src/test/java/com/google/gson/functional/GsonVersionDiagnosticsTest.java
+++ b/gson/src/test/java/com/google/gson/functional/GsonVersionDiagnosticsTest.java
@@ -35,7 +35,9 @@ import junit.framework.TestCase;
  * @author Inderjeet Singh
  */
 public class GsonVersionDiagnosticsTest extends TestCase {
-  private static final Pattern GSON_VERSION_PATTERN = Pattern.compile("(\\(GSON \\d\\.\\d+(\\.\\d)?)(?:[-.][A-Z]+)?\\)$");
+  // We require a patch number, even if it is .0, consistent with https://semver.org/#spec-item-2.
+  private static final Pattern GSON_VERSION_PATTERN =
+      Pattern.compile("(\\(GSON \\d\\.\\d+\\.\\d)(?:[-.][A-Z]+)?\\)$");
 
   private Gson gson;
 

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.google.code.gson</groupId>
     <artifactId>gson-parent</artifactId>
-    <version>2.11-SNAPSHOT</version>
+    <version>2.10.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>gson-metrics</artifactId>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.google.code.gson</groupId>
     <artifactId>gson-parent</artifactId>
-    <version>2.10.1-SNAPSHOT</version>
+    <version>2.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gson-metrics</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.google.code.gson</groupId>
   <artifactId>gson-parent</artifactId>
-  <version>2.11-SNAPSHOT</version>
+  <version>2.10.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Gson Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.google.code.gson</groupId>
   <artifactId>gson-parent</artifactId>
-  <version>2.10.1-SNAPSHOT</version>
+  <version>2.11.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Gson Parent</name>

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.code.gson</groupId>
     <artifactId>gson-parent</artifactId>
-    <version>2.10.1-SNAPSHOT</version>
+    <version>2.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>proto</artifactId>

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.code.gson</groupId>
     <artifactId>gson-parent</artifactId>
-    <version>2.11-SNAPSHOT</version>
+    <version>2.10.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>proto</artifactId>


### PR DESCRIPTION
Gson releases since 2.8.0 have been following this spec. We mistakenly released 2.10 without the .0 patch version, and adjusted `GsonVersionDiagnosticsTest` so it would accept that, as well as the two-digit `10`. Here we make the test no longer accept versions without a patch number, while still accepting two-digit minor versions of course. We also change the snapshot version to 2.11.0-SNAPSHOT instead of 2.11-SNAPSHOT.