### PR TITLE
Remove "Related Content Created by Third Parties" from `README.md`. Fixes #2350.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,6 @@ see [`GsonBuilder.disableJdkUnsafe()`](https://javadoc.io/doc/com.google.code.gs
 
 Please use the ['gson' tag on StackOverflow](https://stackoverflow.com/questions/tagged/gson) or the [google-gson Google group](https://groups.google.com/group/google-gson) to discuss Gson or to post questions.
 
-### Related Content Created by Third Parties
-  * [Gson Tutorial](https://www.studytrails.com/java/json/java-google-json-introduction/) by `StudyTrails`
-  * [Gson Tutorial Series](https://futurestud.io/tutorials/gson-getting-started-with-java-json-serialization-deserialization) by `Future Studio`
-  * [Gson API Report](https://abi-laboratory.pro/java/tracker/timeline/gson/)
-
 ### Building
 
 Gson uses Maven to build the project:


### PR DESCRIPTION
Removed the section "Related Content Created by Third Parties"

### Purpose
The content linked in the "Related Content Created by Third Parties" section of the README is outdated and is causing issues:

- The StudyTrails website seems to have again (https://github.com/google/gson/issues/1843) an outdated TLS certificate
- The "Gson API Report" only goes up to Gson version 2.8.6