### PR TITLE
Remove covered condition in JsonNull.equals()

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonNull.java
+++ b/gson/src/main/java/com/google/gson/JsonNull.java
@@ -64,6 +64,6 @@ public final class JsonNull extends JsonElement {
    */
   @Override
   public boolean equals(Object other) {
-    return this == other || other instanceof JsonNull;
+    return other instanceof JsonNull;
   }
 }


### PR DESCRIPTION
The Condition `this == other` is covered by subsequent condition `other instanceof JsonNull`