### PR TITLE
Validate instances created by `InstanceCreator`

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
+++ b/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
@@ -89,6 +89,19 @@ public final class ConstructorConstructor {
     return null;
   }
 
+  private static <T> T useInstanceCreator(InstanceCreator<T> instanceCreator, Type type, Class<?> rawType) {
+    T instance = instanceCreator.createInstance(type);
+    if (instance == null) {
+      throw new RuntimeException("InstanceCreator " + instanceCreator + " returned null for type " + type);
+    }
+
+    if (!rawType.isInstance(instance)) {
+      throw new ClassCastException("InstanceCreator " + instanceCreator + " created instance of wrong type;"
+          + " expected " + rawType.getName() + " but got instance of unrelated type " + instance.getClass().getName());
+    }
+    return instance;
+  }
+
   public <T> ObjectConstructor<T> get(TypeToken<T> typeToken) {
     final Type type = typeToken.getType();
     final Class<? super T> rawType = typeToken.getRawType();
@@ -100,7 +113,7 @@ public final class ConstructorConstructor {
     if (typeCreator != null) {
       return new ObjectConstructor<T>() {
         @Override public T construct() {
-          return typeCreator.createInstance(type);
+          return useInstanceCreator(typeCreator, type, rawType);
         }
       };
     }
@@ -112,7 +125,7 @@ public final class ConstructorConstructor {
     if (rawTypeCreator != null) {
       return new ObjectConstructor<T>() {
         @Override public T construct() {
-          return rawTypeCreator.createInstance(type);
+          return useInstanceCreator(rawTypeCreator, type, rawType);
         }
       };
     }


### PR DESCRIPTION
### Purpose
Follow-up for https://github.com/google/gson/pull/2435#issuecomment-1646988868 and comment below

### Description
Validate that instances created by an `InstanceCreator` are not `null`, and are actually of the requested type. This hopefully makes troubleshooting for users easier than encountering a `ClassCastException` at a completely different place, without any indication that a faulty `InstanceCreator` is the cause.

As mentioned in https://github.com/google/gson/pull/2435#issuecomment-1646988868, there is currently code which relies on Java type erasure and Gson implementation details to misuse the missing checks and create unrelated instances. It has to be decided if it is acceptable to break that code.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [x] If necessary, new unit tests have been added  
  - [x] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [x] No JUnit 3 features are used (such as extending class `TestCase`)
  - [x] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
