### PR TITLE
Bump com.google.errorprone:error_prone_core from 2.21.1 to 2.22.0

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonPrimitive.java
+++ b/gson/src/main/java/com/google/gson/JsonPrimitive.java
@@ -285,7 +285,7 @@ public final class JsonPrimitive extends JsonElement {
       return other.value == null;
     }
     if (isIntegral(this) && isIntegral(other)) {
-      return this.value instanceof BigInteger || other.value instanceof BigInteger
+      return (this.value instanceof BigInteger || other.value instanceof BigInteger)
           ? this.getAsBigInteger().equals(other.getAsBigInteger())
           : this.getAsNumber().longValue() == other.getAsNumber().longValue();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
               <path>
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_core</artifactId>
-                <version>2.21.1</version>
+                <version>2.22.0</version>
               </path>
             </annotationProcessorPaths>
           </configuration>


### PR DESCRIPTION
Also parentheses to avoid a new Error Prone warning.

Because we compile with `-Werror`, this warning breaks the build.

Bumps [com.google.errorprone:error_prone_core](https://github.com/google/error-prone) from 2.21.1 to 2.22.0.
- [Release notes](https://github.com/google/error-prone/releases)
- [Commits](https://github.com/google/error-prone/compare/v2.21.1...v2.22.0)

---
updated-dependencies:
- dependency-name: com.google.errorprone:error_prone_core
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>