### PR TITLE
Adds Error Prone to the `maven-compiler-plugin`

### DIFF
--- a/extras/src/test/java/com/google/gson/typeadapters/PostConstructAdapterFactoryTest.java
+++ b/extras/src/test/java/com/google/gson/typeadapters/PostConstructAdapterFactoryTest.java
@@ -57,8 +57,8 @@ public class PostConstructAdapterFactoryTest {
         assertEquals(sandwiches, sandwichesFromJson);
     }
 
-    @SuppressWarnings("overrides") // for missing hashCode() override
-    static class Sandwich {
+  @SuppressWarnings({"overrides", "EqualsHashCode"}) // for missing hashCode() override
+  static class Sandwich {
         public String bread;
         public String cheese;
 
@@ -92,7 +92,7 @@ public class PostConstructAdapterFactoryTest {
         }
     }
 
-    @SuppressWarnings("overrides") // for missing hashCode() override
+    @SuppressWarnings({"overrides", "EqualsHashCode"}) // for missing hashCode() override
     static class MultipleSandwiches {
         public List<Sandwich> sandwiches;
 

--- a/gson/src/test/java/com/google/gson/JsonArrayTest.java
+++ b/gson/src/test/java/com/google/gson/JsonArrayTest.java
@@ -35,6 +35,7 @@ public final class JsonArrayTest {
   }
 
   @Test
+  @SuppressWarnings("TruthSelfEquals")
   public void testEqualsNonEmptyArray() {
     JsonArray a = new JsonArray();
     JsonArray b = new JsonArray();

--- a/gson/src/test/java/com/google/gson/JsonObjectTest.java
+++ b/gson/src/test/java/com/google/gson/JsonObjectTest.java
@@ -163,6 +163,7 @@ public class JsonObjectTest {
   }
 
   @Test
+  @SuppressWarnings("TruthSelfEquals")
   public void testEqualsNonEmptyObject() {
     JsonObject a = new JsonObject();
     JsonObject b = new JsonObject();

--- a/gson/src/test/java/com/google/gson/common/TestTypes.java
+++ b/gson/src/test/java/com/google/gson/common/TestTypes.java
@@ -227,7 +227,8 @@ public class TestTypes {
     }
   }
 
-  @SuppressWarnings("overrides") // for missing hashCode() override
+  // for missing hashCode() override
+  @SuppressWarnings({"overrides", "EqualsHashCode"})
   public static class ClassWithNoFields {
     // Nothing here..
     @Override

--- a/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
@@ -101,10 +101,9 @@ public class DefaultTypeAdaptersTest {
   }
 
   @Test
-  @SuppressWarnings("GetClassOnClass")
   public void testClassDeserialization() {
     try {
-      gson.fromJson("String.class", String.class.getClass());
+      gson.fromJson("String.class", Class.class);
       fail();
     } catch (UnsupportedOperationException expected) {
     }

--- a/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
@@ -101,6 +101,7 @@ public class DefaultTypeAdaptersTest {
   }
 
   @Test
+  @SuppressWarnings("GetClassOnClass")
   public void testClassDeserialization() {
     try {
       gson.fromJson("String.class", String.class.getClass());

--- a/gson/src/test/java/com/google/gson/functional/InstanceCreatorTest.java
+++ b/gson/src/test/java/com/google/gson/functional/InstanceCreatorTest.java
@@ -122,11 +122,11 @@ public class InstanceCreatorTest {
 
     Type sortedSetType = new TypeToken<SortedSet<String>>() {}.getType();
     SortedSet<String> set = gson.fromJson("[\"a\"]", sortedSetType);
-    assertThat("a").isEqualTo(set.first());
+    assertThat(set.first()).isEqualTo("a");
     assertThat(set.getClass()).isEqualTo(SubTreeSet.class);
 
     set = gson.fromJson("[\"b\"]", SortedSet.class);
-    assertThat("b").isEqualTo(set.first());
+    assertThat(set.first()).isEqualTo("b");
     assertThat(set.getClass()).isEqualTo(SubTreeSet.class);
   }
 }

--- a/gson/src/test/java/com/google/gson/functional/ReflectionAccessFilterTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ReflectionAccessFilterTest.java
@@ -18,7 +18,7 @@ package com.google.gson.functional;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeNotNull;;
+import static org.junit.Assume.assumeNotNull;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;

--- a/gson/src/test/java/com/google/gson/functional/TypeVariableTest.java
+++ b/gson/src/test/java/com/google/gson/functional/TypeVariableTest.java
@@ -73,7 +73,8 @@ public class TypeVariableTest {
     assertThat(blue2).isEqualTo(blue1);
   }
 
-  @SuppressWarnings("overrides") // for missing hashCode() override
+  // for missing hashCode() override
+  @SuppressWarnings({"overrides", "EqualsHashCode"})
   public static class Blue extends Red<Boolean> {
     public Blue() {
       super(false);
@@ -103,7 +104,7 @@ public class TypeVariableTest {
     }
   }
 
-  @SuppressWarnings("overrides") // for missing hashCode() override
+  @SuppressWarnings({"overrides", "EqualsHashCode"}) // for missing hashCode() override
   public static class Foo<S, T> extends Red<Boolean> {
     private S someSField;
     private T someTField;

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -1698,7 +1698,8 @@ public final class JsonReaderTest {
       reader.beginObject();
       assertThat(reader.nextName()).isEqualTo("a");
     }
-    assertThat(reader.getPath());
+    assertThat(reader.getPath()).isEqualTo("$.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a"
+        + ".a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a");
     assertThat(reader.nextBoolean()).isTrue();
     for (int i = 0; i < 40; i++) {
       reader.endObject();

--- a/pom.xml
+++ b/pom.xml
@@ -311,7 +311,6 @@
         </plugins>
       </build>
     </profile>
-
     <!-- Profile defining additional plugins to be executed for release -->
     <profile>
       <id>release</id>

--- a/pom.xml
+++ b/pom.xml
@@ -291,6 +291,27 @@
   </build>
 
   <profiles>
+    <!-- Disable Error Prone in Java 15 -->
+    <profile>
+      <id>jdk15</id>
+      <activation>
+        <jdk>15</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+             <compilerArgs combine.self="override">
+               <compilerArg>-Xlint:all,-options</compilerArg>
+             </compilerArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <!-- Profile defining additional plugins to be executed for release -->
     <profile>
       <id>release</id>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
             <showDeprecation>true</showDeprecation>
             <fork>true</fork>
             <compilerArgs>
-              <!-- Args related to Error Prone, see: https://github.com/google/error-prone/blob/f8e33bc460be82ab22256a7ef8b979d7a2cacaba/docs/installation.md -->
+              <!-- Args related to Error Prone, see: https://errorprone.info/docs/installation#maven -->
               <arg>-XDcompilePolicy=simple</arg>
               <arg>-Xplugin:ErrorProne</arg>
               <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -290,6 +290,27 @@
   </build>
 
   <profiles>
+    <!-- using github.com/google/error-prone-javac is required when running on JDK 8 -->
+    <profile>
+      <id>jdk8</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <fork>true</fork>
+              <compilerArgs combine.children="append">
+                <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${maven.compiler.release}/javac-${maven.compiler.release}.jar</arg>
+              </compilerArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <!-- Profile defining additional plugins to be executed for release -->
     <profile>
       <id>release</id>

--- a/pom.xml
+++ b/pom.xml
@@ -290,27 +290,6 @@
   </build>
 
   <profiles>
-    <!-- using github.com/google/error-prone-javac is required when running on JDK 8 -->
-    <profile>
-      <id>jdk8</id>
-      <activation>
-        <jdk>1.8</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <fork>true</fork>
-              <compilerArgs combine.children="append">
-                <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${maven.compiler.release}/javac-${maven.compiler.release}.jar</arg>
-              </compilerArgs>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
     <!-- Profile defining additional plugins to be executed for release -->
     <profile>
       <id>release</id>

--- a/pom.xml
+++ b/pom.xml
@@ -94,12 +94,31 @@
           <configuration>
             <showWarnings>true</showWarnings>
             <showDeprecation>true</showDeprecation>
-            <failOnWarning>true</failOnWarning>
+            <fork>true</fork>
             <compilerArgs>
+              <arg>-XDcompilePolicy=simple</arg>
+              <arg>-Xplugin:ErrorProne</arg>
+              <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+              <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+              <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+              <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+              <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+              <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+              <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+              <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+              <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+              <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
               <!-- Enable all warnings, except for ones which cause issues when building with newer JDKs, see also
                 https://docs.oracle.com/en/java/javase/11/tools/javac.html -->
               <compilerArg>-Xlint:all,-options</compilerArg>
             </compilerArgs>
+            <annotationProcessorPaths>
+              <path>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_core</artifactId>
+                <version>2.18.0</version>
+              </path>
+            </annotationProcessorPaths>
             <jdkToolchain>
               <version>[11,)</version>
             </jdkToolchain>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
             <showDeprecation>true</showDeprecation>
             <fork>true</fork>
             <compilerArgs>
+              <!-- Args related to Error Prone, see: https://github.com/google/error-prone/blob/f8e33bc460be82ab22256a7ef8b979d7a2cacaba/docs/installation.md -->
               <arg>-XDcompilePolicy=simple</arg>
               <arg>-Xplugin:ErrorProne</arg>
               <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>


### PR DESCRIPTION
First at all, I have set up the Error Prone in the `pom.xml`.  I had to remove the `<failOnWarning>true</failOnWarning>` otherwise the compiler would stop at every warning that Error Prone gives us.

After, I have add some ` @SuppressWarnings(...)` to avoid errors from Error Prone (that stop the compiler)