### PR TITLE
Update ISO8601Utils parser to default to UTC timezone when the value is not provided

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/util/ISO8601Utils.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/util/ISO8601Utils.java
@@ -170,6 +170,7 @@ public class ISO8601Utils
 
             if (!hasT && (date.length() <= offset)) {
                 Calendar calendar = new GregorianCalendar(year, month - 1, day);
+                calendar.setTimeZone(TIMEZONE_UTC);
                 calendar.setLenient(false);
 
                 pos.setIndex(offset);

--- a/gson/src/test/java/com/google/gson/internal/bind/util/ISO8601UtilsTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/util/ISO8601UtilsTest.java
@@ -78,10 +78,12 @@ public class ISO8601UtilsTest {
 
   @Test
   @SuppressWarnings("UndefinedEquals")
-  public void testDateParseWithDefaultTimezone() throws ParseException {
+  public void testDateParseDefaultsToUTC() throws ParseException {
         String dateStr = "2018-06-25";
         Date date = ISO8601Utils.parse(dateStr, new ParsePosition(0));
-        Date expectedDate = new GregorianCalendar(2018, Calendar.JUNE, 25).getTime();
+        GregorianCalendar calendar = createUtcCalendar();
+        calendar.set(2018, Calendar.JUNE, 25);
+        Date expectedDate = calendar.getTime();
         assertThat(date).isEqualTo(expectedDate);
     }
 


### PR DESCRIPTION

<!--
    Thank you for your contribution!
    Please see the contributing guide: https://github.com/google/.github/blob/master/CONTRIBUTING.md

    Keep in mind that Gson is in maintenance mode. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.
-->

### Purpose
<!-- Describe the purpose of this pull request, for example which new feature it adds or which bug it fixes -->
<!-- If this pull request closes a GitHub issue, please write "Closes #<issue>", for example "Closes #123" -->
This is to create a fix for https://github.com/google/gson/issues/1511 which is marked as a bug. Currently the parser defaults to the local timezone when the value is not provided, but the issue marked as a bug specifies that it should instead parse the time using UTC timezone.

### Description
<!-- If necessary provide more information, for example relevant implementation details or corner cases which are not covered yet -->
<!-- If there are related issues or pull requests, link to them by referencing their number, for example "pull request #123" -->
This is a fix for https://github.com/google/gson/issues/1511

There is existing unit test that checks the parsed time against local timezone. I updated that unit test to instead compare against time generated using UTC time zone.


### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [ ] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [x] If necessary, new unit tests have been added  
  - [x] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [ ] `mvn clean verify javadoc:jar` passes without errors
