### PR TITLE
Enforce build using JDK >= 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,31 @@
   </dependencyManagement>
 
   <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.2.1</version>
+        <executions>
+          <!-- Enforce that correct JDK version is used to avoid cryptic build errors -->
+          <execution>
+            <id>enforce-jdk-version</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <!-- Other plugins of this build require at least JDK 11 -->
+                  <version>[11,)</version>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+
     <pluginManagement>
       <plugins>
         <plugin>
@@ -121,9 +146,6 @@
                 <version>2.18.0</version>
               </path>
             </annotationProcessorPaths>
-            <jdkToolchain>
-              <version>[11,)</version>
-            </jdkToolchain>
           </configuration>
         </plugin>
         <plugin>
@@ -131,9 +153,6 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.5.0</version>
           <configuration>
-            <jdkToolchain>
-              <version>[11,)</version>
-            </jdkToolchain>
             <!-- Specify newer JDK as target to allow linking to newer Java API, and to generate
               module overview in Javadoc for Gson's module descriptor -->
             <release>11</release>


### PR DESCRIPTION
<!--
    Thank you for your contribution!
    Please see the contributing guide: https://github.com/google/.github/blob/master/CONTRIBUTING.md

    Keep in mind that Gson is in maintenance mode. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.
-->

### Purpose
<!-- Describe the purpose of this pull request, for example which new feature it adds or which bug it fixes -->
<!-- If this pull request closes a GitHub issue, please write "Closes #<issue>", for example "Closes #123" -->

Follow-up for https://github.com/google/gson/pull/2324#discussion_r1117995561
Enforces that build uses JDK >= 11

### Description
<!-- If necessary provide more information, for example relevant implementation details or corner cases which are not covered yet -->
<!-- If there are related issues or pull requests, link to them by referencing their number, for example "pull request #123" -->

Building already requires JDK >= 11 (since PR #2324 that is also documented in the README), but previously using a lower JDK version such as JDK 8 would lead to cryptic build errors because some compiler flags are unsupported.
For example currently trying to build Gson with JDK 8 leads to the following error, without giving much information:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile (default-compile) on project gson:
Compilation failure
```

If you edited `pom.xml` to set `<fork>false</fork>` for the compiler plugin, you would at least get:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile (default-compile) on project gson:
Fatal error compiling: invalid flag: --release
```
But that is still not much better.

Using the Maven Enforcer Plugin makes sure that the build fails early with a somewhat better to understand error message:
```
Rule 0: org.apache.maven.enforcer.rules.version.RequireJavaVersion failed with message:
[ERROR] Detected JDK version 1.8.0-362 (JAVA_HOME=...\jdk8u362-b09\jre) is not in the allowed range [11,).
```
It is also possible to define a custom message, but I think the default message is fine, especially since it includes the `JAVA_HOME` directory and the detected Java version.

Maven's JDK toolchain support was unfortunately not very helpful in this regard because when the user has no `toolchains.xml` set up locally, or no JDK declared there matches, it seems to falls back to the `JAVA_HOME` JDK without checking the toolchain requirements against it, such as the minimum JDK version.
Or when using the Maven Toolchains Plugin, it seems to require that you have a `toolchains.xml` file locally, which most users probably don't have, and having to set it up increases the necessary effort to build Gson.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [ ] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
