### PR TITLE
Fix a couple of types in tests.

### DIFF
--- a/gson/src/test/java/com/google/gson/functional/MapTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MapTest.java
@@ -301,7 +301,7 @@ public class MapTest {
   public void testMapStandardSubclassDeserialization() {
     String json = "{a:'1',b:'2'}";
     Type type = new TypeToken<LinkedHashMap<String, String>>() {}.getType();
-    LinkedHashMap<String, Integer> map = gson.fromJson(json, type);
+    LinkedHashMap<String, String> map = gson.fromJson(json, type);
     assertThat(map).containsEntry("a", "1");
     assertThat(map).containsEntry("b", "2");
   }

--- a/gson/src/test/java/com/google/gson/functional/ParameterizedTypesTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ParameterizedTypesTest.java
@@ -161,7 +161,7 @@ public class ParameterizedTypesTest {
         .create();
 
     Reader json = new StringReader(expected.getExpectedJson());
-    MyParameterizedType<Integer> actual = gson.fromJson(json, expectedType);
+    MyParameterizedType<BagOfPrimitives> actual = gson.fromJson(json, expectedType);
     assertThat(actual).isEqualTo(expected);
   }
 


### PR DESCRIPTION
These show up with recent Error Prone analyses for Truth. Because the tests use the overload of `Gson.fromJson` that takes a `Type` argument, rather than the one with a `TypeToken`, the type mismatches were not detected by the compiler.