### PR TITLE
BoundField.write memory optimization

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -166,8 +166,8 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
       writeTypeAdapter = jsonAdapterPresent ? typeAdapter
           : new TypeAdapterRuntimeTypeWrapper<>(context, typeAdapter, fieldType.getType());
     } else {
-      // The field will never be serialized, skip the unnecessary type adapter construction
-      writeTypeAdapter = null;
+      // Will never actually be used, but we set it to avoid confusing nullness-analysis tools
+      writeTypeAdapter = typeAdapter;
     }
     return new BoundField(name, field, serialize, deserialize) {
       @Override void write(JsonWriter writer, Object source)

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -161,6 +161,14 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
 
     @SuppressWarnings("unchecked")
     final TypeAdapter<Object> typeAdapter = (TypeAdapter<Object>) mapped;
+    final TypeAdapter<Object> writeTypeAdapter;
+    if (serialize) {
+      writeTypeAdapter = jsonAdapterPresent ? typeAdapter
+          : new TypeAdapterRuntimeTypeWrapper<>(context, typeAdapter, fieldType.getType());
+    } else {
+      // The field will never be serialized, skip the unnecessary type adapter construction
+      writeTypeAdapter = null;
+    }
     return new BoundField(name, field, serialize, deserialize) {
       @Override void write(JsonWriter writer, Object source)
           throws IOException, IllegalAccessException {
@@ -191,9 +199,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
           return;
         }
         writer.name(name);
-        TypeAdapter<Object> t = jsonAdapterPresent ? typeAdapter
-            : new TypeAdapterRuntimeTypeWrapper<>(context, typeAdapter, fieldType.getType());
-        t.write(writer, fieldValue);
+        writeTypeAdapter.write(writer, fieldValue);
       }
 
       @Override


### PR DESCRIPTION
Declare and initialize the type adapter used for writing BoundFields outside of the anonymous class to ensure that a new TypeAdapterRuntimeTypeWrapper is not constructed each time a BoundField is written. This type adapter is only initialized if the BoundField will be used for serialization.

See #2321 for more details.

Closes #2321.