### PR TITLE
Remove obsolete Error Prone warning suppressions

### DIFF
--- a/graal-native-image-test/src/test/java/com/google/gson/native_test/Java17RecordReflectionTest.java
+++ b/graal-native-image-test/src/test/java/com/google/gson/native_test/Java17RecordReflectionTest.java
@@ -27,7 +27,6 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings("UnusedVariable") // workaround for https://github.com/google/error-prone/issues/2713
 class Java17RecordReflectionTest {
   public record PublicRecord(int i) {
   }

--- a/gson/src/test/java/com/google/gson/functional/Java17RecordTest.java
+++ b/gson/src/test/java/com/google/gson/functional/Java17RecordTest.java
@@ -72,7 +72,6 @@ public final class Java17RecordTest {
         .isEqualTo("v3");
   }
 
-  @SuppressWarnings("unused")
   private record RecordWithCustomNames(
       @SerializedName("name") String a,
       @SerializedName(value = "name1", alternate = {"name2", "name3"}) String b) {}
@@ -256,7 +255,6 @@ public final class Java17RecordTest {
         .isEqualTo("null is not allowed as value for record component 'aByte' of primitive type; at path $.aByte");
   }
 
-  @SuppressWarnings("unused")
   private record RecordWithPrimitives(
       String aString, byte aByte, short aShort, int anInt, long aLong, float aFloat, double aDouble, char aChar, boolean aBoolean) {}
 
@@ -410,9 +408,7 @@ public final class Java17RecordTest {
     assertThat(gson.fromJson("{\"i\":2}", PublicRecord.class)).isEqualTo(new PublicRecord(2));
   }
 
-  @SuppressWarnings("unused")
   private record PrivateRecord(int i) {}
-  @SuppressWarnings("unused")
   public record PublicRecord(int i) {}
 
   /**


### PR DESCRIPTION
### Purpose
The latest Error Prone version fixed a bug which makes these suppressions obsolete.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [ ] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
