### PR TITLE
Fail Maven build on warnings

### DIFF
--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -55,12 +55,6 @@
       <version>31.1-jre</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.errorprone</groupId>
-      <artifactId>error_prone_annotations</artifactId>
-      <version>2.18.0</version>
-      <optional>true</optional>
-    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
             <detectOfflineLinks>false</detectOfflineLinks>
             <!-- Only show warnings and errors -->
             <quiet>true</quiet>
-            <failOnWarning>true</failOnWarning>
+            <failOnWarnings>true</failOnWarnings>
           </configuration>
         </plugin>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,18 @@
     </dependencies>
   </dependencyManagement>
 
+  <dependencies>
+    <!-- Error Prone Annotations is only directly used by gson module, but since this is an optional
+      dependency and other modules depend on gson module they also need the dependency to avoid
+      compiler warnings, see comments on https://bugs.openjdk.org/browse/JDK-6331821 -->
+    <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+      <version>2.18.0</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
       <plugin>
@@ -120,6 +132,7 @@
           <configuration>
             <showWarnings>true</showWarnings>
             <showDeprecation>true</showDeprecation>
+            <failOnWarning>true</failOnWarning>
             <fork>true</fork>
             <compilerArgs>
               <!-- Args related to Error Prone, see: https://errorprone.info/docs/installation#maven -->
@@ -173,6 +186,7 @@
             <detectOfflineLinks>false</detectOfflineLinks>
             <!-- Only show warnings and errors -->
             <quiet>true</quiet>
+            <failOnWarning>true</failOnWarning>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
<!--
    Thank you for your contribution!
    Please see the contributing guide: https://github.com/google/.github/blob/master/CONTRIBUTING.md

    Keep in mind that Gson is in maintenance mode. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.
-->

### Purpose
<!-- Describe the purpose of this pull request, for example which new feature it adds or which bug it fixes -->
<!-- If this pull request closes a GitHub issue, please write "Closes #<issue>", for example "Closes #123" -->

Changes the `pom.xml` to fail when compilation and Javadoc warnings are reported, see also https://github.com/google/gson/pull/2320#issuecomment-1455142677.

### Description
<!-- If necessary provide more information, for example relevant implementation details or corner cases which are not covered yet -->
<!-- If there are related issues or pull requests, link to them by referencing their number, for example "pull request #123" -->

Also moved the optional Error Prone Annotations dependency to the parent `pom.xml` to avoid compiler warnings for the other modules depending on the `gson` module, see https://github.com/google/gson/pull/2320#issuecomment-1455233938.

If you want I can revert the change to also fail on warnings for Javadoc.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [ ] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
