### PR TITLE
validating the date format, add test case, since NumberFormatException extends IllegalArgumentException, it is only necessary to write IllegalArgumentException.

### DIFF
--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -44,6 +44,7 @@ import com.google.gson.stream.JsonWriter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -595,7 +596,12 @@ public final class GsonBuilder {
    */
   @CanIgnoreReturnValue
   public GsonBuilder setDateFormat(String pattern) {
-    // TODO(Joel): Make this fail fast if it is an invalid date format
+    try {
+      new SimpleDateFormat(pattern);
+    } catch (IllegalArgumentException e) {
+      // throw exception if it is an invalid date format
+      throw new IllegalArgumentException("The date pattern '" + pattern + "' is not valid", e);
+    }
     this.datePattern = pattern;
     return this;
   }

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -596,11 +596,13 @@ public final class GsonBuilder {
    */
   @CanIgnoreReturnValue
   public GsonBuilder setDateFormat(String pattern) {
-    try {
-      new SimpleDateFormat(pattern);
-    } catch (IllegalArgumentException e) {
-      // throw exception if it is an invalid date format
-      throw new IllegalArgumentException("The date pattern '" + pattern + "' is not valid", e);
+    if (pattern != null) {
+      try {
+        new SimpleDateFormat(pattern);
+      } catch (IllegalArgumentException e) {
+        // Throw exception if it is an invalid date format
+        throw new IllegalArgumentException("The date pattern '" + pattern + "' is not valid", e);
+      }
     }
     this.datePattern = pattern;
     return this;

--- a/gson/src/main/java/com/google/gson/internal/bind/util/ISO8601Utils.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/util/ISO8601Utils.java
@@ -280,11 +280,7 @@ public class ISO8601Utils
             return calendar.getTime();
             // If we get a ParseException it'll already have the right message/offset.
             // Other exception types can convert here.
-        } catch (IndexOutOfBoundsException e) {
-            fail = e;
-        } catch (NumberFormatException e) {
-            fail = e;
-        } catch (IllegalArgumentException e) {
+        } catch (IndexOutOfBoundsException | IllegalArgumentException e) {
             fail = e;
         }
         String input = (date == null) ? null : ('"' + date + '"');

--- a/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
@@ -720,7 +720,7 @@ public class DefaultTypeAdaptersTest {
     });
   }
   @Test
-  void testSetDateFormatWithValidPattern() {
+  public void testSetDateFormatWithValidPattern() {
     GsonBuilder builder = new GsonBuilder();
     String validPattern = "yyyy-MM-dd";
     builder.setDateFormat(validPattern);

--- a/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
@@ -16,6 +16,7 @@
 package com.google.gson.functional;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import com.google.gson.Gson;
@@ -709,6 +710,20 @@ public class DefaultTypeAdaptersTest {
   public void testStringBufferDeserialization() {
     StringBuffer sb = gson.fromJson("'abc'", StringBuffer.class);
     assertThat(sb.toString()).isEqualTo("abc");
+  }
+  @Test
+  public void testSetDateFormatWithInvalidPattern() {
+    GsonBuilder builder = new GsonBuilder();
+    String invalidPattern = "This is a invalid Pattern";
+    assertThrows(IllegalArgumentException.class, () -> {
+      builder.setDateFormat(invalidPattern);
+    });
+  }
+  @Test
+  void testSetDateFormatWithValidPattern() {
+    GsonBuilder builder = new GsonBuilder();
+    String validPattern = "yyyy-MM-dd";
+    builder.setDateFormat(validPattern);
   }
 
   private static class MyClassTypeAdapter extends TypeAdapter<Class<?>> {

--- a/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
@@ -719,6 +719,7 @@ public class DefaultTypeAdaptersTest {
       builder.setDateFormat(invalidPattern);
     });
   }
+
   @Test
   public void testSetDateFormatWithValidPattern() {
     GsonBuilder builder = new GsonBuilder();

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.2.1</version>
           </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
validating the date format, add test case and since NumberFormatException extends IllegalArgumentException, it is only necessary to write IllegalArgumentException.

#### Purpose

* Throw exception if  `public GsonBuilder setDateFormat(String pattern) ` input pattern is invalid. [[Relate issue](https://github.com/google/gson/issues/2472)](https://github.com/google/gson/issues/2472)
* NumberFormatException extends IllegalArgumentException, it is only necessary to write IllegalArgumentException in `public class ISO8601Utils`


### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)
- [x] If necessary, new public API validates arguments, for example rejects `null`
- [x] New public API has Javadoc
    - [x] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [x] If necessary, new unit tests have been added  
  - [x] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [x] No JUnit 3 features are used (such as extending class `TestCase`)
  - [x] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
