### PR TITLE
Fix #2334

### DIFF
--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -1587,7 +1587,7 @@ public class JsonReader implements Closeable {
    * been read. This supports both unicode escapes "u000A" and two-character
    * escapes "\n".
    *
-   * @throws NumberFormatException if any unicode escape sequences are
+   * @throws MalformedJsonException if any unicode escape sequences are
    *     malformed.
    */
   @SuppressWarnings("fallthrough")
@@ -1614,7 +1614,7 @@ public class JsonReader implements Closeable {
         } else if (c >= 'A' && c <= 'F') {
           result += (c - 'A' + 10);
         } else {
-          throw new NumberFormatException("\\u" + new String(buffer, pos, 4));
+            throw new MalformedJsonException("\\u" + new String(buffer, pos, 4));
         }
       }
       pos += 4;

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -1614,7 +1614,7 @@ public class JsonReader implements Closeable {
         } else if (c >= 'A' && c <= 'F') {
           result += (c - 'A' + 10);
         } else {
-            throw new MalformedJsonException("\\u" + new String(buffer, pos, 4));
+          throw new MalformedJsonException("\\u" + new String(buffer, pos, 4));
         }
       }
       pos += 4;

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -355,7 +355,7 @@ public final class JsonReaderTest {
     try {
       reader.nextString();
       fail();
-    } catch (NumberFormatException expected) {
+    } catch (MalformedJsonException expected) {
     }
   }
 


### PR DESCRIPTION
### Purpose
Closes #2334 


### Description
This PR replaces the `NumberFormatException` with `MalformedJsonException` in the `JsonReader#readEscapeCharacter()` and also fixes the tests.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
