### PR TITLE
Update ProGuard default shrinking rules

### DIFF
--- a/gson/src/main/resources/META-INF/proguard/gson.pro
+++ b/gson/src/main/resources/META-INF/proguard/gson.pro
@@ -65,6 +65,6 @@
 # See also https://github.com/google/gson/pull/2420#discussion_r1241813541 for a more detailed explanation
 -if class *
 -keepclasseswithmembers,allowobfuscation,allowoptimization class <1> {
-  <init>();
+  <init>(...);
   @com.google.gson.annotations.SerializedName <fields>;
 }


### PR DESCRIPTION
This change deals correctly with classes without a no-args constructor. If a no-args constructor was not present the conditional keep rule would not trigger.

See https://issuetracker.google.com/150189783#comment11.