### PR TITLE
Fix the `equals` method of `JsonPrimitive` to work with `BigInteger`

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonPrimitive.java
+++ b/gson/src/main/java/com/google/gson/JsonPrimitive.java
@@ -282,7 +282,7 @@ public final class JsonPrimitive extends JsonElement {
       return other.value == null;
     }
     if (isIntegral(this) && isIntegral(other)) {
-      return getAsNumber().longValue() == other.getAsNumber().longValue();
+      return new BigInteger(getAsNumber().toString()).equals(new BigInteger(other.getAsNumber().toString()));
     }
     if (value instanceof Number && other.value instanceof Number) {
       double a = getAsNumber().doubleValue();

--- a/gson/src/main/java/com/google/gson/JsonPrimitive.java
+++ b/gson/src/main/java/com/google/gson/JsonPrimitive.java
@@ -180,8 +180,11 @@ public final class JsonPrimitive extends JsonElement {
    */
   @Override
   public BigInteger getAsBigInteger() {
-    return value instanceof BigInteger ?
-        (BigInteger) value : new BigInteger(getAsString());
+    return value instanceof BigInteger
+        ? (BigInteger) value
+        : isIntegral(this)
+            ? BigInteger.valueOf(this.getAsNumber().longValue())
+            : new BigInteger(this.getAsString());
   }
 
   /**
@@ -282,7 +285,9 @@ public final class JsonPrimitive extends JsonElement {
       return other.value == null;
     }
     if (isIntegral(this) && isIntegral(other)) {
-      return new BigInteger(getAsNumber().toString()).equals(new BigInteger(other.getAsNumber().toString()));
+      return this.value instanceof BigInteger || other.value instanceof BigInteger
+          ? this.getAsBigInteger().equals(other.getAsBigInteger())
+          : this.getAsNumber().longValue() == other.getAsNumber().longValue();
     }
     if (value instanceof Number && other.value instanceof Number) {
       double a = getAsNumber().doubleValue();

--- a/gson/src/test/java/com/google/gson/JsonPrimitiveTest.java
+++ b/gson/src/test/java/com/google/gson/JsonPrimitiveTest.java
@@ -300,10 +300,8 @@ public class JsonPrimitiveTest {
   @Test
   public void testEqualsIntegerAndBigInteger() {
     JsonPrimitive a = new JsonPrimitive(5L);
-    JsonPrimitive b = new JsonPrimitive(new BigInteger("18446744073709551621")); // 2^64 + 5
-    // Ideally, the following assertion should have failed but the price is too much to pay
-    // assertFalse(a + " equals " + b, a.equals(b));
-    assertWithMessage("%s equals %s", a, b).that(a.equals(b)).isTrue();
+    JsonPrimitive b = new JsonPrimitive(new BigInteger("18446744073709551621"));
+    assertWithMessage("%s not equals %s", a, b).that(a.equals(b)).isFalse();
   }
 
   @Test


### PR DESCRIPTION
This PR should fix the issue #2144.

The `getAsNumber().longValue()` caused an overflow because the `BigInteger` was converted to a `long`.

The idea here is: create a `BigInteger` (that's the biggest int we could rappresent) using the string value and then compare it.