### PR TITLE
Make date-formatting tests less fragile with regular expressions.

### DIFF
--- a/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
@@ -384,11 +384,7 @@ public class DefaultTypeAdaptersTest {
   public void testDefaultDateSerialization() {
     Date now = new Date(1315806903103L);
     String json = gson.toJson(now);
-    if (JavaVersion.isJava9OrLater()) {
-      assertThat(json).isEqualTo("\"Sep 11, 2011, 10:55:03 PM\"");
-    } else {
-      assertThat(json).isEqualTo("\"Sep 11, 2011 10:55:03 PM\"");
-    }
+    assertThat(json).matches("\"Sep 11, 2011,? 10:55:03\\hPM\"");
   }
 
   @Test
@@ -420,11 +416,7 @@ public class DefaultTypeAdaptersTest {
     Gson gson = new GsonBuilder().create();
     Date now = new Date(1315806903103L);
     String json = gson.toJson(now);
-    if (JavaVersion.isJava9OrLater()) {
-      assertThat(json).isEqualTo("\"Sep 11, 2011, 10:55:03 PM\"");
-    } else {
-      assertThat(json).isEqualTo("\"Sep 11, 2011 10:55:03 PM\"");
-    }
+    assertThat(json).matches("\"Sep 11, 2011,? 10:55:03\\hPM\"");
   }
 
   @Test

--- a/gson/src/test/java/com/google/gson/functional/ObjectTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ObjectTest.java
@@ -570,11 +570,8 @@ public class ObjectTest {
   public void testDateAsMapObjectField() {
     HasObjectMap a = new HasObjectMap();
     a.map.put("date", new Date(0));
-    if (JavaVersion.isJava9OrLater()) {
-      assertThat(gson.toJson(a)).isEqualTo("{\"map\":{\"date\":\"Dec 31, 1969, 4:00:00 PM\"}}");
-    } else {
-      assertThat(gson.toJson(a)).isEqualTo("{\"map\":{\"date\":\"Dec 31, 1969 4:00:00 PM\"}}");
-    }
+    assertThat(gson.toJson(a))
+        .matches("\\{\"map\":\\{\"date\":\"Dec 31, 1969,? 4:00:00\\hPM\"\\}\\}");
   }
 
   static class HasObjectMap {

--- a/gson/src/test/java/com/google/gson/internal/bind/DefaultDateTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/DefaultDateTypeAdapterTest.java
@@ -71,7 +71,7 @@ public class DefaultDateTypeAdapterTest {
           DateType.DATE.createAdapterFactory(DateFormat.SHORT, DateFormat.SHORT));
       assertFormatted("Jan 1, 1970,? 12:00:00\\hAM",
           DateType.DATE.createAdapterFactory(DateFormat.MEDIUM, DateFormat.MEDIUM));
-      assertFormatted("January 1, 1970,? 12:00:00\\hAM UTC",
+      assertFormatted("January 1, 1970(,| at)? 12:00:00\\hAM UTC",
           DateType.DATE.createAdapterFactory(DateFormat.LONG, DateFormat.LONG));
       assertFormatted("Thursday, January 1, 1970(,| at)? 12:00:00\\hAM " + utcFull,
           DateType.DATE.createAdapterFactory(DateFormat.FULL, DateFormat.FULL));
@@ -224,20 +224,7 @@ public class DefaultDateTypeAdapterTest {
   private static void assertFormatted(String formattedPattern, TypeAdapterFactory adapterFactory) {
     TypeAdapter<Date> adapter = dateAdapter(adapterFactory);
     String json = adapter.toJson(new Date(0));
-    try {
-      assertThat(json).matches(toLiteral(formattedPattern));
-    } catch (AssertionError e) {
-      StringBuilder sb = new StringBuilder();
-      char[] chars = json.toCharArray();
-      for (char c : chars) {
-        if (c >= ' ' && c <= '~') {
-          sb.append(c);
-        } else {
-          sb.append(String.format("\\u%04x", (int) c));
-        }
-      }
-      throw new AssertionError(sb.toString(), e);
-    }
+    assertThat(json).matches(toLiteral(formattedPattern));
   }
 
   @SuppressWarnings("UndefinedEquals")

--- a/gson/src/test/java/com/google/gson/internal/bind/DefaultDateTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/DefaultDateTypeAdapterTest.java
@@ -223,7 +223,21 @@ public class DefaultDateTypeAdapterTest {
 
   private static void assertFormatted(String formattedPattern, TypeAdapterFactory adapterFactory) {
     TypeAdapter<Date> adapter = dateAdapter(adapterFactory);
-    assertThat(adapter.toJson(new Date(0))).matches(toLiteral(formattedPattern));
+    String json = adapter.toJson(new Date(0));
+    try {
+      assertThat(json).matches(toLiteral(formattedPattern));
+    } catch (AssertionError e) {
+      char[] chars = json.toCharArray();
+      for (char c : chars) {
+        if (c >= ' ' && c <= '~') {
+          System.err.print(c);
+        } else {
+          System.err.printf("\\u%04x", (int) c);
+        }
+      }
+      System.err.println();
+      throw e;
+    }
   }
 
   @SuppressWarnings("UndefinedEquals")

--- a/gson/src/test/java/com/google/gson/internal/bind/DefaultDateTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/DefaultDateTypeAdapterTest.java
@@ -227,16 +227,16 @@ public class DefaultDateTypeAdapterTest {
     try {
       assertThat(json).matches(toLiteral(formattedPattern));
     } catch (AssertionError e) {
+      StringBuilder sb = new StringBuilder();
       char[] chars = json.toCharArray();
       for (char c : chars) {
         if (c >= ' ' && c <= '~') {
-          System.err.print(c);
+          sb.append(c);
         } else {
-          System.err.printf("\\u%04x", (int) c);
+          sb.append(String.format("\\u%04x", (int) c));
         }
       }
-      System.err.println();
-      throw e;
+      throw new AssertionError(sb.toString(), e);
     }
   }
 

--- a/gson/src/test/java/com/google/gson/internal/sql/SqlTypesGsonTest.java
+++ b/gson/src/test/java/com/google/gson/internal/sql/SqlTypesGsonTest.java
@@ -113,11 +113,10 @@ public class SqlTypesGsonTest {
   public void testDefaultSqlTimestampSerialization() {
     Timestamp now = new java.sql.Timestamp(1259875082000L);
     String json = gson.toJson(now);
-    if (JavaVersion.isJava9OrLater()) {
-      assertThat(json).isEqualTo("\"Dec 3, 2009, 1:18:02 PM\"");
-    } else {
-      assertThat(json).isEqualTo("\"Dec 3, 2009 1:18:02 PM\"");
-    }
+    // The exact format of the serialized date-time string depends on the JDK version. The pattern
+    // here allows for an optional comma after the date, and what might be U+202F (Narrow No-Break
+    // Space) before "PM".
+    assertThat(json).matches("\"Dec 3, 2009,? 1:18:02\\hPM\"");
   }
 
   @Test


### PR DESCRIPTION
This is not great. We should really ensure that formatted dates are the same regardless of JDK version. There is code that attempts to do that but it is not really effective. So for we use regular expressions to paper over the differences.

<!--
    Thank you for your contribution!
    Please see the contributing guide: https://github.com/google/.github/blob/master/CONTRIBUTING.md

    Keep in mind that Gson is in maintenance mode. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.
-->

### Purpose
<!-- Describe the purpose of this pull request, for example which new feature it adds or which bug it fixes -->
<!-- If this pull request closes a GitHub issue, please write "Closes #<issue>", for example "Closes #123" -->


### Description
<!-- If necessary provide more information, for example relevant implementation details or corner cases which are not covered yet -->
<!-- If there are related issues or pull requests, link to them by referencing their number, for example "pull request #123" -->



### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [ ] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [ ] `mvn clean verify javadoc:jar` passes without errors
