### PR TITLE
Revised "has" method to "containsKey" and added "containsValue" metho…

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonObject.java
+++ b/gson/src/main/java/com/google/gson/JsonObject.java
@@ -173,9 +173,17 @@ public final class JsonObject extends JsonElement {
    * @param memberName name of the member that is being checked for presence.
    * @return true if there is a member with the specified name, false otherwise.
    */
-  public boolean has(String memberName) {
+  public boolean containsKey(String memberName) {
     return members.containsKey(memberName);
   }
+
+  /**
+   * Convenience method to check if a member is present in this object.
+   *
+   * @param member member that is being checked for presence.
+   * @return true if there is the member, false otherwise.
+   */
+  public boolean containsValue(JsonElement member) { return members.containsValue(member); }
 
   /**
    * Returns the member with the specified name.

--- a/gson/src/test/java/com/google/gson/JsonObjectTest.java
+++ b/gson/src/test/java/com/google/gson/JsonObjectTest.java
@@ -44,7 +44,7 @@ public class JsonObjectTest {
   public void testAddingAndRemovingObjectProperties() {
     JsonObject jsonObj = new JsonObject();
     String propertyName = "property";
-    assertThat(jsonObj.has(propertyName)).isFalse();
+    assertThat(jsonObj.containsKey(propertyName)).isFalse();
     assertThat(jsonObj.get(propertyName)).isNull();
 
     JsonPrimitive value = new JsonPrimitive("blah");
@@ -53,7 +53,7 @@ public class JsonObjectTest {
 
     JsonElement removedElement = jsonObj.remove(propertyName);
     assertThat(removedElement).isEqualTo(value);
-    assertThat(jsonObj.has(propertyName)).isFalse();
+    assertThat(jsonObj.containsKey(propertyName)).isFalse();
     assertThat(jsonObj.get(propertyName)).isNull();
 
     assertThat(jsonObj.remove(propertyName)).isNull();
@@ -65,7 +65,7 @@ public class JsonObjectTest {
     JsonObject jsonObj = new JsonObject();
     jsonObj.add(propertyName, null);
 
-    assertThat(jsonObj.has(propertyName)).isTrue();
+    assertThat(jsonObj.containsKey(propertyName)).isTrue();
 
     JsonElement jsonElement = jsonObj.get(propertyName);
     assertThat(jsonElement).isNotNull();
@@ -90,7 +90,7 @@ public class JsonObjectTest {
     JsonObject jsonObj = new JsonObject();
     jsonObj.addProperty(propertyName, true);
 
-    assertThat(jsonObj.has(propertyName)).isTrue();
+    assertThat(jsonObj.containsKey(propertyName)).isTrue();
 
     JsonElement jsonElement = jsonObj.get(propertyName);
     assertThat(jsonElement).isNotNull();
@@ -105,7 +105,7 @@ public class JsonObjectTest {
     JsonObject jsonObj = new JsonObject();
     jsonObj.addProperty(propertyName, value);
 
-    assertThat(jsonObj.has(propertyName)).isTrue();
+    assertThat(jsonObj.containsKey(propertyName)).isTrue();
 
     JsonElement jsonElement = jsonObj.get(propertyName);
     assertThat(jsonElement).isNotNull();
@@ -120,7 +120,7 @@ public class JsonObjectTest {
     JsonObject jsonObj = new JsonObject();
     jsonObj.addProperty(propertyName, value);
 
-    assertThat(jsonObj.has(propertyName)).isTrue();
+    assertThat(jsonObj.containsKey(propertyName)).isTrue();
 
     JsonElement jsonElement = jsonObj.get(propertyName);
     assertThat(jsonElement).isNotNull();


### PR DESCRIPTION
There were circumstances when I had to check if the specific JsonElement object is in JsonObject. 

I found out that there is already method with name "has" and thought it would not be consistent if just adding new method with name "containsValue". I thought that it would be better to change pre-existing method's name to "containsKey", too. 

