### PR TITLE
Strictness follow-up

### DIFF
--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -127,7 +127,7 @@ For example, let's assume you want to deserialize the following JSON data:
 }
 ```
 
-This will fail with an exception similar to this one: `MalformedJsonException: Use JsonReader.setLenient(true) to accept malformed JSON at line 5 column 4 path $.languages[2]`  
+This will fail with an exception similar to this one: `MalformedJsonException: Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON at line 5 column 4 path $.languages[2]`  
 The problem here is the trailing comma (`,`) after `"French"`, trailing commas are not allowed by the JSON specification. The location information "line 5 column 4" points to the `]` in the JSON data (with some slight inaccuracies) because Gson expected another value after `,` instead of the closing `]`. The JSONPath `$.languages[2]` in the exception message also points there: `$.` refers to the root object, `languages` refers to its member of that name and `[2]` refers to the (missing) third value in the JSON array value of that member (numbering starts at 0, so it is `[2]` instead of `[3]`).  
 The proper solution here is to fix the malformed JSON data.
 

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -29,6 +29,7 @@ import static com.google.gson.Gson.DEFAULT_STRICTNESS;
 import static com.google.gson.Gson.DEFAULT_USE_JDK_UNSAFE;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.InlineMe;
 import com.google.gson.annotations.Since;
 import com.google.gson.annotations.Until;
 import com.google.gson.internal.$Gson$Preconditions;
@@ -528,18 +529,19 @@ public final class GsonBuilder {
   /**
    * Sets the strictness of this builder to {@link Strictness#LENIENT}.
    *
-   * <p>This method has been deprecated. Please use {@link GsonBuilder#setStrictness(Strictness)} instead.
-   * Calling this method is equivalent to {@code setStrictness(Strictness.LENIENT)}</p>
+   * @deprecated This method is equivalent to calling {@link #setStrictness(Strictness)} with
+   * {@link Strictness#LENIENT}: {@code setStrictness(Strictness.LENIENT)}
    *
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern.
    * @see JsonReader#setStrictness(Strictness)
    * @see JsonWriter#setStrictness(Strictness)
    * @see #setStrictness(Strictness)
    */
+  @Deprecated
+  @InlineMe(replacement = "this.setStrictness(Strictness.LENIENT)", imports = "com.google.gson.Strictness")
   @CanIgnoreReturnValue
   public GsonBuilder setLenient() {
-    strictness = Strictness.LENIENT;
-    return this;
+    return setStrictness(Strictness.LENIENT);
   }
 
   /**

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -51,7 +51,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-
 /**
  * <p>Use this builder to construct a {@link Gson} instance when you need to set configuration
  * options other than the default. For {@link Gson} with default configuration, it is simpler to
@@ -73,12 +72,16 @@ import java.util.Objects;
  *     .create();
  * </pre>
  *
- * <p>NOTES:
+ * <p>Notes:
  * <ul>
- * <li> the order of invocation of configuration methods does not matter.</li>
- * <li> The default serialization of {@link Date} and its subclasses in Gson does
+ * <li>The order of invocation of configuration methods does not matter.</li>
+ * <li>The default serialization of {@link Date} and its subclasses in Gson does
  *  not contain time-zone information. So, if you are using date/time instances,
  *  use {@code GsonBuilder} and its {@code setDateFormat} methods.</li>
+ * <li>By default no explicit {@link Strictness} is set; some of the {@link Gson} methods
+ *  behave as if {@link Strictness#LEGACY_STRICT} was used whereas others behave as
+ *  if {@link Strictness#LENIENT} was used. Prefer explicitly setting a strictness
+ *  with {@link #setStrictness(Strictness)} to avoid this legacy behavior.
  * </ul>
  *
  * @author Inderjeet Singh
@@ -549,10 +552,11 @@ public final class GsonBuilder {
    *
    * @param strictness the new strictness mode. May not be {@code null}.
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern.
-   * @see JsonWriter#setStrictness(Strictness)
    * @see JsonReader#setStrictness(Strictness)
+   * @see JsonWriter#setStrictness(Strictness)
    * @since $next-version$
    */
+  @CanIgnoreReturnValue
   public GsonBuilder setStrictness(Strictness strictness) {
     this.strictness = Objects.requireNonNull(strictness);
     return this;

--- a/gson/src/main/java/com/google/gson/JsonElement.java
+++ b/gson/src/main/java/com/google/gson/JsonElement.java
@@ -321,7 +321,8 @@ public abstract class JsonElement {
     try {
       StringWriter stringWriter = new StringWriter();
       JsonWriter jsonWriter = new JsonWriter(stringWriter);
-      jsonWriter.setLenient(true);
+      // Make writer lenient because toString() must not fail, even if for example JsonPrimitive contains NaN
+      jsonWriter.setStrictness(Strictness.LENIENT);
       Streams.write(this, jsonWriter);
       return stringWriter.toString();
     } catch (IOException e) {

--- a/gson/src/main/java/com/google/gson/JsonParser.java
+++ b/gson/src/main/java/com/google/gson/JsonParser.java
@@ -41,7 +41,7 @@ public final class JsonParser {
    * An exception is thrown if the JSON string has multiple top-level JSON elements,
    * or if there is trailing data.
    *
-   * <p>The JSON string is parsed in {@linkplain JsonReader#setLenient(boolean) lenient mode}.
+   * <p>The JSON string is parsed in {@linkplain JsonReader#setStrictness(Strictness) lenient mode}.
    *
    * @param json JSON text
    * @return a parse tree of {@link JsonElement}s corresponding to the specified JSON
@@ -57,7 +57,7 @@ public final class JsonParser {
    * An exception is thrown if the JSON string has multiple top-level JSON elements,
    * or if there is trailing data.
    *
-   * <p>The JSON data is parsed in {@linkplain JsonReader#setLenient(boolean) lenient mode}.
+   * <p>The JSON data is parsed in {@linkplain JsonReader#setStrictness(Strictness) lenient mode}.
    *
    * @param reader JSON text
    * @return a parse tree of {@link JsonElement}s corresponding to the specified JSON
@@ -87,8 +87,8 @@ public final class JsonParser {
    * Unlike the other {@code parse} methods, no exception is thrown if the JSON data has
    * multiple top-level JSON elements, or if there is trailing data.
    *
-   * <p>The JSON data is parsed in {@linkplain JsonReader#setLenient(boolean) lenient mode},
-   * regardless of the lenient mode setting of the provided reader. The lenient mode setting
+   * <p>The JSON data is parsed in {@linkplain JsonReader#setStrictness(Strictness) lenient mode},
+   * regardless of the strictness setting of the provided reader. The strictness setting
    * of the reader is restored once this method returns.
    *
    * @throws JsonParseException if there is an IOException or if the specified
@@ -97,8 +97,8 @@ public final class JsonParser {
    */
   public static JsonElement parseReader(JsonReader reader)
       throws JsonIOException, JsonSyntaxException {
-    boolean lenient = reader.isLenient();
-    reader.setLenient(true);
+    Strictness strictness = reader.getStrictness();
+    reader.setStrictness(Strictness.LENIENT);
     try {
       return Streams.parse(reader);
     } catch (StackOverflowError e) {
@@ -106,7 +106,7 @@ public final class JsonParser {
     } catch (OutOfMemoryError e) {
       throw new JsonParseException("Failed parsing JSON source: " + reader + " to Json", e);
     } finally {
-      reader.setLenient(lenient);
+      reader.setStrictness(strictness);
     }
   }
 

--- a/gson/src/main/java/com/google/gson/JsonStreamParser.java
+++ b/gson/src/main/java/com/google/gson/JsonStreamParser.java
@@ -28,7 +28,7 @@ import java.util.NoSuchElementException;
 /**
  * A streaming parser that allows reading of multiple {@link JsonElement}s from the specified reader
  * asynchronously. The JSON data is parsed in lenient mode, see also
- * {@link JsonReader#setLenient(boolean)}.
+ * {@link JsonReader#setStrictness(Strictness)}.
  *
  * <p>This class is conditionally thread-safe (see Item 70, Effective Java second edition). To
  * properly use this class across multiple threads, you will need to add some external
@@ -66,7 +66,7 @@ public final class JsonStreamParser implements Iterator<JsonElement> {
    */
   public JsonStreamParser(Reader reader) {
     parser = new JsonReader(reader);
-    parser.setLenient(true);
+    parser.setStrictness(Strictness.LENIENT);
     lock = new Object();
   }
 

--- a/gson/src/main/java/com/google/gson/Strictness.java
+++ b/gson/src/main/java/com/google/gson/Strictness.java
@@ -1,17 +1,17 @@
 package com.google.gson;
 
-import com.google.gson.stream.JsonWriter;
 import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 
 /**
  * Modes that indicate how strictly a JSON {@linkplain JsonReader reader} or
  * {@linkplain JsonWriter writer} follows the syntax laid out in the
  * <a href="https://www.ietf.org/rfc/rfc8259.txt">RFC 8259 JSON specification</a>.
  *
- * <p>You can look at {@link JsonWriter#setStrictness(Strictness)} to see how the strictness
- * affects the {@link JsonWriter} and you can look at
- * {@link JsonReader#setStrictness(Strictness)} to see how the strictness
- * affects the {@link JsonReader}.</p>
+ * <p>You can look at {@link JsonReader#setStrictness(Strictness)} to see how the strictness
+ * affects the {@link JsonReader} and you can look at
+ * {@link JsonWriter#setStrictness(Strictness)} to see how the strictness
+ * affects the {@link JsonWriter}.</p>
  *
  * @see JsonReader#setStrictness(Strictness)
  * @see JsonWriter#setStrictness(Strictness)

--- a/gson/src/main/java/com/google/gson/TypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/TypeAdapter.java
@@ -134,10 +134,10 @@ public abstract class TypeAdapter<T> {
 
   /**
    * Converts {@code value} to a JSON document and writes it to {@code out}.
-   * Unlike Gson's similar {@link Gson#toJson(JsonElement, Appendable) toJson}
-   * method, this write is strict. Create a {@link
-   * JsonWriter#setLenient(boolean) lenient} {@code JsonWriter} and call
-   * {@link #write(JsonWriter, Object)} for lenient writing.
+   * The strictness {@link Strictness#LEGACY_STRICT} is used for writing the JSON data.
+   * To use a different strictness setting create a {@link JsonWriter}, call its
+   * {@link JsonWriter#setStrictness(Strictness)} method and then use
+   * {@link #write(JsonWriter, Object)} for writing.
    *
    * @param value the Java object to convert. May be null.
    * @since 2.2
@@ -207,10 +207,11 @@ public abstract class TypeAdapter<T> {
   }
 
   /**
-   * Converts {@code value} to a JSON document. Unlike Gson's similar {@link
-   * Gson#toJson(Object) toJson} method, this write is strict. Create a {@link
-   * JsonWriter#setLenient(boolean) lenient} {@code JsonWriter} and call
-   * {@link #write(JsonWriter, Object)} for lenient writing.
+   * Converts {@code value} to a JSON document.
+   * The strictness {@link Strictness#LEGACY_STRICT} is used for writing the JSON data.
+   * To use a different strictness setting create a {@link JsonWriter}, call its
+   * {@link JsonWriter#setStrictness(Strictness)} method and then use
+   * {@link #write(JsonWriter, Object)} for writing.
    *
    * @throws JsonIOException wrapping {@code IOException}s thrown by {@link #write(JsonWriter, Object)}
    * @param value the Java object to convert. May be null.
@@ -253,10 +254,10 @@ public abstract class TypeAdapter<T> {
   public abstract T read(JsonReader in) throws IOException;
 
   /**
-   * Converts the JSON document in {@code in} to a Java object. Unlike Gson's
-   * similar {@link Gson#fromJson(Reader, Class) fromJson} method, this
-   * read is strict. Create a {@link JsonReader#setLenient(boolean) lenient}
-   * {@code JsonReader} and call {@link #read(JsonReader)} for lenient reading.
+   * Converts the JSON document in {@code in} to a Java object. The strictness
+   * {@link Strictness#LEGACY_STRICT} is used for reading the JSON data. To use a different
+   * strictness setting create a {@link JsonReader}, call its {@link JsonReader#setStrictness(Strictness)}
+   * method and then use {@link #read(JsonReader)} for reading.
    *
    * <p>No exception is thrown if the JSON data has multiple top-level JSON elements,
    * or if there is trailing data.
@@ -270,10 +271,10 @@ public abstract class TypeAdapter<T> {
   }
 
   /**
-   * Converts the JSON document in {@code json} to a Java object. Unlike Gson's
-   * similar {@link Gson#fromJson(String, Class) fromJson} method, this read is
-   * strict. Create a {@link JsonReader#setLenient(boolean) lenient} {@code
-   * JsonReader} and call {@link #read(JsonReader)} for lenient reading.
+   * Converts the JSON document in {@code json} to a Java object. The strictness
+   * {@link Strictness#LEGACY_STRICT} is used for reading the JSON data. To use a different
+   * strictness setting create a {@link JsonReader}, call its {@link JsonReader#setStrictness(Strictness)}
+   * method and then use {@link #read(JsonReader)} for reading.
    *
    * <p>No exception is thrown if the JSON data has multiple top-level JSON elements,
    * or if there is trailing data.

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -182,7 +182,7 @@ import java.util.Objects;
  * <p>Prefixing JSON files with <code>")]}'\n"</code> makes them non-executable
  * by {@code <script>} tags, disarming the attack. Since the prefix is malformed
  * JSON, strict parsing fails when it is encountered. This class permits the
- * non-execute prefix when {@link #setLenient(boolean) lenient parsing} is
+ * non-execute prefix when {@link #setStrictness(Strictness) lenient parsing} is
  * enabled.
  *
  * <p>Each {@code JsonReader} may be used to read a single JSON stream. Instances
@@ -295,16 +295,19 @@ public class JsonReader implements Closeable {
   /**
    * Sets the strictness of this reader.
    *
-   * <p>This method is deprecated. Please use {@link JsonReader#setStrictness(Strictness)} instead.
+   * @deprecated Please use {@link JsonReader#setStrictness(Strictness)} instead.
    * {@code JsonReader.setLenient(true)} should be replaced by {@code JsonReader.setStrictness(Strictness.LENIENT)}
-   * and {@code JsonReader.setLenient(false)} should be replaced by {@code JsonReader.setStrictness(Strictness.LEGACY_STRICT)}.
+   * and {@code JsonReader.setLenient(false)} should be replaced by {@code JsonReader.setStrictness(Strictness.LEGACY_STRICT)}.<br>
+   * However, if you used {@code setLenient(false)} before, you might prefer {@link Strictness#STRICT} now instead.
    *
    * @param lenient whether this reader should be lenient. If true, the strictness is set to {@link Strictness#LENIENT}.
    *                If false, the strictness is set to {@link Strictness#LEGACY_STRICT}.
    * @see #setStrictness(Strictness)
    */
+  @Deprecated
+  @SuppressWarnings("InlineMeSuggester") // Don't specify @InlineMe, so caller with `setLenient(false)` becomes aware of new Strictness.STRICT
   public final void setLenient(boolean lenient) {
-    this.strictness = lenient ? Strictness.LENIENT : Strictness.LEGACY_STRICT;
+    setStrictness(lenient ? Strictness.LENIENT : Strictness.LEGACY_STRICT);
   }
 
   /**
@@ -943,7 +946,7 @@ public class JsonReader implements Closeable {
    * @throws NumberFormatException if the next literal value cannot be parsed
    *     as a double.
    * @throws MalformedJsonException if the next literal value is NaN or Infinity
-   *     and this reader is not {@link #setLenient(boolean) lenient}.
+   *     and this reader is not {@link #setStrictness(Strictness) lenient}.
    */
   public double nextDouble() throws IOException {
     int p = peeked;
@@ -1514,7 +1517,7 @@ public class JsonReader implements Closeable {
 
   private void checkLenient() throws IOException {
     if (strictness != Strictness.LENIENT) {
-      throw syntaxError("Use JsonReader.setLenient(true) to accept malformed JSON");
+      throw syntaxError("Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON");
     }
   }
 

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -228,7 +228,6 @@ public class JsonReader implements Closeable {
   /** The input JSON. */
   private final Reader in;
 
-  /** True to accept non-spec compliant JSON */
   private Strictness strictness = Strictness.LEGACY_STRICT;
 
   static final int BUFFER_SIZE = 1024;
@@ -322,24 +321,21 @@ public class JsonReader implements Closeable {
    *
    * <p>In {@linkplain Strictness#STRICT strict} mode, the
    * parser only accepts JSON in accordance with <a href="https://www.ietf.org/rfc/rfc8259.txt">RFC 8259</a>.
-   * In {@linkplain Strictness#LEGACY_STRICT legacy strict} mode, only JSON in accordance with the <a
-   * href="https://www.ietf.org/rfc/rfc8259.txt">RFC 8259</a> is accepted, with a few exceptions denoted below
-   * for backwards compatibility reasons. In {@linkplain Strictness#LENIENT lenient} mode,
-   * all sort of non-spec compliant JSON is accepted (see below).</p>
+   * In {@linkplain Strictness#LEGACY_STRICT legacy strict} mode (the default), only JSON in accordance with the
+   * RFC 8259 is accepted, with a few exceptions denoted below for backwards compatibility reasons.
+   * In {@linkplain Strictness#LENIENT lenient} mode, all sort of non-spec compliant JSON is accepted (see below).</p>
    *
    * <dl>
    *     <dt>{@link Strictness#STRICT}</dt>
    *     <dd>
-   *         In strict mode, only input compliant with <a href="https://www.ietf.org/rfc/rfc8259.txt">RFC 8259</a>
-   *         is accepted.
+   *         In strict mode, only input compliant with RFC 8259 is accepted.
    *     </dd>
    *     <dt>{@link Strictness#LEGACY_STRICT}</dt>
    *     <dd>
-   *         In legacy strict mode, the following departures from <a href="https://www.ietf.org/rfc/rfc8259.txt">RFC 8259</a>
-   *         are accepted:
+   *         In legacy strict mode, the following departures from RFC 8259 are accepted:
    *         <ul>
    *             <li>JsonReader allows the literals {@code true}, {@code false} and {@code null}
-   *                 to have any capitalization, for example {@code fAlSe} or {@code NULL}.
+   *                 to have any capitalization, for example {@code fAlSe} or {@code NULL}
    *             <li>JsonReader supports the escape sequence {@code \'}, representing a {@code '} (single-quote)
    *             <li>JsonReader supports the escape sequence <code>\<i>LF</i></code> (with {@code LF}
    *                 being the Unicode character {@code U+000A}), resulting in a {@code LF} within the
@@ -350,7 +346,7 @@ public class JsonReader implements Closeable {
    *     <dt>{@link Strictness#LENIENT}</dt>
    *     <dd>
    *         In lenient mode, all input that is accepted in legacy strict mode is accepted in addition to the following
-   *         departures from <a href="https://www.ietf.org/rfc/rfc8259.txt">RFC 8259</a>:
+   *         departures from RFC 8259:
    *         <ul>
    *             <li>Streams that start with the <a href="#nonexecuteprefix">non-execute prefix</a>, {@code ")]}'\n"}
    *             <li>Streams that include multiple top-level values. With legacy strict or strict parsing,
@@ -658,7 +654,7 @@ public class JsonReader implements Closeable {
     String keywordUpper;
     int peeking;
 
-    // Look at the first lower case letter to determine what keyword we are trying to match.
+    // Look at the first letter to determine what keyword we are trying to match.
     if (c == 't' || c == 'T') {
       keyword = "true";
       keywordUpper = "TRUE";
@@ -1062,7 +1058,7 @@ public class JsonReader implements Closeable {
 
         // In strict mode, throw an exception when meeting unescaped control characters (U+0000 through U+001F)
         if (strictness == Strictness.STRICT && c < 0x20) {
-          throw syntaxError("Unescaped control characters (\\u0000-\\u001F) are not allowed in strict mode.");
+          throw syntaxError("Unescaped control characters (\\u0000-\\u001F) are not allowed in strict mode");
         } else if (c == quote) {
           pos = p;
           int len = p - start - 1;
@@ -1693,7 +1689,7 @@ public class JsonReader implements Closeable {
 
     case '\n':
       if (strictness == Strictness.STRICT) {
-        throw syntaxError("Cannot escape a newline character in strict mode!");
+        throw syntaxError("Cannot escape a newline character in strict mode");
       }
       lineNumber++;
       lineStart = pos;

--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -300,7 +300,7 @@ public class JsonWriter implements Closeable, Flushable {
    *     <dt>{@link Strictness#STRICT} &amp; {@link Strictness#LEGACY_STRICT}</dt>
    *     <dd>
    *         The behavior of these is currently identical. In these strictness modes, the writer only writes JSON
-   *         in accordance with <a href="https://www.ietf.org/rfc/rfc8259.txt">RFC 8259</a>.
+   *         in accordance with RFC 8259.
    *     </dd>
    *     <dt>{@link Strictness#LENIENT}</dt>
    *     <dd>
@@ -474,7 +474,7 @@ public class JsonWriter implements Closeable, Flushable {
   public JsonWriter name(String name) throws IOException {
     Objects.requireNonNull(name, "name == null");
     if (deferredName != null) {
-      throw new IllegalStateException();
+      throw new IllegalStateException("Already wrote a name, expecting a value.");
     }
     if (stackSize == 0) {
       throw new IllegalStateException("JsonWriter is closed.");

--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -271,16 +271,19 @@ public class JsonWriter implements Closeable, Flushable {
   /**
    * Sets the strictness of this writer.
    *
-   * <p>This method is deprecated. Please use {@link JsonWriter#setStrictness(Strictness)} instead.
+   * @deprecated Please use {@link JsonWriter#setStrictness(Strictness)} instead.
    * {@code JsonWriter.setLenient(true)} should be replaced by {@code JsonWriter.setStrictness(Strictness.LENIENT)}
-   * and {@code JsonWriter.setLenient(false)} should be replaced by {@code JsonWriter.setStrictness(Strictness.LEGACY_STRICT)}.
+   * and {@code JsonWriter.setLenient(false)} should be replaced by {@code JsonWriter.setStrictness(Strictness.LEGACY_STRICT)}.<br>
+   * However, if you used {@code setLenient(false)} before, you might prefer {@link Strictness#STRICT} now instead.
    *
    * @param lenient whether this writer should be lenient. If true, the strictness is set to {@link Strictness#LENIENT}.
    *                If false, the strictness is set to {@link Strictness#LEGACY_STRICT}.
    * @see #setStrictness(Strictness)
    */
+  @Deprecated
+  @SuppressWarnings("InlineMeSuggester") // Don't specify @InlineMe, so caller with `setLenient(false)` becomes aware of new Strictness.STRICT
   public final void setLenient(boolean lenient) {
-    this.strictness = lenient ? Strictness.LENIENT : Strictness.LEGACY_STRICT;
+    setStrictness(lenient ? Strictness.LENIENT : Strictness.LEGACY_STRICT);
   }
 
   /**
@@ -583,12 +586,12 @@ public class JsonWriter implements Closeable, Flushable {
   /**
    * Encodes {@code value}.
    *
-   * @param value a finite value, or if {@link #setLenient(boolean) lenient},
+   * @param value a finite value, or if {@link #setStrictness(Strictness) lenient},
    *     also {@link Float#isNaN() NaN} or {@link Float#isInfinite()
    *     infinity}.
    * @return this writer.
    * @throws IllegalArgumentException if the value is NaN or Infinity and this writer is not {@link
-   *     #setLenient(boolean) lenient}.
+   *     #setStrictness(Strictness) lenient}.
    * @since 2.9.1
    */
   @CanIgnoreReturnValue
@@ -605,11 +608,11 @@ public class JsonWriter implements Closeable, Flushable {
   /**
    * Encodes {@code value}.
    *
-   * @param value a finite value, or if {@link #setLenient(boolean) lenient},
+   * @param value a finite value, or if {@link #setStrictness(Strictness) lenient},
    *     also {@link Double#isNaN() NaN} or {@link Double#isInfinite() infinity}.
    * @return this writer.
    * @throws IllegalArgumentException if the value is NaN or Infinity and this writer is
-   *     not {@link #setLenient(boolean) lenient}.
+   *     not {@link #setStrictness(Strictness) lenient}.
    */
   @CanIgnoreReturnValue
   public JsonWriter value(double value) throws IOException {
@@ -650,11 +653,11 @@ public class JsonWriter implements Closeable, Flushable {
    * Encodes {@code value}. The value is written by directly writing the {@link Number#toString()}
    * result to JSON. Implementations must make sure that the result represents a valid JSON number.
    *
-   * @param value a finite value, or if {@link #setLenient(boolean) lenient},
+   * @param value a finite value, or if {@link #setStrictness(Strictness) lenient},
    *     also {@link Double#isNaN() NaN} or {@link Double#isInfinite() infinity}.
    * @return this writer.
    * @throws IllegalArgumentException if the value is NaN or Infinity and this writer is
-   *     not {@link #setLenient(boolean) lenient}; or if the {@code toString()} result is not a
+   *     not {@link #setStrictness(Strictness) lenient}; or if the {@code toString()} result is not a
    *     valid JSON number.
    */
   @CanIgnoreReturnValue

--- a/gson/src/main/java/com/google/gson/stream/MalformedJsonException.java
+++ b/gson/src/main/java/com/google/gson/stream/MalformedJsonException.java
@@ -16,11 +16,12 @@
 
 package com.google.gson.stream;
 
+import com.google.gson.Strictness;
 import java.io.IOException;
 
 /**
  * Thrown when a reader encounters malformed JSON. Some syntax errors can be
- * ignored by calling {@link JsonReader#setLenient(boolean)}.
+ * ignored by using {@link Strictness#LENIENT} for {@link JsonReader#setStrictness(Strictness)}.
  */
 public final class MalformedJsonException extends IOException {
   private static final long serialVersionUID = 1L;

--- a/gson/src/test/java/com/google/gson/GsonBuilderTest.java
+++ b/gson/src/test/java/com/google/gson/GsonBuilderTest.java
@@ -235,6 +235,7 @@ public class GsonBuilderTest {
     assertThat(gson.newJsonWriter(new StringWriter()).getStrictness()).isEqualTo(Strictness.LEGACY_STRICT);
   }
 
+  @SuppressWarnings({"deprecation", "InlineMeInliner"}) // for GsonBuilder.setLenient
   @Test
   public void testSetLenient() throws IOException {
     GsonBuilder builder = new GsonBuilder();

--- a/gson/src/test/java/com/google/gson/GsonBuilderTest.java
+++ b/gson/src/test/java/com/google/gson/GsonBuilderTest.java
@@ -231,7 +231,7 @@ public class GsonBuilderTest {
   public void testDefaultStrictness() throws IOException {
     GsonBuilder builder = new GsonBuilder();
     Gson gson = builder.create();
-    assertThat(gson.newJsonReader(new StringReader("{}}")).getStrictness()).isEqualTo(Strictness.LEGACY_STRICT);
+    assertThat(gson.newJsonReader(new StringReader("{}")).getStrictness()).isEqualTo(Strictness.LEGACY_STRICT);
     assertThat(gson.newJsonWriter(new StringWriter()).getStrictness()).isEqualTo(Strictness.LEGACY_STRICT);
   }
 
@@ -240,7 +240,7 @@ public class GsonBuilderTest {
     GsonBuilder builder = new GsonBuilder();
     builder.setLenient();
     Gson gson = builder.create();
-    assertThat(gson.newJsonReader(new StringReader("{}}")).getStrictness()).isEqualTo(Strictness.LENIENT);
+    assertThat(gson.newJsonReader(new StringReader("{}")).getStrictness()).isEqualTo(Strictness.LENIENT);
     assertThat(gson.newJsonWriter(new StringWriter()).getStrictness()).isEqualTo(Strictness.LENIENT);
   }
 
@@ -250,7 +250,7 @@ public class GsonBuilderTest {
     GsonBuilder builder = new GsonBuilder();
     builder.setStrictness(STRICTNESS);
     Gson gson = builder.create();
-    assertThat(gson.newJsonReader(new StringReader("{}}")).getStrictness()).isEqualTo(STRICTNESS);
+    assertThat(gson.newJsonReader(new StringReader("{}")).getStrictness()).isEqualTo(STRICTNESS);
     assertThat(gson.newJsonWriter(new StringWriter()).getStrictness()).isEqualTo(STRICTNESS);
   }
 }

--- a/gson/src/test/java/com/google/gson/GsonTest.java
+++ b/gson/src/test/java/com/google/gson/GsonTest.java
@@ -299,6 +299,7 @@ public final class GsonTest {
     assertThat(writer.toString()).isEqualTo("{\"\\u003ctest2\":true}");
   }
 
+  @SuppressWarnings({"deprecation", "InlineMeInliner"}) // for GsonBuilder.setLenient
   @Test
   public void testNewJsonWriter_Custom() throws IOException {
     StringWriter writer = new StringWriter();
@@ -336,6 +337,7 @@ public final class GsonTest {
     jsonReader.close();
   }
 
+  @SuppressWarnings({"deprecation", "InlineMeInliner"}) // for GsonBuilder.setLenient
   @Test
   public void testNewJsonReader_Custom() throws IOException {
     String json = "test"; // String without quotes

--- a/gson/src/test/java/com/google/gson/JsonParserTest.java
+++ b/gson/src/test/java/com/google/gson/JsonParserTest.java
@@ -170,12 +170,24 @@ public class JsonParserTest {
     CharArrayReader reader = new CharArrayReader(writer.toCharArray());
 
     JsonReader parser = new JsonReader(reader);
-    parser.setLenient(true);
+    parser.setStrictness(Strictness.LENIENT);
     JsonElement element1 = Streams.parse(parser);
     JsonElement element2 = Streams.parse(parser);
     BagOfPrimitives actualOne = gson.fromJson(element1, BagOfPrimitives.class);
     assertThat(actualOne.stringValue).isEqualTo("one");
     BagOfPrimitives actualTwo = gson.fromJson(element2, BagOfPrimitives.class);
     assertThat(actualTwo.stringValue).isEqualTo("two");
+  }
+
+  @Test
+  public void testStrict() {
+    JsonReader reader = new JsonReader(new StringReader("faLsE"));
+    Strictness strictness = Strictness.STRICT;
+    // Strictness is ignored by JsonParser later; always parses in lenient mode
+    reader.setStrictness(strictness);
+
+    assertThat(JsonParser.parseReader(reader)).isEqualTo(new JsonPrimitive(false));
+    // Original strictness was restored
+    assertThat(reader.getStrictness()).isEqualTo(strictness);
   }
 }

--- a/gson/src/test/java/com/google/gson/MixedStreamTest.java
+++ b/gson/src/test/java/com/google/gson/MixedStreamTest.java
@@ -81,6 +81,7 @@ public final class MixedStreamTest {
     jsonReader.endArray();
   }
 
+  @SuppressWarnings("deprecation") // for JsonReader.setLenient
   @Test
   public void testReaderDoesNotMutateState() throws IOException {
     Gson gson = new Gson();
@@ -96,6 +97,7 @@ public final class MixedStreamTest {
     assertThat(jsonReader.isLenient()).isTrue();
   }
 
+  @SuppressWarnings("deprecation") // for JsonWriter.setLenient
   @Test
   public void testWriteDoesNotMutateState() throws IOException {
     Gson gson = new Gson();

--- a/gson/src/test/java/com/google/gson/ToNumberPolicyTest.java
+++ b/gson/src/test/java/com/google/gson/ToNumberPolicyTest.java
@@ -83,7 +83,7 @@ public class ToNumberPolicyTest {
       fail();
     } catch (MalformedJsonException expected) {
       assertThat(expected).hasMessageThat().isEqualTo(
-          "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 1 path $"
+          "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON at line 1 column 1 path $"
           + "\nSee https://github.com/google/gson/blob/master/Troubleshooting.md#malformed-json");
     }
     try {
@@ -91,7 +91,7 @@ public class ToNumberPolicyTest {
       fail();
     } catch (MalformedJsonException expected) {
       assertThat(expected).hasMessageThat().isEqualTo(
-          "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 1 path $"
+          "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON at line 1 column 1 path $"
           + "\nSee https://github.com/google/gson/blob/master/Troubleshooting.md#malformed-json");
     }
     try {
@@ -99,7 +99,7 @@ public class ToNumberPolicyTest {
       fail();
     } catch (MalformedJsonException expected) {
       assertThat(expected).hasMessageThat().isEqualTo(
-          "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 1 path $"
+          "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON at line 1 column 1 path $"
           + "\nSee https://github.com/google/gson/blob/master/Troubleshooting.md#malformed-json");
     }
   }
@@ -157,7 +157,7 @@ public class ToNumberPolicyTest {
 
   private static JsonReader fromStringLenient(String json) {
     JsonReader jsonReader = fromString(json);
-    jsonReader.setLenient(true);
+    jsonReader.setStrictness(Strictness.LENIENT);
     return jsonReader;
   }
 }

--- a/gson/src/test/java/com/google/gson/functional/ArrayTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ArrayTest.java
@@ -28,7 +28,6 @@ import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import org.junit.Before;
 import org.junit.Test;

--- a/gson/src/test/java/com/google/gson/functional/LeniencyTest.java
+++ b/gson/src/test/java/com/google/gson/functional/LeniencyTest.java
@@ -32,6 +32,7 @@ public class LeniencyTest {
 
   private Gson gson;
 
+  @SuppressWarnings({"deprecation", "InlineMeInliner"}) // for GsonBuilder.setLenient
   @Before
   public void setUp() throws Exception {
     gson = new GsonBuilder().setLenient().create();

--- a/gson/src/test/java/com/google/gson/functional/PrettyPrintingTest.java
+++ b/gson/src/test/java/com/google/gson/functional/PrettyPrintingTest.java
@@ -26,7 +26,6 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import org.junit.Before;
@@ -92,7 +91,7 @@ public class PrettyPrintingTest {
     assertThat(json).isEqualTo("[\n  [\n    1,\n    2\n  ],\n  [\n    3,\n    4\n  ],\n  [\n    5,\n    6\n  ],"
         + "\n  [\n    7,\n    8\n  ],\n  [\n    9,\n    0\n  ],\n  [\n    10\n  ]\n]");
   }
-  
+
   @Test
   public void testMap() {
     Map<String, Integer> map = new LinkedHashMap<>();

--- a/gson/src/test/java/com/google/gson/functional/UncategorizedTest.java
+++ b/gson/src/test/java/com/google/gson/functional/UncategorizedTest.java
@@ -28,7 +28,6 @@ import com.google.gson.common.TestTypes.BagOfPrimitives;
 import com.google.gson.common.TestTypes.ClassOverridingEquals;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
-import java.util.Arrays;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonElementReaderTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonElementReaderTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.fail;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
+import com.google.gson.Strictness;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.MalformedJsonException;
 import java.io.IOException;
@@ -45,7 +46,7 @@ public final class JsonElementReaderTest {
   public void testLenientNansAndInfinities() throws IOException {
     JsonElement element = JsonParser.parseString("[NaN, -Infinity, Infinity]");
     JsonTreeReader reader = new JsonTreeReader(element);
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(Double.isNaN(reader.nextDouble())).isTrue();
     assertThat(reader.nextDouble()).isEqualTo(Double.NEGATIVE_INFINITY);
@@ -57,7 +58,7 @@ public final class JsonElementReaderTest {
   public void testStrictNansAndInfinities() throws IOException {
     JsonElement element = JsonParser.parseString("[NaN, -Infinity, Infinity]");
     JsonTreeReader reader = new JsonTreeReader(element);
-    reader.setLenient(false);
+    reader.setStrictness(Strictness.LEGACY_STRICT);
     reader.beginArray();
     try {
       reader.nextDouble();

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.fail;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
+import com.google.gson.Strictness;
 import com.google.gson.common.MoreAsserts;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -86,7 +87,7 @@ public final class JsonTreeWriterTest {
   @Test
   public void testWriteAfterClose() throws Exception {
     JsonTreeWriter writer = new JsonTreeWriter();
-    writer.setLenient(true);
+    writer.setStrictness(Strictness.LENIENT);
     writer.beginArray();
     writer.value("A");
     writer.endArray();
@@ -101,12 +102,13 @@ public final class JsonTreeWriterTest {
   @Test
   public void testPrematureClose() throws Exception {
     JsonTreeWriter writer = new JsonTreeWriter();
-    writer.setLenient(true);
+    writer.setStrictness(Strictness.LENIENT);
     writer.beginArray();
     try {
       writer.close();
       fail();
     } catch (IOException expected) {
+      assertThat(expected).hasMessageThat().isEqualTo("Incomplete document");
     }
   }
 
@@ -174,7 +176,7 @@ public final class JsonTreeWriterTest {
   @Test
   public void testLenientNansAndInfinities() throws IOException {
     JsonTreeWriter writer = new JsonTreeWriter();
-    writer.setLenient(true);
+    writer.setStrictness(Strictness.LENIENT);
     writer.beginArray();
     writer.value(Float.NaN);
     writer.value(Float.NEGATIVE_INFINITY);
@@ -189,7 +191,7 @@ public final class JsonTreeWriterTest {
   @Test
   public void testStrictNansAndInfinities() throws IOException {
     JsonTreeWriter writer = new JsonTreeWriter();
-    writer.setLenient(false);
+    writer.setStrictness(Strictness.LEGACY_STRICT);
     writer.beginArray();
     try {
       writer.value(Float.NaN);
@@ -226,7 +228,7 @@ public final class JsonTreeWriterTest {
   @Test
   public void testStrictBoxedNansAndInfinities() throws IOException {
     JsonTreeWriter writer = new JsonTreeWriter();
-    writer.setLenient(false);
+    writer.setStrictness(Strictness.LEGACY_STRICT);
     writer.beginArray();
     try {
       writer.value(Float.valueOf(Float.NaN));

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderPathTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderPathTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assume.assumeTrue;
 
 import com.google.gson.JsonElement;
+import com.google.gson.Strictness;
 import com.google.gson.internal.Streams;
 import com.google.gson.internal.bind.JsonTreeReader;
 import java.io.IOException;
@@ -201,7 +202,7 @@ public class JsonReaderPathTest {
     assumeTrue(factory == Factory.STRING_READER);
 
     JsonReader reader = factory.create("[][]");
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     reader.endArray();
     assertThat(reader.getPreviousPath()).isEqualTo("$");

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 @SuppressWarnings("resource")
 public final class JsonReaderTest {
 
+  @SuppressWarnings("deprecation") // for JsonWriter.setLenient
   @Test
   public void testSetLenientTrue() {
     JsonReader reader = new JsonReader(reader("{}"));
@@ -48,6 +49,7 @@ public final class JsonReaderTest {
     assertThat(reader.getStrictness()).isEqualTo(Strictness.LENIENT);
   }
 
+  @SuppressWarnings("deprecation") // for JsonReader.setLenient
   @Test
   public void testSetLenientFalse() {
     JsonReader reader = new JsonReader(reader("{}"));
@@ -131,14 +133,14 @@ public final class JsonReaderTest {
     reader.setStrictness(Strictness.STRICT);
 
     IOException expected = assertThrows(IOException.class, reader::nextBoolean);
-    assertThat(expected).hasMessageThat().startsWith("Use JsonReader.setLenient(true) to accept malformed" +
+    assertThat(expected).hasMessageThat().startsWith("Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed" +
         " JSON at line 1 column 1 path $");
 
     reader = new JsonReader(reader("True"));
     reader.setStrictness(Strictness.STRICT);
 
     expected = assertThrows(IOException.class, reader::nextBoolean);
-    assertThat(expected).hasMessageThat().startsWith("Use JsonReader.setLenient(true) to accept malformed" +
+    assertThat(expected).hasMessageThat().startsWith("Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed" +
         " JSON at line 1 column 1 path $");
   }
 
@@ -148,14 +150,14 @@ public final class JsonReaderTest {
     reader.setStrictness(Strictness.STRICT);
 
     IOException expected = assertThrows(IOException.class, reader::nextNull);
-    assertThat(expected).hasMessageThat().startsWith("Use JsonReader.setLenient(true) to accept malformed" +
+    assertThat(expected).hasMessageThat().startsWith("Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed" +
         " JSON at line 1 column 1 path $");
 
     reader = new JsonReader(reader("nulL"));
     reader.setStrictness(Strictness.STRICT);
 
     expected = assertThrows(IOException.class, reader::nextNull);
-    assertThat(expected).hasMessageThat().startsWith("Use JsonReader.setLenient(true) to accept malformed" +
+    assertThat(expected).hasMessageThat().startsWith("Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed" +
         " JSON at line 1 column 1 path $");
   }
 
@@ -165,14 +167,14 @@ public final class JsonReaderTest {
     reader.setStrictness(Strictness.STRICT);
 
     IOException expected = assertThrows(IOException.class, reader::nextBoolean);
-    assertThat(expected).hasMessageThat().startsWith("Use JsonReader.setLenient(true) to accept malformed" +
+    assertThat(expected).hasMessageThat().startsWith("Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed" +
         " JSON at line 1 column 1 path $");
 
     reader = new JsonReader(reader("FaLse"));
     reader.setStrictness(Strictness.STRICT);
 
     expected = assertThrows(IOException.class, reader::nextBoolean);
-    assertThat(expected).hasMessageThat().startsWith("Use JsonReader.setLenient(true) to accept malformed" +
+    assertThat(expected).hasMessageThat().startsWith("Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed" +
         " JSON at line 1 column 1 path $");
   }
 
@@ -304,7 +306,7 @@ public final class JsonReaderTest {
   @Test
   public void testSkipObjectNameSingleQuoted() throws IOException {
     JsonReader reader = new JsonReader(reader("{'a': 1}"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginObject();
     reader.skipValue();
     assertThat(reader.peek()).isEqualTo(JsonToken.NUMBER);
@@ -315,7 +317,7 @@ public final class JsonReaderTest {
   @Test
   public void testSkipObjectNameUnquoted() throws IOException {
     JsonReader reader = new JsonReader(reader("{a: 1}"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginObject();
     reader.skipValue();
     assertThat(reader.peek()).isEqualTo(JsonToken.NUMBER);
@@ -657,7 +659,7 @@ public final class JsonReaderTest {
   public void testLenientNonFiniteDoubles() throws IOException {
     String json = "[NaN, -Infinity, Infinity]";
     JsonReader reader = new JsonReader(reader(json));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(Double.isNaN(reader.nextDouble())).isTrue();
     assertThat(reader.nextDouble()).isEqualTo(Double.NEGATIVE_INFINITY);
@@ -669,7 +671,7 @@ public final class JsonReaderTest {
   public void testLenientQuotedNonFiniteDoubles() throws IOException {
     String json = "[\"NaN\", \"-Infinity\", \"Infinity\"]";
     JsonReader reader = new JsonReader(reader(json));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(Double.isNaN(reader.nextDouble())).isTrue();
     assertThat(reader.nextDouble()).isEqualTo(Double.NEGATIVE_INFINITY);
@@ -772,7 +774,7 @@ public final class JsonReaderTest {
   @Test
   public void testPeekingUnquotedStringsPrefixedWithBooleans() throws IOException {
     JsonReader reader = new JsonReader(reader("[truey]"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(reader.peek()).isEqualTo(STRING);
     try {
@@ -832,7 +834,7 @@ public final class JsonReaderTest {
 
   private void assertNotANumber(String s) throws IOException {
     JsonReader reader = new JsonReader(reader(s));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     assertThat(reader.peek()).isEqualTo(JsonToken.STRING);
     assertThat(reader.nextString()).isEqualTo(s);
 
@@ -841,14 +843,14 @@ public final class JsonReaderTest {
       strictReader.nextDouble();
       fail("Should have failed reading " + s + " as double");
     } catch (MalformedJsonException e) {
-      assertThat(e).hasMessageThat().startsWith("Use JsonReader.setLenient(true) to accept malformed JSON");
+      assertThat(e).hasMessageThat().startsWith("Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON");
     }
   }
 
   @Test
   public void testPeekingUnquotedStringsPrefixedWithIntegers() throws IOException {
     JsonReader reader = new JsonReader(reader("[12.34e5x]"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(reader.peek()).isEqualTo(STRING);
     try {
@@ -862,7 +864,7 @@ public final class JsonReaderTest {
   @Test
   public void testPeekLongMinValue() throws IOException {
     JsonReader reader = new JsonReader(reader("[-9223372036854775808]"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(reader.peek()).isEqualTo(NUMBER);
     assertThat(reader.nextLong()).isEqualTo(-9223372036854775808L);
@@ -871,7 +873,7 @@ public final class JsonReaderTest {
   @Test
   public void testPeekLongMaxValue() throws IOException {
     JsonReader reader = new JsonReader(reader("[9223372036854775807]"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(reader.peek()).isEqualTo(NUMBER);
     assertThat(reader.nextLong()).isEqualTo(9223372036854775807L);
@@ -880,7 +882,7 @@ public final class JsonReaderTest {
   @Test
   public void testLongLargerThanMaxLongThatWrapsAround() throws IOException {
     JsonReader reader = new JsonReader(reader("[22233720368547758070]"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(reader.peek()).isEqualTo(NUMBER);
     try {
@@ -893,7 +895,7 @@ public final class JsonReaderTest {
   @Test
   public void testLongLargerThanMinLongThatWrapsAround() throws IOException {
     JsonReader reader = new JsonReader(reader("[-22233720368547758070]"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(reader.peek()).isEqualTo(NUMBER);
     try {
@@ -909,7 +911,7 @@ public final class JsonReaderTest {
   @Test
   public void testNegativeZero() throws Exception {
     JsonReader reader = new JsonReader(reader("[-0]"));
-    reader.setLenient(false);
+    reader.setStrictness(Strictness.LEGACY_STRICT);
     reader.beginArray();
     assertThat(reader.peek()).isEqualTo(NUMBER);
     assertThat(reader.nextString()).isEqualTo("-0");
@@ -923,7 +925,7 @@ public final class JsonReaderTest {
   @Ignore
   public void testPeekLargerThanLongMaxValue() throws IOException {
     JsonReader reader = new JsonReader(reader("[9223372036854775808]"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(reader.peek()).isEqualTo(NUMBER);
     try {
@@ -943,7 +945,7 @@ public final class JsonReaderTest {
     @SuppressWarnings("FloatingPointLiteralPrecision")
     double d = -9223372036854775809d;
     JsonReader reader = new JsonReader(reader("[-9223372036854775809]"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(reader.peek()).isEqualTo(NUMBER);
     try {
@@ -973,7 +975,7 @@ public final class JsonReaderTest {
     @SuppressWarnings("FloatingPointLiteralPrecision")
     double d = -92233720368547758080d;
     JsonReader reader = new JsonReader(reader("[-92233720368547758080]"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(reader.peek()).isEqualTo(NUMBER);
     try {
@@ -987,7 +989,7 @@ public final class JsonReaderTest {
   @Test
   public void testQuotedNumberWithEscape() throws IOException {
     JsonReader reader = new JsonReader(reader("[\"12\\u00334\"]"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(reader.peek()).isEqualTo(STRING);
     assertThat(reader.nextInt()).isEqualTo(1234);
@@ -1202,13 +1204,13 @@ public final class JsonReaderTest {
   @Test
   public void testLenientNameValueSeparator() throws IOException {
     JsonReader reader = new JsonReader(reader("{\"a\"=true}"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginObject();
     assertThat(reader.nextName()).isEqualTo("a");
     assertThat(reader.nextBoolean()).isTrue();
 
     reader = new JsonReader(reader("{\"a\"=>true}"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginObject();
     assertThat(reader.nextName()).isEqualTo("a");
     assertThat(reader.nextBoolean()).isTrue();
@@ -1290,17 +1292,17 @@ public final class JsonReaderTest {
   @Test
   public void testLenientComments() throws IOException {
     JsonReader reader = new JsonReader(reader("[// comment \n true]"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(reader.nextBoolean()).isTrue();
 
     reader = new JsonReader(reader("[# comment \n true]"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(reader.nextBoolean()).isTrue();
 
     reader = new JsonReader(reader("[/* comment */ true]"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(reader.nextBoolean()).isTrue();
   }
@@ -1350,7 +1352,7 @@ public final class JsonReaderTest {
   @Test
   public void testLenientUnquotedNames() throws IOException {
     JsonReader reader = new JsonReader(reader("{a:true}"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginObject();
     assertThat(reader.nextName()).isEqualTo("a");
   }
@@ -1382,7 +1384,7 @@ public final class JsonReaderTest {
   @Test
   public void testLenientSingleQuotedNames() throws IOException {
     JsonReader reader = new JsonReader(reader("{'a':true}"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginObject();
     assertThat(reader.nextName()).isEqualTo("a");
   }
@@ -1426,7 +1428,7 @@ public final class JsonReaderTest {
   @Test
   public void testLenientUnquotedStrings() throws IOException {
     JsonReader reader = new JsonReader(reader("[a]"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(reader.nextString()).isEqualTo("a");
   }
@@ -1446,7 +1448,7 @@ public final class JsonReaderTest {
   @Test
   public void testLenientSingleQuotedStrings() throws IOException {
     JsonReader reader = new JsonReader(reader("['a']"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(reader.nextString()).isEqualTo("a");
   }
@@ -1478,7 +1480,7 @@ public final class JsonReaderTest {
   @Test
   public void testLenientSemicolonDelimitedArray() throws IOException {
     JsonReader reader = new JsonReader(reader("[true;true]"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(reader.nextBoolean()).isTrue();
     assertThat(reader.nextBoolean()).isTrue();
@@ -1512,7 +1514,7 @@ public final class JsonReaderTest {
   @Test
   public void testLenientSemicolonDelimitedNameValuePair() throws IOException {
     JsonReader reader = new JsonReader(reader("{\"a\":true;\"b\":true}"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginObject();
     assertThat(reader.nextName()).isEqualTo("a");
     assertThat(reader.nextBoolean()).isTrue();
@@ -1576,7 +1578,7 @@ public final class JsonReaderTest {
   @Test
   public void testLenientUnnecessaryArraySeparators() throws IOException {
     JsonReader reader = new JsonReader(reader("[true,,true]"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(reader.nextBoolean()).isTrue();
     reader.nextNull();
@@ -1584,21 +1586,21 @@ public final class JsonReaderTest {
     reader.endArray();
 
     reader = new JsonReader(reader("[,true]"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     reader.nextNull();
     assertThat(reader.nextBoolean()).isTrue();
     reader.endArray();
 
     reader = new JsonReader(reader("[true,]"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(reader.nextBoolean()).isTrue();
     reader.nextNull();
     reader.endArray();
 
     reader = new JsonReader(reader("[,]"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     reader.nextNull();
     reader.nextNull();
@@ -1662,7 +1664,7 @@ public final class JsonReaderTest {
   @Test
   public void testLenientMultipleTopLevelValues() throws IOException {
     JsonReader reader = new JsonReader(reader("[] true {}"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     reader.endArray();
     assertThat(reader.nextBoolean()).isTrue();
@@ -1744,7 +1746,7 @@ public final class JsonReaderTest {
   @Test
   public void testLenientNonExecutePrefix() throws IOException {
     JsonReader reader = new JsonReader(reader(")]}'\n []"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     reader.endArray();
     assertThat(reader.peek()).isEqualTo(JsonToken.END_DOCUMENT);
@@ -1753,7 +1755,7 @@ public final class JsonReaderTest {
   @Test
   public void testLenientNonExecutePrefixWithLeadingWhitespace() throws IOException {
     JsonReader reader = new JsonReader(reader("\r\n \t)]}'\n []"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     reader.endArray();
     assertThat(reader.peek()).isEqualTo(JsonToken.END_DOCUMENT);
@@ -1762,7 +1764,7 @@ public final class JsonReaderTest {
   @Test
   public void testLenientPartialNonExecutePrefix() throws IOException {
     JsonReader reader = new JsonReader(reader(")]}' []"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     assertThat(reader.nextString()).isEqualTo(")");
     try {
       reader.nextString();
@@ -1848,7 +1850,7 @@ public final class JsonReaderTest {
   private void testFailWithPosition(String message, String json) throws IOException {
     // Validate that it works reading the string normally.
     JsonReader reader1 = new JsonReader(reader(json));
-    reader1.setLenient(true);
+    reader1.setStrictness(Strictness.LENIENT);
     reader1.beginArray();
     String unused1 = reader1.nextString();
     try {
@@ -1860,7 +1862,7 @@ public final class JsonReaderTest {
 
     // Also validate that it works when skipping.
     JsonReader reader2 = new JsonReader(reader(json));
-    reader2.setLenient(true);
+    reader2.setStrictness(Strictness.LENIENT);
     reader2.beginArray();
     reader2.skipValue();
     try {
@@ -1906,7 +1908,7 @@ public final class JsonReaderTest {
   @Test
   public void testLenientVeryLongNumber() throws IOException {
     JsonReader reader = new JsonReader(reader("[0." + repeat('9', 8192) + "]"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(reader.peek()).isEqualTo(JsonToken.STRING);
     assertThat(reader.nextDouble()).isEqualTo(1d);
@@ -1918,7 +1920,7 @@ public final class JsonReaderTest {
   public void testVeryLongUnquotedLiteral() throws IOException {
     String literal = "a" + repeat('b', 8192) + "c";
     JsonReader reader = new JsonReader(reader("[" + literal + "]"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(reader.nextString()).isEqualTo(literal);
     reader.endArray();
@@ -1967,7 +1969,7 @@ public final class JsonReaderTest {
   @Test
   public void testStringEndingInSlash() throws IOException {
     JsonReader reader = new JsonReader(reader("/"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     try {
       reader.peek();
       fail();
@@ -1980,7 +1982,7 @@ public final class JsonReaderTest {
   @Test
   public void testDocumentWithCommentEndingInSlash() throws IOException {
     JsonReader reader = new JsonReader(reader("/* foo *//"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     try {
       reader.peek();
       fail();
@@ -1993,7 +1995,7 @@ public final class JsonReaderTest {
   @Test
   public void testStringWithLeadingSlash() throws IOException {
     JsonReader reader = new JsonReader(reader("/x"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     try {
       reader.peek();
       fail();
@@ -2006,7 +2008,7 @@ public final class JsonReaderTest {
   @Test
   public void testUnterminatedObject() throws IOException {
     JsonReader reader = new JsonReader(reader("{\"a\":\"android\"x"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginObject();
     assertThat(reader.nextName()).isEqualTo("a");
     assertThat(reader.nextString()).isEqualTo("android");
@@ -2038,7 +2040,7 @@ public final class JsonReaderTest {
     String string = new String(stringChars);
     String json = "[" + string + "]";
     JsonReader reader = new JsonReader(reader(json));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(reader.nextString()).isEqualTo(string);
     reader.endArray();
@@ -2051,7 +2053,7 @@ public final class JsonReaderTest {
     String string = new String(stringChars);
     String json = "[" + string;
     JsonReader reader = new JsonReader(reader(json));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(reader.nextString()).isEqualTo(string);
     try {
@@ -2064,7 +2066,7 @@ public final class JsonReaderTest {
   @Test
   public void testSkipVeryLongUnquotedString() throws IOException {
     JsonReader reader = new JsonReader(reader("[" + repeat('x', 8192) + "]"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     reader.skipValue();
     reader.endArray();
@@ -2073,7 +2075,7 @@ public final class JsonReaderTest {
   @Test
   public void testSkipTopLevelUnquotedString() throws IOException {
     JsonReader reader = new JsonReader(reader(repeat('x', 8192)));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.skipValue();
     assertThat(reader.peek()).isEqualTo(JsonToken.END_DOCUMENT);
   }
@@ -2089,7 +2091,7 @@ public final class JsonReaderTest {
   @Test
   public void testSkipTopLevelQuotedString() throws IOException {
     JsonReader reader = new JsonReader(reader("\"" + repeat('x', 8192) + "\""));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.skipValue();
     assertThat(reader.peek()).isEqualTo(JsonToken.END_DOCUMENT);
   }
@@ -2097,7 +2099,7 @@ public final class JsonReaderTest {
   @Test
   public void testStringAsNumberWithTruncatedExponent() throws IOException {
     JsonReader reader = new JsonReader(reader("[123e]"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(reader.peek()).isEqualTo(STRING);
   }
@@ -2105,7 +2107,7 @@ public final class JsonReaderTest {
   @Test
   public void testStringAsNumberWithDigitAndNonDigitExponent() throws IOException {
     JsonReader reader = new JsonReader(reader("[123e4b]"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(reader.peek()).isEqualTo(STRING);
   }
@@ -2113,7 +2115,7 @@ public final class JsonReaderTest {
   @Test
   public void testStringAsNumberWithNonDigitExponent() throws IOException {
     JsonReader reader = new JsonReader(reader("[123eb]"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(reader.peek()).isEqualTo(STRING);
   }
@@ -2121,7 +2123,7 @@ public final class JsonReaderTest {
   @Test
   public void testEmptyStringName() throws IOException {
     JsonReader reader = new JsonReader(reader("{\"\":true}"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     assertThat(reader.peek()).isEqualTo(BEGIN_OBJECT);
     reader.beginObject();
     assertThat(reader.peek()).isEqualTo(NAME);
@@ -2151,7 +2153,7 @@ public final class JsonReaderTest {
   @Test
   public void testLenientExtraCommasInMaps() throws IOException {
     JsonReader reader = new JsonReader(reader("{\"a\":\"b\",}"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginObject();
     assertThat(reader.nextName()).isEqualTo("a");
     assertThat(reader.nextString()).isEqualTo("b");
@@ -2220,7 +2222,7 @@ public final class JsonReaderTest {
   @Test
   public void testUnterminatedStringFailure() throws IOException {
     JsonReader reader = new JsonReader(reader("[\"string"));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     reader.beginArray();
     assertThat(reader.peek()).isEqualTo(JsonToken.STRING);
     try {
@@ -2243,13 +2245,13 @@ public final class JsonReaderTest {
     }
     sb.append("\n)]}'\n3");
     JsonReader reader = new JsonReader(reader(sb.toString()));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     JsonToken token = reader.peek();
     assertThat(token).isEqualTo(JsonToken.NUMBER);
   }
 
   private static void assertStrictError(MalformedJsonException exception, String expectedLocation) {
-    assertThat(exception).hasMessageThat().isEqualTo("Use JsonReader.setLenient(true) to accept malformed JSON at " + expectedLocation
+    assertThat(exception).hasMessageThat().isEqualTo("Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON at " + expectedLocation
         + "\nSee https://github.com/google/gson/blob/master/Troubleshooting.md#malformed-json");
   }
 
@@ -2261,7 +2263,7 @@ public final class JsonReaderTest {
 
   private void assertDocument(String document, Object... expectations) throws IOException {
     JsonReader reader = new JsonReader(reader(document));
-    reader.setLenient(true);
+    reader.setStrictness(Strictness.LENIENT);
     for (Object expectation : expectations) {
       if (expectation == BEGIN_OBJECT) {
         reader.beginObject();

--- a/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
@@ -40,6 +40,7 @@ public final class JsonWriterTest {
     jsonWriter.close();
   }
 
+  @SuppressWarnings("deprecation") // for JsonWriter.setLenient
   @Test
   public void testSetLenientTrue() throws IOException {
     JsonWriter jsonWriter = new JsonWriter(new StringWriter());
@@ -49,6 +50,7 @@ public final class JsonWriterTest {
     jsonWriter.close();
   }
 
+  @SuppressWarnings("deprecation") // for JsonWriter.setLenient
   @Test
   public void testSetLenientFalse() throws IOException {
     JsonWriter jsonWriter = new JsonWriter(new StringWriter());
@@ -264,7 +266,7 @@ public final class JsonWriterTest {
   }
 
   @Test
-  public void testNonFiniteFloatsStrict() throws IOException {
+  public void testNonFiniteFloatsWhenStrict() throws IOException {
     StringWriter stringWriter = new StringWriter();
     JsonWriter jsonWriter = new JsonWriter(stringWriter);
     jsonWriter.setStrictness(Strictness.STRICT);
@@ -297,7 +299,7 @@ public final class JsonWriterTest {
   }
 
   @Test
-  public void testNonFiniteDoublesStrict() throws IOException {
+  public void testNonFiniteDoublesWhenStrict() throws IOException {
     StringWriter stringWriter = new StringWriter();
     JsonWriter jsonWriter = new JsonWriter(stringWriter);
     jsonWriter.setStrictness(Strictness.STRICT);
@@ -333,7 +335,7 @@ public final class JsonWriterTest {
   }
 
   @Test
-  public void testNonFiniteNumbersStrict() throws IOException {
+  public void testNonFiniteNumbersWhenStrict() throws IOException {
     StringWriter stringWriter = new StringWriter();
     JsonWriter jsonWriter = new JsonWriter(stringWriter);
     jsonWriter.setStrictness(Strictness.STRICT);
@@ -356,7 +358,7 @@ public final class JsonWriterTest {
   public void testNonFiniteFloatsWhenLenient() throws IOException {
     StringWriter stringWriter = new StringWriter();
     JsonWriter jsonWriter = new JsonWriter(stringWriter);
-    jsonWriter.setLenient(true);
+    jsonWriter.setStrictness(Strictness.LENIENT);
     jsonWriter.beginArray();
     jsonWriter.value(Float.NaN);
     jsonWriter.value(Float.NEGATIVE_INFINITY);
@@ -369,7 +371,7 @@ public final class JsonWriterTest {
   public void testNonFiniteDoublesWhenLenient() throws IOException {
     StringWriter stringWriter = new StringWriter();
     JsonWriter jsonWriter = new JsonWriter(stringWriter);
-    jsonWriter.setLenient(true);
+    jsonWriter.setStrictness(Strictness.LENIENT);
     jsonWriter.beginArray();
     jsonWriter.value(Double.NaN);
     jsonWriter.value(Double.NEGATIVE_INFINITY);
@@ -382,7 +384,7 @@ public final class JsonWriterTest {
   public void testNonFiniteNumbersWhenLenient() throws IOException {
     StringWriter stringWriter = new StringWriter();
     JsonWriter jsonWriter = new JsonWriter(stringWriter);
-    jsonWriter.setLenient(true);
+    jsonWriter.setStrictness(Strictness.LENIENT);
     jsonWriter.beginArray();
     jsonWriter.value(Double.valueOf(Double.NaN));
     jsonWriter.value(Double.valueOf(Double.NEGATIVE_INFINITY));
@@ -829,7 +831,7 @@ public final class JsonWriterTest {
   public void testLenientWriterPermitsMultipleTopLevelValues() throws IOException {
     StringWriter stringWriter = new StringWriter();
     JsonWriter writer = new JsonWriter(stringWriter);
-    writer.setLenient(true);
+    writer.setStrictness(Strictness.LENIENT);
     writer.beginArray();
     writer.endArray();
     writer.beginArray();
@@ -848,6 +850,7 @@ public final class JsonWriterTest {
       writer.beginArray();
       fail();
     } catch (IllegalStateException expected) {
+      assertThat(expected).hasMessageThat().isEqualTo("JSON must have only one top-level value.");
     }
   }
 


### PR DESCRIPTION
<!--
    Thank you for your contribution!
    Please see the contributing guide: https://github.com/google/.github/blob/master/CONTRIBUTING.md

    Keep in mind that Gson is in maintenance mode. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.
-->

### Purpose
Follow-up for #2323

### Description
- Remove mentions of `null` Gson strictness; this is an implementation detail
- Fix incorrect / outdated documentation
- Reduce links to RFC; if there is already a link to it in a previous sentence don't link to it again
- Extend and update tests
- Minor punctuation changes in documentation for consistency
- Deprecate `setLenient` methods

Feedback is appreciated, especially regarding the documentation changes. Some changes might be a bit opinionated, so no problem if you disagree and want me to change anything.
@marten-voorberg, are these changes ok for you and still in the spirit of what you originally had in mind? Of course if you want to change anything else, feel free to either suggest it here or create an additional pull request as well.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)
- [x] If necessary, new public API validates arguments, for example rejects `null`
- [x] New public API has Javadoc
    - [x] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [x] If necessary, new unit tests have been added  
  - [x] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [x] No JUnit 3 features are used (such as extending class `TestCase`)
  - [x] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
