### PR TITLE
Remove the `final` from `private` method

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/DefaultDateTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/DefaultDateTypeAdapter.java
@@ -62,7 +62,7 @@ public final class DefaultDateTypeAdapter<T extends Date> extends TypeAdapter<T>
 
     protected abstract T deserialize(Date date);
 
-    private final TypeAdapterFactory createFactory(DefaultDateTypeAdapter<T> adapter) {
+    private TypeAdapterFactory createFactory(DefaultDateTypeAdapter<T> adapter) {
       return TypeAdapters.newFactory(dateClass, adapter);
     }
 

--- a/gson/src/test/java/com/google/gson/internal/LinkedTreeMapTest.java
+++ b/gson/src/test/java/com/google/gson/internal/LinkedTreeMapTest.java
@@ -215,7 +215,7 @@ public final class LinkedTreeMapTest extends TestCase {
 
   @SuppressWarnings("varargs")
   @SafeVarargs
-  private final <T> void assertIterationOrder(Iterable<T> actual, T... expected) {
+  private <T> void assertIterationOrder(Iterable<T> actual, T... expected) {
     ArrayList<T> actualList = new ArrayList<>();
     for (T t : actual) {
       actualList.add(t);


### PR DESCRIPTION
Remove the `final` keyword from `private` method because `private` methods are inaccessible, they are implicitly `final`.

Files changed:
- LinkedTreeMapTest.assertIterationOrder()
- DefaultDateTypeAdapter.createFactory()
