### PR TITLE
Add clarifying parentheses to a ternary expression.

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonPrimitive.java
+++ b/gson/src/main/java/com/google/gson/JsonPrimitive.java
@@ -285,7 +285,7 @@ public final class JsonPrimitive extends JsonElement {
       return other.value == null;
     }
     if (isIntegral(this) && isIntegral(other)) {
-      return this.value instanceof BigInteger || other.value instanceof BigInteger
+      return (this.value instanceof BigInteger || other.value instanceof BigInteger)
           ? this.getAsBigInteger().equals(other.getAsBigInteger())
           : this.getAsNumber().longValue() == other.getAsNumber().longValue();
     }


### PR DESCRIPTION
The latest Error Prone version issues a warning without the parentheses. Since we build with `-Werror`, that breaks the build.