### PR TITLE
Add shrinker-test examples with never-referenced constructors

### DIFF
--- a/shrinker-test/common.pro
+++ b/shrinker-test/common.pro
@@ -16,9 +16,9 @@
   public static void runTests(...);
 }
 -keep class com.example.NoSerializedNameMain {
-  public static java.lang.String runTest();
+  public static java.lang.String runTestNoArgsConstructor();
   public static java.lang.String runTestNoJdkUnsafe();
-  public static java.lang.String runTestConstructorHasArgs();
+  public static java.lang.String runTestHasArgsConstructor();
 }
 
 

--- a/shrinker-test/common.pro
+++ b/shrinker-test/common.pro
@@ -18,7 +18,7 @@
 -keep class com.example.NoSerializedNameMain {
   public static java.lang.String runTest();
   public static java.lang.String runTestNoJdkUnsafe();
-  public static java.lang.String runTestNoDefaultConstructor();
+  public static java.lang.String runTestConstructorHasArgs();
 }
 
 

--- a/shrinker-test/proguard.pro
+++ b/shrinker-test/proguard.pro
@@ -12,6 +12,6 @@
 -keepclassmembernames class com.example.NoSerializedNameMain$TestClassNotAbstract {
   <fields>;
 }
--keepclassmembernames class com.example.NoSerializedNameMain$TestClassWithoutDefaultConstructor {
+-keepclassmembernames class com.example.NoSerializedNameMain$TestClassConstructorHasArgs {
   <fields>;
 }

--- a/shrinker-test/proguard.pro
+++ b/shrinker-test/proguard.pro
@@ -6,12 +6,12 @@
 # Unlike R8, ProGuard does not perform aggressive optimization which makes classes abstract,
 # therefore for ProGuard can successfully perform deserialization, and for that need to
 # preserve the field names
--keepclassmembernames class com.example.NoSerializedNameMain$TestClass {
+-keepclassmembernames class com.example.NoSerializedNameMain$TestClassNoArgsConstructor {
   <fields>;
 }
 -keepclassmembernames class com.example.NoSerializedNameMain$TestClassNotAbstract {
   <fields>;
 }
--keepclassmembernames class com.example.NoSerializedNameMain$TestClassConstructorHasArgs {
+-keepclassmembernames class com.example.NoSerializedNameMain$TestClassHasArgsConstructor {
   <fields>;
 }

--- a/shrinker-test/r8.pro
+++ b/shrinker-test/r8.pro
@@ -10,8 +10,8 @@
 -keep,allowshrinking,allowoptimization,allowobfuscation,allowaccessmodification class com.example.GenericClasses$GenericUsingGenericClass
 
 # Don't obfuscate class name, to check it in exception message
--keep,allowshrinking,allowoptimization class com.example.NoSerializedNameMain$TestClass
--keep,allowshrinking,allowoptimization class com.example.NoSerializedNameMain$TestClassConstructorHasArgs
+-keep,allowshrinking,allowoptimization class com.example.NoSerializedNameMain$TestClassNoArgsConstructor
+-keep,allowshrinking,allowoptimization class com.example.NoSerializedNameMain$TestClassHasArgsConstructor
 
 # This rule has the side-effect that R8 still removes the no-args constructor, but does not make the class abstract
 -keep class com.example.NoSerializedNameMain$TestClassNotAbstract {

--- a/shrinker-test/r8.pro
+++ b/shrinker-test/r8.pro
@@ -11,7 +11,7 @@
 
 # Don't obfuscate class name, to check it in exception message
 -keep,allowshrinking,allowoptimization class com.example.NoSerializedNameMain$TestClass
--keep,allowshrinking,allowoptimization class com.example.NoSerializedNameMain$TestClassWithoutDefaultConstructor
+-keep,allowshrinking,allowoptimization class com.example.NoSerializedNameMain$TestClassConstructorHasArgs
 
 # This rule has the side-effect that R8 still removes the no-args constructor, but does not make the class abstract
 -keep class com.example.NoSerializedNameMain$TestClassNotAbstract {

--- a/shrinker-test/src/main/java/com/example/ClassWithHasArgsConstructor.java
+++ b/shrinker-test/src/main/java/com/example/ClassWithHasArgsConstructor.java
@@ -3,15 +3,15 @@ package com.example;
 import com.google.gson.annotations.SerializedName;
 
 /**
- * Class without no-args default constructor, but with field annotated with
+ * Class without no-args constructor, but with field annotated with
  * {@link SerializedName}.
  */
-public class ClassWithoutDefaultConstructor {
+public class ClassWithHasArgsConstructor {
   @SerializedName("myField")
   public int i;
 
   // Specify explicit constructor with args to remove implicit no-args default constructor
-  public ClassWithoutDefaultConstructor(int i) {
+  public ClassWithHasArgsConstructor(int i) {
     this.i = i;
   }
 }

--- a/shrinker-test/src/main/java/com/example/ClassWithNoArgsConstructor.java
+++ b/shrinker-test/src/main/java/com/example/ClassWithNoArgsConstructor.java
@@ -6,11 +6,11 @@ import com.google.gson.annotations.SerializedName;
  * Class with no-args default constructor and with field annotated with
  * {@link SerializedName}.
  */
-public class ClassWithDefaultConstructor {
+public class ClassWithNoArgsConstructor {
   @SerializedName("myField")
   public int i;
 
-  public ClassWithDefaultConstructor() {
+  public ClassWithNoArgsConstructor() {
     i = -3;
   }
 }

--- a/shrinker-test/src/main/java/com/example/ClassWithNoArgsConstructor.java
+++ b/shrinker-test/src/main/java/com/example/ClassWithNoArgsConstructor.java
@@ -3,7 +3,7 @@ package com.example;
 import com.google.gson.annotations.SerializedName;
 
 /**
- * Class with no-args default constructor and with field annotated with
+ * Class with no-args constructor and with field annotated with
  * {@link SerializedName}.
  */
 public class ClassWithNoArgsConstructor {

--- a/shrinker-test/src/main/java/com/example/ClassWithUnreferencedHasArgsConstructor.java
+++ b/shrinker-test/src/main/java/com/example/ClassWithUnreferencedHasArgsConstructor.java
@@ -1,0 +1,19 @@
+package com.example;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Class without no-args constructor, but with field annotated with
+ * {@link SerializedName}. The constructor should not actually be used in the
+ * code, but this shouldn't lead to R8 concluding that values of the type are
+ * not constructible and therefore must be null.
+ */
+public class ClassWithUnreferencedHasArgsConstructor {
+  @SerializedName("myField")
+  public int i;
+
+  // Specify explicit constructor with args to remove implicit no-args default constructor
+  public ClassWithUnreferencedHasArgsConstructor(int i) {
+    this.i = i;
+  }
+}

--- a/shrinker-test/src/main/java/com/example/ClassWithUnreferencedNoArgsConstructor.java
+++ b/shrinker-test/src/main/java/com/example/ClassWithUnreferencedNoArgsConstructor.java
@@ -1,0 +1,18 @@
+package com.example;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Class with no-args constructor and with field annotated with
+ * {@link SerializedName}. The constructor should not actually be used in the
+ * code, but this shouldn't lead to R8 concluding that values of the type are
+ * not constructible and therefore must be null.
+ */
+public class ClassWithUnreferencedNoArgsConstructor {
+  @SerializedName("myField")
+  public int i;
+
+  public ClassWithUnreferencedNoArgsConstructor() {
+    i = -3;
+  }
+}

--- a/shrinker-test/src/main/java/com/example/NoSerializedNameMain.java
+++ b/shrinker-test/src/main/java/com/example/NoSerializedNameMain.java
@@ -49,7 +49,7 @@ public class NoSerializedNameMain {
   }
 
   /**
-   * Main entrypoint, called by {@code ShrinkingIT.testNoSerializedName_ConstructorHasArgs()}.
+   * Main entrypoint, called by {@code ShrinkingIT.testNoSerializedName_HasArgsConstructor()}.
    */
   public static String runTestHasArgsConstructor() {
     TestClassHasArgsConstructor deserialized = new Gson().fromJson(

--- a/shrinker-test/src/main/java/com/example/NoSerializedNameMain.java
+++ b/shrinker-test/src/main/java/com/example/NoSerializedNameMain.java
@@ -10,7 +10,8 @@ import com.google.gson.GsonBuilder;
  * therefore not matched by the default {@code gson.pro} rules.
  */
 public class NoSerializedNameMain {
-  static class TestClass {
+  static class TestClassNoArgsConstructor {
+    // Has a no-args default constructor.
     public String s;
   }
 
@@ -19,11 +20,11 @@ public class NoSerializedNameMain {
     public String s;
   }
 
-  static class TestClassConstructorHasArgs {
+  static class TestClassHasArgsConstructor {
     public String s;
 
     // Specify explicit constructor with args to remove implicit no-args default constructor
-    public TestClassConstructorHasArgs(String s) {
+    public TestClassHasArgsConstructor(String s) {
       this.s = s;
     }
   }
@@ -31,8 +32,9 @@ public class NoSerializedNameMain {
   /**
    * Main entrypoint, called by {@code ShrinkingIT.testNoSerializedName_NoArgsConstructor()}.
    */
-  public static String runTest() {
-    TestClass deserialized = new Gson().fromJson("{\"s\":\"value\"}", same(TestClass.class));
+  public static String runTestNoArgsConstructor() {
+    TestClassNoArgsConstructor deserialized = new Gson().fromJson(
+        "{\"s\":\"value\"}", same(TestClassNoArgsConstructor.class));
     return deserialized.s;
   }
 
@@ -41,15 +43,17 @@ public class NoSerializedNameMain {
    */
   public static String runTestNoJdkUnsafe() {
     Gson gson = new GsonBuilder().disableJdkUnsafe().create();
-    TestClassNotAbstract deserialized = gson.fromJson("{\"s\": \"value\"}", same(TestClassNotAbstract.class));
+    TestClassNotAbstract deserialized = gson.fromJson(
+        "{\"s\": \"value\"}", same(TestClassNotAbstract.class));
     return deserialized.s;
   }
 
   /**
    * Main entrypoint, called by {@code ShrinkingIT.testNoSerializedName_ConstructorHasArgs()}.
    */
-  public static String runTestConstructorHasArgs() {
-    TestClassConstructorHasArgs deserialized = new Gson().fromJson("{\"s\":\"value\"}", same(TestClassConstructorHasArgs.class));
+  public static String runTestHasArgsConstructor() {
+    TestClassHasArgsConstructor deserialized = new Gson().fromJson(
+        "{\"s\":\"value\"}", same(TestClassHasArgsConstructor.class));
     return deserialized.s;
   }
 }

--- a/shrinker-test/src/main/java/com/example/NoSerializedNameMain.java
+++ b/shrinker-test/src/main/java/com/example/NoSerializedNameMain.java
@@ -29,7 +29,7 @@ public class NoSerializedNameMain {
   }
 
   /**
-   * Main entrypoint, called by {@code ShrinkingIT.testNoSerializedName_ConstructorHasArgs()}.
+   * Main entrypoint, called by {@code ShrinkingIT.testNoSerializedName_NoArgsConstructor()}.
    */
   public static String runTest() {
     TestClass deserialized = new Gson().fromJson("{\"s\":\"value\"}", same(TestClass.class));

--- a/shrinker-test/src/main/java/com/example/NoSerializedNameMain.java
+++ b/shrinker-test/src/main/java/com/example/NoSerializedNameMain.java
@@ -19,17 +19,17 @@ public class NoSerializedNameMain {
     public String s;
   }
 
-  static class TestClassWithoutDefaultConstructor {
+  static class TestClassConstructorHasArgs {
     public String s;
 
     // Specify explicit constructor with args to remove implicit no-args default constructor
-    public TestClassWithoutDefaultConstructor(String s) {
+    public TestClassConstructorHasArgs(String s) {
       this.s = s;
     }
   }
 
   /**
-   * Main entrypoint, called by {@code ShrinkingIT.testNoSerializedName_DefaultConstructor()}.
+   * Main entrypoint, called by {@code ShrinkingIT.testNoSerializedName_ConstructorHasArgs()}.
    */
   public static String runTest() {
     TestClass deserialized = new Gson().fromJson("{\"s\":\"value\"}", same(TestClass.class));
@@ -37,7 +37,7 @@ public class NoSerializedNameMain {
   }
 
   /**
-   * Main entrypoint, called by {@code ShrinkingIT.testNoSerializedName_DefaultConstructorNoJdkUnsafe()}.
+   * Main entrypoint, called by {@code ShrinkingIT.testNoSerializedName_NoArgsConstructorNoJdkUnsafe()}.
    */
   public static String runTestNoJdkUnsafe() {
     Gson gson = new GsonBuilder().disableJdkUnsafe().create();
@@ -46,10 +46,10 @@ public class NoSerializedNameMain {
   }
 
   /**
-   * Main entrypoint, called by {@code ShrinkingIT.testNoSerializedName_NoDefaultConstructor()}.
+   * Main entrypoint, called by {@code ShrinkingIT.testNoSerializedName_ConstructorHasArgs()}.
    */
-  public static String runTestNoDefaultConstructor() {
-    TestClassWithoutDefaultConstructor deserialized = new Gson().fromJson("{\"s\":\"value\"}", same(TestClassWithoutDefaultConstructor.class));
+  public static String runTestConstructorHasArgs() {
+    TestClassConstructorHasArgs deserialized = new Gson().fromJson("{\"s\":\"value\"}", same(TestClassConstructorHasArgs.class));
     return deserialized.s;
   }
 }

--- a/shrinker-test/src/test/java/com/google/gson/it/ShrinkingIT.java
+++ b/shrinker-test/src/test/java/com/google/gson/it/ShrinkingIT.java
@@ -213,7 +213,7 @@ public class ShrinkingIT {
   @Test
   public void testNoSerializedName_NoArgsConstructor() throws Exception {
     runTest("com.example.NoSerializedNameMain", c -> {
-      Method m = c.getMethod("runTest");
+      Method m = c.getMethod("runTestNoArgsConstructor");
 
       if (jarToTest.equals(PROGUARD_RESULT_PATH)) {
         Object result = m.invoke(null);
@@ -223,7 +223,7 @@ public class ShrinkingIT {
         Exception e = assertThrows(InvocationTargetException.class, () -> m.invoke(null));
         assertThat(e).hasCauseThat().hasMessageThat().isEqualTo(
             "Abstract classes can't be instantiated! Adjust the R8 configuration or register an InstanceCreator"
-            + " or a TypeAdapter for this type. Class name: com.example.NoSerializedNameMain$TestClass"
+            + " or a TypeAdapter for this type. Class name: com.example.NoSerializedNameMain$TestClassNoArgsConstructor"
             + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#r8-abstract-class"
         );
       }
@@ -252,9 +252,9 @@ public class ShrinkingIT {
   }
 
   @Test
-  public void testNoSerializedName_ConstructorHasArgs() throws Exception {
+  public void testNoSerializedName_HasArgsConstructor() throws Exception {
     runTest("com.example.NoSerializedNameMain", c -> {
-      Method m = c.getMethod("runTestConstructorHasArgs");
+      Method m = c.getMethod("runTestHasArgsConstructor");
 
       if (jarToTest.equals(PROGUARD_RESULT_PATH)) {
         Object result = m.invoke(null);
@@ -264,7 +264,7 @@ public class ShrinkingIT {
         Exception e = assertThrows(InvocationTargetException.class, () -> m.invoke(null));
         assertThat(e).hasCauseThat().hasMessageThat().isEqualTo(
             "Abstract classes can't be instantiated! Adjust the R8 configuration or register an InstanceCreator"
-            + " or a TypeAdapter for this type. Class name: com.example.NoSerializedNameMain$TestClassConstructorHasArgs"
+            + " or a TypeAdapter for this type. Class name: com.example.NoSerializedNameMain$TestClassHasArgsConstructor"
             + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#r8-abstract-class"
         );
       }

--- a/shrinker-test/src/test/java/com/google/gson/it/ShrinkingIT.java
+++ b/shrinker-test/src/test/java/com/google/gson/it/ShrinkingIT.java
@@ -129,12 +129,32 @@ public class ShrinkingIT {
         "Read: SerializedName",
         "3",
         "===",
-        "Write: No default constructor",
+        "Write: No args constructor",
+        "{",
+        "  \"myField\": -3",
+        "}",
+        "===",
+        "Read: No args constructor; initial constructor value",
+        "-3",
+        "===",
+        "Read: No args constructor; custom value",
+        "3",
+        "===",
+        "Write: Constructor with args",
         "{",
         "  \"myField\": 2",
         "}",
         "===",
-        "Read: No default constructor",
+        "Read: Constructor with args",
+        "3",
+        "===",
+        "Read: Unreferenced no args constructor; initial constructor value",
+        "-3",
+        "===",
+        "Read: Unreferenced no args constructor; custom value",
+        "3",
+        "===",
+        "Read: Unreferenced constructor with args",
         "3",
         "===",
         "Read: No JDK Unsafe; initial constructor value",
@@ -191,7 +211,7 @@ public class ShrinkingIT {
   }
 
   @Test
-  public void testNoSerializedName_DefaultConstructor() throws Exception {
+  public void testNoSerializedName_NoArgsConstructor() throws Exception {
     runTest("com.example.NoSerializedNameMain", c -> {
       Method m = c.getMethod("runTest");
 
@@ -211,7 +231,7 @@ public class ShrinkingIT {
   }
 
   @Test
-  public void testNoSerializedName_DefaultConstructorNoJdkUnsafe() throws Exception {
+  public void testNoSerializedName_NoArgsConstructorNoJdkUnsafe() throws Exception {
     runTest("com.example.NoSerializedNameMain", c -> {
       Method m = c.getMethod("runTestNoJdkUnsafe");
 
@@ -232,9 +252,9 @@ public class ShrinkingIT {
   }
 
   @Test
-  public void testNoSerializedName_NoDefaultConstructor() throws Exception {
+  public void testNoSerializedName_ConstructorHasArgs() throws Exception {
     runTest("com.example.NoSerializedNameMain", c -> {
-      Method m = c.getMethod("runTestNoDefaultConstructor");
+      Method m = c.getMethod("runTestConstructorHasArgs");
 
       if (jarToTest.equals(PROGUARD_RESULT_PATH)) {
         Object result = m.invoke(null);
@@ -244,7 +264,7 @@ public class ShrinkingIT {
         Exception e = assertThrows(InvocationTargetException.class, () -> m.invoke(null));
         assertThat(e).hasCauseThat().hasMessageThat().isEqualTo(
             "Abstract classes can't be instantiated! Adjust the R8 configuration or register an InstanceCreator"
-            + " or a TypeAdapter for this type. Class name: com.example.NoSerializedNameMain$TestClassWithoutDefaultConstructor"
+            + " or a TypeAdapter for this type. Class name: com.example.NoSerializedNameMain$TestClassConstructorHasArgs"
             + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#r8-abstract-class"
         );
       }


### PR DESCRIPTION
R8 can do some optimizations that assume values of types whose constructors are never referenced are `null`. (A bit confused why the rules here are sufficient to avoid that optimization in the case of a class whose sole constructor has arguments and is unreferenced, since the keep rule only refers to `<init>()` instead of `<init>(...)`. Does R8 have special behavior for `<init>()` where attempting to keep that makes it assume a class is constructable even if it doesn't have a no-args constructor?)

Also rename some test classes/names to refer to `NoArgs` instead of `Default` constructors. The examples here care about whether a no-argument constructor is present. While a no-argument constructor (explicitly defined or not) is used by default in some circumstances, the Java documentation consistently uses "default constructor" to refer only to constructors whose implementation is implicitly provided by the complier (all default constructors are no-argument constructors, but not vice versa).