### PR TITLE
Fix graal-native-image-test module causing failure for 'Check API compatibility'

### DIFF
--- a/graal-native-image-test/pom.xml
+++ b/graal-native-image-test/pom.xml
@@ -87,6 +87,15 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <configuration>
+            <!-- This module has no 'main' source code, so no JAR is created which could be installed;
+              see maven-jar-plugin configuration above -->
+            <skip>true</skip>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
           <configuration>
             <!-- Not deployed -->

--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,11 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>3.1.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
           <version>3.3.0</version>
         </plugin>


### PR DESCRIPTION
### Purpose
Follow-up for #2466


### Description
The 'Check API compatibility' workflow runs `mvn install` to install the previous version in the local Maven repository to compare it afterwards. However this fails for the graal-native-image-test module because it does not produce a JAR.

Therefore now skip execution of the maven-install-plugin for that module. I hope no further issues (e.g. on release) occur due to the graal-native-image-test module having no JAR file.

Unfortunately I overlooked that for my previous PR.


The 'Check API compatibility' failure for this PR here is 'expected' and is exactly what this PR tries to fix. But because the 'Check API compatibility' workflow runs `mvn install` for the target branch of a PR, it still fails for this PR, but should work fine again for any subsequent ones.