### PR TITLE
Revert "Bump org.codehaus.plexus:plexus-utils from 3.5.1 to 4.0.0"

### DIFF
--- a/graal-native-image-test/pom.xml
+++ b/graal-native-image-test/pom.xml
@@ -170,7 +170,7 @@
                 <artifactId>plexus-utils</artifactId>
                 <!-- Don't upgrade version to >= 4 because that seems to contain potentially backward
                   incompatible changes -->
-                <version>4.0.0</version>
+                <version>3.5.1</version>
               </dependency>
             </dependencies>
           </plugin>


### PR DESCRIPTION
Reverts google/gson#2468.

As noted by @Marcono1234, this should not be updated for now. That information was right there in a comment before the updated `<version>` but I didn't see it.