### PR TITLE
changes to ensure if no object is opened user won't be able to add pr…

### DIFF
--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -498,6 +498,10 @@ public class JsonWriter implements Closeable, Flushable {
     if (stackSize == 0) {
       throw new IllegalStateException("JsonWriter is closed.");
     }
+    // As currently in any valid case name function cannot be called if stack top has these 2 statuses
+    if (stackSize == 1 && ( peek() == EMPTY_DOCUMENT || peek() == NONEMPTY_DOCUMENT )) {
+      throw new IllegalStateException("Please begin an object before this.");
+    }
     deferredName = name;
     return this;
   }

--- a/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
@@ -28,6 +28,8 @@ import java.io.StringWriter;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import org.junit.Test;
+import java.util.Arrays;
+import java.util.List;
 
 @SuppressWarnings("resource")
 public final class JsonWriterTest {
@@ -114,13 +116,36 @@ public final class JsonWriterTest {
   public void testInvalidTopLevelTypes() throws IOException {
     StringWriter stringWriter = new StringWriter();
     JsonWriter jsonWriter = new JsonWriter(stringWriter);
-    jsonWriter.name("hello"); // TODO: This should throw, see https://github.com/google/gson/issues/2407
-    try {
-      jsonWriter.value("world");
-      fail();
-    } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Nesting problem.");
+    assertThrows(IllegalStateException.class, () -> jsonWriter.name("hello"));
+    //removed nested exception test on jsonwriter.writevalue as it seems currently valid case per code
+  }
+
+  @Test
+  public void closeAllObjectsAndTryToAddElements() throws IOException {
+    StringWriter stringWriter = new StringWriter();
+    JsonWriter jsonWriter = new JsonWriter(stringWriter);
+    jsonWriter.beginObject();
+    jsonWriter.name("a").value(20);
+    jsonWriter.name("age").value(30);
+
+    // Start the nested "address" object
+    jsonWriter.name("address").beginObject();
+    jsonWriter.name("city").value("New York");
+    jsonWriter.name("country").value("USA");
+    jsonWriter.endObject(); // End the nested "address" object
+    jsonWriter.name("random_prop").value(78);
+    // Add an array of phone numbers (list of numbers)
+    List<Integer> phoneNumbers = Arrays.asList(1234567890, 98989, 9909);
+    jsonWriter.name("phoneNumbers").beginArray();
+    for (Integer phoneNumber : phoneNumbers) {
+      jsonWriter.value(phoneNumber);
     }
+    jsonWriter.endArray(); // End the array
+    jsonWriter.endObject(); // End the outer object
+    assertThrows(IllegalStateException.class, () -> jsonWriter.name("this_throw_exception_as_all_objects_are_closed"));
+    assertThrows(IllegalStateException.class, () -> jsonWriter.value("this_throw_exception_as_only_one_top_level_entry"));
+    jsonWriter.close();
+
   }
 
   @Test


### PR DESCRIPTION
…op in the object

<!--
    Thank you for your contribution!
    Please see the contributing guide: https://github.com/google/.github/blob/master/CONTRIBUTING.md

    Keep in mind that Gson is in maintenance mode. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.
-->

### Purpose
Currently, even if the no object is opened or begin object is not called or all open objects are ended using jsonwriter.endObject()
Still user is able to add json object property name, which shouldn't be happening
<!-- If this pull request closes a GitHub issue, please write "Closes #<issue>", for example "Closes #123" --> 

Closes #2407


### Description
Currently when the Jsonwriter name method is called no check is there to identify if it's an empty document or all open objects are closed and stack size reaches 1 and the top element is NON_EMPTY_DOC 
basically the two case

- The user calls jsonwrite.name() for the first time in an empty document or when the beginobject method has not been called.
- The user calls jsonwrite.name() when all opened objects are closed.

In both of these invalid cases, the stack size should be 1 as per the current implementation
In the first case, we stack will be having one status only which will be EMPTY_DOCUMENT
In the second case, all other statuses will be popped from the stack and only one status NONEMPTY_DOCUMENT will be present in the stack


So added a check in the name method for these 2 special cases

Also added and changed the unit test as per requirement

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [ ] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [ ] `mvn clean verify javadoc:jar` passes without errors
