### PR TITLE
Remove obsolete Native Maven Plugin plugin dependency

### DIFF
--- a/graal-native-image-test/pom.xml
+++ b/graal-native-image-test/pom.xml
@@ -163,16 +163,6 @@
                 </configuration>
               </execution>
             </executions>
-            <dependencies>
-              <!-- Workaround for https://github.com/graalvm/native-build-tools/issues/418 -->
-              <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-utils</artifactId>
-                <!-- Don't upgrade version to >= 4 because that seems to contain potentially backward
-                  incompatible changes -->
-                <version>3.5.1</version>
-              </dependency>
-            </dependencies>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
### Purpose
Remove obsolete Native Maven Plugin plugin dependency.

### Description
Plugin had been updated to a newer version without this bug in the meantime.

This can be seen by running the following Maven command with GraalVM as JDK:
```
mvn clean test -P native-image-test -Dagent=true
```

With Maven >= 3.9.0 and the old version of the plugin (and without the extra plexus-utils dependency), this failed with the error "A required class was missing while executing ...".
Now, with the currently specified plugin version this does not fail anymore with this error.
