### PR TITLE
Fix incorrect inherited URLs in `pom.xml`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,8 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"
+    child.project.url.inherit.append.path="false">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.google.code.gson</groupId>
@@ -39,7 +40,9 @@
     <maven.compiler.testRelease>11</maven.compiler.testRelease>
   </properties>
 
-  <scm>
+  <!-- These attributes specify that the URLs should be inherited by the modules as is, to avoid constructing
+    invalid URLs, see also https://maven.apache.org/ref/3.9.1/maven-model-builder/index.html#inheritance-assembly -->
+  <scm child.scm.url.inherit.append.path="false" child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false">
     <url>https://github.com/google/gson/</url>
     <connection>scm:git:https://github.com/google/gson.git</connection>
     <developerConnection>scm:git:git@github.com:google/gson.git</developerConnection>


### PR DESCRIPTION
<!--
    Thank you for your contribution!
    Please see the contributing guide: https://github.com/google/.github/blob/master/CONTRIBUTING.md

    Keep in mind that Gson is in maintenance mode. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.
-->

### Purpose
Fixes incorrect inherited URLs in the `pom.xml`, mainly in the one of the `gson` Maven module

### Description
Previously Maven appended the artifact ID of the modules which lead for example for the `gson` module to the incorrect URL https://github.com/google/gson/gson (note the extra `/gson` at the end). This could be seen for example with `mvn help:effective-pom`:
```xml
...
 <url>https://github.com/google/gson/gson</url>
...
  <scm>
    <connection>scm:git:https://github.com/google/gson.git/gson</connection>
    <developerConnection>scm:git:git@github.com:google/gson.git/gson</developerConnection>
    <url>https://github.com/google/gson/gson/</url>
  </scm>
...
```
Other situations where this might have been visible are when using plugins to generate a summary of dependencies of a project and probably also the [Sonatype Maven Central browser](https://central.sonatype.com/artifact/com.google.code.gson/gson/2.10.1) (see "Project URL" on the right).

This pull request uses the attributes described [here](https://maven.apache.org/ref/3.9.1/maven-model-builder/index.html#inheritance-assembly) to disable appending the artifact ID of the modules. With these changes the output of `mvn help:effective-pom` looks correct:
```xml
...
  <url>https://github.com/google/gson</url>
...
  <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
    <connection>scm:git:https://github.com/google/gson.git</connection>
    <developerConnection>scm:git:git@github.com:google/gson.git</developerConnection>
    <url>https://github.com/google/gson/</url>
  </scm>
...
```

See also the related Guava issue: https://github.com/google/guava/issues/5618

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [ ] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
