### PR TITLE
Remove EOFException special casing of JsonStreamParser.next()

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonStreamParser.java
+++ b/gson/src/main/java/com/google/gson/JsonStreamParser.java
@@ -75,7 +75,7 @@ public final class JsonStreamParser implements Iterator<JsonElement> {
    * {@link NoSuchElementException} if no element is available.
    *
    * @return the next available {@code JsonElement} on the reader.
-   * @throws JsonSyntaxException if the incoming stream is malformed JSON.
+   * @throws JsonParseException if the incoming stream is malformed JSON.
    * @throws NoSuchElementException if no {@code JsonElement} is available.
    * @since 1.4
    */
@@ -97,7 +97,7 @@ public final class JsonStreamParser implements Iterator<JsonElement> {
   /**
    * Returns true if a {@link JsonElement} is available on the input for consumption
    * @return true if a {@link JsonElement} is available on the input, false otherwise
-   * @throws JsonSyntaxException if the incoming stream is malformed JSON.
+   * @throws JsonParseException if the incoming stream is malformed JSON.
    * @since 1.4
    */
   @Override

--- a/gson/src/main/java/com/google/gson/JsonStreamParser.java
+++ b/gson/src/main/java/com/google/gson/JsonStreamParser.java
@@ -15,17 +15,15 @@
  */
 package com.google.gson;
 
-import java.io.EOFException;
+import com.google.gson.internal.Streams;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.MalformedJsonException;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-
-import com.google.gson.internal.Streams;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonToken;
-import com.google.gson.stream.MalformedJsonException;
 
 /**
  * A streaming parser that allows reading of multiple {@link JsonElement}s from the specified reader
@@ -61,7 +59,7 @@ public final class JsonStreamParser implements Iterator<JsonElement> {
   public JsonStreamParser(String json) {
     this(new StringReader(json));
   }
-  
+
   /**
    * @param reader The data stream containing JSON elements concatenated to each other.
    * @since 1.4
@@ -71,7 +69,7 @@ public final class JsonStreamParser implements Iterator<JsonElement> {
     parser.setLenient(true);
     lock = new Object();
   }
-  
+
   /**
    * Returns the next available {@link JsonElement} on the reader. Throws a
    * {@link NoSuchElementException} if no element is available.
@@ -86,15 +84,13 @@ public final class JsonStreamParser implements Iterator<JsonElement> {
     if (!hasNext()) {
       throw new NoSuchElementException();
     }
-    
+
     try {
       return Streams.parse(parser);
     } catch (StackOverflowError e) {
       throw new JsonParseException("Failed parsing JSON source to Json", e);
     } catch (OutOfMemoryError e) {
       throw new JsonParseException("Failed parsing JSON source to Json", e);
-    } catch (JsonParseException e) {
-      throw e.getCause() instanceof EOFException ? new NoSuchElementException() : e;
     }
   }
 

--- a/gson/src/test/java/com/google/gson/JsonStreamParserTest.java
+++ b/gson/src/test/java/com/google/gson/JsonStreamParserTest.java
@@ -15,24 +15,30 @@
  */
 package com.google.gson;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import java.io.EOFException;
 import java.util.NoSuchElementException;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Unit tests for {@link JsonStreamParser}
- * 
+ *
  * @author Inderjeet Singh
  */
-public class JsonStreamParserTest extends TestCase {
+public class JsonStreamParserTest {
   private JsonStreamParser parser;
-  
-  @Override
-  protected void setUp() throws Exception {
-    super.setUp();
+
+  @Before
+  public void setUp() throws Exception {
     parser = new JsonStreamParser("'one' 'two'");
   }
 
+  @Test
   public void testParseTwoStrings() {
     String actualOne = parser.next().getAsString();
     assertEquals("one", actualOne);
@@ -40,6 +46,7 @@ public class JsonStreamParserTest extends TestCase {
     assertEquals("two", actualTwo);
   }
 
+  @Test
   public void testIterator() {
     assertTrue(parser.hasNext());
     assertEquals("one", parser.next().getAsString());
@@ -48,20 +55,22 @@ public class JsonStreamParserTest extends TestCase {
     assertFalse(parser.hasNext());
   }
 
+  @Test
   public void testNoSideEffectForHasNext() throws Exception {
     assertTrue(parser.hasNext());
     assertTrue(parser.hasNext());
     assertTrue(parser.hasNext());
     assertEquals("one", parser.next().getAsString());
-    
+
     assertTrue(parser.hasNext());
     assertTrue(parser.hasNext());
     assertEquals("two", parser.next().getAsString());
-    
+
     assertFalse(parser.hasNext());
     assertFalse(parser.hasNext());
   }
 
+  @Test
   public void testCallingNextBeyondAvailableInput() {
     parser.next();
     parser.next();
@@ -69,6 +78,53 @@ public class JsonStreamParserTest extends TestCase {
       parser.next();
       fail("Parser should not go beyond available input");
     } catch (NoSuchElementException expected) {
+    }
+  }
+
+  @Test
+  public void testEmptyInput() {
+    JsonStreamParser parser = new JsonStreamParser("");
+    try {
+      parser.next();
+      fail();
+    } catch (JsonIOException e) {
+      assertTrue(e.getCause() instanceof EOFException);
+    }
+
+    parser = new JsonStreamParser("");
+    try {
+      parser.hasNext();
+      fail();
+    } catch (JsonIOException e) {
+      assertTrue(e.getCause() instanceof EOFException);
+    }
+  }
+
+  @Test
+  public void testIncompleteInput() {
+    JsonStreamParser parser = new JsonStreamParser("[");
+    assertTrue(parser.hasNext());
+    try {
+      parser.next();
+      fail();
+    } catch (JsonSyntaxException e) {
+    }
+  }
+
+  @Test
+  public void testMalformedInput() {
+    JsonStreamParser parser = new JsonStreamParser(":");
+    try {
+      parser.hasNext();
+      fail();
+    } catch (JsonSyntaxException e) {
+    }
+
+    parser = new JsonStreamParser(":");
+    try {
+      parser.next();
+      fail();
+    } catch (JsonSyntaxException e) {
     }
   }
 }


### PR DESCRIPTION
The previous behavior violated the Iterator contract where for `JsonStreamParser("[")` a call to `hasNext()` would return true, but `next()` would throw a NoSuchElementException.
I currently cannot think of a use case where such behavior would be desired for incomplete JSON. Maybe that code is just a historic remnant from when `next()` did not delegate to `hasNext()` which itself would run into the `EOFException`.

This should hopefully fix issue #2110 and #2176, though we can also keep them open and (hopefully) let oss-fuzz detect on its own that they are resolved.