### PR TITLE
Improve exception message for duplicate field names

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/reflect/ReflectionHelper.java
+++ b/gson/src/main/java/com/google/gson/internal/reflect/ReflectionHelper.java
@@ -53,8 +53,7 @@ public class ReflectionHelper {
     String description;
 
     if (object instanceof Field) {
-      Field field = (Field) object;
-      description = "field '" + field.getDeclaringClass().getName() + "#" + field.getName() + "'";
+      description = "field '" + fieldToString((Field) object) + "'";
     } else if (object instanceof Method) {
       Method method = (Method) object;
 
@@ -73,6 +72,14 @@ public class ReflectionHelper {
       description = Character.toUpperCase(description.charAt(0)) + description.substring(1);
     }
     return description;
+  }
+
+  /**
+   * Creates a string representation for a field, omitting modifiers and
+   * the field type.
+   */
+  public static String fieldToString(Field field) {
+    return field.getDeclaringClass().getName() + "#" + field.getName();
   }
 
   /**

--- a/gson/src/test/java/com/google/gson/functional/NamingPolicyTest.java
+++ b/gson/src/test/java/com/google/gson/functional/NamingPolicyTest.java
@@ -22,10 +22,8 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.common.TestTypes.ClassWithSerializedNameFields;
 import com.google.gson.common.TestTypes.StringWrapper;
-
-import junit.framework.TestCase;
-
 import java.lang.reflect.Field;
+import junit.framework.TestCase;
 
 /**
  * Functional tests for naming policies.
@@ -122,6 +120,12 @@ public class NamingPolicyTest extends TestCase {
       gson.toJson(target);
       fail();
     } catch (IllegalArgumentException expected) {
+      assertEquals(
+          "Class com.google.gson.functional.NamingPolicyTest$ClassWithDuplicateFields declares multiple JSON fields named 'a';"
+          + " conflict is caused by fields com.google.gson.functional.NamingPolicyTest$ClassWithDuplicateFields#a and"
+          + " com.google.gson.functional.NamingPolicyTest$ClassWithDuplicateFields#b",
+          expected.getMessage()
+      );
     }
   }
 

--- a/gson/src/test/java/com/google/gson/functional/ObjectTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ObjectTest.java
@@ -145,6 +145,31 @@ public class ObjectTest extends TestCase {
     assertEquals(expected, target);
   }
 
+  private static class Subclass extends Superclass1 {
+  }
+  private static class Superclass1 extends Superclass2 {
+    @SuppressWarnings("unused")
+    String s;
+  }
+  private static class Superclass2 {
+    @SuppressWarnings("unused")
+    String s;
+  }
+
+  public void testClassWithDuplicateFields() {
+    try {
+      gson.getAdapter(Subclass.class);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals(
+          "Class com.google.gson.functional.ObjectTest$Subclass declares multiple JSON fields named 's';"
+          + " conflict is caused by fields com.google.gson.functional.ObjectTest$Superclass1#s and"
+          + " com.google.gson.functional.ObjectTest$Superclass2#s",
+          e.getMessage()
+      );
+    }
+  }
+
   public void testNestedSerialization() throws Exception {
     Nested target = new Nested(new BagOfPrimitives(10, 20, false, "stringValue"),
        new BagOfPrimitives(30, 40, true, "stringValue"));


### PR DESCRIPTION
This hopefully makes it easier to troubleshoot this issue, especially when there is a conflict between `@SerializedName` and an inherited field, or when users depend on Java or Android platform types. In the latter case it will be easier as external person to spot the underlying cause of the issue (i.e. serializing third-party types).