### PR TITLE
Make dependency on Error Prone Annotations non-optional

### DIFF
--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -38,6 +38,17 @@
   </properties>
 
   <dependencies>
+    <!-- This dependency can be considered optional; omitting it during runtime will most likely
+      not cause any issues. However, it is not declared with `<optional>true</optional>` because
+      that can lead to cryptic compiler warnings for consumers, and to be on the safe side in case
+      there are actually issues which could occur when the dependency is missing at runtime.
+      See also discussion at https://github.com/google/gson/pull/2320#issuecomment-1455233938 -->
+    <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+      <version>2.18.0</version>
+    </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -85,18 +85,6 @@
     </dependencies>
   </dependencyManagement>
 
-  <dependencies>
-    <!-- Error Prone Annotations is only directly used by gson module, but since this is an optional
-      dependency and other modules depend on gson module they also need the dependency to avoid
-      compiler warnings, see also comments on https://bugs.openjdk.org/browse/JDK-6365854 -->
-    <dependency>
-      <groupId>com.google.errorprone</groupId>
-      <artifactId>error_prone_annotations</artifactId>
-      <version>2.18.0</version>
-      <optional>true</optional>
-    </dependency>
-  </dependencies>
-
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
<!--
    Thank you for your contribution!
    Please see the contributing guide: https://github.com/google/.github/blob/master/CONTRIBUTING.md

    Keep in mind that Gson is in maintenance mode. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.
-->

### Purpose
<!-- Describe the purpose of this pull request, for example which new feature it adds or which bug it fixes -->
<!-- If this pull request closes a GitHub issue, please write "Closes #<issue>", for example "Closes #123" -->
Avoid problems for users which could occur due to dependency being optional

### Description
<!-- If necessary provide more information, for example relevant implementation details or corner cases which are not covered yet -->
<!-- If there are related issues or pull requests, link to them by referencing their number, for example "pull request #123" -->

See discussion starting at https://github.com/google/gson/pull/2320#issuecomment-1455233938
Making the dependency non-optional seems to be safer and avoids confusing warnings for users.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [ ] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
