### PR TITLE
Improve documentation about default `JsonReader` and `JsonWriter` behavior

### DIFF
--- a/gson/src/main/java/com/google/gson/TypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/TypeAdapter.java
@@ -130,9 +130,10 @@ public abstract class TypeAdapter<T> {
 
   /**
    * Converts {@code value} to a JSON document and writes it to {@code out}.
-   * A {@link JsonWriter} with default configuration is used for writing the JSON
-   * data. To customize this behavior, create a {@link JsonWriter}, configure it
-   * and then use {@link #write(JsonWriter, Object)} instead.
+   *
+   * <p>A {@link JsonWriter} with default configuration is used for writing the
+   * JSON data. To customize this behavior, create a {@link JsonWriter}, configure
+   * it and then use {@link #write(JsonWriter, Object)} instead.
    *
    * @param value the Java object to convert. May be {@code null}.
    * @since 2.2
@@ -201,9 +202,10 @@ public abstract class TypeAdapter<T> {
 
   /**
    * Converts {@code value} to a JSON document.
-   * A {@link JsonWriter} with default configuration is used for writing the JSON
-   * data. To customize this behavior, create a {@link JsonWriter}, configure it
-   * and then use {@link #write(JsonWriter, Object)} instead.
+   *
+   * <p>A {@link JsonWriter} with default configuration is used for writing the
+   * JSON data. To customize this behavior, create a {@link JsonWriter}, configure
+   * it and then use {@link #write(JsonWriter, Object)} instead.
    *
    * @throws JsonIOException wrapping {@code IOException}s thrown by {@link #write(JsonWriter, Object)}
    * @param value the Java object to convert. May be {@code null}.
@@ -247,7 +249,8 @@ public abstract class TypeAdapter<T> {
 
   /**
    * Converts the JSON document in {@code in} to a Java object.
-   * A {@link JsonReader} with default configuration (that is with
+   *
+   * <p>A {@link JsonReader} with default configuration (that is with
    * {@link Strictness#LEGACY_STRICT} as strictness) is used for reading the JSON data.
    * To customize this behavior, create a {@link JsonReader}, configure it and then
    * use {@link #read(JsonReader)} instead.
@@ -265,7 +268,8 @@ public abstract class TypeAdapter<T> {
 
   /**
    * Converts the JSON document in {@code json} to a Java object.
-   * A {@link JsonReader} with default configuration (that is with
+   *
+   * <p>A {@link JsonReader} with default configuration (that is with
    * {@link Strictness#LEGACY_STRICT} as strictness) is used for reading the JSON data.
    * To customize this behavior, create a {@link JsonReader}, configure it and then
    * use {@link #read(JsonReader)} instead.

--- a/gson/src/main/java/com/google/gson/TypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/TypeAdapter.java
@@ -34,8 +34,7 @@ import java.io.Writer;
  * By default Gson converts application classes to JSON using its built-in type
  * adapters. If Gson's default JSON conversion isn't appropriate for a type,
  * extend this class to customize the conversion. Here's an example of a type
- * adapter for an (X,Y) coordinate point: <pre>   {@code
- *
+ * adapter for an (X,Y) coordinate point: <pre>{@code
  *   public class PointAdapter extends TypeAdapter<Point> {
  *     public Point read(JsonReader reader) throws IOException {
  *       if (reader.peek() == JsonToken.NULL) {
@@ -85,8 +84,7 @@ import java.io.Writer;
  * guarantees of {@link Gson} might not apply.
  *
  * <p>To use a custom type adapter with Gson, you must <i>register</i> it with a
- * {@link GsonBuilder}: <pre>   {@code
- *
+ * {@link GsonBuilder}: <pre>{@code
  *   GsonBuilder builder = new GsonBuilder();
  *   builder.registerTypeAdapter(Point.class, new PointAdapter());
  *   // if PointAdapter didn't check for nulls in its read/write methods, you should instead use
@@ -102,14 +100,12 @@ import java.io.Writer;
 // <h2>JSON Conversion</h2>
 // <p>A type adapter registered with Gson is automatically invoked while serializing
 // or deserializing JSON. However, you can also use type adapters directly to serialize
-// and deserialize JSON. Here is an example for deserialization: <pre>   {@code
-//
+// and deserialize JSON. Here is an example for deserialization: <pre>{@code
 //   String json = "{'origin':'0,0','points':['1,2','3,4']}";
 //   TypeAdapter<Graph> graphAdapter = gson.getAdapter(Graph.class);
 //   Graph graph = graphAdapter.fromJson(json);
 // }</pre>
-// And an example for serialization: <pre>   {@code
-//
+// And an example for serialization: <pre>{@code
 //   Graph graph = new Graph(...);
 //   TypeAdapter<Graph> graphAdapter = gson.getAdapter(Graph.class);
 //   String json = graphAdapter.toJson(graph);
@@ -134,12 +130,12 @@ public abstract class TypeAdapter<T> {
 
   /**
    * Converts {@code value} to a JSON document and writes it to {@code out}.
-   * Unlike Gson's similar {@link Gson#toJson(JsonElement, Appendable) toJson}
-   * method, this write is strict. Create a {@link
-   * JsonWriter#setLenient(boolean) lenient} {@code JsonWriter} and call
-   * {@link #write(JsonWriter, Object)} for lenient writing.
+   * Unlike {@code Gson}'s similar {@link Gson#toJson(Object, Appendable) toJson}
+   * method, this write is strict, does not escape HTML characters and
+   * serializes {@code null}. To customize this behavior, create a {@link JsonWriter},
+   * configure it and then call {@link #write(JsonWriter, Object)} instead.
    *
-   * @param value the Java object to convert. May be null.
+   * @param value the Java object to convert. May be {@code null}.
    * @since 2.2
    */
   public final void toJson(Writer out, T value) throws IOException {
@@ -151,8 +147,7 @@ public abstract class TypeAdapter<T> {
    * This wrapper method is used to make a type adapter null tolerant. In general, a
    * type adapter is required to handle nulls in write and read methods. Here is how this
    * is typically done:<br>
-   * <pre>   {@code
-   *
+   * <pre>{@code
    * Gson gson = new GsonBuilder().registerTypeAdapter(Foo.class,
    *   new TypeAdapter<Foo>() {
    *     public Foo read(JsonReader in) throws IOException {
@@ -173,8 +168,7 @@ public abstract class TypeAdapter<T> {
    * }</pre>
    * You can avoid this boilerplate handling of nulls by wrapping your type adapter with
    * this method. Here is how we will rewrite the above example:
-   * <pre>   {@code
-   *
+   * <pre>{@code
    * Gson gson = new GsonBuilder().registerTypeAdapter(Foo.class,
    *   new TypeAdapter<Foo>() {
    *     public Foo read(JsonReader in) throws IOException {
@@ -207,13 +201,14 @@ public abstract class TypeAdapter<T> {
   }
 
   /**
-   * Converts {@code value} to a JSON document. Unlike Gson's similar {@link
-   * Gson#toJson(Object) toJson} method, this write is strict. Create a {@link
-   * JsonWriter#setLenient(boolean) lenient} {@code JsonWriter} and call
-   * {@link #write(JsonWriter, Object)} for lenient writing.
+   * Converts {@code value} to a JSON document.
+   * Unlike {@code Gson}'s similar {@link Gson#toJson(Object) toJson}
+   * method, this write is strict, does not escape HTML characters and
+   * serializes {@code null}. To customize this behavior, create a {@link JsonWriter},
+   * configure it and then call {@link #write(JsonWriter, Object)} instead.
    *
    * @throws JsonIOException wrapping {@code IOException}s thrown by {@link #write(JsonWriter, Object)}
-   * @param value the Java object to convert. May be null.
+   * @param value the Java object to convert. May be {@code null}.
    * @since 2.2
    */
   public final String toJson(T value) {
@@ -229,7 +224,7 @@ public abstract class TypeAdapter<T> {
   /**
    * Converts {@code value} to a JSON tree.
    *
-   * @param value the Java object to convert. May be null.
+   * @param value the Java object to convert. May be {@code null}.
    * @return the converted JSON tree. May be {@link JsonNull}.
    * @throws JsonIOException wrapping {@code IOException}s thrown by {@link #write(JsonWriter, Object)}
    * @since 2.2
@@ -248,20 +243,20 @@ public abstract class TypeAdapter<T> {
    * Reads one JSON value (an array, object, string, number, boolean or null)
    * and converts it to a Java object. Returns the converted object.
    *
-   * @return the converted Java object. May be null.
+   * @return the converted Java object. May be {@code null}.
    */
   public abstract T read(JsonReader in) throws IOException;
 
   /**
-   * Converts the JSON document in {@code in} to a Java object. Unlike Gson's
+   * Converts the JSON document in {@code in} to a Java object. Unlike {@code Gson}'s
    * similar {@link Gson#fromJson(Reader, Class) fromJson} method, this
-   * read is strict. Create a {@link JsonReader#setLenient(boolean) lenient}
-   * {@code JsonReader} and call {@link #read(JsonReader)} for lenient reading.
+   * read is strict. For lenient reading create a {@link JsonReader#setLenient(boolean) lenient}
+   * {@code JsonReader} and call {@link #read(JsonReader)}.
    *
    * <p>No exception is thrown if the JSON data has multiple top-level JSON elements,
    * or if there is trailing data.
    *
-   * @return the converted Java object. May be null.
+   * @return the converted Java object. May be {@code null}.
    * @since 2.2
    */
   public final T fromJson(Reader in) throws IOException {
@@ -270,15 +265,15 @@ public abstract class TypeAdapter<T> {
   }
 
   /**
-   * Converts the JSON document in {@code json} to a Java object. Unlike Gson's
+   * Converts the JSON document in {@code json} to a Java object. Unlike {@code Gson}'s
    * similar {@link Gson#fromJson(String, Class) fromJson} method, this read is
-   * strict. Create a {@link JsonReader#setLenient(boolean) lenient} {@code
-   * JsonReader} and call {@link #read(JsonReader)} for lenient reading.
+   * strict. For lenient reading create a {@link JsonReader#setLenient(boolean) lenient}
+   * {@code JsonReader} and call {@link #read(JsonReader)}.
    *
    * <p>No exception is thrown if the JSON data has multiple top-level JSON elements,
    * or if there is trailing data.
    *
-   * @return the converted Java object. May be null.
+   * @return the converted Java object. May be {@code null}.
    * @since 2.2
    */
   public final T fromJson(String json) throws IOException {
@@ -289,7 +284,7 @@ public abstract class TypeAdapter<T> {
    * Converts {@code jsonTree} to a Java object.
    *
    * @param jsonTree the JSON element to convert. May be {@link JsonNull}.
-   * @return the converted Java object. May be null.
+   * @return the converted Java object. May be {@code null}.
    * @throws JsonIOException wrapping {@code IOException}s thrown by {@link #read(JsonReader)}
    * @since 2.2
    */

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -16,6 +16,8 @@
 
 package com.google.gson.stream;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.Strictness;
 import com.google.gson.internal.JsonReaderInternalAccess;
 import com.google.gson.internal.TroubleshootingGuide;
@@ -63,6 +65,16 @@ import java.util.Objects;
  * <p>If a value may be null, you should first check using {@link #peek()}.
  * Null literals can be consumed using either {@link #nextNull()} or {@link
  * #skipValue()}.
+ *
+ * <h2>Configuration</h2>
+ * The behavior of this reader can be customized with the following methods:
+ * <ul>
+ *   <li>{@link #setStrictness(Strictness)}, the default is {@link Strictness#LEGACY_STRICT}
+ * </ul>
+ *
+ * The default configuration of {@code JsonReader} instances used internally by
+ * the {@link Gson} class differs, and can be adjusted with the various
+ * {@link GsonBuilder} methods.
  *
  * <h2>Example</h2>
  * Suppose we'd like to parse a stream of messages such as the following: <pre> {@code

--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -379,7 +379,7 @@ public class JsonWriter implements Closeable, Flushable {
    * given bracket.
    */
   private JsonWriter close(int empty, int nonempty, char closeBracket)
-          throws IOException {
+      throws IOException {
     int context = peek();
     if (context != nonempty && context != empty) {
       throw new IllegalStateException("Nesting problem.");
@@ -590,7 +590,7 @@ public class JsonWriter implements Closeable, Flushable {
     // Note: Don't consider LazilyParsedNumber trusted because it could contain
     // an arbitrary malformed string
     return c == Integer.class || c == Long.class || c == Double.class || c == Float.class || c == Byte.class || c == Short.class
-            || c == BigDecimal.class || c == BigInteger.class || c == AtomicInteger.class || c == AtomicLong.class;
+        || c == BigDecimal.class || c == BigInteger.class || c == AtomicInteger.class || c == AtomicLong.class;
   }
 
   /**
@@ -720,33 +720,33 @@ public class JsonWriter implements Closeable, Flushable {
   @SuppressWarnings("fallthrough")
   private void beforeValue() throws IOException {
     switch (peek()) {
-      case NONEMPTY_DOCUMENT:
-        if (!lenient) {
-          throw new IllegalStateException(
-                  "JSON must have only one top-level value.");
-        }
-        // fall-through
-      case EMPTY_DOCUMENT: // first in document
-        replaceTop(NONEMPTY_DOCUMENT);
-        break;
+    case NONEMPTY_DOCUMENT:
+      if (!lenient) {
+        throw new IllegalStateException(
+            "JSON must have only one top-level value.");
+      }
+      // fall-through
+    case EMPTY_DOCUMENT: // first in document
+      replaceTop(NONEMPTY_DOCUMENT);
+      break;
 
-      case EMPTY_ARRAY: // first in array
-        replaceTop(NONEMPTY_ARRAY);
-        newline();
-        break;
+    case EMPTY_ARRAY: // first in array
+      replaceTop(NONEMPTY_ARRAY);
+      newline();
+      break;
 
-      case NONEMPTY_ARRAY: // another in array
-        out.append(',');
-        newline();
-        break;
+    case NONEMPTY_ARRAY: // another in array
+      out.append(',');
+      newline();
+      break;
 
-      case DANGLING_NAME: // value for name
-        out.append(separator);
-        replaceTop(NONEMPTY_OBJECT);
-        break;
+    case DANGLING_NAME: // value for name
+      out.append(separator);
+      replaceTop(NONEMPTY_OBJECT);
+      break;
 
-      default:
-        throw new IllegalStateException("Nesting problem.");
+    default:
+      throw new IllegalStateException("Nesting problem.");
     }
   }
 }

--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -26,6 +26,8 @@ import static com.google.gson.stream.JsonScope.NONEMPTY_OBJECT;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.gson.FormattingStyle;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.Strictness;
 import java.io.Closeable;
 import java.io.Flushable;
@@ -64,14 +66,16 @@ import java.util.regex.Pattern;
  * <h2>Configuration</h2>
  * The behavior of this writer can be customized with the following methods:
  * <ul>
- *   <li>{@link #setFormattingStyle(FormattingStyle)}, by default a compact
- *       formatting style is used which does not write any whitespace
+ *   <li>{@link #setFormattingStyle(FormattingStyle)}, the default is {@link FormattingStyle#COMPACT}
  *   <li>{@link #setHtmlSafe(boolean)}, by default HTML characters are not escaped
  *       in the JSON output
- *   <li>{@link #setStrictness(Strictness)}, the default strictness is
- *       {@link Strictness#LEGACY_STRICT}
+ *   <li>{@link #setStrictness(Strictness)}, the default is {@link Strictness#LEGACY_STRICT}
  *   <li>{@link #setSerializeNulls(boolean)}, by default {@code null} is serialized
  * </ul>
+ *
+ * The default configuration of {@code JsonWriter} instances used internally by
+ * the {@link Gson} class differs, and can be adjusted with the various
+ * {@link GsonBuilder} methods.
  *
  * <h2>Example</h2>
  * Suppose we'd like to encode a stream of messages such as the following: <pre> {@code


### PR DESCRIPTION
<!--
    Thank you for your contribution!
    Please see the contributing guide: https://github.com/google/.github/blob/master/CONTRIBUTING.md

    Keep in mind that Gson is in maintenance mode. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.
-->

### Purpose
<!-- Describe the purpose of this pull request, for example which new feature it adds or which bug it fixes -->
<!-- If this pull request closes a GitHub issue, please write "Closes #<issue>", for example "Closes #123" -->
Tries to improve the documentation about default `JsonReader` and `JsonWriter` behavior, and related `TypeAdapter` methods

### Description
<!-- If necessary provide more information, for example relevant implementation details or corner cases which are not covered yet -->
<!-- If there are related issues or pull requests, link to them by referencing their number, for example "pull request #123" -->

The current default behavior was not explicitly mentioned; also for the `TypeAdapter` methods it was not clear that their behavior differs from the default `Gson` behavior, see also #1133.

Also removes some empty lines at the start of `<pre>` blocks in the documentation (they also appeared in the rendered HTML).

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [ ] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
