### PR TITLE
Updated dependency

### DIFF
--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>jsr250-api</artifactId>
-      <version>1.0</version>
+      <version>1.0-20050927.133100</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Solves issue #2310 as the issue occurs because the jsr250-api dependency is not compatible with the version of Java that we are using. The 1.0 version of the dependency is only compatible with Java 5 and earlier. The 1.0-20050927.133100 version of the dependency is compatible with Java 6 and later.