### PR TITLE
Enable Error Prone HidingField bug pattern again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,6 @@
               <arg>-XDcompilePolicy=simple</arg>
               <arg>-Xplugin:ErrorProne
                 -XepExcludedPaths:.*/generated-test-sources/protobuf/.*
-                -Xep:HidingField:OFF <!-- https://github.com/google/error-prone/issues/3895 -->
                 -Xep:NotJavadoc:OFF <!-- Triggered by local class. -->
               </arg>
               <!-- Enable all warnings, except for ones which cause issues when building with newer JDKs, see also


### PR DESCRIPTION
Bug which required disabling this bug pattern was fixed in 2.19.1 and Error Prone dependency was updated to that version in commit 3c4b0721005dbc5e0d7515b95a321715d48b3291.

See also pull request #2387 which disabled this bug pattern initially.