### PR TITLE
Support non-generic type for `TypeToken.getParameterized` for legacy reasons

### DIFF
--- a/gson/src/main/java/com/google/gson/reflect/TypeToken.java
+++ b/gson/src/main/java/com/google/gson/reflect/TypeToken.java
@@ -337,9 +337,12 @@ public class TypeToken<T> {
    * As seen here the result is a {@code TypeToken<?>}; this method cannot provide any type safety,
    * and care must be taken to pass in the correct number of type arguments.
    *
+   * <p>If {@code rawType} is a non-generic class and no type arguments are provided, this method
+   * simply delegates to {@link #get(Class)} and creates a {@code TypeToken(Class)}.
+   *
    * @throws IllegalArgumentException
-   *   If {@code rawType} is not of type {@code Class}, if it is not a generic type, or if the
-   *   type arguments are invalid for the raw type
+   *   If {@code rawType} is not of type {@code Class}, or if the type arguments are invalid for
+   *   the raw type
    */
   public static TypeToken<?> getParameterized(Type rawType, Type... typeArguments) {
     Objects.requireNonNull(rawType);
@@ -354,23 +357,22 @@ public class TypeToken<T> {
     Class<?> rawClass = (Class<?>) rawType;
     TypeVariable<?>[] typeVariables = rawClass.getTypeParameters();
 
-    // Note: Does not check if owner type of rawType is generic because this factory method
-    // does not support specifying owner type
-    if (typeVariables.length == 0) {
-      throw new IllegalArgumentException(rawClass.getName() + " is not a generic type");
+    int expectedArgsCount = typeVariables.length;
+    int actualArgsCount = typeArguments.length;
+    if (actualArgsCount != expectedArgsCount) {
+      throw new IllegalArgumentException(rawClass.getName() + " requires " + expectedArgsCount +
+          " type arguments, but got " + actualArgsCount);
+    }
+
+    // For legacy reasons create a TypeToken(Class) if the type is not generic
+    if (typeArguments.length == 0) {
+      return get(rawClass);
     }
 
     // Check for this here to avoid misleading exception thrown by ParameterizedTypeImpl
     if ($Gson$Types.requiresOwnerType(rawType)) {
       throw new IllegalArgumentException("Raw type " + rawClass.getName() + " is not supported because"
           + " it requires specifying an owner type");
-    }
-
-    int expectedArgsCount = typeVariables.length;
-    int actualArgsCount = typeArguments.length;
-    if (actualArgsCount != expectedArgsCount) {
-      throw new IllegalArgumentException(rawClass.getName() + " requires " + expectedArgsCount +
-          " type arguments, but got " + actualArgsCount);
     }
 
     for (int i = 0; i < expectedArgsCount; i++) {

--- a/gson/src/test/java/com/google/gson/reflect/TypeTokenTest.java
+++ b/gson/src/test/java/com/google/gson/reflect/TypeTokenTest.java
@@ -146,6 +146,9 @@ public final class TypeTokenTest {
     class LocalGenericClass<T> {}
     TypeToken<?> expectedLocalType = new TypeToken<LocalGenericClass<Integer>>() {};
     assertThat(TypeToken.getParameterized(LocalGenericClass.class, Integer.class)).isEqualTo(expectedLocalType);
+
+    // For legacy reasons, if requesting parameterized type for non-generic class, create a `TypeToken(Class)`
+    assertThat(TypeToken.getParameterized(String.class)).isEqualTo(TypeToken.get(String.class));
   }
 
   @Test
@@ -158,7 +161,7 @@ public final class TypeTokenTest {
     assertThat(e).hasMessageThat().isEqualTo("rawType must be of type Class, but was java.lang.String[]");
 
     e = assertThrows(IllegalArgumentException.class, () -> TypeToken.getParameterized(String.class, Number.class));
-    assertThat(e).hasMessageThat().isEqualTo("java.lang.String is not a generic type");
+    assertThat(e).hasMessageThat().isEqualTo("java.lang.String requires 0 type arguments, but got 1");
 
     e = assertThrows(IllegalArgumentException.class, () -> TypeToken.getParameterized(List.class, new Type[0]));
     assertThat(e).hasMessageThat().isEqualTo("java.util.List requires 1 type arguments, but got 0");


### PR DESCRIPTION


<!--
    Thank you for your contribution!
    Please see the contributing guide: https://github.com/google/.github/blob/master/CONTRIBUTING.md

    Keep in mind that Gson is in maintenance mode. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.
-->

### Purpose
Follow-up for https://github.com/google/gson/pull/2375#discussion_r1273736816

### Description
This partially restores the behavior before a589ef20087b4b0f1ec3048d3ceaef1eedccd09d, except that back then for a non-generic type a bogus `TypeToken(ParameterizedType)` was created, whereas now a `TypeToken(Class)` is created instead.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [x] If necessary, new unit tests have been added  
  - [x] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [x] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
