### PR TITLE
Fix flaky test in CustomTypeAdaptersTest

### DIFF
--- a/gson/src/test/java/com/google/gson/functional/CustomTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CustomTypeAdaptersTest.java
@@ -125,7 +125,8 @@ public class CustomTypeAdaptersTest {
       }
     }).create();
     ClassWithCustomTypeConverter target = new ClassWithCustomTypeConverter();
-    assertThat(gson.toJson(target)).isEqualTo("{\"bag\":6,\"value\":10}");
+    String targetStr = gson.toJson(target);
+    assertThat(targetStr.equals("{\"bag\":6,\"value\":10}") || targetStr.equals("{\"value\":10,\"bag\":6}")).isTrue();
   }
 
   @Test


### PR DESCRIPTION
### Purpose
The test `testCustomNestedSerializers` in `CustomTypeAdaptersTest` is detected flaky because the `gson.toJson()` gives a non-deterministic output.

### Description
After modifying the tests to check if the `gson.toJson()` output to is one of the possible json string values, the test passes, instead of checking against only 1 string.

**Reason:**
The `gson.toJson()` internally calls `com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.getBoundFields` which makes a call to `getDeclaredFields`
https://github.com/google/gson/blob/e685705b2bf3ae174958612a185bd231c0e0c5d9/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java#L265
And according to this [stackoverlow discussion](https://stackoverflow.com/questions/18325666/does-class-getdeclaredfields-return-members-in-a-consistent-order), `getDeclaredFields` in Java 8 does not return elements in a consistent order.

### Reproduction of error
The test runs fail on 4/5 runs of the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool

**Command to reproduce the failure:**
```
mvn -pl gson edu.illinois:nondex-maven-plugin:2.1.1:debug -Dtest=com.google.gson.functional.CustomTypeAdaptersTest#testCustomNestedSerializers
```
**Error Message:**
```
Running com.google.gson.functional.CustomTypeAdaptersTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.689 s <<< FAILURE! -- in com.google.gson.functional.CustomTypeAdaptersTest
[ERROR] com.google.gson.functional.CustomTypeAdaptersTest.testCustomNestedSerializers -- Time elapsed: 0.660 s <<< FAILURE!
value of: toJson(...)
expected: {"bag":6,"value":10}
but was : {"value":10,"bag":6}
        at com.google.gson.functional.CustomTypeAdaptersTest.testCustomNestedSerializers(CustomTypeAdaptersTest.java:128)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   CustomTypeAdaptersTest.testCustomNestedSerializers:128 value of: toJson(...)
expected: {"bag":6,"value":10}
but was : {"value":10,"bag":6}
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
```

