### PR TITLE
Add test for unused class to shrinker-test

### DIFF
--- a/shrinker-test/common.pro
+++ b/shrinker-test/common.pro
@@ -38,3 +38,7 @@
 -keepclassmembernames class com.example.ClassWithVersionAnnotations {
   <fields>;
 }
+
+# Keep the name of the class to allow using reflection to check if this class still exists
+# after shrinking
+-keepnames class com.example.UnusedClass

--- a/shrinker-test/src/main/java/com/example/UnusedClass.java
+++ b/shrinker-test/src/main/java/com/example/UnusedClass.java
@@ -1,0 +1,17 @@
+package com.example;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Class with no-args constructor and field annotated with {@code @SerializedName},
+ * but which is not actually used anywhere in the code.
+ *
+ * <p>The default ProGuard rules should not keep this class.
+ */
+public class UnusedClass {
+  public UnusedClass() {
+  }
+
+  @SerializedName("i")
+  public int i;
+}

--- a/shrinker-test/src/test/java/com/google/gson/it/ShrinkingIT.java
+++ b/shrinker-test/src/test/java/com/google/gson/it/ShrinkingIT.java
@@ -19,7 +19,9 @@ package com.google.gson.it;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
+import com.example.UnusedClass;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
@@ -247,5 +249,19 @@ public class ShrinkingIT {
         );
       }
     });
+  }
+
+  @Test
+  public void testUnusedClassRemoved() throws Exception {
+    // For some reason this test only works for R8 but not for ProGuard; ProGuard keeps the unused class
+    assumeTrue(jarToTest.equals(R8_RESULT_PATH));
+
+    String className = UnusedClass.class.getName();
+    ClassNotFoundException e = assertThrows(ClassNotFoundException.class, () -> {
+      runTest(className, c -> {
+        fail("Class should have been removed during shrinking: " + c);
+      });
+    });
+    assertThat(e).hasMessageThat().contains(className);
   }
 }


### PR DESCRIPTION
### Purpose
Extends tests of `shrinker-test` for unused classes


### Description
Based on #2448

Adds a test case for a class with a field annotated with `@SerializedName`, but which is not actually used anywhere. The default Gson ProGuard rules should allow this class to be removed.

Note: This actually works as intended for R8, but not for ProGuard which keeps the class. Not sure if it is worth investigating that further at the moment.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [ ] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [ ] `mvn clean verify javadoc:jar` passes without errors
