### PR TITLE
Improve creation of `ParameterizedType`

### DIFF
--- a/gson/src/main/java/com/google/gson/reflect/TypeToken.java
+++ b/gson/src/main/java/com/google/gson/reflect/TypeToken.java
@@ -97,8 +97,8 @@ public class TypeToken<T> {
     }
     // Check for raw TypeToken as superclass
     else if (superclass == TypeToken.class) {
-      throw new IllegalStateException("TypeToken must be created with a type argument: new TypeToken<...>() {}; "
-          + "When using code shrinkers (ProGuard, R8, ...) make sure that generic signatures are preserved.");
+      throw new IllegalStateException("TypeToken must be created with a type argument: new TypeToken<...>() {};"
+          + " When using code shrinkers (ProGuard, R8, ...) make sure that generic signatures are preserved.");
     }
 
     // User created subclass of subclass of TypeToken
@@ -335,8 +335,8 @@ public class TypeToken<T> {
    * and care must be taken to pass in the correct number of type arguments.
    *
    * @throws IllegalArgumentException
-   *   If {@code rawType} is not of type {@code Class}, or if the type arguments are invalid for
-   *   the raw type
+   *   If {@code rawType} is not of type {@code Class}, if it is not a generic type, or if the
+   *   type arguments are invalid for the raw type
    */
   public static TypeToken<?> getParameterized(Type rawType, Type... typeArguments) {
     Objects.requireNonNull(rawType);
@@ -351,6 +351,18 @@ public class TypeToken<T> {
     Class<?> rawClass = (Class<?>) rawType;
     TypeVariable<?>[] typeVariables = rawClass.getTypeParameters();
 
+    // Note: Does not check if owner type of rawType is generic because this factory method
+    // does not support specifying owner type
+    if (typeVariables.length == 0) {
+      throw new IllegalArgumentException(rawClass.getName() + " is not a generic type");
+    }
+
+    // Check for this here to avoid misleading exception thrown by ParameterizedTypeImpl
+    if ($Gson$Types.requiresOwnerType(rawType)) {
+      throw new IllegalArgumentException("Raw type " + rawClass.getName() + " is not supported because"
+          + " it requires specifying an owner type");
+    }
+
     int expectedArgsCount = typeVariables.length;
     int actualArgsCount = typeArguments.length;
     if (actualArgsCount != expectedArgsCount) {
@@ -359,7 +371,7 @@ public class TypeToken<T> {
     }
 
     for (int i = 0; i < expectedArgsCount; i++) {
-      Type typeArgument = typeArguments[i];
+      Type typeArgument = Objects.requireNonNull(typeArguments[i], "Type argument must not be null");
       Class<?> rawTypeArgument = $Gson$Types.getRawType(typeArgument);
       TypeVariable<?> typeVariable = typeVariables[i];
 
@@ -367,8 +379,8 @@ public class TypeToken<T> {
         Class<?> rawBound = $Gson$Types.getRawType(bound);
 
         if (!rawBound.isAssignableFrom(rawTypeArgument)) {
-          throw new IllegalArgumentException("Type argument " + typeArgument + " does not satisfy bounds "
-              + "for type variable " + typeVariable + " declared by " + rawType);
+          throw new IllegalArgumentException("Type argument " + typeArgument + " does not satisfy bounds"
+              + " for type variable " + typeVariable + " declared by " + rawType);
         }
       }
     }

--- a/gson/src/test/java/com/google/gson/reflect/TypeTokenTest.java
+++ b/gson/src/test/java/com/google/gson/reflect/TypeTokenTest.java
@@ -17,9 +17,10 @@
 package com.google.gson.reflect;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
@@ -103,11 +104,13 @@ public final class TypeTokenTest {
     Type listOfString = new TypeToken<List<String>>() {}.getType();
     assertThat(TypeToken.getArray(listOfString)).isEqualTo(expectedListOfStringArray);
 
-    try {
-      TypeToken.getArray(null);
-      fail();
-    } catch (NullPointerException e) {
-    }
+    TypeToken<?> expectedIntArray = new TypeToken<int[]>() {};
+    assertThat(TypeToken.getArray(int.class)).isEqualTo(expectedIntArray);
+
+    assertThrows(NullPointerException.class, () -> TypeToken.getArray(null));
+  }
+
+  static class NestedGeneric<T> {
   }
 
   @Test
@@ -131,84 +134,70 @@ public final class TypeTokenTest {
 
     TypeToken<?> expectedSatisfyingTwoBounds = new TypeToken<GenericWithMultiBound<ClassSatisfyingBounds>>() {};
     assertThat(TypeToken.getParameterized(GenericWithMultiBound.class, ClassSatisfyingBounds.class)).isEqualTo(expectedSatisfyingTwoBounds);
+
+    TypeToken<?> nestedTypeToken = TypeToken.getParameterized(NestedGeneric.class, Integer.class);
+    ParameterizedType nestedParameterizedType = (ParameterizedType) nestedTypeToken.getType();
+    // TODO: This seems to differ from how Java reflection behaves; when using TypeToken<NestedGeneric<Integer>>,
+    // then NestedGeneric<Integer> does have an owner type
+    assertThat(nestedParameterizedType.getOwnerType()).isNull();
+    assertThat(nestedParameterizedType.getRawType()).isEqualTo(NestedGeneric.class);
+    assertThat(nestedParameterizedType.getActualTypeArguments()).asList().containsExactly(Integer.class);
+
+    class LocalGenericClass<T> {}
+    TypeToken<?> expectedLocalType = new TypeToken<LocalGenericClass<Integer>>() {};
+    assertThat(TypeToken.getParameterized(LocalGenericClass.class, Integer.class)).isEqualTo(expectedLocalType);
   }
 
   @Test
   public void testParameterizedFactory_Invalid() {
-    try {
-      TypeToken.getParameterized(null, new Type[0]);
-      fail();
-    } catch (NullPointerException e) {
-    }
+    assertThrows(NullPointerException.class, () -> TypeToken.getParameterized(null, new Type[0]));
+    assertThrows(NullPointerException.class, () -> TypeToken.getParameterized(List.class, new Type[] { null }));
 
     GenericArrayType arrayType = (GenericArrayType) TypeToken.getArray(String.class).getType();
-    try {
-      TypeToken.getParameterized(arrayType, new Type[0]);
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessageThat().isEqualTo("rawType must be of type Class, but was java.lang.String[]");
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> TypeToken.getParameterized(arrayType, new Type[0]));
+    assertThat(e).hasMessageThat().isEqualTo("rawType must be of type Class, but was java.lang.String[]");
+
+    e = assertThrows(IllegalArgumentException.class, () -> TypeToken.getParameterized(String.class, Number.class));
+    assertThat(e).hasMessageThat().isEqualTo("java.lang.String is not a generic type");
+
+    e = assertThrows(IllegalArgumentException.class, () -> TypeToken.getParameterized(List.class, new Type[0]));
+    assertThat(e).hasMessageThat().isEqualTo("java.util.List requires 1 type arguments, but got 0");
+
+    e = assertThrows(IllegalArgumentException.class, () -> TypeToken.getParameterized(List.class, String.class, String.class));
+    assertThat(e).hasMessageThat().isEqualTo("java.util.List requires 1 type arguments, but got 2");
+
+    // Primitive types must not be used as type argument
+    e = assertThrows(IllegalArgumentException.class, () -> TypeToken.getParameterized(List.class, int.class));
+    assertThat(e).hasMessageThat().isEqualTo("Type argument int does not satisfy bounds"
+        + " for type variable E declared by " + List.class);
+
+    e = assertThrows(IllegalArgumentException.class, () -> TypeToken.getParameterized(GenericWithBound.class, String.class));
+    assertThat(e).hasMessageThat().isEqualTo("Type argument class java.lang.String does not satisfy bounds"
+        + " for type variable T declared by " + GenericWithBound.class);
+
+    e = assertThrows(IllegalArgumentException.class, () -> TypeToken.getParameterized(GenericWithBound.class, Object.class));
+    assertThat(e).hasMessageThat().isEqualTo("Type argument class java.lang.Object does not satisfy bounds"
+        + " for type variable T declared by " + GenericWithBound.class);
+
+    e = assertThrows(IllegalArgumentException.class, () -> TypeToken.getParameterized(GenericWithMultiBound.class, Number.class));
+    assertThat(e).hasMessageThat().isEqualTo("Type argument class java.lang.Number does not satisfy bounds"
+        + " for type variable T declared by " + GenericWithMultiBound.class);
+
+    e = assertThrows(IllegalArgumentException.class, () -> TypeToken.getParameterized(GenericWithMultiBound.class, CharSequence.class));
+    assertThat(e).hasMessageThat().isEqualTo("Type argument interface java.lang.CharSequence does not satisfy bounds"
+        + " for type variable T declared by " + GenericWithMultiBound.class);
+
+    e = assertThrows(IllegalArgumentException.class, () -> TypeToken.getParameterized(GenericWithMultiBound.class, Object.class));
+    assertThat(e).hasMessageThat().isEqualTo("Type argument class java.lang.Object does not satisfy bounds"
+        + " for type variable T declared by " + GenericWithMultiBound.class);
+
+    class Outer {
+      class NonStaticInner<T> {}
     }
 
-    try {
-      TypeToken.getParameterized(String.class, String.class);
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessageThat().isEqualTo("java.lang.String requires 0 type arguments, but got 1");
-    }
-
-    try {
-      TypeToken.getParameterized(List.class, new Type[0]);
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessageThat().isEqualTo("java.util.List requires 1 type arguments, but got 0");
-    }
-
-    try {
-      TypeToken.getParameterized(List.class, String.class, String.class);
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessageThat().isEqualTo("java.util.List requires 1 type arguments, but got 2");
-    }
-
-    try {
-      TypeToken.getParameterized(GenericWithBound.class, String.class);
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessageThat().isEqualTo("Type argument class java.lang.String does not satisfy bounds "
-          + "for type variable T declared by " + GenericWithBound.class);
-    }
-
-    try {
-      TypeToken.getParameterized(GenericWithBound.class, Object.class);
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessageThat().isEqualTo("Type argument class java.lang.Object does not satisfy bounds "
-          + "for type variable T declared by " + GenericWithBound.class);
-    }
-
-    try {
-      TypeToken.getParameterized(GenericWithMultiBound.class, Number.class);
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessageThat().isEqualTo("Type argument class java.lang.Number does not satisfy bounds "
-          + "for type variable T declared by " + GenericWithMultiBound.class);
-    }
-
-    try {
-      TypeToken.getParameterized(GenericWithMultiBound.class, CharSequence.class);
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessageThat().isEqualTo("Type argument interface java.lang.CharSequence does not satisfy bounds "
-          + "for type variable T declared by " + GenericWithMultiBound.class);
-    }
-
-    try {
-      TypeToken.getParameterized(GenericWithMultiBound.class, Object.class);
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessageThat().isEqualTo("Type argument class java.lang.Object does not satisfy bounds "
-          + "for type variable T declared by " + GenericWithMultiBound.class);
-    }
+    e = assertThrows(IllegalArgumentException.class, () -> TypeToken.getParameterized(Outer.NonStaticInner.class, Object.class));
+    assertThat(e).hasMessageThat().isEqualTo("Raw type " + Outer.NonStaticInner.class.getName()
+        + " is not supported because it requires specifying an owner type");
   }
 
   private static class CustomTypeToken extends TypeToken<String> {
@@ -231,38 +220,22 @@ public final class TypeTokenTest {
     class SubSubTypeToken1<T> extends SubTypeToken<T> {}
     class SubSubTypeToken2 extends SubTypeToken<Integer> {}
 
-    try {
-      new SubTypeToken<Integer>() {};
-      fail();
-    } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Must only create direct subclasses of TypeToken");
-    }
+    IllegalStateException e = assertThrows(IllegalStateException.class, () -> new SubTypeToken<Integer>() {});
+    assertThat(e).hasMessageThat().isEqualTo("Must only create direct subclasses of TypeToken");
 
-    try {
-      new SubSubTypeToken1<Integer>();
-      fail();
-    } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Must only create direct subclasses of TypeToken");
-    }
+    e = assertThrows(IllegalStateException.class, () -> new SubSubTypeToken1<Integer>());
+    assertThat(e).hasMessageThat().isEqualTo("Must only create direct subclasses of TypeToken");
 
-    try {
-      new SubSubTypeToken2();
-      fail();
-    } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Must only create direct subclasses of TypeToken");
-    }
+    e = assertThrows(IllegalStateException.class, () -> new SubSubTypeToken2());
+    assertThat(e).hasMessageThat().isEqualTo("Must only create direct subclasses of TypeToken");
   }
 
   @SuppressWarnings("rawtypes")
   @Test
   public void testTypeTokenRaw() {
-    try {
-      new TypeToken() {};
-      fail();
-    } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("TypeToken must be created with a type argument: new TypeToken<...>() {}; "
-          + "When using code shrinkers (ProGuard, R8, ...) make sure that generic signatures are preserved.");
-    }
+    IllegalStateException e = assertThrows(IllegalStateException.class, () -> new TypeToken() {});
+    assertThat(e).hasMessageThat().isEqualTo("TypeToken must be created with a type argument: new TypeToken<...>() {};"
+        + " When using code shrinkers (ProGuard, R8, ...) make sure that generic signatures are preserved.");
   }
 }
 


### PR DESCRIPTION
<!--
    Thank you for your contribution!
    Please see the contributing guide: https://github.com/google/.github/blob/master/CONTRIBUTING.md

    Keep in mind that Gson is in maintenance mode. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.
-->

### Purpose
Improve creation and validation of `ParameterizedType`

### Description
- Reject non-generic raw types for `TypeToken.getParameterized`
- Fix `ParameterizedTypeImpl` erroneously requiring owner type for types without owner (mainly / only local classes?)
- Extend tests and use `assertThrows`

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)
- [x] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [x] If necessary, new unit tests have been added  
  - [x] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [x] No JUnit 3 features are used (such as extending class `TestCase`)
  - [x] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
