### PR TITLE
Remove the `final` keyword from `private` method

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/DefaultDateTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/DefaultDateTypeAdapter.java
@@ -62,7 +62,7 @@ public final class DefaultDateTypeAdapter<T extends Date> extends TypeAdapter<T>
 
     protected abstract T deserialize(Date date);
 
-    private final TypeAdapterFactory createFactory(DefaultDateTypeAdapter<T> adapter) {
+    private TypeAdapterFactory createFactory(DefaultDateTypeAdapter<T> adapter) {
       return TypeAdapters.newFactory(dateClass, adapter);
     }
 


### PR DESCRIPTION
Remove the `final` keyword from `private` method. `private` methods are implicitly `final`