### PR TITLE
Formats codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ Despite supporting older Java versions, Gson also provides a JPMS module descrip
 These are the optional Java Platform Module System (JPMS) JDK modules which Gson depends on.
 This only applies when running Java 9 or newer.
 
-- `java.sql` (optional since Gson 2.8.9)  
+- `java.sql` (optional since Gson 2.8.9)
 When this module is present, Gson provides default adapters for some SQL date and time classes.
 
-- `jdk.unsupported`, respectively class `sun.misc.Unsafe` (optional)  
+- `jdk.unsupported`, respectively class `sun.misc.Unsafe` (optional)
 When this module is present, Gson can use the `Unsafe` class to create instances of classes without no-args constructor.
 However, care should be taken when relying on this. `Unsafe` is not available in all environments and its usage has some pitfalls,
 see [`GsonBuilder.disableJdkUnsafe()`](https://javadoc.io/doc/com.google.code.gson/gson/latest/com.google.gson/com/google/gson/GsonBuilder.html#disableJdkUnsafe()).
@@ -87,7 +87,7 @@ JDK 11 or newer is required for building, JDK 17 is recommended.
 
 ### Contributing
 
-See the [contributing guide](https://github.com/google/.github/blob/master/CONTRIBUTING.md).  
+See the [contributing guide](https://github.com/google/.github/blob/master/CONTRIBUTING.md).
 Please perform a quick search to check if there are already existing issues or pull requests related to your contribution.
 
 Keep in mind that Gson is in maintenance mode. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.

--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -127,8 +127,8 @@ For example, let's assume you want to deserialize the following JSON data:
 }
 ```
 
-This will fail with an exception similar to this one: `MalformedJsonException: Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON at line 5 column 4 path $.languages[2]`  
-The problem here is the trailing comma (`,`) after `"French"`, trailing commas are not allowed by the JSON specification. The location information "line 5 column 4" points to the `]` in the JSON data (with some slight inaccuracies) because Gson expected another value after `,` instead of the closing `]`. The JSONPath `$.languages[2]` in the exception message also points there: `$.` refers to the root object, `languages` refers to its member of that name and `[2]` refers to the (missing) third value in the JSON array value of that member (numbering starts at 0, so it is `[2]` instead of `[3]`).  
+This will fail with an exception similar to this one: `MalformedJsonException: Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON at line 5 column 4 path $.languages[2]`
+The problem here is the trailing comma (`,`) after `"French"`, trailing commas are not allowed by the JSON specification. The location information "line 5 column 4" points to the `]` in the JSON data (with some slight inaccuracies) because Gson expected another value after `,` instead of the closing `]`. The JSONPath `$.languages[2]` in the exception message also points there: `$.` refers to the root object, `languages` refers to its member of that name and `[2]` refers to the (missing) third value in the JSON array value of that member (numbering starts at 0, so it is `[2]` instead of `[3]`).
 The proper solution here is to fix the malformed JSON data.
 
 To spot syntax errors in the JSON data easily you can open it in an editor with support for JSON, for example Visual Studio Code. It will highlight within the JSON data the error location and show why the JSON data is considered invalid.
@@ -178,8 +178,8 @@ And you want to deserialize the following JSON data:
 }
 ```
 
-This will fail with an exception similar to this one: `IllegalStateException: Expected a string but was BEGIN_ARRAY at line 2 column 17 path $.languages`  
-This means Gson expected a JSON string value but found the beginning of a JSON array (`[`). The location information "line 2 column 17" points to the `[` in the JSON data (with some slight inaccuracies), so does the JSONPath `$.languages` in the exception message. It refers to the `languages` member of the root object (`$.`).  
+This will fail with an exception similar to this one: `IllegalStateException: Expected a string but was BEGIN_ARRAY at line 2 column 17 path $.languages`
+This means Gson expected a JSON string value but found the beginning of a JSON array (`[`). The location information "line 2 column 17" points to the `[` in the JSON data (with some slight inaccuracies), so does the JSONPath `$.languages` in the exception message. It refers to the `languages` member of the root object (`$.`).
 The solution here is to change in the `WebPage` class the field `String languages` to `List<String> languages`.
 
 ## <a id="adapter-not-null-safe"></a> `IllegalStateException`: "Expected ... but was NULL"
@@ -287,7 +287,7 @@ This will not initialize arbitrary classes, and it will throw a `ClassCastExcept
 
 ## <a id="type-token-raw"></a> `IllegalStateException`: 'TypeToken must be created with a type argument' <br> `RuntimeException`: 'Missing type parameter'
 
-**Symptom:** An `IllegalStateException` with the message 'TypeToken must be created with a type argument' is thrown.  
+**Symptom:** An `IllegalStateException` with the message 'TypeToken must be created with a type argument' is thrown.
 For older Gson versions a `RuntimeException` with message 'Missing type parameter' is thrown.
 
 **Reason:**

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -405,7 +405,7 @@ gson.registerTypeAdapter(MyType.class, new MyDeserializer());
 gson.registerTypeAdapter(MyType.class, new MyInstanceCreator());
 ```
 
-`registerTypeAdapter` call checks 
+`registerTypeAdapter` call checks
 1. if the type adapter implements more than one of these interfaces, in that case it registers the adapter for all of them.
 2. if the type adapter is for the Object class or JsonElement or any of its subclasses, in that case it throws IllegalArgumentException because overriding the built-in adapters for these types is not supported.
 

--- a/extras/src/main/java/com/google/gson/extras/examples/rawcollections/RawCollectionsExample.java
+++ b/extras/src/main/java/com/google/gson/extras/examples/rawcollections/RawCollectionsExample.java
@@ -15,28 +15,29 @@
  */
 package com.google.gson.extras.examples.rawcollections;
 
-import java.util.ArrayList;
-import java.util.Collection;
-
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonParser;
+import java.util.ArrayList;
+import java.util.Collection;
 
 public class RawCollectionsExample {
   static class Event {
     private String name;
     private String source;
+
     private Event(String name, String source) {
       this.name = name;
       this.source = source;
     }
+
     @Override
     public String toString() {
       return String.format("(name=%s, source=%s)", name, source);
     }
   }
 
-  @SuppressWarnings({ "unchecked", "rawtypes" })
+  @SuppressWarnings({"unchecked", "rawtypes"})
   public static void main(String[] args) {
     Gson gson = new Gson();
     Collection collection = new ArrayList();

--- a/extras/src/main/java/com/google/gson/graph/GraphAdapterBuilder.java
+++ b/extras/src/main/java/com/google/gson/graph/GraphAdapterBuilder.java
@@ -38,26 +38,28 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Queue;
 
-/**
- * Writes a graph of objects as a list of named nodes.
- */
+/** Writes a graph of objects as a list of named nodes. */
 // TODO: proper documentation
 public final class GraphAdapterBuilder {
   private final Map<Type, InstanceCreator<?>> instanceCreators;
   private final ConstructorConstructor constructorConstructor;
 
   public GraphAdapterBuilder() {
-      this.instanceCreators = new HashMap<>();
-      this.constructorConstructor = new ConstructorConstructor(instanceCreators, true, Collections.<ReflectionAccessFilter>emptyList());
+    this.instanceCreators = new HashMap<>();
+    this.constructorConstructor =
+        new ConstructorConstructor(
+            instanceCreators, true, Collections.<ReflectionAccessFilter>emptyList());
   }
+
   public GraphAdapterBuilder addType(Type type) {
     final ObjectConstructor<?> objectConstructor = constructorConstructor.get(TypeToken.get(type));
-    InstanceCreator<Object> instanceCreator = new InstanceCreator<Object>() {
-      @Override
-      public Object createInstance(Type type) {
-        return objectConstructor.construct();
-      }
-    };
+    InstanceCreator<Object> instanceCreator =
+        new InstanceCreator<Object>() {
+          @Override
+          public Object createInstance(Type type) {
+            return objectConstructor.construct();
+          }
+        };
     return addType(type, instanceCreator);
   }
 
@@ -79,6 +81,7 @@ public final class GraphAdapterBuilder {
 
   static class Factory implements TypeAdapterFactory, InstanceCreator<Object> {
     private final Map<Type, InstanceCreator<?>> instanceCreators;
+
     @SuppressWarnings("ThreadLocalUsage")
     private final ThreadLocal<Graph> graphThreadLocal = new ThreadLocal<>();
 
@@ -95,7 +98,8 @@ public final class GraphAdapterBuilder {
       final TypeAdapter<T> typeAdapter = gson.getDelegateAdapter(this, type);
       final TypeAdapter<JsonElement> elementAdapter = gson.getAdapter(JsonElement.class);
       return new TypeAdapter<T>() {
-        @Override public void write(JsonWriter out, T value) throws IOException {
+        @Override
+        public void write(JsonWriter out, T value) throws IOException {
           if (value == null) {
             out.nullValue();
             return;
@@ -144,7 +148,8 @@ public final class GraphAdapterBuilder {
           }
         }
 
-        @Override public T read(JsonReader in) throws IOException {
+        @Override
+        public T read(JsonReader in) throws IOException {
           if (in.peek() == JsonToken.NULL) {
             in.nextNull();
             return null;
@@ -207,13 +212,12 @@ public final class GraphAdapterBuilder {
     }
 
     /**
-     * Hook for the graph adapter to get a reference to a deserialized value
-     * before that value is fully populated. This is useful to deserialize
-     * values that directly or indirectly reference themselves: we can hand
-     * out an instance before read() returns.
+     * Hook for the graph adapter to get a reference to a deserialized value before that value is
+     * fully populated. This is useful to deserialize values that directly or indirectly reference
+     * themselves: we can hand out an instance before read() returns.
      *
-     * <p>Gson should only ever call this method when we're expecting it to;
-     * that is only when we've called back into Gson to deserialize a tree.
+     * <p>Gson should only ever call this method when we're expecting it to; that is only when we've
+     * called back into Gson to deserialize a tree.
      */
     @Override
     public Object createInstance(Type type) {
@@ -231,22 +235,17 @@ public final class GraphAdapterBuilder {
 
   static class Graph {
     /**
-     * The graph elements. On serialization keys are objects (using an identity
-     * hash map) and on deserialization keys are the string names (using a
-     * standard hash map).
+     * The graph elements. On serialization keys are objects (using an identity hash map) and on
+     * deserialization keys are the string names (using a standard hash map).
      */
     private final Map<Object, Element<?>> map;
 
-    /**
-     * The queue of elements to write during serialization. Unused during
-     * deserialization.
-     */
+    /** The queue of elements to write during serialization. Unused during deserialization. */
     private final Queue<Element<?>> queue = new ArrayDeque<>();
 
     /**
-     * The instance currently being deserialized. Used as a backdoor between
-     * the graph traversal (which needs to know instances) and instance creators
-     * which create them.
+     * The instance currently being deserialized. Used as a backdoor between the graph traversal
+     * (which needs to know instances) and instance creators which create them.
      */
     private Element<Object> nextCreate;
 
@@ -254,37 +253,24 @@ public final class GraphAdapterBuilder {
       this.map = map;
     }
 
-    /**
-     * Returns a unique name for an element to be inserted into the graph.
-     */
+    /** Returns a unique name for an element to be inserted into the graph. */
     public String nextName() {
       return "0x" + Integer.toHexString(map.size() + 1);
     }
   }
 
-  /**
-   * An element of the graph during serialization or deserialization.
-   */
+  /** An element of the graph during serialization or deserialization. */
   static class Element<T> {
-    /**
-     * This element's name in the top level graph object.
-     */
+    /** This element's name in the top level graph object. */
     private final String id;
 
-    /**
-     * The value if known. During deserialization this is lazily populated.
-     */
+    /** The value if known. During deserialization this is lazily populated. */
     private T value;
 
-    /**
-     * This element's type adapter if known. During deserialization this is
-     * lazily populated.
-     */
+    /** This element's type adapter if known. During deserialization this is lazily populated. */
     private TypeAdapter<T> typeAdapter;
 
-    /**
-     * The element to deserialize. Unused in serialization.
-     */
+    /** The element to deserialize. Unused in serialization. */
     private final JsonElement element;
 
     Element(T value, String id, TypeAdapter<T> typeAdapter, JsonElement element) {

--- a/extras/src/main/java/com/google/gson/interceptors/Intercept.java
+++ b/extras/src/main/java/com/google/gson/interceptors/Intercept.java
@@ -21,13 +21,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-
 /**
- * Use this annotation to indicate various interceptors for class instances after
- * they have been processed by Gson. For example, you can use it to validate an instance
- * after it has been deserialized from Json.
- * Here is an example of how this annotation is used:
+ * Use this annotation to indicate various interceptors for class instances after they have been
+ * processed by Gson. For example, you can use it to validate an instance after it has been
+ * deserialized from Json. Here is an example of how this annotation is used:
+ *
  * <p>Here is an example of how this annotation is used:
+ *
  * <pre>
  * &#64;Intercept(postDeserialize=UserValidator.class)
  * public class User {
@@ -56,8 +56,8 @@ import java.lang.annotation.Target;
 public @interface Intercept {
 
   /**
-   * Specify the class that provides the methods that should be invoked after an instance
-   * has been deserialized.
+   * Specify the class that provides the methods that should be invoked after an instance has been
+   * deserialized.
    */
   @SuppressWarnings("rawtypes")
   public Class<? extends JsonPostDeserializer> postDeserialize();

--- a/extras/src/main/java/com/google/gson/interceptors/InterceptorFactory.java
+++ b/extras/src/main/java/com/google/gson/interceptors/InterceptorFactory.java
@@ -24,11 +24,10 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 
-/**
- * A type adapter factory that implements {@code @Intercept}.
- */
+/** A type adapter factory that implements {@code @Intercept}. */
 public final class InterceptorFactory implements TypeAdapterFactory {
-  @Override public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+  @Override
+  public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
     Intercept intercept = type.getRawType().getAnnotation(Intercept.class);
     if (intercept == null) {
       return null;
@@ -52,11 +51,13 @@ public final class InterceptorFactory implements TypeAdapterFactory {
       }
     }
 
-    @Override public void write(JsonWriter out, T value) throws IOException {
+    @Override
+    public void write(JsonWriter out, T value) throws IOException {
       delegate.write(out, value);
     }
 
-    @Override public T read(JsonReader in) throws IOException {
+    @Override
+    public T read(JsonReader in) throws IOException {
       T result = delegate.read(in);
       postDeserializer.postDeserialize(result);
       return result;

--- a/extras/src/main/java/com/google/gson/interceptors/JsonPostDeserializer.java
+++ b/extras/src/main/java/com/google/gson/interceptors/JsonPostDeserializer.java
@@ -18,16 +18,14 @@ package com.google.gson.interceptors;
 import com.google.gson.InstanceCreator;
 
 /**
- * This interface is implemented by a class that wishes to inspect or modify an object
- * after it has been deserialized. You must define a no-args constructor or register an
- * {@link InstanceCreator} for such a class.
+ * This interface is implemented by a class that wishes to inspect or modify an object after it has
+ * been deserialized. You must define a no-args constructor or register an {@link InstanceCreator}
+ * for such a class.
  *
  * @author Inderjeet Singh
  */
 public interface JsonPostDeserializer<T> {
 
-  /**
-   * This method is called by Gson after the object has been deserialized from Json.
-   */
+  /** This method is called by Gson after the object has been deserialized from Json. */
   public void postDeserialize(T object);
 }

--- a/extras/src/main/java/com/google/gson/typeadapters/PostConstructAdapterFactory.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/PostConstructAdapterFactory.java
@@ -16,61 +16,63 @@
 
 package com.google.gson.typeadapters;
 
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
-import javax.annotation.PostConstruct;
-
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import javax.annotation.PostConstruct;
 
 public class PostConstructAdapterFactory implements TypeAdapterFactory {
-    // copied from https://gist.github.com/swankjesse/20df26adaf639ed7fd160f145a0b661a
+  // copied from https://gist.github.com/swankjesse/20df26adaf639ed7fd160f145a0b661a
+  @Override
+  public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+    for (Class<?> t = type.getRawType();
+        (t != Object.class) && (t.getSuperclass() != null);
+        t = t.getSuperclass()) {
+      for (Method m : t.getDeclaredMethods()) {
+        if (m.isAnnotationPresent(PostConstruct.class)) {
+          m.setAccessible(true);
+          TypeAdapter<T> delegate = gson.getDelegateAdapter(this, type);
+          return new PostConstructAdapter<>(delegate, m);
+        }
+      }
+    }
+    return null;
+  }
+
+  static final class PostConstructAdapter<T> extends TypeAdapter<T> {
+    private final TypeAdapter<T> delegate;
+    private final Method method;
+
+    public PostConstructAdapter(TypeAdapter<T> delegate, Method method) {
+      this.delegate = delegate;
+      this.method = method;
+    }
+
     @Override
-    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
-        for (Class<?> t = type.getRawType(); (t != Object.class) && (t.getSuperclass() != null); t = t.getSuperclass()) {
-            for (Method m : t.getDeclaredMethods()) {
-                if (m.isAnnotationPresent(PostConstruct.class)) {
-                    m.setAccessible(true);
-                    TypeAdapter<T> delegate = gson.getDelegateAdapter(this, type);
-                    return new PostConstructAdapter<>(delegate, m);
-                }
-            }
+    public T read(JsonReader in) throws IOException {
+      T result = delegate.read(in);
+      if (result != null) {
+        try {
+          method.invoke(result);
+        } catch (IllegalAccessException e) {
+          throw new AssertionError();
+        } catch (InvocationTargetException e) {
+          if (e.getCause() instanceof RuntimeException) throw (RuntimeException) e.getCause();
+          throw new RuntimeException(e.getCause());
         }
-        return null;
+      }
+      return result;
     }
 
-    final static class PostConstructAdapter<T> extends TypeAdapter<T> {
-        private final TypeAdapter<T> delegate;
-        private final Method method;
-
-        public PostConstructAdapter(TypeAdapter<T> delegate, Method method) {
-            this.delegate = delegate;
-            this.method = method;
-        }
-
-        @Override public T read(JsonReader in) throws IOException {
-            T result = delegate.read(in);
-            if (result != null) {
-                try {
-                    method.invoke(result);
-                } catch (IllegalAccessException e) {
-                    throw new AssertionError();
-                } catch (InvocationTargetException e) {
-                    if (e.getCause() instanceof RuntimeException) throw (RuntimeException) e.getCause();
-                    throw new RuntimeException(e.getCause());
-                }
-            }
-            return result;
-        }
-
-        @Override public void write(JsonWriter out, T value) throws IOException {
-            delegate.write(out, value);
-        }
+    @Override
+    public void write(JsonWriter out, T value) throws IOException {
+      delegate.write(out, value);
     }
+  }
 }

--- a/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
@@ -32,104 +32,127 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * Adapts values whose runtime type may differ from their declaration type. This
- * is necessary when a field's type is not the same type that GSON should create
- * when deserializing that field. For example, consider these types:
- * <pre>   {@code
- *   abstract class Shape {
- *     int x;
- *     int y;
- *   }
- *   class Circle extends Shape {
- *     int radius;
- *   }
- *   class Rectangle extends Shape {
- *     int width;
- *     int height;
- *   }
- *   class Diamond extends Shape {
- *     int width;
- *     int height;
- *   }
- *   class Drawing {
- *     Shape bottomShape;
- *     Shape topShape;
- *   }
+ * Adapts values whose runtime type may differ from their declaration type. This is necessary when a
+ * field's type is not the same type that GSON should create when deserializing that field. For
+ * example, consider these types:
+ *
+ * <pre>{@code
+ * abstract class Shape {
+ *   int x;
+ *   int y;
+ * }
+ * class Circle extends Shape {
+ *   int radius;
+ * }
+ * class Rectangle extends Shape {
+ *   int width;
+ *   int height;
+ * }
+ * class Diamond extends Shape {
+ *   int width;
+ *   int height;
+ * }
+ * class Drawing {
+ *   Shape bottomShape;
+ *   Shape topShape;
+ * }
  * }</pre>
- * <p>Without additional type information, the serialized JSON is ambiguous. Is
- * the bottom shape in this drawing a rectangle or a diamond? <pre>   {@code
- *   {
- *     "bottomShape": {
- *       "width": 10,
- *       "height": 5,
- *       "x": 0,
- *       "y": 0
- *     },
- *     "topShape": {
- *       "radius": 2,
- *       "x": 4,
- *       "y": 1
- *     }
- *   }}</pre>
- * This class addresses this problem by adding type information to the
- * serialized JSON and honoring that type information when the JSON is
- * deserialized: <pre>   {@code
- *   {
- *     "bottomShape": {
- *       "type": "Diamond",
- *       "width": 10,
- *       "height": 5,
- *       "x": 0,
- *       "y": 0
- *     },
- *     "topShape": {
- *       "type": "Circle",
- *       "radius": 2,
- *       "x": 4,
- *       "y": 1
- *     }
- *   }}</pre>
- * Both the type field name ({@code "type"}) and the type labels ({@code
- * "Rectangle"}) are configurable.
+ *
+ * <p>Without additional type information, the serialized JSON is ambiguous. Is the bottom shape in
+ * this drawing a rectangle or a diamond?
+ *
+ * <pre>{@code
+ * {
+ *   "bottomShape": {
+ *     "width": 10,
+ *     "height": 5,
+ *     "x": 0,
+ *     "y": 0
+ *   },
+ *   "topShape": {
+ *     "radius": 2,
+ *     "x": 4,
+ *     "y": 1
+ *   }
+ * }
+ * }</pre>
+ *
+ * This class addresses this problem by adding type information to the serialized JSON and honoring
+ * that type information when the JSON is deserialized:
+ *
+ * <pre>{@code
+ * {
+ *   "bottomShape": {
+ *     "type": "Diamond",
+ *     "width": 10,
+ *     "height": 5,
+ *     "x": 0,
+ *     "y": 0
+ *   },
+ *   "topShape": {
+ *     "type": "Circle",
+ *     "radius": 2,
+ *     "x": 4,
+ *     "y": 1
+ *   }
+ * }
+ * }</pre>
+ *
+ * Both the type field name ({@code "type"}) and the type labels ({@code "Rectangle"}) are
+ * configurable.
  *
  * <h2>Registering Types</h2>
- * Create a {@code RuntimeTypeAdapterFactory} by passing the base type and type field
- * name to the {@link #of} factory method. If you don't supply an explicit type
- * field name, {@code "type"} will be used. <pre>   {@code
- *   RuntimeTypeAdapterFactory<Shape> shapeAdapterFactory
- *       = RuntimeTypeAdapterFactory.of(Shape.class, "type");
+ *
+ * Create a {@code RuntimeTypeAdapterFactory} by passing the base type and type field name to the
+ * {@link #of} factory method. If you don't supply an explicit type field name, {@code "type"} will
+ * be used.
+ *
+ * <pre>{@code
+ * RuntimeTypeAdapterFactory<Shape> shapeAdapterFactory
+ *     = RuntimeTypeAdapterFactory.of(Shape.class, "type");
  * }</pre>
- * Next register all of your subtypes. Every subtype must be explicitly
- * registered. This protects your application from injection attacks. If you
- * don't supply an explicit type label, the type's simple name will be used.
- * <pre>   {@code
- *   shapeAdapterFactory.registerSubtype(Rectangle.class, "Rectangle");
- *   shapeAdapterFactory.registerSubtype(Circle.class, "Circle");
- *   shapeAdapterFactory.registerSubtype(Diamond.class, "Diamond");
+ *
+ * Next register all of your subtypes. Every subtype must be explicitly registered. This protects
+ * your application from injection attacks. If you don't supply an explicit type label, the type's
+ * simple name will be used.
+ *
+ * <pre>{@code
+ * shapeAdapterFactory.registerSubtype(Rectangle.class, "Rectangle");
+ * shapeAdapterFactory.registerSubtype(Circle.class, "Circle");
+ * shapeAdapterFactory.registerSubtype(Diamond.class, "Diamond");
  * }</pre>
+ *
  * Finally, register the type adapter factory in your application's GSON builder:
- * <pre>   {@code
- *   Gson gson = new GsonBuilder()
- *       .registerTypeAdapterFactory(shapeAdapterFactory)
- *       .create();
+ *
+ * <pre>{@code
+ * Gson gson = new GsonBuilder()
+ *     .registerTypeAdapterFactory(shapeAdapterFactory)
+ *     .create();
  * }</pre>
- * Like {@code GsonBuilder}, this API supports chaining: <pre>   {@code
- *   RuntimeTypeAdapterFactory<Shape> shapeAdapterFactory = RuntimeTypeAdapterFactory.of(Shape.class)
- *       .registerSubtype(Rectangle.class)
- *       .registerSubtype(Circle.class)
- *       .registerSubtype(Diamond.class);
+ *
+ * Like {@code GsonBuilder}, this API supports chaining:
+ *
+ * <pre>{@code
+ * RuntimeTypeAdapterFactory<Shape> shapeAdapterFactory = RuntimeTypeAdapterFactory.of(Shape.class)
+ *     .registerSubtype(Rectangle.class)
+ *     .registerSubtype(Circle.class)
+ *     .registerSubtype(Diamond.class);
  * }</pre>
  *
  * <h2>Serialization and deserialization</h2>
- * In order to serialize and deserialize a polymorphic object,
- * you must specify the base type explicitly.
- * <pre>   {@code
- *   Diamond diamond = new Diamond();
- *   String json = gson.toJson(diamond, Shape.class);
+ *
+ * In order to serialize and deserialize a polymorphic object, you must specify the base type
+ * explicitly.
+ *
+ * <pre>{@code
+ * Diamond diamond = new Diamond();
+ * String json = gson.toJson(diamond, Shape.class);
  * }</pre>
+ *
  * And then:
- * <pre>   {@code
- *   Shape shape = gson.fromJson(json, Shape.class);
+ *
+ * <pre>{@code
+ * Shape shape = gson.fromJson(json, Shape.class);
  * }</pre>
  */
 public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
@@ -140,8 +163,7 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
   private final boolean maintainType;
   private boolean recognizeSubtypes;
 
-  private RuntimeTypeAdapterFactory(
-      Class<?> baseType, String typeFieldName, boolean maintainType) {
+  private RuntimeTypeAdapterFactory(Class<?> baseType, String typeFieldName, boolean maintainType) {
     if (typeFieldName == null || baseType == null) {
       throw new NullPointerException();
     }
@@ -151,34 +173,35 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
   }
 
   /**
-   * Creates a new runtime type adapter using for {@code baseType} using {@code
-   * typeFieldName} as the type field name. Type field names are case sensitive.
+   * Creates a new runtime type adapter using for {@code baseType} using {@code typeFieldName} as
+   * the type field name. Type field names are case sensitive.
    *
    * @param maintainType true if the type field should be included in deserialized objects
    */
-  public static <T> RuntimeTypeAdapterFactory<T> of(Class<T> baseType, String typeFieldName, boolean maintainType) {
+  public static <T> RuntimeTypeAdapterFactory<T> of(
+      Class<T> baseType, String typeFieldName, boolean maintainType) {
     return new RuntimeTypeAdapterFactory<>(baseType, typeFieldName, maintainType);
   }
 
   /**
-   * Creates a new runtime type adapter using for {@code baseType} using {@code
-   * typeFieldName} as the type field name. Type field names are case sensitive.
+   * Creates a new runtime type adapter using for {@code baseType} using {@code typeFieldName} as
+   * the type field name. Type field names are case sensitive.
    */
   public static <T> RuntimeTypeAdapterFactory<T> of(Class<T> baseType, String typeFieldName) {
     return new RuntimeTypeAdapterFactory<>(baseType, typeFieldName, false);
   }
 
   /**
-   * Creates a new runtime type adapter for {@code baseType} using {@code "type"} as
-   * the type field name.
+   * Creates a new runtime type adapter for {@code baseType} using {@code "type"} as the type field
+   * name.
    */
   public static <T> RuntimeTypeAdapterFactory<T> of(Class<T> baseType) {
     return new RuntimeTypeAdapterFactory<>(baseType, "type", false);
   }
 
   /**
-   * Ensures that this factory will handle not just the given {@code baseType}, but any subtype
-   * of that type.
+   * Ensures that this factory will handle not just the given {@code baseType}, but any subtype of
+   * that type.
    */
   @CanIgnoreReturnValue
   public RuntimeTypeAdapterFactory<T> recognizeSubtypes() {
@@ -187,11 +210,10 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
   }
 
   /**
-   * Registers {@code type} identified by {@code label}. Labels are case
-   * sensitive.
+   * Registers {@code type} identified by {@code label}. Labels are case sensitive.
    *
-   * @throws IllegalArgumentException if either {@code type} or {@code label}
-   *     have already been registered on this type adapter.
+   * @throws IllegalArgumentException if either {@code type} or {@code label} have already been
+   *     registered on this type adapter.
    */
   @CanIgnoreReturnValue
   public RuntimeTypeAdapterFactory<T> registerSubtype(Class<? extends T> type, String label) {
@@ -207,11 +229,11 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
   }
 
   /**
-   * Registers {@code type} identified by its {@link Class#getSimpleName simple
-   * name}. Labels are case sensitive.
+   * Registers {@code type} identified by its {@link Class#getSimpleName simple name}. Labels are
+   * case sensitive.
    *
-   * @throws IllegalArgumentException if either {@code type} or its simple name
-   *     have already been registered on this type adapter.
+   * @throws IllegalArgumentException if either {@code type} or its simple name have already been
+   *     registered on this type adapter.
    */
   @CanIgnoreReturnValue
   public RuntimeTypeAdapterFactory<T> registerSubtype(Class<? extends T> type) {
@@ -240,37 +262,46 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
     }
 
     return new TypeAdapter<R>() {
-      @Override public R read(JsonReader in) throws IOException {
+      @Override
+      public R read(JsonReader in) throws IOException {
         JsonElement jsonElement = jsonElementAdapter.read(in);
         JsonElement labelJsonElement;
         if (maintainType) {
-            labelJsonElement = jsonElement.getAsJsonObject().get(typeFieldName);
+          labelJsonElement = jsonElement.getAsJsonObject().get(typeFieldName);
         } else {
-            labelJsonElement = jsonElement.getAsJsonObject().remove(typeFieldName);
+          labelJsonElement = jsonElement.getAsJsonObject().remove(typeFieldName);
         }
 
         if (labelJsonElement == null) {
-          throw new JsonParseException("cannot deserialize " + baseType
-              + " because it does not define a field named " + typeFieldName);
+          throw new JsonParseException(
+              "cannot deserialize "
+                  + baseType
+                  + " because it does not define a field named "
+                  + typeFieldName);
         }
         String label = labelJsonElement.getAsString();
         @SuppressWarnings("unchecked") // registration requires that subtype extends T
         TypeAdapter<R> delegate = (TypeAdapter<R>) labelToDelegate.get(label);
         if (delegate == null) {
-          throw new JsonParseException("cannot deserialize " + baseType + " subtype named "
-              + label + "; did you forget to register a subtype?");
+          throw new JsonParseException(
+              "cannot deserialize "
+                  + baseType
+                  + " subtype named "
+                  + label
+                  + "; did you forget to register a subtype?");
         }
         return delegate.fromJsonTree(jsonElement);
       }
 
-      @Override public void write(JsonWriter out, R value) throws IOException {
+      @Override
+      public void write(JsonWriter out, R value) throws IOException {
         Class<?> srcType = value.getClass();
         String label = subtypeToLabel.get(srcType);
         @SuppressWarnings("unchecked") // registration requires that subtype extends T
         TypeAdapter<R> delegate = (TypeAdapter<R>) subtypeToDelegate.get(srcType);
         if (delegate == null) {
-          throw new JsonParseException("cannot serialize " + srcType.getName()
-              + "; did you forget to register a subtype?");
+          throw new JsonParseException(
+              "cannot serialize " + srcType.getName() + "; did you forget to register a subtype?");
         }
         JsonObject jsonObject = delegate.toJsonTree(value).getAsJsonObject();
 
@@ -282,8 +313,11 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
         JsonObject clone = new JsonObject();
 
         if (jsonObject.has(typeFieldName)) {
-          throw new JsonParseException("cannot serialize " + srcType.getName()
-              + " because it already defines a field named " + typeFieldName);
+          throw new JsonParseException(
+              "cannot serialize "
+                  + srcType.getName()
+                  + " because it already defines a field named "
+                  + typeFieldName);
         }
         clone.add(typeFieldName, new JsonPrimitive(label));
 

--- a/extras/src/main/java/com/google/gson/typeadapters/UtcDateTypeAdapter.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/UtcDateTypeAdapter.java
@@ -16,6 +16,10 @@
 
 package com.google.gson.typeadapters;
 
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.text.ParseException;
 import java.text.ParsePosition;
@@ -24,11 +28,6 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.TimeZone;
-import com.google.gson.JsonParseException;
-import com.google.gson.TypeAdapter;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonToken;
-import com.google.gson.stream.JsonWriter;
 
 public final class UtcDateTypeAdapter extends TypeAdapter<Date> {
   private final TimeZone UTC_TIME_ZONE = TimeZone.getTimeZone("UTC");
@@ -74,45 +73,46 @@ public final class UtcDateTypeAdapter extends TypeAdapter<Date> {
    * @return the date formatted as yyyy-MM-ddThh:mm:ss[.sss][Z|[+-]hh:mm]
    */
   private static String format(Date date, boolean millis, TimeZone tz) {
-      Calendar calendar = new GregorianCalendar(tz, Locale.US);
-      calendar.setTime(date);
+    Calendar calendar = new GregorianCalendar(tz, Locale.US);
+    calendar.setTime(date);
 
-      // estimate capacity of buffer as close as we can (yeah, that's pedantic ;)
-      int capacity = "yyyy-MM-ddThh:mm:ss".length();
-      capacity += millis ? ".sss".length() : 0;
-      capacity += tz.getRawOffset() == 0 ? "Z".length() : "+hh:mm".length();
-      StringBuilder formatted = new StringBuilder(capacity);
+    // estimate capacity of buffer as close as we can (yeah, that's pedantic ;)
+    int capacity = "yyyy-MM-ddThh:mm:ss".length();
+    capacity += millis ? ".sss".length() : 0;
+    capacity += tz.getRawOffset() == 0 ? "Z".length() : "+hh:mm".length();
+    StringBuilder formatted = new StringBuilder(capacity);
 
-      padInt(formatted, calendar.get(Calendar.YEAR), "yyyy".length());
-      formatted.append('-');
-      padInt(formatted, calendar.get(Calendar.MONTH) + 1, "MM".length());
-      formatted.append('-');
-      padInt(formatted, calendar.get(Calendar.DAY_OF_MONTH), "dd".length());
-      formatted.append('T');
-      padInt(formatted, calendar.get(Calendar.HOUR_OF_DAY), "hh".length());
+    padInt(formatted, calendar.get(Calendar.YEAR), "yyyy".length());
+    formatted.append('-');
+    padInt(formatted, calendar.get(Calendar.MONTH) + 1, "MM".length());
+    formatted.append('-');
+    padInt(formatted, calendar.get(Calendar.DAY_OF_MONTH), "dd".length());
+    formatted.append('T');
+    padInt(formatted, calendar.get(Calendar.HOUR_OF_DAY), "hh".length());
+    formatted.append(':');
+    padInt(formatted, calendar.get(Calendar.MINUTE), "mm".length());
+    formatted.append(':');
+    padInt(formatted, calendar.get(Calendar.SECOND), "ss".length());
+    if (millis) {
+      formatted.append('.');
+      padInt(formatted, calendar.get(Calendar.MILLISECOND), "sss".length());
+    }
+
+    int offset = tz.getOffset(calendar.getTimeInMillis());
+    if (offset != 0) {
+      int hours = Math.abs((offset / (60 * 1000)) / 60);
+      int minutes = Math.abs((offset / (60 * 1000)) % 60);
+      formatted.append(offset < 0 ? '-' : '+');
+      padInt(formatted, hours, "hh".length());
       formatted.append(':');
-      padInt(formatted, calendar.get(Calendar.MINUTE), "mm".length());
-      formatted.append(':');
-      padInt(formatted, calendar.get(Calendar.SECOND), "ss".length());
-      if (millis) {
-          formatted.append('.');
-          padInt(formatted, calendar.get(Calendar.MILLISECOND), "sss".length());
-      }
+      padInt(formatted, minutes, "mm".length());
+    } else {
+      formatted.append('Z');
+    }
 
-      int offset = tz.getOffset(calendar.getTimeInMillis());
-      if (offset != 0) {
-          int hours = Math.abs((offset / (60 * 1000)) / 60);
-          int minutes = Math.abs((offset / (60 * 1000)) % 60);
-          formatted.append(offset < 0 ? '-' : '+');
-          padInt(formatted, hours, "hh".length());
-          formatted.append(':');
-          padInt(formatted, minutes, "mm".length());
-      } else {
-          formatted.append('Z');
-      }
-
-      return formatted.toString();
+    return formatted.toString();
   }
+
   /**
    * Zero pad a number to a specified length
    *
@@ -121,11 +121,11 @@ public final class UtcDateTypeAdapter extends TypeAdapter<Date> {
    * @param length the length of the string we should zero pad
    */
   private static void padInt(StringBuilder buffer, int value, int length) {
-      String strValue = Integer.toString(value);
-      for (int i = length - strValue.length(); i > 0; i--) {
-          buffer.append('0');
-      }
-      buffer.append(strValue);
+    String strValue = Integer.toString(value);
+    for (int i = length - strValue.length(); i > 0; i--) {
+      buffer.append('0');
+    }
+    buffer.append(strValue);
   }
 
   /**
@@ -160,7 +160,8 @@ public final class UtcDateTypeAdapter extends TypeAdapter<Date> {
       int hour = 0;
       int minutes = 0;
       int seconds = 0;
-      int milliseconds = 0; // always use 0 otherwise returned date will include millis of current time
+      // always use 0 otherwise returned date will include millis of current time
+      int milliseconds = 0;
       if (checkOffset(date, offset, 'T')) {
 
         // extract hours, minutes, seconds and milliseconds
@@ -230,7 +231,8 @@ public final class UtcDateTypeAdapter extends TypeAdapter<Date> {
       fail = e;
     }
     String input = (date == null) ? null : ("'" + date + "'");
-    throw new ParseException("Failed to parse date [" + input + "]: " + fail.getMessage(), pos.getIndex());
+    throw new ParseException(
+        "Failed to parse date [" + input + "]: " + fail.getMessage(), pos.getIndex());
   }
 
   /**
@@ -254,7 +256,8 @@ public final class UtcDateTypeAdapter extends TypeAdapter<Date> {
    * @return the int
    * @throws NumberFormatException if the value is not a number
    */
-  private static int parseInt(String value, int beginIndex, int endIndex) throws NumberFormatException {
+  private static int parseInt(String value, int beginIndex, int endIndex)
+      throws NumberFormatException {
     if (beginIndex < 0 || endIndex > value.length() || beginIndex > endIndex) {
       throw new NumberFormatException(value);
     }

--- a/extras/src/test/java/com/google/gson/graph/GraphAdapterBuilderTest.java
+++ b/extras/src/test/java/com/google/gson/graph/GraphAdapterBuilderTest.java
@@ -19,16 +19,14 @@ package com.google.gson.graph;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
 import org.junit.Test;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.reflect.TypeToken;
 
 public final class GraphAdapterBuilderTest {
   @Test
@@ -41,27 +39,25 @@ public final class GraphAdapterBuilderTest {
     paper.beats = rock;
 
     GsonBuilder gsonBuilder = new GsonBuilder();
-    new GraphAdapterBuilder()
-        .addType(Roshambo.class)
-        .registerOn(gsonBuilder);
+    new GraphAdapterBuilder().addType(Roshambo.class).registerOn(gsonBuilder);
     Gson gson = gsonBuilder.create();
 
-    assertEquals("{'0x1':{'name':'ROCK','beats':'0x2'}," +
-        "'0x2':{'name':'SCISSORS','beats':'0x3'}," +
-        "'0x3':{'name':'PAPER','beats':'0x1'}}",
+    assertEquals(
+        "{'0x1':{'name':'ROCK','beats':'0x2'},"
+            + "'0x2':{'name':'SCISSORS','beats':'0x3'},"
+            + "'0x3':{'name':'PAPER','beats':'0x1'}}",
         gson.toJson(rock).replace('"', '\''));
   }
 
   @Test
   public void testDeserialization() {
-    String json = "{'0x1':{'name':'ROCK','beats':'0x2'}," +
-        "'0x2':{'name':'SCISSORS','beats':'0x3'}," +
-        "'0x3':{'name':'PAPER','beats':'0x1'}}";
+    String json =
+        "{'0x1':{'name':'ROCK','beats':'0x2'},"
+            + "'0x2':{'name':'SCISSORS','beats':'0x3'},"
+            + "'0x3':{'name':'PAPER','beats':'0x1'}}";
 
     GsonBuilder gsonBuilder = new GsonBuilder();
-    new GraphAdapterBuilder()
-        .addType(Roshambo.class)
-        .registerOn(gsonBuilder);
+    new GraphAdapterBuilder().addType(Roshambo.class).registerOn(gsonBuilder);
     Gson gson = gsonBuilder.create();
 
     Roshambo rock = gson.fromJson(json, Roshambo.class);
@@ -78,9 +74,7 @@ public final class GraphAdapterBuilderTest {
     String json = "{'0x1':{'name':'SUICIDE','beats':'0x1'}}";
 
     GsonBuilder gsonBuilder = new GsonBuilder();
-    new GraphAdapterBuilder()
-        .addType(Roshambo.class)
-        .registerOn(gsonBuilder);
+    new GraphAdapterBuilder().addType(Roshambo.class).registerOn(gsonBuilder);
     Gson gson = gsonBuilder.create();
 
     Roshambo suicide = gson.fromJson(json, Roshambo.class);
@@ -140,9 +134,10 @@ public final class GraphAdapterBuilderTest {
         .registerOn(gsonBuilder);
     Gson gson = gsonBuilder.create();
 
-    assertEquals("{'0x1':{'name':'Google','employees':['0x2','0x3']},"
-        + "'0x2':{'name':'Jesse','company':'0x1'},"
-        + "'0x3':{'name':'Joel','company':'0x1'}}",
+    assertEquals(
+        "{'0x1':{'name':'Google','employees':['0x2','0x3']},"
+            + "'0x2':{'name':'Jesse','company':'0x1'},"
+            + "'0x3':{'name':'Joel','company':'0x1'}}",
         gson.toJson(google).replace('"', '\''));
   }
 
@@ -155,9 +150,10 @@ public final class GraphAdapterBuilderTest {
         .registerOn(gsonBuilder);
     Gson gson = gsonBuilder.create();
 
-    String json = "{'0x1':{'name':'Google','employees':['0x2','0x3']},"
-        + "'0x2':{'name':'Jesse','company':'0x1'},"
-        + "'0x3':{'name':'Joel','company':'0x1'}}";
+    String json =
+        "{'0x1':{'name':'Google','employees':['0x2','0x3']},"
+            + "'0x2':{'name':'Jesse','company':'0x1'},"
+            + "'0x3':{'name':'Joel','company':'0x1'}}";
     Company company = gson.fromJson(json, Company.class);
     assertEquals("Google", company.name);
     Employee jesse = company.employees.get(0);
@@ -171,6 +167,7 @@ public final class GraphAdapterBuilderTest {
   static class Roshambo {
     String name;
     Roshambo beats;
+
     Roshambo(String name) {
       this.name = name;
     }
@@ -179,6 +176,7 @@ public final class GraphAdapterBuilderTest {
   static class Employee {
     final String name;
     final Company company;
+
     Employee(String name, Company company) {
       this.name = name;
       this.company = company;
@@ -189,6 +187,7 @@ public final class GraphAdapterBuilderTest {
   static class Company {
     final String name;
     final List<Employee> employees = new ArrayList<>();
+
     Company(String name) {
       this.name = name;
     }

--- a/extras/src/test/java/com/google/gson/interceptors/InterceptorTest.java
+++ b/extras/src/test/java/com/google/gson/interceptors/InterceptorTest.java
@@ -46,10 +46,11 @@ public final class InterceptorTest {
 
   @Before
   public void setUp() throws Exception {
-    this.gson = new GsonBuilder()
-        .registerTypeAdapterFactory(new InterceptorFactory())
-        .enableComplexMapKeySerialization()
-        .create();
+    this.gson =
+        new GsonBuilder()
+            .registerTypeAdapterFactory(new InterceptorFactory())
+            .enableComplexMapKeySerialization()
+            .create();
   }
 
   @Test
@@ -57,7 +58,8 @@ public final class InterceptorTest {
     try {
       gson.fromJson("{}", User.class);
       fail();
-    } catch (JsonParseException expected) {}
+    } catch (JsonParseException expected) {
+    }
   }
 
   @Test
@@ -68,27 +70,33 @@ public final class InterceptorTest {
 
   @Test
   public void testList() {
-    List<User> list = gson.fromJson("[{name:'bob',password:'pwd'}]", new TypeToken<List<User>>(){}.getType());
+    List<User> list =
+        gson.fromJson("[{name:'bob',password:'pwd'}]", new TypeToken<List<User>>() {}.getType());
     User user = list.get(0);
     assertEquals(User.DEFAULT_EMAIL, user.email);
   }
 
   @Test
   public void testCollection() {
-    Collection<User> list = gson.fromJson("[{name:'bob',password:'pwd'}]", new TypeToken<Collection<User>>(){}.getType());
+    Collection<User> list =
+        gson.fromJson(
+            "[{name:'bob',password:'pwd'}]", new TypeToken<Collection<User>>() {}.getType());
     User user = list.iterator().next();
     assertEquals(User.DEFAULT_EMAIL, user.email);
   }
 
   @Test
   public void testMapKeyAndValues() {
-    Type mapType = new TypeToken<Map<User, Address>>(){}.getType();
+    Type mapType = new TypeToken<Map<User, Address>>() {}.getType();
     try {
       gson.fromJson("[[{name:'bob',password:'pwd'},{}]]", mapType);
       fail();
-    } catch (JsonSyntaxException expected) {}
-    Map<User, Address> map = gson.fromJson("[[{name:'bob',password:'pwd'},{city:'Mountain View',state:'CA',zip:'94043'}]]",
-        mapType);
+    } catch (JsonSyntaxException expected) {
+    }
+    Map<User, Address> map =
+        gson.fromJson(
+            "[[{name:'bob',password:'pwd'},{city:'Mountain View',state:'CA',zip:'94043'}]]",
+            mapType);
     Entry<User, Address> entry = map.entrySet().iterator().next();
     assertEquals(User.DEFAULT_EMAIL, entry.getKey().email);
     assertEquals(Address.DEFAULT_FIRST_LINE, entry.getValue().firstLine);
@@ -102,24 +110,29 @@ public final class InterceptorTest {
 
   @Test
   public void testCustomTypeAdapter() {
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(User.class, new TypeAdapter<User>() {
-          @Override public void write(JsonWriter out, User value) throws IOException {
-            throw new UnsupportedOperationException();
-          }
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                User.class,
+                new TypeAdapter<User>() {
+                  @Override
+                  public void write(JsonWriter out, User value) throws IOException {
+                    throw new UnsupportedOperationException();
+                  }
 
-          @Override public User read(JsonReader in) throws IOException {
-            in.beginObject();
-            String unused1 = in.nextName();
-            String name = in.nextString();
-            String unused2 = in.nextName();
-            String password = in.nextString();
-            in.endObject();
-            return new User(name, password);
-          }
-        })
-        .registerTypeAdapterFactory(new InterceptorFactory())
-        .create();
+                  @Override
+                  public User read(JsonReader in) throws IOException {
+                    in.beginObject();
+                    String unused1 = in.nextName();
+                    String name = in.nextString();
+                    String unused2 = in.nextName();
+                    String password = in.nextString();
+                    in.endObject();
+                    return new User(name, password);
+                  }
+                })
+            .registerTypeAdapterFactory(new InterceptorFactory())
+            .create();
     UserGroup userGroup = gson.fromJson("{user:{name:'bob',password:'pwd'}}", UserGroup.class);
     assertEquals(User.DEFAULT_EMAIL, userGroup.user.email);
   }
@@ -145,6 +158,7 @@ public final class InterceptorTest {
     String password;
     String email;
     Address address;
+
     public User(String name, String password) {
       this.name = name;
       this.password = password;
@@ -152,7 +166,8 @@ public final class InterceptorTest {
   }
 
   public static final class UserValidator implements JsonPostDeserializer<User> {
-    @Override public void postDeserialize(User user) {
+    @Override
+    public void postDeserialize(User user) {
       if (user.name == null || user.password == null) {
         throw new JsonSyntaxException("name and password are required fields.");
       }
@@ -172,7 +187,8 @@ public final class InterceptorTest {
   }
 
   public static final class AddressValidator implements JsonPostDeserializer<Address> {
-    @Override public void postDeserialize(Address address) {
+    @Override
+    public void postDeserialize(Address address) {
       if (address.city == null || address.state == null || address.zip == null) {
         throw new JsonSyntaxException("Address city, state and zip are required fields.");
       }

--- a/extras/src/test/java/com/google/gson/typeadapters/PostConstructAdapterFactoryTest.java
+++ b/extras/src/test/java/com/google/gson/typeadapters/PostConstructAdapterFactoryTest.java
@@ -29,90 +29,96 @@ import org.junit.Test;
 public class PostConstructAdapterFactoryTest {
   @Test
   public void test() throws Exception {
-        Gson gson = new GsonBuilder()
-                .registerTypeAdapterFactory(new PostConstructAdapterFactory())
-                .create();
-        gson.fromJson("{\"bread\": \"white\", \"cheese\": \"cheddar\"}", Sandwich.class);
-        try {
-            gson.fromJson("{\"bread\": \"cheesey bread\", \"cheese\": \"swiss\"}", Sandwich.class);
-            fail();
-        } catch (IllegalArgumentException expected) {
-            assertEquals("too cheesey", expected.getMessage());
-        }
+    Gson gson =
+        new GsonBuilder().registerTypeAdapterFactory(new PostConstructAdapterFactory()).create();
+    gson.fromJson("{\"bread\": \"white\", \"cheese\": \"cheddar\"}", Sandwich.class);
+    try {
+      gson.fromJson("{\"bread\": \"cheesey bread\", \"cheese\": \"swiss\"}", Sandwich.class);
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertEquals("too cheesey", expected.getMessage());
     }
+  }
 
   @Test
   public void testList() {
-        MultipleSandwiches sandwiches = new MultipleSandwiches(Arrays.asList(
-            new Sandwich("white", "cheddar"),
-            new Sandwich("whole wheat", "swiss")));
+    MultipleSandwiches sandwiches =
+        new MultipleSandwiches(
+            Arrays.asList(new Sandwich("white", "cheddar"), new Sandwich("whole wheat", "swiss")));
 
-        Gson gson = new GsonBuilder().registerTypeAdapterFactory(new PostConstructAdapterFactory()).create();
+    Gson gson =
+        new GsonBuilder().registerTypeAdapterFactory(new PostConstructAdapterFactory()).create();
 
-        // Throws NullPointerException without the fix in https://github.com/google/gson/pull/1103
-        String json = gson.toJson(sandwiches);
-        assertEquals("{\"sandwiches\":[{\"bread\":\"white\",\"cheese\":\"cheddar\"},{\"bread\":\"whole wheat\",\"cheese\":\"swiss\"}]}", json);
+    // Throws NullPointerException without the fix in https://github.com/google/gson/pull/1103
+    String json = gson.toJson(sandwiches);
+    assertEquals(
+        "{\"sandwiches\":[{\"bread\":\"white\",\"cheese\":\"cheddar\"},{\"bread\":\"whole"
+            + " wheat\",\"cheese\":\"swiss\"}]}",
+        json);
 
-        MultipleSandwiches sandwichesFromJson = gson.fromJson(json, MultipleSandwiches.class);
-        assertEquals(sandwiches, sandwichesFromJson);
-    }
+    MultipleSandwiches sandwichesFromJson = gson.fromJson(json, MultipleSandwiches.class);
+    assertEquals(sandwiches, sandwichesFromJson);
+  }
 
   @SuppressWarnings({"overrides", "EqualsHashCode"}) // for missing hashCode() override
   static class Sandwich {
-        public String bread;
-        public String cheese;
+    public String bread;
+    public String cheese;
 
-        public Sandwich(String bread, String cheese) {
-            this.bread = bread;
-            this.cheese = cheese;
-        }
-
-        @PostConstruct private void validate() {
-            if (bread.equals("cheesey bread") && cheese != null) {
-                throw new IllegalArgumentException("too cheesey");
-            }
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (o == this) {
-                return true;
-            }
-            if (!(o instanceof Sandwich)) {
-                return false;
-            }
-            final Sandwich other = (Sandwich) o;
-            if (this.bread == null ? other.bread != null : !this.bread.equals(other.bread)) {
-                return false;
-            }
-            if (this.cheese == null ? other.cheese != null : !this.cheese.equals(other.cheese)) {
-                return false;
-            }
-            return true;
-        }
+    public Sandwich(String bread, String cheese) {
+      this.bread = bread;
+      this.cheese = cheese;
     }
 
-    @SuppressWarnings({"overrides", "EqualsHashCode"}) // for missing hashCode() override
-    static class MultipleSandwiches {
-        public List<Sandwich> sandwiches;
-
-        public MultipleSandwiches(List<Sandwich> sandwiches) {
-            this.sandwiches = sandwiches;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (o == this) {
-                return true;
-            }
-            if (!(o instanceof MultipleSandwiches)) {
-                return false;
-            }
-            final MultipleSandwiches other = (MultipleSandwiches) o;
-            if (this.sandwiches == null ? other.sandwiches != null : !this.sandwiches.equals(other.sandwiches)) {
-                return false;
-            }
-            return true;
-        }
+    @PostConstruct
+    private void validate() {
+      if (bread.equals("cheesey bread") && cheese != null) {
+        throw new IllegalArgumentException("too cheesey");
+      }
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (!(o instanceof Sandwich)) {
+        return false;
+      }
+      final Sandwich other = (Sandwich) o;
+      if (this.bread == null ? other.bread != null : !this.bread.equals(other.bread)) {
+        return false;
+      }
+      if (this.cheese == null ? other.cheese != null : !this.cheese.equals(other.cheese)) {
+        return false;
+      }
+      return true;
+    }
+  }
+
+  @SuppressWarnings({"overrides", "EqualsHashCode"}) // for missing hashCode() override
+  static class MultipleSandwiches {
+    public List<Sandwich> sandwiches;
+
+    public MultipleSandwiches(List<Sandwich> sandwiches) {
+      this.sandwiches = sandwiches;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (!(o instanceof MultipleSandwiches)) {
+        return false;
+      }
+      final MultipleSandwiches other = (MultipleSandwiches) o;
+      if (this.sandwiches == null
+          ? other.sandwiches != null
+          : !this.sandwiches.equals(other.sandwiches)) {
+        return false;
+      }
+      return true;
+    }
+  }
 }

--- a/extras/src/test/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactoryTest.java
+++ b/extras/src/test/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactoryTest.java
@@ -31,18 +31,16 @@ public final class RuntimeTypeAdapterFactoryTest {
 
   @Test
   public void testRuntimeTypeAdapter() {
-    RuntimeTypeAdapterFactory<BillingInstrument> rta = RuntimeTypeAdapterFactory.of(
-        BillingInstrument.class)
-        .registerSubtype(CreditCard.class);
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapterFactory(rta)
-        .create();
+    RuntimeTypeAdapterFactory<BillingInstrument> rta =
+        RuntimeTypeAdapterFactory.of(BillingInstrument.class).registerSubtype(CreditCard.class);
+    Gson gson = new GsonBuilder().registerTypeAdapterFactory(rta).create();
 
     CreditCard original = new CreditCard("Jesse", 234);
-    assertEquals("{\"type\":\"CreditCard\",\"cvv\":234,\"ownerName\":\"Jesse\"}",
+    assertEquals(
+        "{\"type\":\"CreditCard\",\"cvv\":234,\"ownerName\":\"Jesse\"}",
         gson.toJson(original, BillingInstrument.class));
-    BillingInstrument deserialized = gson.fromJson(
-        "{type:'CreditCard',cvv:234,ownerName:'Jesse'}", BillingInstrument.class);
+    BillingInstrument deserialized =
+        gson.fromJson("{type:'CreditCard',cvv:234,ownerName:'Jesse'}", BillingInstrument.class);
     assertEquals("Jesse", deserialized.ownerName);
     assertTrue(deserialized instanceof CreditCard);
   }
@@ -52,37 +50,34 @@ public final class RuntimeTypeAdapterFactoryTest {
     // We don't have an explicit factory for CreditCard.class, but we do have one for
     // BillingInstrument.class that has recognizeSubtypes(). So it should recognize CreditCard, and
     // when we call gson.toJson(original) below, without an explicit type, it should be invoked.
-    RuntimeTypeAdapterFactory<BillingInstrument> rta = RuntimeTypeAdapterFactory.of(
-        BillingInstrument.class)
-        .recognizeSubtypes()
-        .registerSubtype(CreditCard.class);
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapterFactory(rta)
-        .create();
+    RuntimeTypeAdapterFactory<BillingInstrument> rta =
+        RuntimeTypeAdapterFactory.of(BillingInstrument.class)
+            .recognizeSubtypes()
+            .registerSubtype(CreditCard.class);
+    Gson gson = new GsonBuilder().registerTypeAdapterFactory(rta).create();
 
     CreditCard original = new CreditCard("Jesse", 234);
-    assertEquals("{\"type\":\"CreditCard\",\"cvv\":234,\"ownerName\":\"Jesse\"}",
-        gson.toJson(original));
-    BillingInstrument deserialized = gson.fromJson(
-        "{type:'CreditCard',cvv:234,ownerName:'Jesse'}", BillingInstrument.class);
+    assertEquals(
+        "{\"type\":\"CreditCard\",\"cvv\":234,\"ownerName\":\"Jesse\"}", gson.toJson(original));
+    BillingInstrument deserialized =
+        gson.fromJson("{type:'CreditCard',cvv:234,ownerName:'Jesse'}", BillingInstrument.class);
     assertEquals("Jesse", deserialized.ownerName);
     assertTrue(deserialized instanceof CreditCard);
   }
 
   @Test
   public void testRuntimeTypeIsBaseType() {
-    TypeAdapterFactory rta = RuntimeTypeAdapterFactory.of(
-        BillingInstrument.class)
-        .registerSubtype(BillingInstrument.class);
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapterFactory(rta)
-        .create();
+    TypeAdapterFactory rta =
+        RuntimeTypeAdapterFactory.of(BillingInstrument.class)
+            .registerSubtype(BillingInstrument.class);
+    Gson gson = new GsonBuilder().registerTypeAdapterFactory(rta).create();
 
     BillingInstrument original = new BillingInstrument("Jesse");
-    assertEquals("{\"type\":\"BillingInstrument\",\"ownerName\":\"Jesse\"}",
+    assertEquals(
+        "{\"type\":\"BillingInstrument\",\"ownerName\":\"Jesse\"}",
         gson.toJson(original, BillingInstrument.class));
-    BillingInstrument deserialized = gson.fromJson(
-        "{type:'BillingInstrument',ownerName:'Jesse'}", BillingInstrument.class);
+    BillingInstrument deserialized =
+        gson.fromJson("{type:'BillingInstrument',ownerName:'Jesse'}", BillingInstrument.class);
     assertEquals("Jesse", deserialized.ownerName);
   }
 
@@ -106,8 +101,8 @@ public final class RuntimeTypeAdapterFactoryTest {
 
   @Test
   public void testNullSubtype() {
-    RuntimeTypeAdapterFactory<BillingInstrument> rta = RuntimeTypeAdapterFactory.of(
-        BillingInstrument.class);
+    RuntimeTypeAdapterFactory<BillingInstrument> rta =
+        RuntimeTypeAdapterFactory.of(BillingInstrument.class);
     try {
       rta.registerSubtype(null);
       fail();
@@ -117,8 +112,8 @@ public final class RuntimeTypeAdapterFactoryTest {
 
   @Test
   public void testNullLabel() {
-    RuntimeTypeAdapterFactory<BillingInstrument> rta = RuntimeTypeAdapterFactory.of(
-        BillingInstrument.class);
+    RuntimeTypeAdapterFactory<BillingInstrument> rta =
+        RuntimeTypeAdapterFactory.of(BillingInstrument.class);
     try {
       rta.registerSubtype(CreditCard.class, null);
       fail();
@@ -128,8 +123,8 @@ public final class RuntimeTypeAdapterFactoryTest {
 
   @Test
   public void testDuplicateSubtype() {
-    RuntimeTypeAdapterFactory<BillingInstrument> rta = RuntimeTypeAdapterFactory.of(
-        BillingInstrument.class);
+    RuntimeTypeAdapterFactory<BillingInstrument> rta =
+        RuntimeTypeAdapterFactory.of(BillingInstrument.class);
     rta.registerSubtype(CreditCard.class, "CC");
     try {
       rta.registerSubtype(CreditCard.class, "Visa");
@@ -140,8 +135,8 @@ public final class RuntimeTypeAdapterFactoryTest {
 
   @Test
   public void testDuplicateLabel() {
-    RuntimeTypeAdapterFactory<BillingInstrument> rta = RuntimeTypeAdapterFactory.of(
-        BillingInstrument.class);
+    RuntimeTypeAdapterFactory<BillingInstrument> rta =
+        RuntimeTypeAdapterFactory.of(BillingInstrument.class);
     rta.registerSubtype(CreditCard.class, "CC");
     try {
       rta.registerSubtype(BankTransfer.class, "CC");
@@ -152,11 +147,9 @@ public final class RuntimeTypeAdapterFactoryTest {
 
   @Test
   public void testDeserializeMissingTypeField() {
-    TypeAdapterFactory billingAdapter = RuntimeTypeAdapterFactory.of(BillingInstrument.class)
-        .registerSubtype(CreditCard.class);
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapterFactory(billingAdapter)
-        .create();
+    TypeAdapterFactory billingAdapter =
+        RuntimeTypeAdapterFactory.of(BillingInstrument.class).registerSubtype(CreditCard.class);
+    Gson gson = new GsonBuilder().registerTypeAdapterFactory(billingAdapter).create();
     try {
       gson.fromJson("{ownerName:'Jesse'}", BillingInstrument.class);
       fail();
@@ -166,11 +159,9 @@ public final class RuntimeTypeAdapterFactoryTest {
 
   @Test
   public void testDeserializeMissingSubtype() {
-    TypeAdapterFactory billingAdapter = RuntimeTypeAdapterFactory.of(BillingInstrument.class)
-        .registerSubtype(BankTransfer.class);
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapterFactory(billingAdapter)
-        .create();
+    TypeAdapterFactory billingAdapter =
+        RuntimeTypeAdapterFactory.of(BillingInstrument.class).registerSubtype(BankTransfer.class);
+    Gson gson = new GsonBuilder().registerTypeAdapterFactory(billingAdapter).create();
     try {
       gson.fromJson("{type:'CreditCard',ownerName:'Jesse'}", BillingInstrument.class);
       fail();
@@ -180,11 +171,9 @@ public final class RuntimeTypeAdapterFactoryTest {
 
   @Test
   public void testSerializeMissingSubtype() {
-    TypeAdapterFactory billingAdapter = RuntimeTypeAdapterFactory.of(BillingInstrument.class)
-        .registerSubtype(BankTransfer.class);
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapterFactory(billingAdapter)
-        .create();
+    TypeAdapterFactory billingAdapter =
+        RuntimeTypeAdapterFactory.of(BillingInstrument.class).registerSubtype(BankTransfer.class);
+    Gson gson = new GsonBuilder().registerTypeAdapterFactory(billingAdapter).create();
     try {
       gson.toJson(new CreditCard("Jesse", 456), BillingInstrument.class);
       fail();
@@ -194,11 +183,10 @@ public final class RuntimeTypeAdapterFactoryTest {
 
   @Test
   public void testSerializeCollidingTypeFieldName() {
-    TypeAdapterFactory billingAdapter = RuntimeTypeAdapterFactory.of(BillingInstrument.class, "cvv")
-        .registerSubtype(CreditCard.class);
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapterFactory(billingAdapter)
-        .create();
+    TypeAdapterFactory billingAdapter =
+        RuntimeTypeAdapterFactory.of(BillingInstrument.class, "cvv")
+            .registerSubtype(CreditCard.class);
+    Gson gson = new GsonBuilder().registerTypeAdapterFactory(billingAdapter).create();
     try {
       gson.toJson(new CreditCard("Jesse", 456), BillingInstrument.class);
       fail();
@@ -208,19 +196,21 @@ public final class RuntimeTypeAdapterFactoryTest {
 
   @Test
   public void testSerializeWrappedNullValue() {
-    TypeAdapterFactory billingAdapter = RuntimeTypeAdapterFactory.of(BillingInstrument.class)
-        .registerSubtype(CreditCard.class)
-        .registerSubtype(BankTransfer.class);    
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapterFactory(billingAdapter)
-        .create();    
-    String serialized = gson.toJson(new BillingInstrumentWrapper(null), BillingInstrumentWrapper.class);
-    BillingInstrumentWrapper deserialized = gson.fromJson(serialized, BillingInstrumentWrapper.class);
+    TypeAdapterFactory billingAdapter =
+        RuntimeTypeAdapterFactory.of(BillingInstrument.class)
+            .registerSubtype(CreditCard.class)
+            .registerSubtype(BankTransfer.class);
+    Gson gson = new GsonBuilder().registerTypeAdapterFactory(billingAdapter).create();
+    String serialized =
+        gson.toJson(new BillingInstrumentWrapper(null), BillingInstrumentWrapper.class);
+    BillingInstrumentWrapper deserialized =
+        gson.fromJson(serialized, BillingInstrumentWrapper.class);
     assertNull(deserialized.instrument);
   }
 
   static class BillingInstrumentWrapper {
     BillingInstrument instrument;
+
     BillingInstrumentWrapper(BillingInstrument instrument) {
       this.instrument = instrument;
     }
@@ -228,6 +218,7 @@ public final class RuntimeTypeAdapterFactoryTest {
 
   static class BillingInstrument {
     private final String ownerName;
+
     BillingInstrument(String ownerName) {
       this.ownerName = ownerName;
     }
@@ -235,6 +226,7 @@ public final class RuntimeTypeAdapterFactoryTest {
 
   static class CreditCard extends BillingInstrument {
     int cvv;
+
     CreditCard(String ownerName, int cvv) {
       super(ownerName);
       this.cvv = cvv;
@@ -243,6 +235,7 @@ public final class RuntimeTypeAdapterFactoryTest {
 
   static class BankTransfer extends BillingInstrument {
     int bankAccount;
+
     BankTransfer(String ownerName, int bankAccount) {
       super(ownerName);
       this.bankAccount = bankAccount;

--- a/extras/src/test/java/com/google/gson/typeadapters/UtcDateTypeAdapterTest.java
+++ b/extras/src/test/java/com/google/gson/typeadapters/UtcDateTypeAdapterTest.java
@@ -31,9 +31,8 @@ import org.junit.Test;
 
 @SuppressWarnings("JavaUtilDate")
 public final class UtcDateTypeAdapterTest {
-  private final Gson gson = new GsonBuilder()
-    .registerTypeAdapter(Date.class, new UtcDateTypeAdapter())
-    .create();
+  private final Gson gson =
+      new GsonBuilder().registerTypeAdapter(Date.class, new UtcDateTypeAdapter()).create();
 
   @Test
   public void testLocalTimeZone() {
@@ -56,21 +55,21 @@ public final class UtcDateTypeAdapterTest {
   }
 
   /**
-   * JDK 1.7 introduced support for XXX format to indicate UTC date. But Android is older JDK.
-   * We want to make sure that this date is parseable in Android.
+   * JDK 1.7 introduced support for XXX format to indicate UTC date. But Android is older JDK. We
+   * want to make sure that this date is parseable in Android.
    */
   @Test
   public void testUtcDatesOnJdkBefore1_7() {
-    Gson gson = new GsonBuilder()
-      .registerTypeAdapter(Date.class, new UtcDateTypeAdapter())
-      .create();
+    Gson gson =
+        new GsonBuilder().registerTypeAdapter(Date.class, new UtcDateTypeAdapter()).create();
     Date unused = gson.fromJson("'2014-12-05T04:00:00.000Z'", Date.class);
   }
 
   @Test
   public void testUtcWithJdk7Default() {
     Date expected = new Date();
-    SimpleDateFormat iso8601Format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.US);
+    SimpleDateFormat iso8601Format =
+        new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.US);
     iso8601Format.setTimeZone(TimeZone.getTimeZone("UTC"));
     String expectedJson = "\"" + iso8601Format.format(expected) + "\"";
     String actualJson = gson.toJson(expected);
@@ -91,7 +90,9 @@ public final class UtcDateTypeAdapterTest {
       gson.fromJson("2017-06-20T14:32:30", Date.class);
       fail("No exception");
     } catch (JsonParseException exe) {
-      assertEquals("java.text.ParseException: Failed to parse date ['2017-06-20T14']: 2017-06-20T14", exe.getMessage());
+      assertEquals(
+          "java.text.ParseException: Failed to parse date ['2017-06-20T14']: 2017-06-20T14",
+          exe.getMessage());
     }
   }
 }

--- a/graal-native-image-test/src/test/java/com/google/gson/native_test/Java17RecordReflectionTest.java
+++ b/graal-native-image-test/src/test/java/com/google/gson/native_test/Java17RecordReflectionTest.java
@@ -28,8 +28,7 @@ import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 class Java17RecordReflectionTest {
-  public record PublicRecord(int i) {
-  }
+  public record PublicRecord(int i) {}
 
   @Test
   void testPublicRecord() {
@@ -39,8 +38,7 @@ class Java17RecordReflectionTest {
   }
 
   // Private record has implicit private canonical constructor
-  private record PrivateRecord(int i) {
-  }
+  private record PrivateRecord(int i) {}
 
   @Test
   void testPrivateRecord() {
@@ -51,8 +49,7 @@ class Java17RecordReflectionTest {
 
   @Test
   void testLocalRecord() {
-    record LocalRecordDeserialization(int i) {
-    }
+    record LocalRecordDeserialization(int i) {}
 
     Gson gson = new Gson();
     LocalRecordDeserialization r = gson.fromJson("{\"i\":1}", LocalRecordDeserialization.class);
@@ -61,20 +58,19 @@ class Java17RecordReflectionTest {
 
   @Test
   void testLocalRecordSerialization() {
-    record LocalRecordSerialization(int i) {
-    }
+    record LocalRecordSerialization(int i) {}
 
     Gson gson = new Gson();
     assertThat(gson.toJson(new LocalRecordSerialization(1))).isEqualTo("{\"i\":1}");
   }
 
-  private record RecordWithSerializedName(@SerializedName("custom-name") int i) {
-  }
+  private record RecordWithSerializedName(@SerializedName("custom-name") int i) {}
 
   @Test
   void testSerializedName() {
     Gson gson = new Gson();
-    RecordWithSerializedName r = gson.fromJson("{\"custom-name\":1}", RecordWithSerializedName.class);
+    RecordWithSerializedName r =
+        gson.fromJson("{\"custom-name\":1}", RecordWithSerializedName.class);
     assertThat(r.i).isEqualTo(1);
 
     assertThat(gson.toJson(new RecordWithSerializedName(2))).isEqualTo("{\"custom-name\":2}");
@@ -133,9 +129,7 @@ class Java17RecordReflectionTest {
   }
 
   private record RecordWithCustomFieldAdapter(
-      @JsonAdapter(RecordWithCustomFieldAdapter.CustomAdapter.class)
-      int i
-  ) {
+      @JsonAdapter(RecordWithCustomFieldAdapter.CustomAdapter.class) int i) {
     private static class CustomAdapter extends TypeAdapter<Integer> {
       @Override
       public Integer read(JsonReader in) throws IOException {
@@ -158,24 +152,27 @@ class Java17RecordReflectionTest {
     assertThat(gson.toJson(new RecordWithCustomFieldAdapter(1))).isEqualTo("{\"i\":7}");
   }
 
-  private record RecordWithRegisteredAdapter(int i) {
-  }
+  private record RecordWithRegisteredAdapter(int i) {}
 
   @Test
   void testCustomAdapter() {
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(RecordWithRegisteredAdapter.class, new TypeAdapter<RecordWithRegisteredAdapter>() {
-          @Override
-          public RecordWithRegisteredAdapter read(JsonReader in) throws IOException {
-            return new RecordWithRegisteredAdapter(in.nextInt() + 5);
-          }
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                RecordWithRegisteredAdapter.class,
+                new TypeAdapter<RecordWithRegisteredAdapter>() {
+                  @Override
+                  public RecordWithRegisteredAdapter read(JsonReader in) throws IOException {
+                    return new RecordWithRegisteredAdapter(in.nextInt() + 5);
+                  }
 
-          @Override
-          public void write(JsonWriter out, RecordWithRegisteredAdapter value) throws IOException {
-            out.value(value.i + 6);
-          }
-        })
-        .create();
+                  @Override
+                  public void write(JsonWriter out, RecordWithRegisteredAdapter value)
+                      throws IOException {
+                    out.value(value.i + 6);
+                  }
+                })
+            .create();
 
     RecordWithRegisteredAdapter r = gson.fromJson("1", RecordWithRegisteredAdapter.class);
     assertThat(r.i).isEqualTo(6);

--- a/graal-native-image-test/src/test/java/com/google/gson/native_test/ReflectionTest.java
+++ b/graal-native-image-test/src/test/java/com/google/gson/native_test/ReflectionTest.java
@@ -56,7 +56,8 @@ class ReflectionTest {
   void testCustomDefaultConstructor() {
     Gson gson = new Gson();
 
-    ClassWithCustomDefaultConstructor c = gson.fromJson("{\"i\":2}", ClassWithCustomDefaultConstructor.class);
+    ClassWithCustomDefaultConstructor c =
+        gson.fromJson("{\"i\":2}", ClassWithCustomDefaultConstructor.class);
     assertThat(c.i).isEqualTo(2);
 
     c = gson.fromJson("{}", ClassWithCustomDefaultConstructor.class);
@@ -75,34 +76,41 @@ class ReflectionTest {
   /**
    * Tests deserializing a class without default constructor.
    *
-   * <p>This should use JDK Unsafe, and would normally require specifying {@code "unsafeAllocated": true}
-   * in the reflection metadata for GraalVM, though for some reason it also seems to work without it? Possibly
-   * because GraalVM seems to have special support for Gson, see its class {@code com.oracle.svm.thirdparty.gson.GsonFeature}.
+   * <p>This should use JDK Unsafe, and would normally require specifying {@code "unsafeAllocated":
+   * true} in the reflection metadata for GraalVM, though for some reason it also seems to work
+   * without it? Possibly because GraalVM seems to have special support for Gson, see its class
+   * {@code com.oracle.svm.thirdparty.gson.GsonFeature}.
    */
   @Test
   void testClassWithoutDefaultConstructor() {
     Gson gson = new Gson();
 
-    ClassWithoutDefaultConstructor c = gson.fromJson("{\"i\":1}", ClassWithoutDefaultConstructor.class);
+    ClassWithoutDefaultConstructor c =
+        gson.fromJson("{\"i\":1}", ClassWithoutDefaultConstructor.class);
     assertThat(c.i).isEqualTo(1);
 
     c = gson.fromJson("{}", ClassWithoutDefaultConstructor.class);
-    // Class is instantiated with JDK Unsafe, so field keeps its default value instead of assigned -1
+    // Class is instantiated with JDK Unsafe, so field keeps its default value instead of assigned
+    // -1
     assertThat(c.i).isEqualTo(0);
   }
 
   @Test
   void testInstanceCreator() {
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(ClassWithoutDefaultConstructor.class, new InstanceCreator<ClassWithoutDefaultConstructor>() {
-          @Override
-          public ClassWithoutDefaultConstructor createInstance(Type type) {
-            return new ClassWithoutDefaultConstructor(-2);
-          }
-        })
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                ClassWithoutDefaultConstructor.class,
+                new InstanceCreator<ClassWithoutDefaultConstructor>() {
+                  @Override
+                  public ClassWithoutDefaultConstructor createInstance(Type type) {
+                    return new ClassWithoutDefaultConstructor(-2);
+                  }
+                })
+            .create();
 
-    ClassWithoutDefaultConstructor c = gson.fromJson("{\"i\":1}", ClassWithoutDefaultConstructor.class);
+    ClassWithoutDefaultConstructor c =
+        gson.fromJson("{\"i\":1}", ClassWithoutDefaultConstructor.class);
     assertThat(c.i).isEqualTo(1);
 
     c = gson.fromJson("{}", ClassWithoutDefaultConstructor.class);
@@ -220,19 +228,23 @@ class ReflectionTest {
 
   @Test
   void testCustomAdapter() {
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(ClassWithRegisteredAdapter.class, new TypeAdapter<ClassWithRegisteredAdapter>() {
-          @Override
-          public ClassWithRegisteredAdapter read(JsonReader in) throws IOException {
-            return new ClassWithRegisteredAdapter(in.nextInt() + 5);
-          }
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                ClassWithRegisteredAdapter.class,
+                new TypeAdapter<ClassWithRegisteredAdapter>() {
+                  @Override
+                  public ClassWithRegisteredAdapter read(JsonReader in) throws IOException {
+                    return new ClassWithRegisteredAdapter(in.nextInt() + 5);
+                  }
 
-          @Override
-          public void write(JsonWriter out, ClassWithRegisteredAdapter value) throws IOException {
-            out.value(value.i + 6);
-          }
-        })
-        .create();
+                  @Override
+                  public void write(JsonWriter out, ClassWithRegisteredAdapter value)
+                      throws IOException {
+                    out.value(value.i + 6);
+                  }
+                })
+            .create();
 
     ClassWithRegisteredAdapter c = gson.fromJson("1", ClassWithRegisteredAdapter.class);
     assertThat(c.i).isEqualTo(6);
@@ -244,12 +256,17 @@ class ReflectionTest {
   void testGenerics() {
     Gson gson = new Gson();
 
-    List<ClassWithDefaultConstructor> list = gson.fromJson("[{\"i\":1}]", new TypeToken<List<ClassWithDefaultConstructor>>() {});
+    List<ClassWithDefaultConstructor> list =
+        gson.fromJson("[{\"i\":1}]", new TypeToken<List<ClassWithDefaultConstructor>>() {});
     assertThat(list).hasSize(1);
     assertThat(list.get(0).i).isEqualTo(1);
 
     @SuppressWarnings("unchecked")
-    List<ClassWithDefaultConstructor> list2 = (List<ClassWithDefaultConstructor>) gson.fromJson("[{\"i\":1}]", TypeToken.getParameterized(List.class, ClassWithDefaultConstructor.class));
+    List<ClassWithDefaultConstructor> list2 =
+        (List<ClassWithDefaultConstructor>)
+            gson.fromJson(
+                "[{\"i\":1}]",
+                TypeToken.getParameterized(List.class, ClassWithDefaultConstructor.class));
     assertThat(list2).hasSize(1);
     assertThat(list2.get(0).i).isEqualTo(1);
   }

--- a/gson/src/main/java/com/google/gson/ExclusionStrategy.java
+++ b/gson/src/main/java/com/google/gson/ExclusionStrategy.java
@@ -17,12 +17,13 @@
 package com.google.gson;
 
 /**
- * A strategy (or policy) definition that is used to decide whether or not a field or
- * class should be serialized or deserialized as part of the JSON output/input.
+ * A strategy (or policy) definition that is used to decide whether or not a field or class should
+ * be serialized or deserialized as part of the JSON output/input.
  *
  * <p>The following are a few examples that shows how you can use this exclusion mechanism.
  *
  * <p><strong>Exclude fields and objects based on a particular class type:</strong>
+ *
  * <pre class="code">
  * private static class SpecificClassExclusionStrategy implements ExclusionStrategy {
  *   private final Class&lt;?&gt; excludedThisClass;
@@ -42,6 +43,7 @@ package com.google.gson;
  * </pre>
  *
  * <p><strong>Excludes fields and objects based on a particular annotation:</strong>
+ *
  * <pre class="code">
  * public &#64;interface FooAnnotation {
  *   // some implementation here
@@ -59,9 +61,10 @@ package com.google.gson;
  * }
  * </pre>
  *
- * <p>Now if you want to configure {@code Gson} to use a user defined exclusion strategy, then
- * the {@code GsonBuilder} is required. The following is an example of how you can use the
- * {@code GsonBuilder} to configure Gson to use one of the above samples:
+ * <p>Now if you want to configure {@code Gson} to use a user defined exclusion strategy, then the
+ * {@code GsonBuilder} is required. The following is an example of how you can use the {@code
+ * GsonBuilder} to configure Gson to use one of the above samples:
+ *
  * <pre class="code">
  * ExclusionStrategy excludeStrings = new UserDefinedExclusionStrategy(String.class);
  * Gson gson = new GsonBuilder()
@@ -70,10 +73,10 @@ package com.google.gson;
  * </pre>
  *
  * <p>For certain model classes, you may only want to serialize a field, but exclude it for
- * deserialization. To do that, you can write an {@code ExclusionStrategy} as per normal;
- * however, you would register it with the
- * {@link GsonBuilder#addDeserializationExclusionStrategy(ExclusionStrategy)} method.
- * For example:
+ * deserialization. To do that, you can write an {@code ExclusionStrategy} as per normal; however,
+ * you would register it with the {@link
+ * GsonBuilder#addDeserializationExclusionStrategy(ExclusionStrategy)} method. For example:
+ *
  * <pre class="code">
  * ExclusionStrategy excludeStrings = new UserDefinedExclusionStrategy(String.class);
  * Gson gson = new GsonBuilder()
@@ -83,11 +86,9 @@ package com.google.gson;
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
- *
  * @see GsonBuilder#setExclusionStrategies(ExclusionStrategy...)
  * @see GsonBuilder#addDeserializationExclusionStrategy(ExclusionStrategy)
  * @see GsonBuilder#addSerializationExclusionStrategy(ExclusionStrategy)
- *
  * @since 1.4
  */
 public interface ExclusionStrategy {

--- a/gson/src/main/java/com/google/gson/FieldAttributes.java
+++ b/gson/src/main/java/com/google/gson/FieldAttributes.java
@@ -30,7 +30,6 @@ import java.util.Objects;
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
- *
  * @since 1.4
  */
 public final class FieldAttributes {
@@ -67,6 +66,7 @@ public final class FieldAttributes {
    * Returns the declared generic type of the field.
    *
    * <p>For example, assume the following class definition:
+   *
    * <pre class="code">
    * public class Foo {
    *   private String bar;
@@ -76,8 +76,8 @@ public final class FieldAttributes {
    * Type listParameterizedType = new TypeToken&lt;List&lt;String&gt;&gt;() {}.getType();
    * </pre>
    *
-   * <p>This method would return {@code String.class} for the {@code bar} field and
-   * {@code listParameterizedType} for the {@code red} field.
+   * <p>This method would return {@code String.class} for the {@code bar} field and {@code
+   * listParameterizedType} for the {@code red} field.
    *
    * @return the specific type declared for this field
    */
@@ -89,6 +89,7 @@ public final class FieldAttributes {
    * Returns the {@code Class} object that was declared for this field.
    *
    * <p>For example, assume the following class definition:
+   *
    * <pre class="code">
    * public class Foo {
    *   private String bar;
@@ -96,8 +97,8 @@ public final class FieldAttributes {
    * }
    * </pre>
    *
-   * <p>This method would return {@code String.class} for the {@code bar} field and
-   * {@code List.class} for the {@code red} field.
+   * <p>This method would return {@code String.class} for the {@code bar} field and {@code
+   * List.class} for the {@code red} field.
    *
    * @return the specific class object that was declared for the field
    */
@@ -106,8 +107,8 @@ public final class FieldAttributes {
   }
 
   /**
-   * Returns the {@code T} annotation object from this field if it exists; otherwise returns
-   * {@code null}.
+   * Returns the {@code T} annotation object from this field if it exists; otherwise returns {@code
+   * null}.
    *
    * @param annotation the class of the annotation that will be retrieved
    * @return the annotation instance if it is bound to the field; otherwise {@code null}
@@ -130,6 +131,7 @@ public final class FieldAttributes {
    * Returns {@code true} if the field is defined with the {@code modifier}.
    *
    * <p>This method is meant to be called as:
+   *
    * <pre class="code">
    * boolean hasPublicModifier = fieldAttribute.hasModifier(java.lang.reflect.Modifier.PUBLIC);
    * </pre>

--- a/gson/src/main/java/com/google/gson/FieldNamingPolicy.java
+++ b/gson/src/main/java/com/google/gson/FieldNamingPolicy.java
@@ -20,150 +20,161 @@ import java.lang.reflect.Field;
 import java.util.Locale;
 
 /**
- * An enumeration that defines a few standard naming conventions for JSON field names.
- * This enumeration should be used in conjunction with {@link com.google.gson.GsonBuilder}
- * to configure a {@link com.google.gson.Gson} instance to properly translate Java field
- * names into the desired JSON field names.
+ * An enumeration that defines a few standard naming conventions for JSON field names. This
+ * enumeration should be used in conjunction with {@link com.google.gson.GsonBuilder} to configure a
+ * {@link com.google.gson.Gson} instance to properly translate Java field names into the desired
+ * JSON field names.
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
  */
 public enum FieldNamingPolicy implements FieldNamingStrategy {
 
-  /**
-   * Using this naming policy with Gson will ensure that the field name is
-   * unchanged.
-   */
+  /** Using this naming policy with Gson will ensure that the field name is unchanged. */
   IDENTITY() {
-    @Override public String translateName(Field f) {
+    @Override
+    public String translateName(Field f) {
       return f.getName();
     }
   },
 
   /**
-   * Using this naming policy with Gson will ensure that the first "letter" of the Java
-   * field name is capitalized when serialized to its JSON form.
+   * Using this naming policy with Gson will ensure that the first "letter" of the Java field name
+   * is capitalized when serialized to its JSON form.
    *
-   * <p>Here are a few examples of the form "Java Field Name" ---&gt; "JSON Field Name":</p>
+   * <p>Here are a few examples of the form "Java Field Name" ---&gt; "JSON Field Name":
+   *
    * <ul>
-   *   <li>someFieldName ---&gt; SomeFieldName</li>
-   *   <li>_someFieldName ---&gt; _SomeFieldName</li>
+   *   <li>someFieldName ---&gt; SomeFieldName
+   *   <li>_someFieldName ---&gt; _SomeFieldName
    * </ul>
    */
   UPPER_CAMEL_CASE() {
-    @Override public String translateName(Field f) {
+    @Override
+    public String translateName(Field f) {
       return upperCaseFirstLetter(f.getName());
     }
   },
 
   /**
-   * Using this naming policy with Gson will ensure that the first "letter" of the Java
-   * field name is capitalized when serialized to its JSON form and the words will be
-   * separated by a space.
+   * Using this naming policy with Gson will ensure that the first "letter" of the Java field name
+   * is capitalized when serialized to its JSON form and the words will be separated by a space.
    *
-   * <p>Here are a few examples of the form "Java Field Name" ---&gt; "JSON Field Name":</p>
+   * <p>Here are a few examples of the form "Java Field Name" ---&gt; "JSON Field Name":
+   *
    * <ul>
-   *   <li>someFieldName ---&gt; Some Field Name</li>
-   *   <li>_someFieldName ---&gt; _Some Field Name</li>
+   *   <li>someFieldName ---&gt; Some Field Name
+   *   <li>_someFieldName ---&gt; _Some Field Name
    * </ul>
    *
    * @since 1.4
    */
   UPPER_CAMEL_CASE_WITH_SPACES() {
-    @Override public String translateName(Field f) {
+    @Override
+    public String translateName(Field f) {
       return upperCaseFirstLetter(separateCamelCase(f.getName(), ' '));
     }
   },
 
   /**
-   * Using this naming policy with Gson will modify the Java Field name from its camel cased
-   * form to an upper case field name where each word is separated by an underscore (_).
+   * Using this naming policy with Gson will modify the Java Field name from its camel cased form to
+   * an upper case field name where each word is separated by an underscore (_).
    *
-   * <p>Here are a few examples of the form "Java Field Name" ---&gt; "JSON Field Name":</p>
+   * <p>Here are a few examples of the form "Java Field Name" ---&gt; "JSON Field Name":
+   *
    * <ul>
-   *   <li>someFieldName ---&gt; SOME_FIELD_NAME</li>
-   *   <li>_someFieldName ---&gt; _SOME_FIELD_NAME</li>
-   *   <li>aStringField ---&gt; A_STRING_FIELD</li>
-   *   <li>aURL ---&gt; A_U_R_L</li>
+   *   <li>someFieldName ---&gt; SOME_FIELD_NAME
+   *   <li>_someFieldName ---&gt; _SOME_FIELD_NAME
+   *   <li>aStringField ---&gt; A_STRING_FIELD
+   *   <li>aURL ---&gt; A_U_R_L
    * </ul>
    *
    * @since 2.9.0
    */
   UPPER_CASE_WITH_UNDERSCORES() {
-    @Override public String translateName(Field f) {
+    @Override
+    public String translateName(Field f) {
       return separateCamelCase(f.getName(), '_').toUpperCase(Locale.ENGLISH);
     }
   },
 
   /**
-   * Using this naming policy with Gson will modify the Java Field name from its camel cased
-   * form to a lower case field name where each word is separated by an underscore (_).
+   * Using this naming policy with Gson will modify the Java Field name from its camel cased form to
+   * a lower case field name where each word is separated by an underscore (_).
    *
-   * <p>Here are a few examples of the form "Java Field Name" ---&gt; "JSON Field Name":</p>
+   * <p>Here are a few examples of the form "Java Field Name" ---&gt; "JSON Field Name":
+   *
    * <ul>
-   *   <li>someFieldName ---&gt; some_field_name</li>
-   *   <li>_someFieldName ---&gt; _some_field_name</li>
-   *   <li>aStringField ---&gt; a_string_field</li>
-   *   <li>aURL ---&gt; a_u_r_l</li>
+   *   <li>someFieldName ---&gt; some_field_name
+   *   <li>_someFieldName ---&gt; _some_field_name
+   *   <li>aStringField ---&gt; a_string_field
+   *   <li>aURL ---&gt; a_u_r_l
    * </ul>
    */
   LOWER_CASE_WITH_UNDERSCORES() {
-    @Override public String translateName(Field f) {
+    @Override
+    public String translateName(Field f) {
       return separateCamelCase(f.getName(), '_').toLowerCase(Locale.ENGLISH);
     }
   },
 
   /**
-   * Using this naming policy with Gson will modify the Java Field name from its camel cased
-   * form to a lower case field name where each word is separated by a dash (-).
+   * Using this naming policy with Gson will modify the Java Field name from its camel cased form to
+   * a lower case field name where each word is separated by a dash (-).
    *
-   * <p>Here are a few examples of the form "Java Field Name" ---&gt; "JSON Field Name":</p>
+   * <p>Here are a few examples of the form "Java Field Name" ---&gt; "JSON Field Name":
+   *
    * <ul>
-   *   <li>someFieldName ---&gt; some-field-name</li>
-   *   <li>_someFieldName ---&gt; _some-field-name</li>
-   *   <li>aStringField ---&gt; a-string-field</li>
-   *   <li>aURL ---&gt; a-u-r-l</li>
+   *   <li>someFieldName ---&gt; some-field-name
+   *   <li>_someFieldName ---&gt; _some-field-name
+   *   <li>aStringField ---&gt; a-string-field
+   *   <li>aURL ---&gt; a-u-r-l
    * </ul>
+   *
    * Using dashes in JavaScript is not recommended since dash is also used for a minus sign in
    * expressions. This requires that a field named with dashes is always accessed as a quoted
-   * property like {@code myobject['my-field']}. Accessing it as an object field
-   * {@code myobject.my-field} will result in an unintended JavaScript expression.
+   * property like {@code myobject['my-field']}. Accessing it as an object field {@code
+   * myobject.my-field} will result in an unintended JavaScript expression.
    *
    * @since 1.4
    */
   LOWER_CASE_WITH_DASHES() {
-    @Override public String translateName(Field f) {
+    @Override
+    public String translateName(Field f) {
       return separateCamelCase(f.getName(), '-').toLowerCase(Locale.ENGLISH);
     }
   },
 
   /**
-   * Using this naming policy with Gson will modify the Java Field name from its camel cased
-   * form to a lower case field name where each word is separated by a dot (.).
+   * Using this naming policy with Gson will modify the Java Field name from its camel cased form to
+   * a lower case field name where each word is separated by a dot (.).
    *
-   * <p>Here are a few examples of the form "Java Field Name" ---&gt; "JSON Field Name":</p>
+   * <p>Here are a few examples of the form "Java Field Name" ---&gt; "JSON Field Name":
+   *
    * <ul>
-   *   <li>someFieldName ---&gt; some.field.name</li>
-   *   <li>_someFieldName ---&gt; _some.field.name</li>
-   *   <li>aStringField ---&gt; a.string.field</li>
-   *   <li>aURL ---&gt; a.u.r.l</li>
+   *   <li>someFieldName ---&gt; some.field.name
+   *   <li>_someFieldName ---&gt; _some.field.name
+   *   <li>aStringField ---&gt; a.string.field
+   *   <li>aURL ---&gt; a.u.r.l
    * </ul>
+   *
    * Using dots in JavaScript is not recommended since dot is also used for a member sign in
-   * expressions. This requires that a field named with dots is always accessed as a quoted
-   * property like {@code myobject['my.field']}. Accessing it as an object field
-   * {@code myobject.my.field} will result in an unintended JavaScript expression.
+   * expressions. This requires that a field named with dots is always accessed as a quoted property
+   * like {@code myobject['my.field']}. Accessing it as an object field {@code myobject.my.field}
+   * will result in an unintended JavaScript expression.
    *
    * @since 2.8.4
    */
   LOWER_CASE_WITH_DOTS() {
-    @Override public String translateName(Field f) {
+    @Override
+    public String translateName(Field f) {
       return separateCamelCase(f.getName(), '.').toLowerCase(Locale.ENGLISH);
     }
   };
 
   /**
-   * Converts the field name that uses camel-case define word separation into
-   * separate words that are separated by the provided {@code separator}.
+   * Converts the field name that uses camel-case define word separation into separate words that
+   * are separated by the provided {@code separator}.
    */
   static String separateCamelCase(String name, char separator) {
     StringBuilder translation = new StringBuilder();
@@ -177,9 +188,7 @@ public enum FieldNamingPolicy implements FieldNamingStrategy {
     return translation.toString();
   }
 
-  /**
-   * Ensures the JSON field names begins with an upper case letter.
-   */
+  /** Ensures the JSON field names begins with an upper case letter. */
   static String upperCaseFirstLetter(String s) {
     int length = s.length();
     for (int i = 0; i < length; i++) {

--- a/gson/src/main/java/com/google/gson/FieldNamingStrategy.java
+++ b/gson/src/main/java/com/google/gson/FieldNamingStrategy.java
@@ -20,8 +20,8 @@ import java.lang.reflect.Field;
 
 /**
  * A mechanism for providing custom field naming in Gson. This allows the client code to translate
- * field names into a particular convention that is not supported as a normal Java field
- * declaration rules. For example, Java does not support "-" characters in a field name.
+ * field names into a particular convention that is not supported as a normal Java field declaration
+ * rules. For example, Java does not support "-" characters in a field name.
  *
  * @author Inderjeet Singh
  * @author Joel Leitch

--- a/gson/src/main/java/com/google/gson/FormattingStyle.java
+++ b/gson/src/main/java/com/google/gson/FormattingStyle.java
@@ -22,8 +22,9 @@ import java.util.Objects;
 /**
  * A class used to control what the serialization output looks like.
  *
- * <p>It currently has the following configuration methods, but more methods
- * might be added in the future:
+ * <p>It currently has the following configuration methods, but more methods might be added in the
+ * future:
+ *
  * <ul>
  *   <li>{@link #withNewline(String)}
  *   <li>{@link #withIndent(String)}
@@ -33,7 +34,6 @@ import java.util.Objects;
  * @see GsonBuilder#setFormattingStyle(FormattingStyle)
  * @see JsonWriter#setFormattingStyle(FormattingStyle)
  * @see <a href="https://en.wikipedia.org/wiki/Newline">Wikipedia Newline article</a>
- *
  * @since $next-version$
  */
 public class FormattingStyle {
@@ -43,6 +43,7 @@ public class FormattingStyle {
 
   /**
    * The default compact formatting style:
+   *
    * <ul>
    *   <li>no newline
    *   <li>no indent
@@ -53,14 +54,14 @@ public class FormattingStyle {
 
   /**
    * The default pretty printing formatting style:
+   *
    * <ul>
    *   <li>{@code "\n"} as newline
    *   <li>two spaces as indent
    *   <li>a space between {@code ':'} and the subsequent value
    * </ul>
    */
-  public static final FormattingStyle PRETTY =
-      new FormattingStyle("\n", "  ", true);
+  public static final FormattingStyle PRETTY = new FormattingStyle("\n", "  ", true);
 
   private FormattingStyle(String newline, String indent, boolean spaceAfterSeparators) {
     Objects.requireNonNull(newline, "newline == null");
@@ -81,11 +82,11 @@ public class FormattingStyle {
   /**
    * Creates a {@link FormattingStyle} with the specified newline setting.
    *
-   * <p>It can be used to accommodate certain OS convention, for example
-   * hardcode {@code "\n"} for Linux and macOS, {@code "\r\n"} for Windows, or
-   * call {@link java.lang.System#lineSeparator()} to match the current OS.</p>
+   * <p>It can be used to accommodate certain OS convention, for example hardcode {@code "\n"} for
+   * Linux and macOS, {@code "\r\n"} for Windows, or call {@link java.lang.System#lineSeparator()}
+   * to match the current OS.
    *
-   * <p>Only combinations of {@code \n} and {@code \r} are allowed.</p>
+   * <p>Only combinations of {@code \n} and {@code \r} are allowed.
    *
    * @param newline the string value that will be used as newline.
    * @return a newly created {@link FormattingStyle}
@@ -97,7 +98,7 @@ public class FormattingStyle {
   /**
    * Creates a {@link FormattingStyle} with the specified indent string.
    *
-   * <p>Only combinations of spaces and tabs allowed in indent.</p>
+   * <p>Only combinations of spaces and tabs allowed in indent.
    *
    * @param indent the string value that will be used as indent.
    * @return a newly created {@link FormattingStyle}
@@ -107,12 +108,12 @@ public class FormattingStyle {
   }
 
   /**
-   * Creates a {@link FormattingStyle} which either uses a space after
-   * the separators {@code ','} and {@code ':'} in the JSON output, or not.
+   * Creates a {@link FormattingStyle} which either uses a space after the separators {@code ','}
+   * and {@code ':'} in the JSON output, or not.
    *
-   * <p>This setting has no effect on the {@linkplain #withNewline(String) configured newline}.
-   * If a non-empty newline is configured, it will always be added after
-   * {@code ','} and no space is added after the {@code ','} in that case.</p>
+   * <p>This setting has no effect on the {@linkplain #withNewline(String) configured newline}. If a
+   * non-empty newline is configured, it will always be added after {@code ','} and no space is
+   * added after the {@code ','} in that case.
    *
    * @param spaceAfterSeparators whether to output a space after {@code ','} and {@code ':'}.
    * @return a newly created {@link FormattingStyle}
@@ -139,9 +140,7 @@ public class FormattingStyle {
     return this.indent;
   }
 
-  /**
-   * Returns whether a space will be used after {@code ','} and {@code ':'}.
-   */
+  /** Returns whether a space will be used after {@code ','} and {@code ':'}. */
   public boolean usesSpaceAfterSeparators() {
     return this.spaceAfterSeparators;
   }

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -63,15 +63,14 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongArray;
 
 /**
- * This is the main class for using Gson. Gson is typically used by first constructing a
- * Gson instance and then invoking {@link #toJson(Object)} or {@link #fromJson(String, Class)}
- * methods on it. Gson instances are Thread-safe so you can reuse them freely across multiple
- * threads.
+ * This is the main class for using Gson. Gson is typically used by first constructing a Gson
+ * instance and then invoking {@link #toJson(Object)} or {@link #fromJson(String, Class)} methods on
+ * it. Gson instances are Thread-safe so you can reuse them freely across multiple threads.
  *
- * <p>You can create a Gson instance by invoking {@code new Gson()} if the default configuration
- * is all you need. You can also use {@link GsonBuilder} to build a Gson instance with various
+ * <p>You can create a Gson instance by invoking {@code new Gson()} if the default configuration is
+ * all you need. You can also use {@link GsonBuilder} to build a Gson instance with various
  * configuration options such as versioning support, pretty printing, custom newline, custom indent,
- * custom {@link JsonSerializer}s, {@link JsonDeserializer}s, and {@link InstanceCreator}s.</p>
+ * custom {@link JsonSerializer}s, {@link JsonDeserializer}s, and {@link InstanceCreator}s.
  *
  * <p>Here is an example of how Gson is used for a simple Class:
  *
@@ -82,13 +81,13 @@ import java.util.concurrent.atomic.AtomicLongArray;
  * MyType target2 = gson.fromJson(json, MyType.class); // deserializes json into target2
  * </pre>
  *
- * <p>If the type of the object that you are converting is a {@code ParameterizedType}
- * (i.e. has at least one type argument, for example {@code List<MyType>}) then for
- * deserialization you must use a {@code fromJson} method with {@link Type} or {@link TypeToken}
- * parameter to specify the parameterized type. For serialization specifying a {@code Type}
- * or {@code TypeToken} is optional, otherwise Gson will use the runtime type of the object.
- * {@link TypeToken} is a class provided by Gson which helps creating parameterized types.
- * Here is an example showing how this can be done:
+ * <p>If the type of the object that you are converting is a {@code ParameterizedType} (i.e. has at
+ * least one type argument, for example {@code List<MyType>}) then for deserialization you must use
+ * a {@code fromJson} method with {@link Type} or {@link TypeToken} parameter to specify the
+ * parameterized type. For serialization specifying a {@code Type} or {@code TypeToken} is optional,
+ * otherwise Gson will use the runtime type of the object. {@link TypeToken} is a class provided by
+ * Gson which helps creating parameterized types. Here is an example showing how this can be done:
+ *
  * <pre>
  * TypeToken&lt;List&lt;MyType&gt;&gt; listType = new TypeToken&lt;List&lt;MyType&gt;&gt;() {};
  * List&lt;MyType&gt; target = new LinkedList&lt;MyType&gt;();
@@ -104,50 +103,53 @@ import java.util.concurrent.atomic.AtomicLongArray;
  * </pre>
  *
  * <p>See the <a href="https://github.com/google/gson/blob/main/UserGuide.md">Gson User Guide</a>
- * for a more complete set of examples.</p>
+ * for a more complete set of examples.
  *
  * <h2 id="default-lenient">JSON Strictness handling</h2>
- * For legacy reasons most of the {@code Gson} methods allow JSON data which does not
- * comply with the JSON specification when no explicit {@linkplain Strictness strictness} is set (the default).
- * To specify the strictness of a {@code Gson} instance, you should set it through
- * {@link GsonBuilder#setStrictness(Strictness)}.
  *
- * <p>For older Gson versions, which don't have the strictness mode API, the following
- * workarounds can be used:
+ * For legacy reasons most of the {@code Gson} methods allow JSON data which does not comply with
+ * the JSON specification when no explicit {@linkplain Strictness strictness} is set (the default).
+ * To specify the strictness of a {@code Gson} instance, you should set it through {@link
+ * GsonBuilder#setStrictness(Strictness)}.
+ *
+ * <p>For older Gson versions, which don't have the strictness mode API, the following workarounds
+ * can be used:
  *
  * <h3>Serialization</h3>
+ *
  * <ol>
  *   <li>Use {@link #getAdapter(Class)} to obtain the adapter for the type to be serialized
  *   <li>When using an existing {@code JsonWriter}, manually apply the writer settings of this
  *       {@code Gson} instance listed by {@link #newJsonWriter(Writer)}.<br>
- *       Otherwise, when not using an existing {@code JsonWriter}, use {@link #newJsonWriter(Writer)}
- *       to construct one.
+ *       Otherwise, when not using an existing {@code JsonWriter}, use {@link
+ *       #newJsonWriter(Writer)} to construct one.
  *   <li>Call {@link TypeAdapter#write(JsonWriter, Object)}
  * </ol>
  *
  * <h3>Deserialization</h3>
+ *
  * <ol>
  *   <li>Use {@link #getAdapter(Class)} to obtain the adapter for the type to be deserialized
  *   <li>When using an existing {@code JsonReader}, manually apply the reader settings of this
  *       {@code Gson} instance listed by {@link #newJsonReader(Reader)}.<br>
- *       Otherwise, when not using an existing {@code JsonReader}, use {@link #newJsonReader(Reader)}
- *       to construct one.
+ *       Otherwise, when not using an existing {@code JsonReader}, use {@link
+ *       #newJsonReader(Reader)} to construct one.
  *   <li>Call {@link TypeAdapter#read(JsonReader)}
  *   <li>Call {@link JsonReader#peek()} and verify that the result is {@link JsonToken#END_DOCUMENT}
  *       to make sure there is no trailing data
  * </ol>
  *
- * Note that the {@code JsonReader} created this way is only 'legacy strict', it mostly adheres
- * to the JSON specification but allows small deviations. See {@link JsonReader#setStrictness(Strictness)}
- * for details.
+ * Note that the {@code JsonReader} created this way is only 'legacy strict', it mostly adheres to
+ * the JSON specification but allows small deviations. See {@link
+ * JsonReader#setStrictness(Strictness)} for details.
  *
  * @see TypeToken
- *
  * @author Inderjeet Singh
  * @author Joel Leitch
  * @author Jesse Wilson
  */
 public final class Gson {
+
   static final boolean DEFAULT_JSON_NON_EXECUTABLE = false;
   // Strictness of `null` is the legacy mode where some Gson APIs are always lenient
   static final Strictness DEFAULT_STRICTNESS = null;
@@ -160,26 +162,28 @@ public final class Gson {
   static final String DEFAULT_DATE_PATTERN = null;
   static final FieldNamingStrategy DEFAULT_FIELD_NAMING_STRATEGY = FieldNamingPolicy.IDENTITY;
   static final ToNumberStrategy DEFAULT_OBJECT_TO_NUMBER_STRATEGY = ToNumberPolicy.DOUBLE;
-  static final ToNumberStrategy DEFAULT_NUMBER_TO_NUMBER_STRATEGY = ToNumberPolicy.LAZILY_PARSED_NUMBER;
+  static final ToNumberStrategy DEFAULT_NUMBER_TO_NUMBER_STRATEGY =
+      ToNumberPolicy.LAZILY_PARSED_NUMBER;
 
   private static final String JSON_NON_EXECUTABLE_PREFIX = ")]}'\n";
 
   /**
-   * This thread local guards against reentrant calls to {@link #getAdapter(TypeToken)}.
-   * In certain object graphs, creating an adapter for a type may recursively
-   * require an adapter for the same type! Without intervention, the recursive
-   * lookup would stack overflow. We cheat by returning a proxy type adapter,
-   * {@link FutureTypeAdapter}, which is wired up once the initial adapter has
+   * This thread local guards against reentrant calls to {@link #getAdapter(TypeToken)}. In certain
+   * object graphs, creating an adapter for a type may recursively require an adapter for the same
+   * type! Without intervention, the recursive lookup would stack overflow. We cheat by returning a
+   * proxy type adapter, {@link FutureTypeAdapter}, which is wired up once the initial adapter has
    * been created.
    *
-   * <p>The map stores the type adapters for ongoing {@code getAdapter} calls,
-   * with the type token provided to {@code getAdapter} as key and either
-   * {@code FutureTypeAdapter} or a regular {@code TypeAdapter} as value.
+   * <p>The map stores the type adapters for ongoing {@code getAdapter} calls, with the type token
+   * provided to {@code getAdapter} as key and either {@code FutureTypeAdapter} or a regular {@code
+   * TypeAdapter} as value.
    */
   @SuppressWarnings("ThreadLocalUsage")
-  private final ThreadLocal<Map<TypeToken<?>, TypeAdapter<?>>> threadLocalAdapterResults = new ThreadLocal<>();
+  private final ThreadLocal<Map<TypeToken<?>, TypeAdapter<?>>> threadLocalAdapterResults =
+      new ThreadLocal<>();
 
-  private final ConcurrentMap<TypeToken<?>, TypeAdapter<?>> typeTokenCache = new ConcurrentHashMap<>();
+  private final ConcurrentMap<TypeToken<?>, TypeAdapter<?>> typeTokenCache =
+      new ConcurrentHashMap<>();
 
   private final ConstructorConstructor constructorConstructor;
   private final JsonAdapterAnnotationTypeAdapterFactory jsonAdapterFactory;
@@ -210,68 +214,95 @@ public final class Gson {
   /**
    * Constructs a Gson object with default configuration. The default configuration has the
    * following settings:
+   *
    * <ul>
    *   <li>The JSON generated by <code>toJson</code> methods is in compact representation. This
-   *   means that all the unneeded white-space is removed. You can change this behavior with
-   *   {@link GsonBuilder#setPrettyPrinting()}.</li>
+   *       means that all the unneeded white-space is removed. You can change this behavior with
+   *       {@link GsonBuilder#setPrettyPrinting()}.
    *   <li>When the JSON generated contains more than one line, the kind of newline and indent to
-   *   use can be configured with {@link GsonBuilder#setFormattingStyle(FormattingStyle)}.</li>
-   *   <li>The generated JSON omits all the fields that are null. Note that nulls in arrays are
-   *   kept as is since an array is an ordered list. Moreover, if a field is not null, but its
-   *   generated JSON is empty, the field is kept. You can configure Gson to serialize null values
-   *   by setting {@link GsonBuilder#serializeNulls()}.</li>
-   *   <li>Gson provides default serialization and deserialization for Enums, {@link Map},
-   *   {@link java.net.URL}, {@link java.net.URI}, {@link java.util.Locale}, {@link java.util.Date},
-   *   {@link java.math.BigDecimal}, and {@link java.math.BigInteger} classes. If you would prefer
-   *   to change the default representation, you can do so by registering a type adapter through
-   *   {@link GsonBuilder#registerTypeAdapter(Type, Object)}. </li>
+   *       use can be configured with {@link GsonBuilder#setFormattingStyle(FormattingStyle)}.
+   *   <li>The generated JSON omits all the fields that are null. Note that nulls in arrays are kept
+   *       as is since an array is an ordered list. Moreover, if a field is not null, but its
+   *       generated JSON is empty, the field is kept. You can configure Gson to serialize null
+   *       values by setting {@link GsonBuilder#serializeNulls()}.
+   *   <li>Gson provides default serialization and deserialization for Enums, {@link Map}, {@link
+   *       java.net.URL}, {@link java.net.URI}, {@link java.util.Locale}, {@link java.util.Date},
+   *       {@link java.math.BigDecimal}, and {@link java.math.BigInteger} classes. If you would
+   *       prefer to change the default representation, you can do so by registering a type adapter
+   *       through {@link GsonBuilder#registerTypeAdapter(Type, Object)}.
    *   <li>The default Date format is same as {@link java.text.DateFormat#DEFAULT}. This format
-   *   ignores the millisecond portion of the date during serialization. You can change
-   *   this by invoking {@link GsonBuilder#setDateFormat(int)} or
-   *   {@link GsonBuilder#setDateFormat(String)}. </li>
-   *   <li>By default, Gson ignores the {@link com.google.gson.annotations.Expose} annotation.
-   *   You can enable Gson to serialize/deserialize only those fields marked with this annotation
-   *   through {@link GsonBuilder#excludeFieldsWithoutExposeAnnotation()}. </li>
+   *       ignores the millisecond portion of the date during serialization. You can change this by
+   *       invoking {@link GsonBuilder#setDateFormat(int)} or {@link
+   *       GsonBuilder#setDateFormat(String)}.
+   *   <li>By default, Gson ignores the {@link com.google.gson.annotations.Expose} annotation. You
+   *       can enable Gson to serialize/deserialize only those fields marked with this annotation
+   *       through {@link GsonBuilder#excludeFieldsWithoutExposeAnnotation()}.
    *   <li>By default, Gson ignores the {@link com.google.gson.annotations.Since} annotation. You
-   *   can enable Gson to use this annotation through {@link GsonBuilder#setVersion(double)}.</li>
+   *       can enable Gson to use this annotation through {@link GsonBuilder#setVersion(double)}.
    *   <li>The default field naming policy for the output JSON is same as in Java. So, a Java class
-   *   field <code>versionNumber</code> will be output as <code>&quot;versionNumber&quot;</code> in
-   *   JSON. The same rules are applied for mapping incoming JSON to the Java classes. You can
-   *   change this policy through {@link GsonBuilder#setFieldNamingPolicy(FieldNamingPolicy)}.</li>
+   *       field <code>versionNumber</code> will be output as <code>&quot;versionNumber&quot;</code>
+   *       in JSON. The same rules are applied for mapping incoming JSON to the Java classes. You
+   *       can change this policy through {@link
+   *       GsonBuilder#setFieldNamingPolicy(FieldNamingPolicy)}.
    *   <li>By default, Gson excludes <code>transient</code> or <code>static</code> fields from
-   *   consideration for serialization and deserialization. You can change this behavior through
-   *   {@link GsonBuilder#excludeFieldsWithModifiers(int...)}.</li>
-   *   <li>No explicit strictness is set. You can change this by calling
-   *   {@link GsonBuilder#setStrictness(Strictness)}.</li>
+   *       consideration for serialization and deserialization. You can change this behavior through
+   *       {@link GsonBuilder#excludeFieldsWithModifiers(int...)}.
+   *   <li>No explicit strictness is set. You can change this by calling {@link
+   *       GsonBuilder#setStrictness(Strictness)}.
    * </ul>
    */
   public Gson() {
-    this(Excluder.DEFAULT, DEFAULT_FIELD_NAMING_STRATEGY,
-        Collections.<Type, InstanceCreator<?>>emptyMap(), DEFAULT_SERIALIZE_NULLS,
-        DEFAULT_COMPLEX_MAP_KEYS, DEFAULT_JSON_NON_EXECUTABLE, DEFAULT_ESCAPE_HTML,
-        DEFAULT_FORMATTING_STYLE, DEFAULT_STRICTNESS, DEFAULT_SPECIALIZE_FLOAT_VALUES,
+    this(
+        Excluder.DEFAULT,
+        DEFAULT_FIELD_NAMING_STRATEGY,
+        Collections.<Type, InstanceCreator<?>>emptyMap(),
+        DEFAULT_SERIALIZE_NULLS,
+        DEFAULT_COMPLEX_MAP_KEYS,
+        DEFAULT_JSON_NON_EXECUTABLE,
+        DEFAULT_ESCAPE_HTML,
+        DEFAULT_FORMATTING_STYLE,
+        DEFAULT_STRICTNESS,
+        DEFAULT_SPECIALIZE_FLOAT_VALUES,
         DEFAULT_USE_JDK_UNSAFE,
-        LongSerializationPolicy.DEFAULT, DEFAULT_DATE_PATTERN, DateFormat.DEFAULT, DateFormat.DEFAULT,
-        Collections.<TypeAdapterFactory>emptyList(), Collections.<TypeAdapterFactory>emptyList(),
-        Collections.<TypeAdapterFactory>emptyList(), DEFAULT_OBJECT_TO_NUMBER_STRATEGY, DEFAULT_NUMBER_TO_NUMBER_STRATEGY,
+        LongSerializationPolicy.DEFAULT,
+        DEFAULT_DATE_PATTERN,
+        DateFormat.DEFAULT,
+        DateFormat.DEFAULT,
+        Collections.<TypeAdapterFactory>emptyList(),
+        Collections.<TypeAdapterFactory>emptyList(),
+        Collections.<TypeAdapterFactory>emptyList(),
+        DEFAULT_OBJECT_TO_NUMBER_STRATEGY,
+        DEFAULT_NUMBER_TO_NUMBER_STRATEGY,
         Collections.<ReflectionAccessFilter>emptyList());
   }
 
-  Gson(Excluder excluder, FieldNamingStrategy fieldNamingStrategy,
-      Map<Type, InstanceCreator<?>> instanceCreators, boolean serializeNulls,
-      boolean complexMapKeySerialization, boolean generateNonExecutableGson, boolean htmlSafe,
-      FormattingStyle formattingStyle, Strictness strictness, boolean serializeSpecialFloatingPointValues,
+  Gson(
+      Excluder excluder,
+      FieldNamingStrategy fieldNamingStrategy,
+      Map<Type, InstanceCreator<?>> instanceCreators,
+      boolean serializeNulls,
+      boolean complexMapKeySerialization,
+      boolean generateNonExecutableGson,
+      boolean htmlSafe,
+      FormattingStyle formattingStyle,
+      Strictness strictness,
+      boolean serializeSpecialFloatingPointValues,
       boolean useJdkUnsafe,
-      LongSerializationPolicy longSerializationPolicy, String datePattern, int dateStyle,
-      int timeStyle, List<TypeAdapterFactory> builderFactories,
+      LongSerializationPolicy longSerializationPolicy,
+      String datePattern,
+      int dateStyle,
+      int timeStyle,
+      List<TypeAdapterFactory> builderFactories,
       List<TypeAdapterFactory> builderHierarchyFactories,
       List<TypeAdapterFactory> factoriesToBeAdded,
-      ToNumberStrategy objectToNumberStrategy, ToNumberStrategy numberToNumberStrategy,
+      ToNumberStrategy objectToNumberStrategy,
+      ToNumberStrategy numberToNumberStrategy,
       List<ReflectionAccessFilter> reflectionFilters) {
     this.excluder = excluder;
     this.fieldNamingStrategy = fieldNamingStrategy;
     this.instanceCreators = instanceCreators;
-    this.constructorConstructor = new ConstructorConstructor(instanceCreators, useJdkUnsafe, reflectionFilters);
+    this.constructorConstructor =
+        new ConstructorConstructor(instanceCreators, useJdkUnsafe, reflectionFilters);
     this.serializeNulls = serializeNulls;
     this.complexMapKeySerialization = complexMapKeySerialization;
     this.generateNonExecutableJson = generateNonExecutableGson;
@@ -310,23 +341,28 @@ public final class Gson {
     factories.add(TypeAdapters.SHORT_FACTORY);
     TypeAdapter<Number> longAdapter = longAdapter(longSerializationPolicy);
     factories.add(TypeAdapters.newFactory(long.class, Long.class, longAdapter));
-    factories.add(TypeAdapters.newFactory(double.class, Double.class,
-            doubleAdapter(serializeSpecialFloatingPointValues)));
-    factories.add(TypeAdapters.newFactory(float.class, Float.class,
-            floatAdapter(serializeSpecialFloatingPointValues)));
+    factories.add(
+        TypeAdapters.newFactory(
+            double.class, Double.class, doubleAdapter(serializeSpecialFloatingPointValues)));
+    factories.add(
+        TypeAdapters.newFactory(
+            float.class, Float.class, floatAdapter(serializeSpecialFloatingPointValues)));
     factories.add(NumberTypeAdapter.getFactory(numberToNumberStrategy));
     factories.add(TypeAdapters.ATOMIC_INTEGER_FACTORY);
     factories.add(TypeAdapters.ATOMIC_BOOLEAN_FACTORY);
     factories.add(TypeAdapters.newFactory(AtomicLong.class, atomicLongAdapter(longAdapter)));
-    factories.add(TypeAdapters.newFactory(AtomicLongArray.class, atomicLongArrayAdapter(longAdapter)));
+    factories.add(
+        TypeAdapters.newFactory(AtomicLongArray.class, atomicLongArrayAdapter(longAdapter)));
     factories.add(TypeAdapters.ATOMIC_INTEGER_ARRAY_FACTORY);
     factories.add(TypeAdapters.CHARACTER_FACTORY);
     factories.add(TypeAdapters.STRING_BUILDER_FACTORY);
     factories.add(TypeAdapters.STRING_BUFFER_FACTORY);
     factories.add(TypeAdapters.newFactory(BigDecimal.class, TypeAdapters.BIG_DECIMAL));
     factories.add(TypeAdapters.newFactory(BigInteger.class, TypeAdapters.BIG_INTEGER));
-    // Add adapter for LazilyParsedNumber because user can obtain it from Gson and then try to serialize it again
-    factories.add(TypeAdapters.newFactory(LazilyParsedNumber.class, TypeAdapters.LAZILY_PARSED_NUMBER));
+    // Add adapter for LazilyParsedNumber because user can obtain it from Gson and then try to
+    // serialize it again
+    factories.add(
+        TypeAdapters.newFactory(LazilyParsedNumber.class, TypeAdapters.LAZILY_PARSED_NUMBER));
     factories.add(TypeAdapters.URL_FACTORY);
     factories.add(TypeAdapters.URI_FACTORY);
     factories.add(TypeAdapters.UUID_FACTORY);
@@ -352,8 +388,13 @@ public final class Gson {
     this.jsonAdapterFactory = new JsonAdapterAnnotationTypeAdapterFactory(constructorConstructor);
     factories.add(jsonAdapterFactory);
     factories.add(TypeAdapters.ENUM_FACTORY);
-    factories.add(new ReflectiveTypeAdapterFactory(
-        constructorConstructor, fieldNamingStrategy, excluder, jsonAdapterFactory, reflectionFilters));
+    factories.add(
+        new ReflectiveTypeAdapterFactory(
+            constructorConstructor,
+            fieldNamingStrategy,
+            excluder,
+            jsonAdapterFactory,
+            reflectionFilters));
 
     this.factories = Collections.unmodifiableList(factories);
   }
@@ -371,7 +412,7 @@ public final class Gson {
 
   /**
    * @deprecated This method by accident exposes an internal Gson class; it might be removed in a
-   * future version.
+   *     future version.
    */
   @Deprecated
   public Excluder excluder() {
@@ -388,8 +429,8 @@ public final class Gson {
   }
 
   /**
-   * Returns whether this Gson instance is serializing JSON object properties with
-   * {@code null} values, or just omits them.
+   * Returns whether this Gson instance is serializing JSON object properties with {@code null}
+   * values, or just omits them.
    *
    * @see GsonBuilder#serializeNulls()
    */
@@ -398,8 +439,8 @@ public final class Gson {
   }
 
   /**
-   * Returns whether this Gson instance produces JSON output which is
-   * HTML-safe, that means all HTML characters are escaped.
+   * Returns whether this Gson instance produces JSON output which is HTML-safe, that means all HTML
+   * characters are escaped.
    *
    * @see GsonBuilder#disableHtmlEscaping()
    */
@@ -412,14 +453,17 @@ public final class Gson {
       return TypeAdapters.DOUBLE;
     }
     return new TypeAdapter<Number>() {
-      @Override public Double read(JsonReader in) throws IOException {
+      @Override
+      public Double read(JsonReader in) throws IOException {
         if (in.peek() == JsonToken.NULL) {
           in.nextNull();
           return null;
         }
         return in.nextDouble();
       }
-      @Override public void write(JsonWriter out, Number value) throws IOException {
+
+      @Override
+      public void write(JsonWriter out, Number value) throws IOException {
         if (value == null) {
           out.nullValue();
           return;
@@ -436,14 +480,17 @@ public final class Gson {
       return TypeAdapters.FLOAT;
     }
     return new TypeAdapter<Number>() {
-      @Override public Float read(JsonReader in) throws IOException {
+      @Override
+      public Float read(JsonReader in) throws IOException {
         if (in.peek() == JsonToken.NULL) {
           in.nextNull();
           return null;
         }
         return (float) in.nextDouble();
       }
-      @Override public void write(JsonWriter out, Number value) throws IOException {
+
+      @Override
+      public void write(JsonWriter out, Number value) throws IOException {
         if (value == null) {
           out.nullValue();
           return;
@@ -460,9 +507,10 @@ public final class Gson {
 
   static void checkValidFloatingPoint(double value) {
     if (Double.isNaN(value) || Double.isInfinite(value)) {
-      throw new IllegalArgumentException(value
-          + " is not a valid double value as per JSON specification. To override this"
-          + " behavior, use GsonBuilder.serializeSpecialFloatingPointValues() method.");
+      throw new IllegalArgumentException(
+          value
+              + " is not a valid double value as per JSON specification. To override this"
+              + " behavior, use GsonBuilder.serializeSpecialFloatingPointValues() method.");
     }
   }
 
@@ -471,14 +519,17 @@ public final class Gson {
       return TypeAdapters.LONG;
     }
     return new TypeAdapter<Number>() {
-      @Override public Number read(JsonReader in) throws IOException {
+      @Override
+      public Number read(JsonReader in) throws IOException {
         if (in.peek() == JsonToken.NULL) {
           in.nextNull();
           return null;
         }
         return in.nextLong();
       }
-      @Override public void write(JsonWriter out, Number value) throws IOException {
+
+      @Override
+      public void write(JsonWriter out, Number value) throws IOException {
         if (value == null) {
           out.nullValue();
           return;
@@ -490,31 +541,38 @@ public final class Gson {
 
   private static TypeAdapter<AtomicLong> atomicLongAdapter(final TypeAdapter<Number> longAdapter) {
     return new TypeAdapter<AtomicLong>() {
-      @Override public void write(JsonWriter out, AtomicLong value) throws IOException {
+      @Override
+      public void write(JsonWriter out, AtomicLong value) throws IOException {
         longAdapter.write(out, value.get());
       }
-      @Override public AtomicLong read(JsonReader in) throws IOException {
+
+      @Override
+      public AtomicLong read(JsonReader in) throws IOException {
         Number value = longAdapter.read(in);
         return new AtomicLong(value.longValue());
       }
     }.nullSafe();
   }
 
-  private static TypeAdapter<AtomicLongArray> atomicLongArrayAdapter(final TypeAdapter<Number> longAdapter) {
+  private static TypeAdapter<AtomicLongArray> atomicLongArrayAdapter(
+      final TypeAdapter<Number> longAdapter) {
     return new TypeAdapter<AtomicLongArray>() {
-      @Override public void write(JsonWriter out, AtomicLongArray value) throws IOException {
+      @Override
+      public void write(JsonWriter out, AtomicLongArray value) throws IOException {
         out.beginArray();
         for (int i = 0, length = value.length(); i < length; i++) {
           longAdapter.write(out, value.get(i));
         }
         out.endArray();
       }
-      @Override public AtomicLongArray read(JsonReader in) throws IOException {
+
+      @Override
+      public AtomicLongArray read(JsonReader in) throws IOException {
         List<Long> list = new ArrayList<>();
         in.beginArray();
         while (in.hasNext()) {
-            long value = longAdapter.read(in).longValue();
-            list.add(value);
+          long value = longAdapter.read(in).longValue();
+          list.add(value);
         }
         in.endArray();
         int length = list.size();
@@ -530,13 +588,13 @@ public final class Gson {
   /**
    * Returns the type adapter for {@code type}.
    *
-   * <p>When calling this method concurrently from multiple threads and requesting
-   * an adapter for the same type this method may return different {@code TypeAdapter}
-   * instances. However, that should normally not be an issue because {@code TypeAdapter}
-   * implementations are supposed to be stateless.
+   * <p>When calling this method concurrently from multiple threads and requesting an adapter for
+   * the same type this method may return different {@code TypeAdapter} instances. However, that
+   * should normally not be an issue because {@code TypeAdapter} implementations are supposed to be
+   * stateless.
    *
-   * @throws IllegalArgumentException if this Gson instance cannot serialize and
-   *     deserialize {@code type}.
+   * @throws IllegalArgumentException if this Gson instance cannot serialize and deserialize {@code
+   *     type}.
    */
   public <T> TypeAdapter<T> getAdapter(TypeToken<T> type) {
     Objects.requireNonNull(type, "type must not be null");
@@ -583,7 +641,8 @@ public final class Gson {
     }
 
     if (candidate == null) {
-      throw new IllegalArgumentException("GSON (" + GsonBuildConfig.VERSION + ") cannot handle " + type);
+      throw new IllegalArgumentException(
+          "GSON (" + GsonBuildConfig.VERSION + ") cannot handle " + type);
     }
 
     if (isInitialAdapterRequest) {
@@ -599,14 +658,16 @@ public final class Gson {
   }
 
   /**
-   * This method is used to get an alternate type adapter for the specified type. This is used
-   * to access a type adapter that is overridden by a {@link TypeAdapterFactory} that you
-   * may have registered. This feature is typically used when you want to register a type
-   * adapter that does a little bit of work but then delegates further processing to the Gson
-   * default type adapter. Here is an example:
-   * <p>Let's say we want to write a type adapter that counts the number of objects being read
-   * from or written to JSON. We can achieve this by writing a type adapter factory that uses
-   * the <code>getDelegateAdapter</code> method:
+   * This method is used to get an alternate type adapter for the specified type. This is used to
+   * access a type adapter that is overridden by a {@link TypeAdapterFactory} that you may have
+   * registered. This feature is typically used when you want to register a type adapter that does a
+   * little bit of work but then delegates further processing to the Gson default type adapter. Here
+   * is an example:
+   *
+   * <p>Let's say we want to write a type adapter that counts the number of objects being read from
+   * or written to JSON. We can achieve this by writing a type adapter factory that uses the <code>
+   * getDelegateAdapter</code> method:
+   *
    * <pre>{@code
    * class StatsTypeAdapterFactory implements TypeAdapterFactory {
    *   public int numReads = 0;
@@ -626,7 +687,9 @@ public final class Gson {
    *   }
    * }
    * }</pre>
+   *
    * This factory can now be used like this:
+   *
    * <pre>{@code
    * StatsTypeAdapterFactory stats = new StatsTypeAdapterFactory();
    * Gson gson = new GsonBuilder().registerTypeAdapterFactory(stats).create();
@@ -634,26 +697,25 @@ public final class Gson {
    * System.out.println("Num JSON reads: " + stats.numReads);
    * System.out.println("Num JSON writes: " + stats.numWrites);
    * }</pre>
+   *
    * Note that this call will skip all factories registered before {@code skipPast}. In case of
-   * multiple TypeAdapterFactories registered it is up to the caller of this function to ensure
-   * that the order of registration does not prevent this method from reaching a factory they
-   * would expect to reply from this call.
-   * Note that since you can not override the type adapter factories for some types, see
-   * {@link GsonBuilder#registerTypeAdapter(Type, Object)}, our stats factory will not count
-   * the number of instances of those types that will be read or written.
+   * multiple TypeAdapterFactories registered it is up to the caller of this function to ensure that
+   * the order of registration does not prevent this method from reaching a factory they would
+   * expect to reply from this call. Note that since you can not override the type adapter factories
+   * for some types, see {@link GsonBuilder#registerTypeAdapter(Type, Object)}, our stats factory
+   * will not count the number of instances of those types that will be read or written.
    *
-   * <p>If {@code skipPast} is a factory which has neither been registered on the {@link GsonBuilder}
-   * nor specified with the {@link JsonAdapter @JsonAdapter} annotation on a class, then this
-   * method behaves as if {@link #getAdapter(TypeToken)} had been called. This also means that
-   * for fields with {@code @JsonAdapter} annotation this method behaves normally like {@code getAdapter}
-   * (except for corner cases where a custom {@link InstanceCreator} is used to create an
-   * instance of the factory).
+   * <p>If {@code skipPast} is a factory which has neither been registered on the {@link
+   * GsonBuilder} nor specified with the {@link JsonAdapter @JsonAdapter} annotation on a class,
+   * then this method behaves as if {@link #getAdapter(TypeToken)} had been called. This also means
+   * that for fields with {@code @JsonAdapter} annotation this method behaves normally like {@code
+   * getAdapter} (except for corner cases where a custom {@link InstanceCreator} is used to create
+   * an instance of the factory).
    *
-   * @param skipPast The type adapter factory that needs to be skipped while searching for
-   *   a matching type adapter. In most cases, you should just pass <i>this</i> (the type adapter
-   *   factory from where {@code getDelegateAdapter} method is being invoked).
+   * @param skipPast The type adapter factory that needs to be skipped while searching for a
+   *     matching type adapter. In most cases, you should just pass <i>this</i> (the type adapter
+   *     factory from where {@code getDelegateAdapter} method is being invoked).
    * @param type Type for which the delegate adapter is being searched for.
-   *
    * @since 2.2
    */
   public <T> TypeAdapter<T> getDelegateAdapter(TypeAdapterFactory skipPast, TypeToken<T> type) {
@@ -690,8 +752,8 @@ public final class Gson {
   /**
    * Returns the type adapter for {@code type}.
    *
-   * @throws IllegalArgumentException if this Gson instance cannot serialize and
-   *     deserialize {@code type}.
+   * @throws IllegalArgumentException if this Gson instance cannot serialize and deserialize {@code
+   *     type}.
    */
   public <T> TypeAdapter<T> getAdapter(Class<T> type) {
     return getAdapter(TypeToken.get(type));
@@ -702,14 +764,13 @@ public final class Gson {
    * {@link JsonElement}s. This method should be used when the specified object is not a generic
    * type. This method uses {@link Class#getClass()} to get the type for the specified object, but
    * the {@code getClass()} loses the generic type information because of the Type Erasure feature
-   * of Java. Note that this method works fine if any of the object fields are of generic type,
-   * just the object itself should not be of a generic type. If the object is of generic type, use
-   * {@link #toJsonTree(Object, Type)} instead.
+   * of Java. Note that this method works fine if any of the object fields are of generic type, just
+   * the object itself should not be of a generic type. If the object is of generic type, use {@link
+   * #toJsonTree(Object, Type)} instead.
    *
    * @param src the object for which JSON representation is to be created
    * @return JSON representation of {@code src}.
    * @since 1.4
-   *
    * @see #toJsonTree(Object, Type)
    */
   public JsonElement toJsonTree(Object src) {
@@ -726,15 +787,15 @@ public final class Gson {
    * instead.
    *
    * @param src the object for which JSON representation is to be created
-   * @param typeOfSrc The specific genericized type of src. You can obtain
-   * this type by using the {@link com.google.gson.reflect.TypeToken} class. For example,
-   * to get the type for {@code Collection<Foo>}, you should use:
-   * <pre>
+   * @param typeOfSrc The specific genericized type of src. You can obtain this type by using the
+   *     {@link com.google.gson.reflect.TypeToken} class. For example, to get the type for {@code
+   *     Collection<Foo>}, you should use:
+   *     <pre>
    * Type typeOfSrc = new TypeToken&lt;Collection&lt;Foo&gt;&gt;(){}.getType();
    * </pre>
+   *
    * @return JSON representation of {@code src}.
    * @since 1.4
-   *
    * @see #toJsonTree(Object)
    */
   public JsonElement toJsonTree(Object src, Type typeOfSrc) {
@@ -744,18 +805,17 @@ public final class Gson {
   }
 
   /**
-   * This method serializes the specified object into its equivalent JSON representation.
-   * This method should be used when the specified object is not a generic type. This method uses
-   * {@link Class#getClass()} to get the type for the specified object, but the
-   * {@code getClass()} loses the generic type information because of the Type Erasure feature
-   * of Java. Note that this method works fine if any of the object fields are of generic type,
-   * just the object itself should not be of a generic type. If the object is of generic type, use
-   * {@link #toJson(Object, Type)} instead. If you want to write out the object to a
-   * {@link Writer}, use {@link #toJson(Object, Appendable)} instead.
+   * This method serializes the specified object into its equivalent JSON representation. This
+   * method should be used when the specified object is not a generic type. This method uses {@link
+   * Class#getClass()} to get the type for the specified object, but the {@code getClass()} loses
+   * the generic type information because of the Type Erasure feature of Java. Note that this method
+   * works fine if any of the object fields are of generic type, just the object itself should not
+   * be of a generic type. If the object is of generic type, use {@link #toJson(Object, Type)}
+   * instead. If you want to write out the object to a {@link Writer}, use {@link #toJson(Object,
+   * Appendable)} instead.
    *
    * @param src the object for which JSON representation is to be created
    * @return JSON representation of {@code src}.
-   *
    * @see #toJson(Object, Appendable)
    * @see #toJson(Object, Type)
    */
@@ -773,14 +833,14 @@ public final class Gson {
    * the object to a {@link Appendable}, use {@link #toJson(Object, Type, Appendable)} instead.
    *
    * @param src the object for which JSON representation is to be created
-   * @param typeOfSrc The specific genericized type of src. You can obtain
-   * this type by using the {@link com.google.gson.reflect.TypeToken} class. For example,
-   * to get the type for {@code Collection<Foo>}, you should use:
-   * <pre>
+   * @param typeOfSrc The specific genericized type of src. You can obtain this type by using the
+   *     {@link com.google.gson.reflect.TypeToken} class. For example, to get the type for {@code
+   *     Collection<Foo>}, you should use:
+   *     <pre>
    * Type typeOfSrc = new TypeToken&lt;Collection&lt;Foo&gt;&gt;(){}.getType();
    * </pre>
-   * @return JSON representation of {@code src}.
    *
+   * @return JSON representation of {@code src}.
    * @see #toJson(Object, Type, Appendable)
    * @see #toJson(Object)
    */
@@ -791,20 +851,18 @@ public final class Gson {
   }
 
   /**
-   * This method serializes the specified object into its equivalent JSON representation and
-   * writes it to the writer.
-   * This method should be used when the specified object is not a generic type. This method uses
-   * {@link Class#getClass()} to get the type for the specified object, but the
-   * {@code getClass()} loses the generic type information because of the Type Erasure feature
-   * of Java. Note that this method works fine if any of the object fields are of generic type,
-   * just the object itself should not be of a generic type. If the object is of generic type, use
-   * {@link #toJson(Object, Type, Appendable)} instead.
+   * This method serializes the specified object into its equivalent JSON representation and writes
+   * it to the writer. This method should be used when the specified object is not a generic type.
+   * This method uses {@link Class#getClass()} to get the type for the specified object, but the
+   * {@code getClass()} loses the generic type information because of the Type Erasure feature of
+   * Java. Note that this method works fine if any of the object fields are of generic type, just
+   * the object itself should not be of a generic type. If the object is of generic type, use {@link
+   * #toJson(Object, Type, Appendable)} instead.
    *
    * @param src the object for which JSON representation is to be created
    * @param writer Writer to which the JSON representation needs to be written
    * @throws JsonIOException if there was a problem writing to the writer
    * @since 1.2
-   *
    * @see #toJson(Object)
    * @see #toJson(Object, Type, Appendable)
    */
@@ -818,21 +876,21 @@ public final class Gson {
 
   /**
    * This method serializes the specified object, including those of generic types, into its
-   * equivalent JSON representation and writes it to the writer.
-   * This method must be used if the specified object is a generic type. For non-generic objects,
-   * use {@link #toJson(Object, Appendable)} instead.
+   * equivalent JSON representation and writes it to the writer. This method must be used if the
+   * specified object is a generic type. For non-generic objects, use {@link #toJson(Object,
+   * Appendable)} instead.
    *
    * @param src the object for which JSON representation is to be created
-   * @param typeOfSrc The specific genericized type of src. You can obtain
-   * this type by using the {@link com.google.gson.reflect.TypeToken} class. For example,
-   * to get the type for {@code Collection<Foo>}, you should use:
-   * <pre>
+   * @param typeOfSrc The specific genericized type of src. You can obtain this type by using the
+   *     {@link com.google.gson.reflect.TypeToken} class. For example, to get the type for {@code
+   *     Collection<Foo>}, you should use:
+   *     <pre>
    * Type typeOfSrc = new TypeToken&lt;Collection&lt;Foo&gt;&gt;(){}.getType();
    * </pre>
+   *
    * @param writer Writer to which the JSON representation of src needs to be written
    * @throws JsonIOException if there was a problem writing to the writer
    * @since 1.2
-   *
    * @see #toJson(Object, Type)
    * @see #toJson(Object, Appendable)
    */
@@ -846,24 +904,24 @@ public final class Gson {
   }
 
   /**
-   * Writes the JSON representation of {@code src} of type {@code typeOfSrc} to
-   * {@code writer}.
+   * Writes the JSON representation of {@code src} of type {@code typeOfSrc} to {@code writer}.
    *
-   * <p>If the {@code Gson} instance has an {@linkplain GsonBuilder#setStrictness(Strictness) explicit strictness setting},
-   * this setting will be used for writing the JSON regardless of the {@linkplain JsonWriter#getStrictness() strictness}
-   * of the provided {@link JsonWriter}. For legacy reasons, if the {@code Gson} instance has no explicit strictness setting
-   * and the writer does not have the strictness {@link Strictness#STRICT}, the JSON will be written in {@link Strictness#LENIENT}
-   * mode.<br>
-   * Note that in all cases the old strictness setting of the writer will be restored when this method returns.
+   * <p>If the {@code Gson} instance has an {@linkplain GsonBuilder#setStrictness(Strictness)
+   * explicit strictness setting}, this setting will be used for writing the JSON regardless of the
+   * {@linkplain JsonWriter#getStrictness() strictness} of the provided {@link JsonWriter}. For
+   * legacy reasons, if the {@code Gson} instance has no explicit strictness setting and the writer
+   * does not have the strictness {@link Strictness#STRICT}, the JSON will be written in {@link
+   * Strictness#LENIENT} mode.<br>
+   * Note that in all cases the old strictness setting of the writer will be restored when this
+   * method returns.
    *
    * <p>The 'HTML-safe' and 'serialize {@code null}' settings of this {@code Gson} instance
-   * (configured by the {@link GsonBuilder}) are applied, and the original settings of the
-   * writer are restored once this method returns.
+   * (configured by the {@link GsonBuilder}) are applied, and the original settings of the writer
+   * are restored once this method returns.
    *
    * @param src the object for which JSON representation is to be created
    * @param typeOfSrc the type of the object to be written
    * @param writer Writer to which the JSON representation of src needs to be written
-   *
    * @throws JsonIOException if there was a problem writing to the writer
    */
   public void toJson(Object src, Type typeOfSrc, JsonWriter writer) throws JsonIOException {
@@ -887,7 +945,8 @@ public final class Gson {
     } catch (IOException e) {
       throw new JsonIOException(e);
     } catch (AssertionError e) {
-      throw new AssertionError("AssertionError (GSON " + GsonBuildConfig.VERSION + "): " + e.getMessage(), e);
+      throw new AssertionError(
+          "AssertionError (GSON " + GsonBuildConfig.VERSION + "): " + e.getMessage(), e);
     } finally {
       writer.setStrictness(oldStrictness);
       writer.setHtmlSafe(oldHtmlSafe);
@@ -929,16 +988,17 @@ public final class Gson {
    * Returns a new JSON writer configured for the settings on this Gson instance.
    *
    * <p>The following settings are considered:
+   *
    * <ul>
-   *   <li>{@link GsonBuilder#disableHtmlEscaping()}</li>
-   *   <li>{@link GsonBuilder#generateNonExecutableJson()}</li>
-   *   <li>{@link GsonBuilder#serializeNulls()}</li>
-   *   <li>{@link GsonBuilder#setStrictness(Strictness)}. If no
-   *   {@linkplain GsonBuilder#setStrictness(Strictness) explicit strictness has been set} the created
-   *   writer will have a strictness of {@link Strictness#LEGACY_STRICT}. Otherwise, the strictness of
-   *   the {@code Gson} instance will be used for the created writer.</li>
-   *   <li>{@link GsonBuilder#setPrettyPrinting()}</li>
-   *   <li>{@link GsonBuilder#setFormattingStyle(FormattingStyle)}</li>
+   *   <li>{@link GsonBuilder#disableHtmlEscaping()}
+   *   <li>{@link GsonBuilder#generateNonExecutableJson()}
+   *   <li>{@link GsonBuilder#serializeNulls()}
+   *   <li>{@link GsonBuilder#setStrictness(Strictness)}. If no {@linkplain
+   *       GsonBuilder#setStrictness(Strictness) explicit strictness has been set} the created
+   *       writer will have a strictness of {@link Strictness#LEGACY_STRICT}. Otherwise, the
+   *       strictness of the {@code Gson} instance will be used for the created writer.
+   *   <li>{@link GsonBuilder#setPrettyPrinting()}
+   *   <li>{@link GsonBuilder#setFormattingStyle(FormattingStyle)}
    * </ul>
    */
   public JsonWriter newJsonWriter(Writer writer) throws IOException {
@@ -957,11 +1017,12 @@ public final class Gson {
    * Returns a new JSON reader configured for the settings on this Gson instance.
    *
    * <p>The following settings are considered:
+   *
    * <ul>
-   *   <li>{@link GsonBuilder#setStrictness(Strictness)}. If no
-   *   {@linkplain GsonBuilder#setStrictness(Strictness) explicit strictness has been set} the created
-   *   reader will have a strictness of {@link Strictness#LEGACY_STRICT}. Otherwise, the strictness of
-   *   the {@code Gson} instance will be used for the created reader.</li>
+   *   <li>{@link GsonBuilder#setStrictness(Strictness)}. If no {@linkplain
+   *       GsonBuilder#setStrictness(Strictness) explicit strictness has been set} the created
+   *       reader will have a strictness of {@link Strictness#LEGACY_STRICT}. Otherwise, the
+   *       strictness of the {@code Gson} instance will be used for the created reader.
    * </ul>
    */
   public JsonReader newJsonReader(Reader reader) {
@@ -973,16 +1034,18 @@ public final class Gson {
   /**
    * Writes the JSON for {@code jsonElement} to {@code writer}.
    *
-   * <p>If the {@code Gson} instance has an {@linkplain GsonBuilder#setStrictness(Strictness) explicit strictness setting},
-   * this setting will be used for writing the JSON regardless of the {@linkplain JsonWriter#getStrictness() strictness}
-   * of the provided {@link JsonWriter}. For legacy reasons, if the {@code Gson} instance has no explicit strictness setting
-   * and the writer does not have the strictness {@link Strictness#STRICT}, the JSON will be written in {@link Strictness#LENIENT}
-   * mode.<br>
-   * Note that in all cases the old strictness setting of the writer will be restored when this method returns.
+   * <p>If the {@code Gson} instance has an {@linkplain GsonBuilder#setStrictness(Strictness)
+   * explicit strictness setting}, this setting will be used for writing the JSON regardless of the
+   * {@linkplain JsonWriter#getStrictness() strictness} of the provided {@link JsonWriter}. For
+   * legacy reasons, if the {@code Gson} instance has no explicit strictness setting and the writer
+   * does not have the strictness {@link Strictness#STRICT}, the JSON will be written in {@link
+   * Strictness#LENIENT} mode.<br>
+   * Note that in all cases the old strictness setting of the writer will be restored when this
+   * method returns.
    *
    * <p>The 'HTML-safe' and 'serialize {@code null}' settings of this {@code Gson} instance
-   * (configured by the {@link GsonBuilder}) are applied, and the original settings of the
-   * writer are restored once this method returns.
+   * (configured by the {@link GsonBuilder}) are applied, and the original settings of the writer
+   * are restored once this method returns.
    *
    * @param jsonElement the JSON element to be written
    * @param writer the JSON writer to which the provided element will be written
@@ -1007,7 +1070,8 @@ public final class Gson {
     } catch (IOException e) {
       throw new JsonIOException(e);
     } catch (AssertionError e) {
-      throw new AssertionError("AssertionError (GSON " + GsonBuildConfig.VERSION + "): " + e.getMessage(), e);
+      throw new AssertionError(
+          "AssertionError (GSON " + GsonBuildConfig.VERSION + "): " + e.getMessage(), e);
     } finally {
       writer.setStrictness(oldStrictness);
       writer.setHtmlSafe(oldHtmlSafe);
@@ -1019,11 +1083,11 @@ public final class Gson {
    * This method deserializes the specified JSON into an object of the specified class. It is not
    * suitable to use if the specified class is a generic type since it will not have the generic
    * type information because of the Type Erasure feature of Java. Therefore, this method should not
-   * be used if the desired type is a generic type. Note that this method works fine if any of
-   * the fields of the specified object are generics, just the object itself should not be a
-   * generic type. For the cases when the object is of generic type, invoke
-   * {@link #fromJson(String, TypeToken)}. If you have the JSON in a {@link Reader} instead of
-   * a String, use {@link #fromJson(Reader, Class)} instead.
+   * be used if the desired type is a generic type. Note that this method works fine if any of the
+   * fields of the specified object are generics, just the object itself should not be a generic
+   * type. For the cases when the object is of generic type, invoke {@link #fromJson(String,
+   * TypeToken)}. If you have the JSON in a {@link Reader} instead of a String, use {@link
+   * #fromJson(Reader, Class)} instead.
    *
    * <p>An exception is thrown if the JSON string has multiple top-level JSON elements, or if there
    * is trailing data. Use {@link #fromJson(JsonReader, Type)} if this behavior is not desired.
@@ -1031,11 +1095,10 @@ public final class Gson {
    * @param <T> the type of the desired object
    * @param json the string from which the object is to be deserialized
    * @param classOfT the class of T
-   * @return an object of type T from the string. Returns {@code null} if {@code json} is {@code null}
-   * or if {@code json} is empty.
+   * @return an object of type T from the string. Returns {@code null} if {@code json} is {@code
+   *     null} or if {@code json} is empty.
    * @throws JsonSyntaxException if json is not a valid representation for an object of type
-   * classOfT
-   *
+   *     classOfT
    * @see #fromJson(Reader, Class)
    * @see #fromJson(String, TypeToken)
    */
@@ -1046,26 +1109,24 @@ public final class Gson {
 
   /**
    * This method deserializes the specified JSON into an object of the specified type. This method
-   * is useful if the specified object is a generic type. For non-generic objects, use
-   * {@link #fromJson(String, Class)} instead. If you have the JSON in a {@link Reader} instead of
-   * a String, use {@link #fromJson(Reader, Type)} instead.
+   * is useful if the specified object is a generic type. For non-generic objects, use {@link
+   * #fromJson(String, Class)} instead. If you have the JSON in a {@link Reader} instead of a
+   * String, use {@link #fromJson(Reader, Type)} instead.
    *
-   * <p>Since {@code Type} is not parameterized by T, this method is not type-safe and
-   * should be used carefully. If you are creating the {@code Type} from a {@link TypeToken},
-   * prefer using {@link #fromJson(String, TypeToken)} instead since its return type is based
-   * on the {@code TypeToken} and is therefore more type-safe.
+   * <p>Since {@code Type} is not parameterized by T, this method is not type-safe and should be
+   * used carefully. If you are creating the {@code Type} from a {@link TypeToken}, prefer using
+   * {@link #fromJson(String, TypeToken)} instead since its return type is based on the {@code
+   * TypeToken} and is therefore more type-safe.
    *
-   * <p>An exception is thrown if the JSON string has multiple top-level JSON elements,
-   * or if there is trailing data. Use {@link #fromJson(JsonReader, Type)} if this behavior is
-   * not desired.
+   * <p>An exception is thrown if the JSON string has multiple top-level JSON elements, or if there
+   * is trailing data. Use {@link #fromJson(JsonReader, Type)} if this behavior is not desired.
    *
    * @param <T> the type of the desired object
    * @param json the string from which the object is to be deserialized
    * @param typeOfT The specific genericized type of src
-   * @return an object of type T from the string. Returns {@code null} if {@code json} is {@code null}
-   * or if {@code json} is empty.
+   * @return an object of type T from the string. Returns {@code null} if {@code json} is {@code
+   *     null} or if {@code json} is empty.
    * @throws JsonSyntaxException if json is not a valid representation for an object of type typeOfT
-   *
    * @see #fromJson(Reader, Type)
    * @see #fromJson(String, Class)
    * @see #fromJson(String, TypeToken)
@@ -1077,9 +1138,9 @@ public final class Gson {
 
   /**
    * This method deserializes the specified JSON into an object of the specified type. This method
-   * is useful if the specified object is a generic type. For non-generic objects, use
-   * {@link #fromJson(String, Class)} instead. If you have the JSON in a {@link Reader} instead of
-   * a String, use {@link #fromJson(Reader, TypeToken)} instead.
+   * is useful if the specified object is a generic type. For non-generic objects, use {@link
+   * #fromJson(String, Class)} instead. If you have the JSON in a {@link Reader} instead of a
+   * String, use {@link #fromJson(Reader, TypeToken)} instead.
    *
    * <p>An exception is thrown if the JSON string has multiple top-level JSON elements, or if there
    * is trailing data. Use {@link #fromJson(JsonReader, TypeToken)} if this behavior is not desired.
@@ -1087,15 +1148,16 @@ public final class Gson {
    * @param <T> the type of the desired object
    * @param json the string from which the object is to be deserialized
    * @param typeOfT The specific genericized type of src. You should create an anonymous subclass of
-   * {@code TypeToken} with the specific generic type arguments. For example, to get the type for
-   * {@code Collection<Foo>}, you should use:
-   * <pre>
+   *     {@code TypeToken} with the specific generic type arguments. For example, to get the type
+   *     for {@code Collection<Foo>}, you should use:
+   *     <pre>
    * new TypeToken&lt;Collection&lt;Foo&gt;&gt;(){}
    * </pre>
-   * @return an object of type T from the string. Returns {@code null} if {@code json} is {@code null}
-   * or if {@code json} is empty.
-   * @throws JsonSyntaxException if json is not a valid representation for an object of the type typeOfT
    *
+   * @return an object of type T from the string. Returns {@code null} if {@code json} is {@code
+   *     null} or if {@code json} is empty.
+   * @throws JsonSyntaxException if json is not a valid representation for an object of the type
+   *     typeOfT
    * @see #fromJson(Reader, TypeToken)
    * @see #fromJson(String, Class)
    * @since 2.10
@@ -1112,14 +1174,14 @@ public final class Gson {
    * This method deserializes the JSON read from the specified reader into an object of the
    * specified class. It is not suitable to use if the specified class is a generic type since it
    * will not have the generic type information because of the Type Erasure feature of Java.
-   * Therefore, this method should not be used if the desired type is a generic type. Note that
-   * this method works fine if any of the fields of the specified object are generics, just the
-   * object itself should not be a generic type. For the cases when the object is of generic type,
-   * invoke {@link #fromJson(Reader, TypeToken)}. If you have the JSON in a String form instead of a
-   * {@link Reader}, use {@link #fromJson(String, Class)} instead.
+   * Therefore, this method should not be used if the desired type is a generic type. Note that this
+   * method works fine if any of the fields of the specified object are generics, just the object
+   * itself should not be a generic type. For the cases when the object is of generic type, invoke
+   * {@link #fromJson(Reader, TypeToken)}. If you have the JSON in a String form instead of a {@link
+   * Reader}, use {@link #fromJson(String, Class)} instead.
    *
-   * <p>An exception is thrown if the JSON data has multiple top-level JSON elements, or if there
-   * is trailing data. Use {@link #fromJson(JsonReader, Type)} if this behavior is not desired.
+   * <p>An exception is thrown if the JSON data has multiple top-level JSON elements, or if there is
+   * trailing data. Use {@link #fromJson(JsonReader, Type)} if this behavior is not desired.
    *
    * @param <T> the type of the desired object
    * @param json the reader producing the JSON from which the object is to be deserialized.
@@ -1128,11 +1190,11 @@ public final class Gson {
    * @throws JsonIOException if there was a problem reading from the Reader
    * @throws JsonSyntaxException if json is not a valid representation for an object of type typeOfT
    * @since 1.2
-   *
    * @see #fromJson(String, Class)
    * @see #fromJson(Reader, TypeToken)
    */
-  public <T> T fromJson(Reader json, Class<T> classOfT) throws JsonSyntaxException, JsonIOException {
+  public <T> T fromJson(Reader json, Class<T> classOfT)
+      throws JsonSyntaxException, JsonIOException {
     T object = fromJson(json, TypeToken.get(classOfT));
     return Primitives.wrap(classOfT).cast(object);
   }
@@ -1143,13 +1205,13 @@ public final class Gson {
    * non-generic objects, use {@link #fromJson(Reader, Class)} instead. If you have the JSON in a
    * String form instead of a {@link Reader}, use {@link #fromJson(String, Type)} instead.
    *
-   * <p>Since {@code Type} is not parameterized by T, this method is not type-safe and
-   * should be used carefully. If you are creating the {@code Type} from a {@link TypeToken},
-   * prefer using {@link #fromJson(Reader, TypeToken)} instead since its return type is based
-   * on the {@code TypeToken} and is therefore more type-safe.
+   * <p>Since {@code Type} is not parameterized by T, this method is not type-safe and should be
+   * used carefully. If you are creating the {@code Type} from a {@link TypeToken}, prefer using
+   * {@link #fromJson(Reader, TypeToken)} instead since its return type is based on the {@code
+   * TypeToken} and is therefore more type-safe.
    *
-   * <p>An exception is thrown if the JSON data has multiple top-level JSON elements, or if there
-   * is trailing data. Use {@link #fromJson(JsonReader, Type)} if this behavior is not desired.
+   * <p>An exception is thrown if the JSON data has multiple top-level JSON elements, or if there is
+   * trailing data. Use {@link #fromJson(JsonReader, Type)} if this behavior is not desired.
    *
    * @param <T> the type of the desired object
    * @param json the reader producing JSON from which the object is to be deserialized
@@ -1158,7 +1220,6 @@ public final class Gson {
    * @throws JsonIOException if there was a problem reading from the Reader
    * @throws JsonSyntaxException if json is not a valid representation for an object of type typeOfT
    * @since 1.2
-   *
    * @see #fromJson(String, Type)
    * @see #fromJson(Reader, Class)
    * @see #fromJson(Reader, TypeToken)
@@ -1174,26 +1235,28 @@ public final class Gson {
    * non-generic objects, use {@link #fromJson(Reader, Class)} instead. If you have the JSON in a
    * String form instead of a {@link Reader}, use {@link #fromJson(String, TypeToken)} instead.
    *
-   * <p>An exception is thrown if the JSON data has multiple top-level JSON elements, or if there
-   * is trailing data. Use {@link #fromJson(JsonReader, TypeToken)} if this behavior is not desired.
+   * <p>An exception is thrown if the JSON data has multiple top-level JSON elements, or if there is
+   * trailing data. Use {@link #fromJson(JsonReader, TypeToken)} if this behavior is not desired.
    *
    * @param <T> the type of the desired object
    * @param json the reader producing JSON from which the object is to be deserialized
    * @param typeOfT The specific genericized type of src. You should create an anonymous subclass of
-   * {@code TypeToken} with the specific generic type arguments. For example, to get the type for
-   * {@code Collection<Foo>}, you should use:
-   * <pre>
+   *     {@code TypeToken} with the specific generic type arguments. For example, to get the type
+   *     for {@code Collection<Foo>}, you should use:
+   *     <pre>
    * new TypeToken&lt;Collection&lt;Foo&gt;&gt;(){}
    * </pre>
+   *
    * @return an object of type T from the Reader. Returns {@code null} if {@code json} is at EOF.
    * @throws JsonIOException if there was a problem reading from the Reader
-   * @throws JsonSyntaxException if json is not a valid representation for an object of type of typeOfT
-   *
+   * @throws JsonSyntaxException if json is not a valid representation for an object of type of
+   *     typeOfT
    * @see #fromJson(String, TypeToken)
    * @see #fromJson(Reader, Class)
    * @since 2.10
    */
-  public <T> T fromJson(Reader json, TypeToken<T> typeOfT) throws JsonIOException, JsonSyntaxException {
+  public <T> T fromJson(Reader json, TypeToken<T> typeOfT)
+      throws JsonIOException, JsonSyntaxException {
     JsonReader jsonReader = newJsonReader(json);
     T object = fromJson(jsonReader, typeOfT);
     assertFullConsumption(object, jsonReader);
@@ -1213,77 +1276,85 @@ public final class Gson {
   }
 
   // fromJson(JsonReader, Class) is unfortunately missing and cannot be added now without breaking
-  // source compatibility in certain cases, see https://github.com/google/gson/pull/1700#discussion_r973764414
+  // source compatibility in certain cases, see
+  // https://github.com/google/gson/pull/1700#discussion_r973764414
 
   /**
-   * Reads the next JSON value from {@code reader} and converts it to an object
-   * of type {@code typeOfT}. Returns {@code null}, if the {@code reader} is at EOF.
+   * Reads the next JSON value from {@code reader} and converts it to an object of type {@code
+   * typeOfT}. Returns {@code null}, if the {@code reader} is at EOF.
    *
-   * <p>Since {@code Type} is not parameterized by T, this method is not type-safe and
-   * should be used carefully. If you are creating the {@code Type} from a {@link TypeToken},
-   * prefer using {@link #fromJson(JsonReader, TypeToken)} instead since its return type is based
-   * on the {@code TypeToken} and is therefore more type-safe. If the provided type is a
-   * {@code Class} the {@code TypeToken} can be created with {@link TypeToken#get(Class)}.
+   * <p>Since {@code Type} is not parameterized by T, this method is not type-safe and should be
+   * used carefully. If you are creating the {@code Type} from a {@link TypeToken}, prefer using
+   * {@link #fromJson(JsonReader, TypeToken)} instead since its return type is based on the {@code
+   * TypeToken} and is therefore more type-safe. If the provided type is a {@code Class} the {@code
+   * TypeToken} can be created with {@link TypeToken#get(Class)}.
    *
    * <p>Unlike the other {@code fromJson} methods, no exception is thrown if the JSON data has
    * multiple top-level JSON elements, or if there is trailing data.
    *
-   * <p>If the {@code Gson} instance has an {@linkplain GsonBuilder#setStrictness(Strictness) explicit strictness setting},
-   * this setting will be used for reading the JSON regardless of the {@linkplain JsonReader#getStrictness() strictness}
-   * of the provided {@link JsonReader}. For legacy reasons, if the {@code Gson} instance has no explicit strictness setting
-   * and the reader does not have the strictness {@link Strictness#STRICT}, the JSON will be written in {@link Strictness#LENIENT}
-   * mode.<br>
-   * Note that in all cases the old strictness setting of the reader will be restored when this method returns.
+   * <p>If the {@code Gson} instance has an {@linkplain GsonBuilder#setStrictness(Strictness)
+   * explicit strictness setting}, this setting will be used for reading the JSON regardless of the
+   * {@linkplain JsonReader#getStrictness() strictness} of the provided {@link JsonReader}. For
+   * legacy reasons, if the {@code Gson} instance has no explicit strictness setting and the reader
+   * does not have the strictness {@link Strictness#STRICT}, the JSON will be written in {@link
+   * Strictness#LENIENT} mode.<br>
+   * Note that in all cases the old strictness setting of the reader will be restored when this
+   * method returns.
    *
    * @param <T> the type of the desired object
    * @param reader the reader whose next JSON value should be deserialized
    * @param typeOfT The specific genericized type of src
-   * @return an object of type T from the JsonReader. Returns {@code null} if {@code reader} is at EOF.
+   * @return an object of type T from the JsonReader. Returns {@code null} if {@code reader} is at
+   *     EOF.
    * @throws JsonIOException if there was a problem reading from the JsonReader
    * @throws JsonSyntaxException if json is not a valid representation for an object of type typeOfT
-   *
    * @see #fromJson(Reader, Type)
    * @see #fromJson(JsonReader, TypeToken)
    */
   @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
-  public <T> T fromJson(JsonReader reader, Type typeOfT) throws JsonIOException, JsonSyntaxException {
+  public <T> T fromJson(JsonReader reader, Type typeOfT)
+      throws JsonIOException, JsonSyntaxException {
     return (T) fromJson(reader, TypeToken.get(typeOfT));
   }
 
   /**
-   * Reads the next JSON value from {@code reader} and converts it to an object
-   * of type {@code typeOfT}. Returns {@code null}, if the {@code reader} is at EOF.
-   * This method is useful if the specified object is a generic type. For non-generic objects,
-   * {@link #fromJson(JsonReader, Type)} can be called, or {@link TypeToken#get(Class)} can
-   * be used to create the type token.
+   * Reads the next JSON value from {@code reader} and converts it to an object of type {@code
+   * typeOfT}. Returns {@code null}, if the {@code reader} is at EOF. This method is useful if the
+   * specified object is a generic type. For non-generic objects, {@link #fromJson(JsonReader,
+   * Type)} can be called, or {@link TypeToken#get(Class)} can be used to create the type token.
    *
    * <p>Unlike the other {@code fromJson} methods, no exception is thrown if the JSON data has
    * multiple top-level JSON elements, or if there is trailing data.
    *
-   * <p>If the {@code Gson} instance has an {@linkplain GsonBuilder#setStrictness(Strictness) explicit strictness setting},
-   * this setting will be used for reading the JSON regardless of the {@linkplain JsonReader#getStrictness() strictness}
-   * of the provided {@link JsonReader}. For legacy reasons, if the {@code Gson} instance has no explicit strictness setting
-   * and the reader does not have the strictness {@link Strictness#STRICT}, the JSON will be written in {@link Strictness#LENIENT}
-   * mode.<br>
-   * Note that in all cases the old strictness setting of the reader will be restored when this method returns.
+   * <p>If the {@code Gson} instance has an {@linkplain GsonBuilder#setStrictness(Strictness)
+   * explicit strictness setting}, this setting will be used for reading the JSON regardless of the
+   * {@linkplain JsonReader#getStrictness() strictness} of the provided {@link JsonReader}. For
+   * legacy reasons, if the {@code Gson} instance has no explicit strictness setting and the reader
+   * does not have the strictness {@link Strictness#STRICT}, the JSON will be written in {@link
+   * Strictness#LENIENT} mode.<br>
+   * Note that in all cases the old strictness setting of the reader will be restored when this
+   * method returns.
    *
    * @param <T> the type of the desired object
    * @param reader the reader whose next JSON value should be deserialized
    * @param typeOfT The specific genericized type of src. You should create an anonymous subclass of
-   * {@code TypeToken} with the specific generic type arguments. For example, to get the type for
-   * {@code Collection<Foo>}, you should use:
-   * <pre>
+   *     {@code TypeToken} with the specific generic type arguments. For example, to get the type
+   *     for {@code Collection<Foo>}, you should use:
+   *     <pre>
    * new TypeToken&lt;Collection&lt;Foo&gt;&gt;(){}
    * </pre>
-   * @return an object of type T from the JsonReader. Returns {@code null} if {@code reader} is at EOF.
-   * @throws JsonIOException if there was a problem reading from the JsonReader
-   * @throws JsonSyntaxException if json is not a valid representation for an object of the type typeOfT
    *
+   * @return an object of type T from the JsonReader. Returns {@code null} if {@code reader} is at
+   *     EOF.
+   * @throws JsonIOException if there was a problem reading from the JsonReader
+   * @throws JsonSyntaxException if json is not a valid representation for an object of the type
+   *     typeOfT
    * @see #fromJson(Reader, TypeToken)
    * @see #fromJson(JsonReader, Type)
    * @since 2.10
    */
-  public <T> T fromJson(JsonReader reader, TypeToken<T> typeOfT) throws JsonIOException, JsonSyntaxException {
+  public <T> T fromJson(JsonReader reader, TypeToken<T> typeOfT)
+      throws JsonIOException, JsonSyntaxException {
     boolean isEmpty = true;
     Strictness oldStrictness = reader.getStrictness();
 
@@ -1313,7 +1384,8 @@ public final class Gson {
       // TODO(inder): Figure out whether it is indeed right to rethrow this as JsonSyntaxException
       throw new JsonSyntaxException(e);
     } catch (AssertionError e) {
-      throw new AssertionError("AssertionError (GSON " + GsonBuildConfig.VERSION + "): " + e.getMessage(), e);
+      throw new AssertionError(
+          "AssertionError (GSON " + GsonBuildConfig.VERSION + "): " + e.getMessage(), e);
     } finally {
       reader.setStrictness(oldStrictness);
     }
@@ -1323,20 +1395,20 @@ public final class Gson {
    * This method deserializes the JSON read from the specified parse tree into an object of the
    * specified type. It is not suitable to use if the specified class is a generic type since it
    * will not have the generic type information because of the Type Erasure feature of Java.
-   * Therefore, this method should not be used if the desired type is a generic type. Note that
-   * this method works fine if any of the fields of the specified object are generics, just the
-   * object itself should not be a generic type. For the cases when the object is of generic type,
-   * invoke {@link #fromJson(JsonElement, TypeToken)}.
+   * Therefore, this method should not be used if the desired type is a generic type. Note that this
+   * method works fine if any of the fields of the specified object are generics, just the object
+   * itself should not be a generic type. For the cases when the object is of generic type, invoke
+   * {@link #fromJson(JsonElement, TypeToken)}.
    *
    * @param <T> the type of the desired object
-   * @param json the root of the parse tree of {@link JsonElement}s from which the object is to
-   * be deserialized
+   * @param json the root of the parse tree of {@link JsonElement}s from which the object is to be
+   *     deserialized
    * @param classOfT The class of T
    * @return an object of type T from the JSON. Returns {@code null} if {@code json} is {@code null}
-   * or if {@code json} is empty.
-   * @throws JsonSyntaxException if json is not a valid representation for an object of type classOfT
+   *     or if {@code json} is empty.
+   * @throws JsonSyntaxException if json is not a valid representation for an object of type
+   *     classOfT
    * @since 1.3
-   *
    * @see #fromJson(Reader, Class)
    * @see #fromJson(JsonElement, TypeToken)
    */
@@ -1350,20 +1422,19 @@ public final class Gson {
    * specified type. This method is useful if the specified object is a generic type. For
    * non-generic objects, use {@link #fromJson(JsonElement, Class)} instead.
    *
-   * <p>Since {@code Type} is not parameterized by T, this method is not type-safe and
-   * should be used carefully. If you are creating the {@code Type} from a {@link TypeToken},
-   * prefer using {@link #fromJson(JsonElement, TypeToken)} instead since its return type is based
-   * on the {@code TypeToken} and is therefore more type-safe.
+   * <p>Since {@code Type} is not parameterized by T, this method is not type-safe and should be
+   * used carefully. If you are creating the {@code Type} from a {@link TypeToken}, prefer using
+   * {@link #fromJson(JsonElement, TypeToken)} instead since its return type is based on the {@code
+   * TypeToken} and is therefore more type-safe.
    *
    * @param <T> the type of the desired object
-   * @param json the root of the parse tree of {@link JsonElement}s from which the object is to
-   * be deserialized
+   * @param json the root of the parse tree of {@link JsonElement}s from which the object is to be
+   *     deserialized
    * @param typeOfT The specific genericized type of src
    * @return an object of type T from the JSON. Returns {@code null} if {@code json} is {@code null}
-   * or if {@code json} is empty.
+   *     or if {@code json} is empty.
    * @throws JsonSyntaxException if json is not a valid representation for an object of type typeOfT
    * @since 1.3
-   *
    * @see #fromJson(Reader, Type)
    * @see #fromJson(JsonElement, Class)
    * @see #fromJson(JsonElement, TypeToken)
@@ -1379,18 +1450,18 @@ public final class Gson {
    * non-generic objects, use {@link #fromJson(JsonElement, Class)} instead.
    *
    * @param <T> the type of the desired object
-   * @param json the root of the parse tree of {@link JsonElement}s from which the object is to
-   * be deserialized
+   * @param json the root of the parse tree of {@link JsonElement}s from which the object is to be
+   *     deserialized
    * @param typeOfT The specific genericized type of src. You should create an anonymous subclass of
-   * {@code TypeToken} with the specific generic type arguments. For example, to get the type for
-   * {@code Collection<Foo>}, you should use:
-   * <pre>
+   *     {@code TypeToken} with the specific generic type arguments. For example, to get the type
+   *     for {@code Collection<Foo>}, you should use:
+   *     <pre>
    * new TypeToken&lt;Collection&lt;Foo&gt;&gt;(){}
    * </pre>
-   * @return an object of type T from the JSON. Returns {@code null} if {@code json} is {@code null}
-   * or if {@code json} is empty.
-   * @throws JsonSyntaxException if json is not a valid representation for an object of type typeOfT
    *
+   * @return an object of type T from the JSON. Returns {@code null} if {@code json} is {@code null}
+   *     or if {@code json} is empty.
+   * @throws JsonSyntaxException if json is not a valid representation for an object of type typeOfT
    * @see #fromJson(Reader, TypeToken)
    * @see #fromJson(JsonElement, Class)
    * @since 2.10
@@ -1405,9 +1476,8 @@ public final class Gson {
   /**
    * Proxy type adapter for cyclic type graphs.
    *
-   * <p><b>Important:</b> Setting the delegate adapter is not thread-safe; instances of
-   * {@code FutureTypeAdapter} must only be published to other threads after the delegate
-   * has been set.
+   * <p><b>Important:</b> Setting the delegate adapter is not thread-safe; instances of {@code
+   * FutureTypeAdapter} must only be published to other threads after the delegate has been set.
    *
    * @see Gson#threadLocalAdapterResults
    */
@@ -1424,32 +1494,40 @@ public final class Gson {
     private TypeAdapter<T> delegate() {
       TypeAdapter<T> delegate = this.delegate;
       if (delegate == null) {
-        // Can occur when adapter is leaked to other thread or when adapter is used for (de-)serialization
+        // Can occur when adapter is leaked to other thread or when adapter is used for
+        // (de-)serialization
         // directly within the TypeAdapterFactory which requested it
-        throw new IllegalStateException("Adapter for type with cyclic dependency has been used"
-            + " before dependency has been resolved");
+        throw new IllegalStateException(
+            "Adapter for type with cyclic dependency has been used"
+                + " before dependency has been resolved");
       }
       return delegate;
     }
 
-    @Override public TypeAdapter<T> getSerializationDelegate() {
+    @Override
+    public TypeAdapter<T> getSerializationDelegate() {
       return delegate();
     }
 
-    @Override public T read(JsonReader in) throws IOException {
+    @Override
+    public T read(JsonReader in) throws IOException {
       return delegate().read(in);
     }
 
-    @Override public void write(JsonWriter out, T value) throws IOException {
+    @Override
+    public void write(JsonWriter out, T value) throws IOException {
       delegate().write(out, value);
     }
   }
 
   @Override
   public String toString() {
-    return "{serializeNulls:" + serializeNulls
-        + ",factories:" + factories
-        + ",instanceCreators:" + constructorConstructor
+    return "{serializeNulls:"
+        + serializeNulls
+        + ",factories:"
+        + factories
+        + ",instanceCreators:"
+        + constructorConstructor
         + "}";
   }
 }

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -41,7 +41,6 @@ import com.google.gson.internal.sql.SqlTypesSupport;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.text.DateFormat;
 import java.util.ArrayDeque;
@@ -54,10 +53,10 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * <p>Use this builder to construct a {@link Gson} instance when you need to set configuration
- * options other than the default. For {@link Gson} with default configuration, it is simpler to
- * use {@code new Gson()}. {@code GsonBuilder} is best used by creating it, and then invoking its
- * various configuration methods, and finally calling create.</p>
+ * Use this builder to construct a {@link Gson} instance when you need to set configuration options
+ * other than the default. For {@link Gson} with default configuration, it is simpler to use {@code
+ * new Gson()}. {@code GsonBuilder} is best used by creating it, and then invoking its various
+ * configuration methods, and finally calling create.
  *
  * <p>The following example shows how to use the {@code GsonBuilder} to construct a Gson instance:
  *
@@ -74,15 +73,16 @@ import java.util.Objects;
  * </pre>
  *
  * <p>Notes:
+ *
  * <ul>
- * <li>The order of invocation of configuration methods does not matter.</li>
- * <li>The default serialization of {@link Date} and its subclasses in Gson does
- *  not contain time-zone information. So, if you are using date/time instances,
- *  use {@code GsonBuilder} and its {@code setDateFormat} methods.</li>
- * <li>By default no explicit {@link Strictness} is set; some of the {@link Gson} methods
- *  behave as if {@link Strictness#LEGACY_STRICT} was used whereas others behave as
- *  if {@link Strictness#LENIENT} was used. Prefer explicitly setting a strictness
- *  with {@link #setStrictness(Strictness)} to avoid this legacy behavior.
+ *   <li>The order of invocation of configuration methods does not matter.
+ *   <li>The default serialization of {@link Date} and its subclasses in Gson does not contain
+ *       time-zone information. So, if you are using date/time instances, use {@code GsonBuilder}
+ *       and its {@code setDateFormat} methods.
+ *   <li>By default no explicit {@link Strictness} is set; some of the {@link Gson} methods behave
+ *       as if {@link Strictness#LEGACY_STRICT} was used whereas others behave as if {@link
+ *       Strictness#LENIENT} was used. Prefer explicitly setting a strictness with {@link
+ *       #setStrictness(Strictness)} to avoid this legacy behavior.
  * </ul>
  *
  * @author Inderjeet Singh
@@ -95,8 +95,10 @@ public final class GsonBuilder {
   private FieldNamingStrategy fieldNamingPolicy = FieldNamingPolicy.IDENTITY;
   private final Map<Type, InstanceCreator<?>> instanceCreators = new HashMap<>();
   private final List<TypeAdapterFactory> factories = new ArrayList<>();
+
   /** tree-style hierarchy factories. These come after factories for backwards compatibility. */
   private final List<TypeAdapterFactory> hierarchyFactories = new ArrayList<>();
+
   private boolean serializeNulls = DEFAULT_SERIALIZE_NULLS;
   private String datePattern = DEFAULT_DATE_PATTERN;
   private int dateStyle = DateFormat.DEFAULT;
@@ -114,16 +116,14 @@ public final class GsonBuilder {
 
   /**
    * Creates a GsonBuilder instance that can be used to build Gson with various configuration
-   * settings. GsonBuilder follows the builder pattern, and it is typically used by first
-   * invoking various configuration methods to set desired options, and finally calling
-   * {@link #create()}.
+   * settings. GsonBuilder follows the builder pattern, and it is typically used by first invoking
+   * various configuration methods to set desired options, and finally calling {@link #create()}.
    */
-  public GsonBuilder() {
-  }
+  public GsonBuilder() {}
 
   /**
-   * Constructs a GsonBuilder instance from a Gson instance. The newly constructed GsonBuilder
-   * has the same configuration as the previously built Gson instance.
+   * Constructs a GsonBuilder instance from a Gson instance. The newly constructed GsonBuilder has
+   * the same configuration as the previously built Gson instance.
    *
    * @param gson the gson instance whose configuration should be applied to a new GsonBuilder.
    */
@@ -151,13 +151,13 @@ public final class GsonBuilder {
   }
 
   /**
-   * Configures Gson to enable versioning support. Versioning support works based on the
-   * annotation types {@link Since} and {@link Until}. It allows including or excluding fields
-   * and classes based on the specified version. See the documentation of these annotation
-   * types for more information.
+   * Configures Gson to enable versioning support. Versioning support works based on the annotation
+   * types {@link Since} and {@link Until}. It allows including or excluding fields and classes
+   * based on the specified version. See the documentation of these annotation types for more
+   * information.
    *
-   * <p>By default versioning support is disabled and usage of {@code @Since} and {@code @Until}
-   * has no effect.
+   * <p>By default versioning support is disabled and usage of {@code @Since} and {@code @Until} has
+   * no effect.
    *
    * @param version the version number to use.
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
@@ -179,13 +179,13 @@ public final class GsonBuilder {
    * Gson will exclude all fields marked {@code transient} or {@code static}. This method will
    * override that behavior.
    *
-   * <p>This is a convenience method which behaves as if an {@link ExclusionStrategy} which
-   * excludes these fields was {@linkplain #setExclusionStrategies(ExclusionStrategy...) registered with this builder}.
+   * <p>This is a convenience method which behaves as if an {@link ExclusionStrategy} which excludes
+   * these fields was {@linkplain #setExclusionStrategies(ExclusionStrategy...) registered with this
+   * builder}.
    *
-   * @param modifiers the field modifiers. You must use the modifiers specified in the
-   * {@link java.lang.reflect.Modifier} class. For example,
-   * {@link java.lang.reflect.Modifier#TRANSIENT},
-   * {@link java.lang.reflect.Modifier#STATIC}.
+   * @param modifiers the field modifiers. You must use the modifiers specified in the {@link
+   *     java.lang.reflect.Modifier} class. For example, {@link
+   *     java.lang.reflect.Modifier#TRANSIENT}, {@link java.lang.reflect.Modifier#STATIC}.
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
    */
   @CanIgnoreReturnValue
@@ -197,9 +197,8 @@ public final class GsonBuilder {
 
   /**
    * Makes the output JSON non-executable in Javascript by prefixing the generated JSON with some
-   * special text. This prevents attacks from third-party sites through script sourcing. See
-   * <a href="http://code.google.com/p/google-gson/issues/detail?id=42">Gson Issue 42</a>
-   * for details.
+   * special text. This prevents attacks from third-party sites through script sourcing. See <a
+   * href="http://code.google.com/p/google-gson/issues/detail?id=42">Gson Issue 42</a> for details.
    *
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
    * @since 1.3
@@ -215,7 +214,8 @@ public final class GsonBuilder {
    * that do not have the {@link com.google.gson.annotations.Expose} annotation.
    *
    * <p>This is a convenience method which behaves as if an {@link ExclusionStrategy} which excludes
-   * these fields was {@linkplain #setExclusionStrategies(ExclusionStrategy...) registered with this builder}.
+   * these fields was {@linkplain #setExclusionStrategies(ExclusionStrategy...) registered with this
+   * builder}.
    *
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
    */
@@ -226,8 +226,8 @@ public final class GsonBuilder {
   }
 
   /**
-   * Configure Gson to serialize null fields. By default, Gson omits all fields that are null
-   * during serialization.
+   * Configure Gson to serialize null fields. By default, Gson omits all fields that are null during
+   * serialization.
    *
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
    * @since 1.2
@@ -239,79 +239,81 @@ public final class GsonBuilder {
   }
 
   /**
-   * Enabling this feature will only change the serialized form if the map key is
-   * a complex type (i.e. non-primitive) in its <strong>serialized</strong> JSON
-   * form. The default implementation of map serialization uses {@code toString()}
-   * on the key; however, when this is called then one of the following cases
-   * apply:
+   * Enabling this feature will only change the serialized form if the map key is a complex type
+   * (i.e. non-primitive) in its <strong>serialized</strong> JSON form. The default implementation
+   * of map serialization uses {@code toString()} on the key; however, when this is called then one
+   * of the following cases apply:
    *
    * <p><b>Maps as JSON objects</b>
    *
-   * <p>For this case, assume that a type adapter is registered to serialize and
-   * deserialize some {@code Point} class, which contains an x and y coordinate,
-   * to/from the JSON Primitive string value {@code "(x,y)"}. The Java map would
-   * then be serialized as a {@link JsonObject}.
+   * <p>For this case, assume that a type adapter is registered to serialize and deserialize some
+   * {@code Point} class, which contains an x and y coordinate, to/from the JSON Primitive string
+   * value {@code "(x,y)"}. The Java map would then be serialized as a {@link JsonObject}.
    *
    * <p>Below is an example:
-   * <pre>  {@code
-   *   Gson gson = new GsonBuilder()
-   *       .register(Point.class, new MyPointTypeAdapter())
-   *       .enableComplexMapKeySerialization()
-   *       .create();
    *
-   *   Map<Point, String> original = new LinkedHashMap<>();
-   *   original.put(new Point(5, 6), "a");
-   *   original.put(new Point(8, 8), "b");
-   *   System.out.println(gson.toJson(original, type));
+   * <pre>{@code
+   * Gson gson = new GsonBuilder()
+   *     .register(Point.class, new MyPointTypeAdapter())
+   *     .enableComplexMapKeySerialization()
+   *     .create();
+   *
+   * Map<Point, String> original = new LinkedHashMap<>();
+   * original.put(new Point(5, 6), "a");
+   * original.put(new Point(8, 8), "b");
+   * System.out.println(gson.toJson(original, type));
    * }</pre>
-   * The above code prints this JSON object:<pre>  {@code
-   *   {
-   *     "(5,6)": "a",
-   *     "(8,8)": "b"
-   *   }
+   *
+   * The above code prints this JSON object:
+   *
+   * <pre>{@code
+   * {
+   *   "(5,6)": "a",
+   *   "(8,8)": "b"
+   * }
    * }</pre>
    *
    * <p><b>Maps as JSON arrays</b>
    *
-   * <p>For this case, assume that a type adapter was NOT registered for some
-   * {@code Point} class, but rather the default Gson serialization is applied.
-   * In this case, some {@code new Point(2,3)} would serialize as {@code
-   * {"x":2,"y":3}}.
+   * <p>For this case, assume that a type adapter was NOT registered for some {@code Point} class,
+   * but rather the default Gson serialization is applied. In this case, some {@code new Point(2,3)}
+   * would serialize as {@code {"x":2,"y":3}}.
    *
-   * <p>Given the assumption above, a {@code Map<Point, String>} will be
-   * serialized as an array of arrays (can be viewed as an entry set of pairs).
+   * <p>Given the assumption above, a {@code Map<Point, String>} will be serialized as an array of
+   * arrays (can be viewed as an entry set of pairs).
    *
    * <p>Below is an example of serializing complex types as JSON arrays:
-   * <pre> {@code
-   *   Gson gson = new GsonBuilder()
-   *       .enableComplexMapKeySerialization()
-   *       .create();
    *
-   *   Map<Point, String> original = new LinkedHashMap<>();
-   *   original.put(new Point(5, 6), "a");
-   *   original.put(new Point(8, 8), "b");
-   *   System.out.println(gson.toJson(original, type));
-   * }
-   * </pre>
+   * <pre>{@code
+   * Gson gson = new GsonBuilder()
+   *     .enableComplexMapKeySerialization()
+   *     .create();
+   *
+   * Map<Point, String> original = new LinkedHashMap<>();
+   * original.put(new Point(5, 6), "a");
+   * original.put(new Point(8, 8), "b");
+   * System.out.println(gson.toJson(original, type));
+   * }</pre>
    *
    * The JSON output would look as follows:
-   * <pre>   {@code
+   *
+   * <pre>{@code
+   * [
    *   [
-   *     [
-   *       {
-   *         "x": 5,
-   *         "y": 6
-   *       },
-   *       "a"
-   *     ],
-   *     [
-   *       {
-   *         "x": 8,
-   *         "y": 8
-   *       },
-   *       "b"
-   *     ]
+   *     {
+   *       "x": 5,
+   *       "y": 6
+   *     },
+   *     "a"
+   *   ],
+   *   [
+   *     {
+   *       "x": 8,
+   *       "y": 8
+   *     },
+   *     "b"
    *   ]
+   * ]
    * }</pre>
    *
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
@@ -324,20 +326,22 @@ public final class GsonBuilder {
   }
 
   /**
-   * Configures Gson to exclude inner classes (= non-{@code static} nested classes) during serialization
-   * and deserialization. This is a convenience method which behaves as if an {@link ExclusionStrategy}
-   * which excludes inner classes was {@linkplain #setExclusionStrategies(ExclusionStrategy...) registered with this builder}.
-   * This means inner classes will be serialized as JSON {@code null}, and will be deserialized as
-   * Java {@code null} with their JSON data being ignored. And fields with an inner class as type will
-   * be ignored during serialization and deserialization.
+   * Configures Gson to exclude inner classes (= non-{@code static} nested classes) during
+   * serialization and deserialization. This is a convenience method which behaves as if an {@link
+   * ExclusionStrategy} which excludes inner classes was {@linkplain
+   * #setExclusionStrategies(ExclusionStrategy...) registered with this builder}. This means inner
+   * classes will be serialized as JSON {@code null}, and will be deserialized as Java {@code null}
+   * with their JSON data being ignored. And fields with an inner class as type will be ignored
+   * during serialization and deserialization.
    *
    * <p>By default Gson serializes and deserializes inner classes, but ignores references to the
-   * enclosing instance. Deserialization might not be possible at all when {@link #disableJdkUnsafe()}
-   * is used (and no custom {@link InstanceCreator} is registered), or it can lead to unexpected
-   * {@code NullPointerException}s when the deserialized instance is used afterwards.
+   * enclosing instance. Deserialization might not be possible at all when {@link
+   * #disableJdkUnsafe()} is used (and no custom {@link InstanceCreator} is registered), or it can
+   * lead to unexpected {@code NullPointerException}s when the deserialized instance is used
+   * afterwards.
    *
-   * <p>In general using inner classes with Gson should be avoided; they should be converted to {@code static}
-   * nested classes if possible.
+   * <p>In general using inner classes with Gson should be avoided; they should be converted to
+   * {@code static} nested classes if possible.
    *
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
    * @since 1.3
@@ -374,12 +378,12 @@ public final class GsonBuilder {
   }
 
   /**
-   * Configures Gson to apply a specific naming strategy to an object's fields during
-   * serialization and deserialization.
+   * Configures Gson to apply a specific naming strategy to an object's fields during serialization
+   * and deserialization.
    *
-   * <p>The created Gson instance might only use the field naming strategy once for a
-   * field and cache the result. It is not guaranteed that the strategy will be used
-   * again every time the value of a field is serialized or deserialized.
+   * <p>The created Gson instance might only use the field naming strategy once for a field and
+   * cache the result. It is not guaranteed that the strategy will be used again every time the
+   * value of a field is serialized or deserialized.
    *
    * @param fieldNamingStrategy the naming strategy to apply to the fields
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
@@ -421,25 +425,24 @@ public final class GsonBuilder {
 
   /**
    * Configures Gson to apply a set of exclusion strategies during both serialization and
-   * deserialization. Each of the {@code strategies} will be applied as a disjunction rule.
-   * This means that if one of the {@code strategies} suggests that a field (or class) should be
-   * skipped then that field (or object) is skipped during serialization/deserialization.
-   * The strategies are added to the existing strategies (if any); the existing strategies
-   * are not replaced.
+   * deserialization. Each of the {@code strategies} will be applied as a disjunction rule. This
+   * means that if one of the {@code strategies} suggests that a field (or class) should be skipped
+   * then that field (or object) is skipped during serialization/deserialization. The strategies are
+   * added to the existing strategies (if any); the existing strategies are not replaced.
    *
-   * <p>Fields are excluded for serialization and deserialization when
-   * {@link ExclusionStrategy#shouldSkipField(FieldAttributes) shouldSkipField} returns {@code true},
-   * or when {@link ExclusionStrategy#shouldSkipClass(Class) shouldSkipClass} returns {@code true}
-   * for the field type. Gson behaves as if the field did not exist; its value is not serialized
-   * and on deserialization if a JSON member with this name exists it is skipped by default.<br>
-   * When objects of an excluded type (as determined by
-   * {@link ExclusionStrategy#shouldSkipClass(Class) shouldSkipClass}) are serialized a
-   * JSON null is written to output, and when deserialized the JSON value is skipped and
-   * {@code null} is returned.
+   * <p>Fields are excluded for serialization and deserialization when {@link
+   * ExclusionStrategy#shouldSkipField(FieldAttributes) shouldSkipField} returns {@code true}, or
+   * when {@link ExclusionStrategy#shouldSkipClass(Class) shouldSkipClass} returns {@code true} for
+   * the field type. Gson behaves as if the field did not exist; its value is not serialized and on
+   * deserialization if a JSON member with this name exists it is skipped by default.<br>
+   * When objects of an excluded type (as determined by {@link
+   * ExclusionStrategy#shouldSkipClass(Class) shouldSkipClass}) are serialized a JSON null is
+   * written to output, and when deserialized the JSON value is skipped and {@code null} is
+   * returned.
    *
-   * <p>The created Gson instance might only use an exclusion strategy once for a field or
-   * class and cache the result. It is not guaranteed that the strategy will be used again
-   * every time the value of a field or a class is serialized or deserialized.
+   * <p>The created Gson instance might only use an exclusion strategy once for a field or class and
+   * cache the result. It is not guaranteed that the strategy will be used again every time the
+   * value of a field or a class is serialized or deserialized.
    *
    * @param strategies the set of strategy object to apply during object (de)serialization.
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
@@ -455,15 +458,14 @@ public final class GsonBuilder {
   }
 
   /**
-   * Configures Gson to apply the passed in exclusion strategy during serialization.
-   * If this method is invoked numerous times with different exclusion strategy objects
-   * then the exclusion strategies that were added will be applied as a disjunction rule.
-   * This means that if one of the added exclusion strategies suggests that a field (or
-   * class) should be skipped then that field (or object) is skipped during its
-   * serialization.
+   * Configures Gson to apply the passed in exclusion strategy during serialization. If this method
+   * is invoked numerous times with different exclusion strategy objects then the exclusion
+   * strategies that were added will be applied as a disjunction rule. This means that if one of the
+   * added exclusion strategies suggests that a field (or class) should be skipped then that field
+   * (or object) is skipped during its serialization.
    *
-   * <p>See the documentation of {@link #setExclusionStrategies(ExclusionStrategy...)}
-   * for a detailed description of the effect of exclusion strategies.
+   * <p>See the documentation of {@link #setExclusionStrategies(ExclusionStrategy...)} for a
+   * detailed description of the effect of exclusion strategies.
    *
    * @param strategy an exclusion strategy to apply during serialization.
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
@@ -477,15 +479,14 @@ public final class GsonBuilder {
   }
 
   /**
-   * Configures Gson to apply the passed in exclusion strategy during deserialization.
-   * If this method is invoked numerous times with different exclusion strategy objects
-   * then the exclusion strategies that were added will be applied as a disjunction rule.
-   * This means that if one of the added exclusion strategies suggests that a field (or
-   * class) should be skipped then that field (or object) is skipped during its
-   * deserialization.
+   * Configures Gson to apply the passed in exclusion strategy during deserialization. If this
+   * method is invoked numerous times with different exclusion strategy objects then the exclusion
+   * strategies that were added will be applied as a disjunction rule. This means that if one of the
+   * added exclusion strategies suggests that a field (or class) should be skipped then that field
+   * (or object) is skipped during its deserialization.
    *
-   * <p>See the documentation of {@link #setExclusionStrategies(ExclusionStrategy...)}
-   * for a detailed description of the effect of exclusion strategies.
+   * <p>See the documentation of {@link #setExclusionStrategies(ExclusionStrategy...)} for a
+   * detailed description of the effect of exclusion strategies.
    *
    * @param strategy an exclusion strategy to apply during deserialization.
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
@@ -513,8 +514,9 @@ public final class GsonBuilder {
   }
 
   /**
-   * Configures Gson to output JSON that uses a certain kind of formatting style (for example newline and indent).
-   * This option only affects JSON serialization. By default Gson produces compact JSON output without any formatting.
+   * Configures Gson to output JSON that uses a certain kind of formatting style (for example
+   * newline and indent). This option only affects JSON serialization. By default Gson produces
+   * compact JSON output without any formatting.
    *
    * @param formattingStyle the formatting style to use.
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
@@ -529,16 +531,17 @@ public final class GsonBuilder {
   /**
    * Sets the strictness of this builder to {@link Strictness#LENIENT}.
    *
-   * @deprecated This method is equivalent to calling {@link #setStrictness(Strictness)} with
-   * {@link Strictness#LENIENT}: {@code setStrictness(Strictness.LENIENT)}
-   *
+   * @deprecated This method is equivalent to calling {@link #setStrictness(Strictness)} with {@link
+   *     Strictness#LENIENT}: {@code setStrictness(Strictness.LENIENT)}
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern.
    * @see JsonReader#setStrictness(Strictness)
    * @see JsonWriter#setStrictness(Strictness)
    * @see #setStrictness(Strictness)
    */
   @Deprecated
-  @InlineMe(replacement = "this.setStrictness(Strictness.LENIENT)", imports = "com.google.gson.Strictness")
+  @InlineMe(
+      replacement = "this.setStrictness(Strictness.LENIENT)",
+      imports = "com.google.gson.Strictness")
   @CanIgnoreReturnValue
   public GsonBuilder setLenient() {
     return setStrictness(Strictness.LENIENT);
@@ -547,10 +550,9 @@ public final class GsonBuilder {
   /**
    * Sets the strictness of this builder to the provided parameter.
    *
-   * <p>This changes how strict the
-   * <a href="https://www.ietf.org/rfc/rfc8259.txt">RFC 8259 JSON specification</a> is enforced when parsing or
-   * writing JSON. For details on this, refer to {@link JsonReader#setStrictness(Strictness)} and
-   * {@link JsonWriter#setStrictness(Strictness)}.</p>
+   * <p>This changes how strict the <a href="https://www.ietf.org/rfc/rfc8259.txt">RFC 8259 JSON
+   * specification</a> is enforced when parsing or writing JSON. For details on this, refer to
+   * {@link JsonReader#setStrictness(Strictness)} and {@link JsonWriter#setStrictness(Strictness)}.
    *
    * @param strictness the new strictness mode. May not be {@code null}.
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern.
@@ -583,11 +585,12 @@ public final class GsonBuilder {
    * will be used to decide the serialization format.
    *
    * <p>The date format will be used to serialize and deserialize {@link java.util.Date} and in case
-   * the {@code java.sql} module is present, also {@link java.sql.Timestamp} and {@link java.sql.Date}.
+   * the {@code java.sql} module is present, also {@link java.sql.Timestamp} and {@link
+   * java.sql.Date}.
    *
    * <p>Note that this pattern must abide by the convention provided by {@code SimpleDateFormat}
    * class. See the documentation in {@link java.text.SimpleDateFormat} for more information on
-   * valid date and time patterns.</p>
+   * valid date and time patterns.
    *
    * @param pattern the pattern that dates will be serialized/deserialized to/from
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
@@ -601,16 +604,16 @@ public final class GsonBuilder {
   }
 
   /**
-   * Configures Gson to serialize {@code Date} objects according to the style value provided.
-   * You can call this method or {@link #setDateFormat(String)} multiple times, but only the last
+   * Configures Gson to serialize {@code Date} objects according to the style value provided. You
+   * can call this method or {@link #setDateFormat(String)} multiple times, but only the last
    * invocation will be used to decide the serialization format.
    *
-   * <p>Note that this style value should be one of the predefined constants in the
-   * {@code DateFormat} class. See the documentation in {@link java.text.DateFormat} for more
-   * information on the valid style constants.</p>
+   * <p>Note that this style value should be one of the predefined constants in the {@code
+   * DateFormat} class. See the documentation in {@link java.text.DateFormat} for more information
+   * on the valid style constants.
    *
    * @param style the predefined date style that date objects will be serialized/deserialized
-   * to/from
+   *     to/from
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
    * @since 1.2
    */
@@ -622,16 +625,16 @@ public final class GsonBuilder {
   }
 
   /**
-   * Configures Gson to serialize {@code Date} objects according to the style value provided.
-   * You can call this method or {@link #setDateFormat(String)} multiple times, but only the last
+   * Configures Gson to serialize {@code Date} objects according to the style value provided. You
+   * can call this method or {@link #setDateFormat(String)} multiple times, but only the last
    * invocation will be used to decide the serialization format.
    *
-   * <p>Note that this style value should be one of the predefined constants in the
-   * {@code DateFormat} class. See the documentation in {@link java.text.DateFormat} for more
-   * information on the valid style constants.</p>
+   * <p>Note that this style value should be one of the predefined constants in the {@code
+   * DateFormat} class. See the documentation in {@link java.text.DateFormat} for more information
+   * on the valid style constants.
    *
    * @param dateStyle the predefined date style that date objects will be serialized/deserialized
-   * to/from
+   *     to/from
    * @param timeStyle the predefined style for the time portion of the date objects
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
    * @since 1.2
@@ -655,25 +658,27 @@ public final class GsonBuilder {
    * types! For example, applications registering {@code boolean.class} should also register {@code
    * Boolean.class}.
    *
-   * <p>{@link JsonSerializer} and {@link JsonDeserializer} are made "{@code null}-safe". This
-   * means when trying to serialize {@code null}, Gson will write a JSON {@code null} and the
-   * serializer is not called. Similarly when deserializing a JSON {@code null}, Gson will emit
-   * {@code null} without calling the deserializer. If it is desired to handle {@code null} values,
-   * a {@link TypeAdapter} should be used instead.
+   * <p>{@link JsonSerializer} and {@link JsonDeserializer} are made "{@code null}-safe". This means
+   * when trying to serialize {@code null}, Gson will write a JSON {@code null} and the serializer
+   * is not called. Similarly when deserializing a JSON {@code null}, Gson will emit {@code null}
+   * without calling the deserializer. If it is desired to handle {@code null} values, a {@link
+   * TypeAdapter} should be used instead.
    *
    * @param type the type definition for the type adapter being registered
-   * @param typeAdapter This object must implement at least one of the {@link TypeAdapter},
-   * {@link InstanceCreator}, {@link JsonSerializer}, and a {@link JsonDeserializer} interfaces.
+   * @param typeAdapter This object must implement at least one of the {@link TypeAdapter}, {@link
+   *     InstanceCreator}, {@link JsonSerializer}, and a {@link JsonDeserializer} interfaces.
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
-   * @throws IllegalArgumentException if the type adapter being registered is for {@code Object} class or {@link JsonElement} or any of its subclasses
+   * @throws IllegalArgumentException if the type adapter being registered is for {@code Object}
+   *     class or {@link JsonElement} or any of its subclasses
    */
   @CanIgnoreReturnValue
   public GsonBuilder registerTypeAdapter(Type type, Object typeAdapter) {
     Objects.requireNonNull(type);
-    $Gson$Preconditions.checkArgument(typeAdapter instanceof JsonSerializer<?>
-        || typeAdapter instanceof JsonDeserializer<?>
-        || typeAdapter instanceof InstanceCreator<?>
-        || typeAdapter instanceof TypeAdapter<?>);
+    $Gson$Preconditions.checkArgument(
+        typeAdapter instanceof JsonSerializer<?>
+            || typeAdapter instanceof JsonDeserializer<?>
+            || typeAdapter instanceof InstanceCreator<?>
+            || typeAdapter instanceof TypeAdapter<?>);
 
     if (isTypeObjectOrJsonElement(type)) {
       throw new IllegalArgumentException("Cannot override built-in adapter for " + type);
@@ -688,7 +693,8 @@ public final class GsonBuilder {
     }
     if (typeAdapter instanceof TypeAdapter<?>) {
       @SuppressWarnings({"unchecked", "rawtypes"})
-      TypeAdapterFactory factory = TypeAdapters.newFactory(TypeToken.get(type), (TypeAdapter)typeAdapter);
+      TypeAdapterFactory factory =
+          TypeAdapters.newFactory(TypeToken.get(type), (TypeAdapter) typeAdapter);
       factories.add(factory);
     }
     return this;
@@ -696,19 +702,18 @@ public final class GsonBuilder {
 
   private boolean isTypeObjectOrJsonElement(Type type) {
     return type instanceof Class
-        && (type == Object.class
-            || JsonElement.class.isAssignableFrom((Class<?>) type));
+        && (type == Object.class || JsonElement.class.isAssignableFrom((Class<?>) type));
   }
 
   /**
-   * Register a factory for type adapters. Registering a factory is useful when the type
-   * adapter needs to be configured based on the type of the field being processed. Gson
-   * is designed to handle a large number of factories, so you should consider registering
-   * them to be at par with registering an individual type adapter.
+   * Register a factory for type adapters. Registering a factory is useful when the type adapter
+   * needs to be configured based on the type of the field being processed. Gson is designed to
+   * handle a large number of factories, so you should consider registering them to be at par with
+   * registering an individual type adapter.
    *
-   * <p>The created Gson instance might only use the factory once to create an adapter for
-   * a specific type and cache the result. It is not guaranteed that the factory will be used
-   * again every time the type is serialized or deserialized.
+   * <p>The created Gson instance might only use the factory once to create an adapter for a
+   * specific type and cache the result. It is not guaranteed that the factory will be used again
+   * every time the type is serialized or deserialized.
    *
    * @since 2.1
    */
@@ -721,25 +726,27 @@ public final class GsonBuilder {
 
   /**
    * Configures Gson for custom serialization or deserialization for an inheritance type hierarchy.
-   * This method combines the registration of a {@link TypeAdapter}, {@link JsonSerializer} and
-   * a {@link JsonDeserializer}. If a type adapter was previously registered for the specified
-   * type hierarchy, it is overridden. If a type adapter is registered for a specific type in
-   * the type hierarchy, it will be invoked instead of the one registered for the type hierarchy.
+   * This method combines the registration of a {@link TypeAdapter}, {@link JsonSerializer} and a
+   * {@link JsonDeserializer}. If a type adapter was previously registered for the specified type
+   * hierarchy, it is overridden. If a type adapter is registered for a specific type in the type
+   * hierarchy, it will be invoked instead of the one registered for the type hierarchy.
    *
    * @param baseType the class definition for the type adapter being registered for the base class
-   *        or interface
-   * @param typeAdapter This object must implement at least one of {@link TypeAdapter},
-   *        {@link JsonSerializer} or {@link JsonDeserializer} interfaces.
+   *     or interface
+   * @param typeAdapter This object must implement at least one of {@link TypeAdapter}, {@link
+   *     JsonSerializer} or {@link JsonDeserializer} interfaces.
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
-   * @throws IllegalArgumentException if the type adapter being registered is for {@link JsonElement} or any of its subclasses
+   * @throws IllegalArgumentException if the type adapter being registered is for {@link
+   *     JsonElement} or any of its subclasses
    * @since 1.7
    */
   @CanIgnoreReturnValue
   public GsonBuilder registerTypeHierarchyAdapter(Class<?> baseType, Object typeAdapter) {
     Objects.requireNonNull(baseType);
-    $Gson$Preconditions.checkArgument(typeAdapter instanceof JsonSerializer<?>
-        || typeAdapter instanceof JsonDeserializer<?>
-        || typeAdapter instanceof TypeAdapter<?>);
+    $Gson$Preconditions.checkArgument(
+        typeAdapter instanceof JsonSerializer<?>
+            || typeAdapter instanceof JsonDeserializer<?>
+            || typeAdapter instanceof TypeAdapter<?>);
 
     if (JsonElement.class.isAssignableFrom(baseType)) {
       throw new IllegalArgumentException("Cannot override built-in adapter for " + baseType);
@@ -750,7 +757,8 @@ public final class GsonBuilder {
     }
     if (typeAdapter instanceof TypeAdapter<?>) {
       @SuppressWarnings({"unchecked", "rawtypes"})
-      TypeAdapterFactory factory = TypeAdapters.newTypeHierarchyFactory(baseType, (TypeAdapter)typeAdapter);
+      TypeAdapterFactory factory =
+          TypeAdapters.newTypeHierarchyFactory(baseType, (TypeAdapter) typeAdapter);
       factories.add(factory);
     }
     return this;
@@ -758,20 +766,19 @@ public final class GsonBuilder {
 
   /**
    * Section 6 of <a href="https://www.ietf.org/rfc/rfc8259.txt">JSON specification</a> disallows
-   * special double values (NaN, Infinity, -Infinity). However,
-   * <a href="http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf">Javascript
+   * special double values (NaN, Infinity, -Infinity). However, <a
+   * href="http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf">Javascript
    * specification</a> (see section 4.3.20, 4.3.22, 4.3.23) allows these values as valid Javascript
    * values. Moreover, most JavaScript engines will accept these special values in JSON without
    * problem. So, at a practical level, it makes sense to accept these values as valid JSON even
    * though JSON specification disallows them.
    *
    * <p>Gson always accepts these special values during deserialization. However, it outputs
-   * strictly compliant JSON. Hence, if it encounters a float value {@link Float#NaN},
-   * {@link Float#POSITIVE_INFINITY}, {@link Float#NEGATIVE_INFINITY}, or a double value
-   * {@link Double#NaN}, {@link Double#POSITIVE_INFINITY}, {@link Double#NEGATIVE_INFINITY}, it
-   * will throw an {@link IllegalArgumentException}. This method provides a way to override the
-   * default behavior when you know that the JSON receiver will be able to handle these special
-   * values.
+   * strictly compliant JSON. Hence, if it encounters a float value {@link Float#NaN}, {@link
+   * Float#POSITIVE_INFINITY}, {@link Float#NEGATIVE_INFINITY}, or a double value {@link
+   * Double#NaN}, {@link Double#POSITIVE_INFINITY}, {@link Double#NEGATIVE_INFINITY}, it will throw
+   * an {@link IllegalArgumentException}. This method provides a way to override the default
+   * behavior when you know that the JSON receiver will be able to handle these special values.
    *
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
    * @since 1.3
@@ -785,15 +792,14 @@ public final class GsonBuilder {
   /**
    * Disables usage of JDK's {@code sun.misc.Unsafe}.
    *
-   * <p>By default Gson uses {@code Unsafe} to create instances of classes which don't have
-   * a no-args constructor. However, {@code Unsafe} might not be available for all Java
-   * runtimes. For example Android does not provide {@code Unsafe}, or only with limited
-   * functionality. Additionally {@code Unsafe} creates instances without executing any
-   * constructor or initializer block, or performing initialization of field values. This can
-   * lead to surprising and difficult to debug errors.
-   * Therefore, to get reliable behavior regardless of which runtime is used, and to detect
-   * classes which cannot be deserialized in an early stage of development, this method allows
-   * disabling usage of {@code Unsafe}.
+   * <p>By default Gson uses {@code Unsafe} to create instances of classes which don't have a
+   * no-args constructor. However, {@code Unsafe} might not be available for all Java runtimes. For
+   * example Android does not provide {@code Unsafe}, or only with limited functionality.
+   * Additionally {@code Unsafe} creates instances without executing any constructor or initializer
+   * block, or performing initialization of field values. This can lead to surprising and difficult
+   * to debug errors. Therefore, to get reliable behavior regardless of which runtime is used, and
+   * to detect classes which cannot be deserialized in an early stage of development, this method
+   * allows disabling usage of {@code Unsafe}.
    *
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
    * @since 2.9.0
@@ -805,20 +811,20 @@ public final class GsonBuilder {
   }
 
   /**
-   * Adds a reflection access filter. A reflection access filter prevents Gson from using
-   * reflection for the serialization and deserialization of certain classes. The logic in
-   * the filter specifies which classes those are.
+   * Adds a reflection access filter. A reflection access filter prevents Gson from using reflection
+   * for the serialization and deserialization of certain classes. The logic in the filter specifies
+   * which classes those are.
    *
-   * <p>Filters will be invoked in reverse registration order, that is, the most recently
-   * added filter will be invoked first.
+   * <p>Filters will be invoked in reverse registration order, that is, the most recently added
+   * filter will be invoked first.
    *
-   * <p>By default Gson has no filters configured and will try to use reflection for
-   * all classes for which no {@link TypeAdapter} has been registered, and for which no
-   * built-in Gson {@code TypeAdapter} exists.
+   * <p>By default Gson has no filters configured and will try to use reflection for all classes for
+   * which no {@link TypeAdapter} has been registered, and for which no built-in Gson {@code
+   * TypeAdapter} exists.
    *
-   * <p>The created Gson instance might only use an access filter once for a class or its
-   * members and cache the result. It is not guaranteed that the filter will be used again
-   * every time a class or its members are accessed during serialization or deserialization.
+   * <p>The created Gson instance might only use an access filter once for a class or its members
+   * and cache the result. It is not guaranteed that the filter will be used again every time a
+   * class or its members are accessed during serialization or deserialization.
    *
    * @param filter filter to add
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
@@ -838,7 +844,8 @@ public final class GsonBuilder {
    * @return an instance of Gson configured with the options currently set in this builder
    */
   public Gson create() {
-    List<TypeAdapterFactory> factories = new ArrayList<>(this.factories.size() + this.hierarchyFactories.size() + 3);
+    List<TypeAdapterFactory> factories =
+        new ArrayList<>(this.factories.size() + this.hierarchyFactories.size() + 3);
     factories.addAll(this.factories);
     Collections.reverse(factories);
 
@@ -848,17 +855,32 @@ public final class GsonBuilder {
 
     addTypeAdaptersForDate(datePattern, dateStyle, timeStyle, factories);
 
-    return new Gson(excluder, fieldNamingPolicy, new HashMap<>(instanceCreators),
-        serializeNulls, complexMapKeySerialization,
-        generateNonExecutableJson, escapeHtmlChars, formattingStyle, strictness,
-        serializeSpecialFloatingPointValues, useJdkUnsafe, longSerializationPolicy,
-        datePattern, dateStyle, timeStyle, new ArrayList<>(this.factories),
-        new ArrayList<>(this.hierarchyFactories), factories,
-        objectToNumberStrategy, numberToNumberStrategy, new ArrayList<>(reflectionFilters));
+    return new Gson(
+        excluder,
+        fieldNamingPolicy,
+        new HashMap<>(instanceCreators),
+        serializeNulls,
+        complexMapKeySerialization,
+        generateNonExecutableJson,
+        escapeHtmlChars,
+        formattingStyle,
+        strictness,
+        serializeSpecialFloatingPointValues,
+        useJdkUnsafe,
+        longSerializationPolicy,
+        datePattern,
+        dateStyle,
+        timeStyle,
+        new ArrayList<>(this.factories),
+        new ArrayList<>(this.hierarchyFactories),
+        factories,
+        objectToNumberStrategy,
+        numberToNumberStrategy,
+        new ArrayList<>(reflectionFilters));
   }
 
-  private void addTypeAdaptersForDate(String datePattern, int dateStyle, int timeStyle,
-      List<TypeAdapterFactory> factories) {
+  private void addTypeAdaptersForDate(
+      String datePattern, int dateStyle, int timeStyle, List<TypeAdapterFactory> factories) {
     TypeAdapterFactory dateAdapterFactory;
     boolean sqlTypesSupported = SqlTypesSupport.SUPPORTS_SQL_TYPES;
     TypeAdapterFactory sqlTimestampAdapterFactory = null;
@@ -868,15 +890,19 @@ public final class GsonBuilder {
       dateAdapterFactory = DefaultDateTypeAdapter.DateType.DATE.createAdapterFactory(datePattern);
 
       if (sqlTypesSupported) {
-        sqlTimestampAdapterFactory = SqlTypesSupport.TIMESTAMP_DATE_TYPE.createAdapterFactory(datePattern);
+        sqlTimestampAdapterFactory =
+            SqlTypesSupport.TIMESTAMP_DATE_TYPE.createAdapterFactory(datePattern);
         sqlDateAdapterFactory = SqlTypesSupport.DATE_DATE_TYPE.createAdapterFactory(datePattern);
       }
     } else if (dateStyle != DateFormat.DEFAULT && timeStyle != DateFormat.DEFAULT) {
-      dateAdapterFactory = DefaultDateTypeAdapter.DateType.DATE.createAdapterFactory(dateStyle, timeStyle);
+      dateAdapterFactory =
+          DefaultDateTypeAdapter.DateType.DATE.createAdapterFactory(dateStyle, timeStyle);
 
       if (sqlTypesSupported) {
-        sqlTimestampAdapterFactory = SqlTypesSupport.TIMESTAMP_DATE_TYPE.createAdapterFactory(dateStyle, timeStyle);
-        sqlDateAdapterFactory = SqlTypesSupport.DATE_DATE_TYPE.createAdapterFactory(dateStyle, timeStyle);
+        sqlTimestampAdapterFactory =
+            SqlTypesSupport.TIMESTAMP_DATE_TYPE.createAdapterFactory(dateStyle, timeStyle);
+        sqlDateAdapterFactory =
+            SqlTypesSupport.DATE_DATE_TYPE.createAdapterFactory(dateStyle, timeStyle);
       }
     } else {
       return;

--- a/gson/src/main/java/com/google/gson/InstanceCreator.java
+++ b/gson/src/main/java/com/google/gson/InstanceCreator.java
@@ -20,14 +20,15 @@ import java.lang.reflect.Type;
 
 /**
  * This interface is implemented to create instances of a class that does not define a no-args
- * constructor. If you can modify the class, you should instead add a private, or public
- * no-args constructor. However, that is not possible for library classes, such as JDK classes, or
- * a third-party library that you do not have source-code of. In such cases, you should define an
+ * constructor. If you can modify the class, you should instead add a private, or public no-args
+ * constructor. However, that is not possible for library classes, such as JDK classes, or a
+ * third-party library that you do not have source-code of. In such cases, you should define an
  * instance creator for the class. Implementations of this interface should be registered with
  * {@link GsonBuilder#registerTypeAdapter(Type, Object)} method before Gson will be able to use
  * them.
- * <p>Let us look at an example where defining an InstanceCreator might be useful. The
- * {@code Id} class defined below does not have a default no-args constructor.</p>
+ *
+ * <p>Let us look at an example where defining an InstanceCreator might be useful. The {@code Id}
+ * class defined below does not have a default no-args constructor.
  *
  * <pre>
  * public class Id&lt;T&gt; {
@@ -42,7 +43,7 @@ import java.lang.reflect.Type;
  *
  * <p>If Gson encounters an object of type {@code Id} during deserialization, it will throw an
  * exception. The easiest way to solve this problem will be to add a (public or private) no-args
- * constructor as follows:</p>
+ * constructor as follows:
  *
  * <pre>
  * private Id() {
@@ -51,8 +52,8 @@ import java.lang.reflect.Type;
  * </pre>
  *
  * <p>However, let us assume that the developer does not have access to the source-code of the
- * {@code Id} class, or does not want to define a no-args constructor for it. The developer
- * can solve this problem by defining an {@code InstanceCreator} for {@code Id}:</p>
+ * {@code Id} class, or does not want to define a no-args constructor for it. The developer can
+ * solve this problem by defining an {@code InstanceCreator} for {@code Id}:
  *
  * <pre>
  * class IdInstanceCreator implements InstanceCreator&lt;Id&gt; {
@@ -64,17 +65,15 @@ import java.lang.reflect.Type;
  *
  * <p>Note that it does not matter what the fields of the created instance contain since Gson will
  * overwrite them with the deserialized values specified in JSON. You should also ensure that a
- * <i>new</i> object is returned, not a common object since its fields will be overwritten.
- * The developer will need to register {@code IdInstanceCreator} with Gson as follows:</p>
+ * <i>new</i> object is returned, not a common object since its fields will be overwritten. The
+ * developer will need to register {@code IdInstanceCreator} with Gson as follows:
  *
  * <pre>
  * Gson gson = new GsonBuilder().registerTypeAdapter(Id.class, new IdInstanceCreator()).create();
  * </pre>
  *
  * @param <T> the type of object that will be created by this implementation.
- *
  * @see GsonBuilder#registerTypeAdapter(Type, Object)
- *
  * @author Inderjeet Singh
  * @author Joel Leitch
  */
@@ -82,10 +81,10 @@ public interface InstanceCreator<T> {
 
   /**
    * Gson invokes this call-back method during deserialization to create an instance of the
-   * specified type. The fields of the returned instance are overwritten with the data present
-   * in the JSON. Since the prior contents of the object are destroyed and overwritten, do not
-   * return an instance that is useful elsewhere. In particular, do not return a common instance,
-   * always use {@code new} to create a new instance.
+   * specified type. The fields of the returned instance are overwritten with the data present in
+   * the JSON. Since the prior contents of the object are destroyed and overwritten, do not return
+   * an instance that is useful elsewhere. In particular, do not return a common instance, always
+   * use {@code new} to create a new instance.
    *
    * @param type the parameterized T represented as a {@link Type}.
    * @return a default object instance of type T.

--- a/gson/src/main/java/com/google/gson/JsonArray.java
+++ b/gson/src/main/java/com/google/gson/JsonArray.java
@@ -39,9 +39,7 @@ import java.util.List;
 public final class JsonArray extends JsonElement implements Iterable<JsonElement> {
   private final ArrayList<JsonElement> elements;
 
-  /**
-   * Creates an empty JsonArray.
-   */
+  /** Creates an empty JsonArray. */
   @SuppressWarnings("deprecation") // superclass constructor
   public JsonArray() {
     elements = new ArrayList<>();
@@ -51,8 +49,7 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
    * Creates an empty JsonArray with the desired initial capacity.
    *
    * @param capacity initial capacity.
-   * @throws IllegalArgumentException if the {@code capacity} is
-   *   negative
+   * @throws IllegalArgumentException if the {@code capacity} is negative
    * @since 2.8.1
    */
   @SuppressWarnings("deprecation") // superclass constructor
@@ -152,8 +149,8 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
   }
 
   /**
-   * Removes the first occurrence of the specified element from this array, if it is present.
-   * If the array does not contain the element, it is unchanged.
+   * Removes the first occurrence of the specified element from this array, if it is present. If the
+   * array does not contain the element, it is unchanged.
    *
    * @param element element to be removed from this array, if present
    * @return true if this array contained the specified element, false otherwise
@@ -165,9 +162,8 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
   }
 
   /**
-   * Removes the element at the specified position in this array. Shifts any subsequent elements
-   * to the left (subtracts one from their indices). Returns the element that was removed from
-   * the array.
+   * Removes the element at the specified position in this array. Shifts any subsequent elements to
+   * the left (subtracts one from their indices). Returns the element removed from the array.
    *
    * @param index index the index of the element to be removed
    * @return the element previously at the specified position
@@ -226,7 +222,7 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
    * @param i the index of the element that is being sought.
    * @return the element present at the i-th index.
    * @throws IndexOutOfBoundsException if {@code i} is negative or greater than or equal to the
-   * {@link #size()} of the array.
+   *     {@link #size()} of the array.
    */
   public JsonElement get(int i) {
     return elements.get(i);
@@ -241,9 +237,9 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
   }
 
   /**
-   * Convenience method to get this array as a {@link Number} if it contains a single element.
-   * This method calls {@link JsonElement#getAsNumber()} on the element, therefore any
-   * of the exceptions declared by that method can occur.
+   * Convenience method to get this array as a {@link Number} if it contains a single element. This
+   * method calls {@link JsonElement#getAsNumber()} on the element, therefore any of the exceptions
+   * declared by that method can occur.
    *
    * @return this element as a number if it is single element array.
    * @throws IllegalStateException if the array is empty or has more than one element.
@@ -254,9 +250,9 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
   }
 
   /**
-   * Convenience method to get this array as a {@link String} if it contains a single element.
-   * This method calls {@link JsonElement#getAsString()} on the element, therefore any
-   * of the exceptions declared by that method can occur.
+   * Convenience method to get this array as a {@link String} if it contains a single element. This
+   * method calls {@link JsonElement#getAsString()} on the element, therefore any of the exceptions
+   * declared by that method can occur.
    *
    * @return this element as a String if it is single element array.
    * @throws IllegalStateException if the array is empty or has more than one element.
@@ -267,9 +263,9 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
   }
 
   /**
-   * Convenience method to get this array as a double if it contains a single element.
-   * This method calls {@link JsonElement#getAsDouble()} on the element, therefore any
-   * of the exceptions declared by that method can occur.
+   * Convenience method to get this array as a double if it contains a single element. This method
+   * calls {@link JsonElement#getAsDouble()} on the element, therefore any of the exceptions
+   * declared by that method can occur.
    *
    * @return this element as a double if it is single element array.
    * @throws IllegalStateException if the array is empty or has more than one element.
@@ -281,8 +277,8 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
 
   /**
    * Convenience method to get this array as a {@link BigDecimal} if it contains a single element.
-   * This method calls {@link JsonElement#getAsBigDecimal()} on the element, therefore any
-   * of the exceptions declared by that method can occur.
+   * This method calls {@link JsonElement#getAsBigDecimal()} on the element, therefore any of the
+   * exceptions declared by that method can occur.
    *
    * @return this element as a {@link BigDecimal} if it is single element array.
    * @throws IllegalStateException if the array is empty or has more than one element.
@@ -295,8 +291,8 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
 
   /**
    * Convenience method to get this array as a {@link BigInteger} if it contains a single element.
-   * This method calls {@link JsonElement#getAsBigInteger()} on the element, therefore any
-   * of the exceptions declared by that method can occur.
+   * This method calls {@link JsonElement#getAsBigInteger()} on the element, therefore any of the
+   * exceptions declared by that method can occur.
    *
    * @return this element as a {@link BigInteger} if it is single element array.
    * @throws IllegalStateException if the array is empty or has more than one element.
@@ -308,9 +304,9 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
   }
 
   /**
-   * Convenience method to get this array as a float if it contains a single element.
-   * This method calls {@link JsonElement#getAsFloat()} on the element, therefore any
-   * of the exceptions declared by that method can occur.
+   * Convenience method to get this array as a float if it contains a single element. This method
+   * calls {@link JsonElement#getAsFloat()} on the element, therefore any of the exceptions declared
+   * by that method can occur.
    *
    * @return this element as a float if it is single element array.
    * @throws IllegalStateException if the array is empty or has more than one element.
@@ -321,9 +317,9 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
   }
 
   /**
-   * Convenience method to get this array as a long if it contains a single element.
-   * This method calls {@link JsonElement#getAsLong()} on the element, therefore any
-   * of the exceptions declared by that method can occur.
+   * Convenience method to get this array as a long if it contains a single element. This method
+   * calls {@link JsonElement#getAsLong()} on the element, therefore any of the exceptions declared
+   * by that method can occur.
    *
    * @return this element as a long if it is single element array.
    * @throws IllegalStateException if the array is empty or has more than one element.
@@ -334,9 +330,9 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
   }
 
   /**
-   * Convenience method to get this array as an integer if it contains a single element.
-   * This method calls {@link JsonElement#getAsInt()} on the element, therefore any
-   * of the exceptions declared by that method can occur.
+   * Convenience method to get this array as an integer if it contains a single element. This method
+   * calls {@link JsonElement#getAsInt()} on the element, therefore any of the exceptions declared
+   * by that method can occur.
    *
    * @return this element as an integer if it is single element array.
    * @throws IllegalStateException if the array is empty or has more than one element.
@@ -347,9 +343,9 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
   }
 
   /**
-   * Convenience method to get this array as a primitive byte if it contains a single element.
-   * This method calls {@link JsonElement#getAsByte()} on the element, therefore any
-   * of the exceptions declared by that method can occur.
+   * Convenience method to get this array as a primitive byte if it contains a single element. This
+   * method calls {@link JsonElement#getAsByte()} on the element, therefore any of the exceptions
+   * declared by that method can occur.
    *
    * @return this element as a primitive byte if it is single element array.
    * @throws IllegalStateException if the array is empty or has more than one element.
@@ -360,14 +356,14 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
   }
 
   /**
-   * Convenience method to get this array as a character if it contains a single element.
-   * This method calls {@link JsonElement#getAsCharacter()} on the element, therefore any
-   * of the exceptions declared by that method can occur.
+   * Convenience method to get this array as a character if it contains a single element. This
+   * method calls {@link JsonElement#getAsCharacter()} on the element, therefore any of the
+   * exceptions declared by that method can occur.
    *
    * @return this element as a primitive short if it is single element array.
    * @throws IllegalStateException if the array is empty or has more than one element.
    * @deprecated This method is misleading, as it does not get this element as a char but rather as
-   * a string's first character.
+   *     a string's first character.
    */
   @Deprecated
   @Override
@@ -376,9 +372,9 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
   }
 
   /**
-   * Convenience method to get this array as a primitive short if it contains a single element.
-   * This method calls {@link JsonElement#getAsShort()} on the element, therefore any
-   * of the exceptions declared by that method can occur.
+   * Convenience method to get this array as a primitive short if it contains a single element. This
+   * method calls {@link JsonElement#getAsShort()} on the element, therefore any of the exceptions
+   * declared by that method can occur.
    *
    * @return this element as a primitive short if it is single element array.
    * @throws IllegalStateException if the array is empty or has more than one element.
@@ -389,9 +385,9 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
   }
 
   /**
-   * Convenience method to get this array as a boolean if it contains a single element.
-   * This method calls {@link JsonElement#getAsBoolean()} on the element, therefore any
-   * of the exceptions declared by that method can occur.
+   * Convenience method to get this array as a boolean if it contains a single element. This method
+   * calls {@link JsonElement#getAsBoolean()} on the element, therefore any of the exceptions
+   * declared by that method can occur.
    *
    * @return this element as a boolean if it is single element array.
    * @throws IllegalStateException if the array is empty or has more than one element.
@@ -402,12 +398,12 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
   }
 
   /**
-   * Returns a mutable {@link List} view of this {@code JsonArray}. Changes to the {@code List}
-   * are visible in this {@code JsonArray} and the other way around.
+   * Returns a mutable {@link List} view of this {@code JsonArray}. Changes to the {@code List} are
+   * visible in this {@code JsonArray} and the other way around.
    *
-   * <p>The {@code List} does not permit {@code null} elements. Unlike {@code JsonArray}'s
-   * {@code null} handling, a {@link NullPointerException} is thrown when trying to add {@code null}.
-   * Use {@link JsonNull} for JSON null values.
+   * <p>The {@code List} does not permit {@code null} elements. Unlike {@code JsonArray}'s {@code
+   * null} handling, a {@link NullPointerException} is thrown when trying to add {@code null}. Use
+   * {@link JsonNull} for JSON null values.
    *
    * @return mutable {@code List} view
    * @since 2.10
@@ -417,9 +413,8 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
   }
 
   /**
-   * Returns whether the other object is equal to this. This method only considers
-   * the other object to be equal if it is an instance of {@code JsonArray} and has
-   * equal elements in the same order.
+   * Returns whether the other object is equal to this. This method only considers the other object
+   * to be equal if it is an instance of {@code JsonArray} and has equal elements in the same order.
    */
   @Override
   public boolean equals(Object o) {
@@ -427,8 +422,8 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
   }
 
   /**
-   * Returns the hash code of this array. This method calculates the hash code based
-   * on the elements of this array.
+   * Returns the hash code of this array. This method calculates the hash code based on the elements
+   * of this array.
    */
   @Override
   public int hashCode() {

--- a/gson/src/main/java/com/google/gson/JsonDeserializationContext.java
+++ b/gson/src/main/java/com/google/gson/JsonDeserializationContext.java
@@ -20,8 +20,7 @@ import java.lang.reflect.Type;
 
 /**
  * Context for deserialization that is passed to a custom deserializer during invocation of its
- * {@link JsonDeserializer#deserialize(JsonElement, Type, JsonDeserializationContext)}
- * method.
+ * {@link JsonDeserializer#deserialize(JsonElement, Type, JsonDeserializationContext)} method.
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
@@ -29,10 +28,10 @@ import java.lang.reflect.Type;
 public interface JsonDeserializationContext {
 
   /**
-   * Invokes default deserialization on the specified object. It should never be invoked on
-   * the element received as a parameter of the
-   * {@link JsonDeserializer#deserialize(JsonElement, Type, JsonDeserializationContext)} method. Doing
-   * so will result in an infinite loop since Gson will in-turn call the custom deserializer again.
+   * Invokes default deserialization on the specified object. It should never be invoked on the
+   * element received as a parameter of the {@link JsonDeserializer#deserialize(JsonElement, Type,
+   * JsonDeserializationContext)} method. Doing so will result in an infinite loop since Gson will
+   * in-turn call the custom deserializer again.
    *
    * @param json the parse tree.
    * @param typeOfT type of the expected return value.

--- a/gson/src/main/java/com/google/gson/JsonDeserializer.java
+++ b/gson/src/main/java/com/google/gson/JsonDeserializer.java
@@ -19,13 +19,12 @@ package com.google.gson;
 import java.lang.reflect.Type;
 
 /**
- * <p>Interface representing a custom deserializer for JSON. You should write a custom
- * deserializer, if you are not happy with the default deserialization done by Gson. You will
- * also need to register this deserializer through
- * {@link GsonBuilder#registerTypeAdapter(Type, Object)}.</p>
+ * Interface representing a custom deserializer for JSON. You should write a custom deserializer, if
+ * you are not happy with the default deserialization done by Gson. You will also need to register
+ * this deserializer through {@link GsonBuilder#registerTypeAdapter(Type, Object)}.
  *
  * <p>Let us look at example where defining a deserializer will be useful. The {@code Id} class
- * defined below has two fields: {@code clazz} and {@code value}.</p>
+ * defined below has two fields: {@code clazz} and {@code value}.
  *
  * <pre>
  * public class Id&lt;T&gt; {
@@ -41,11 +40,11 @@ import java.lang.reflect.Type;
  * }
  * </pre>
  *
- * <p>The default deserialization of {@code Id(com.foo.MyObject.class, 20L)} will require the
- * JSON string to be <code>{"clazz":"com.foo.MyObject","value":20}</code>. Suppose, you already know
- * the type of the field that the {@code Id} will be deserialized into, and hence just want to
+ * <p>The default deserialization of {@code Id(com.foo.MyObject.class, 20L)} will require the JSON
+ * string to be <code>{"clazz":"com.foo.MyObject","value":20}</code>. Suppose, you already know the
+ * type of the field that the {@code Id} will be deserialized into, and hence just want to
  * deserialize it from a JSON string {@code 20}. You can achieve that by writing a custom
- * deserializer:</p>
+ * deserializer:
  *
  * <pre>
  * class IdDeserializer implements JsonDeserializer&lt;Id&gt; {
@@ -57,34 +56,34 @@ import java.lang.reflect.Type;
  * }
  * </pre>
  *
- * <p>You will also need to register {@code IdDeserializer} with Gson as follows:</p>
+ * <p>You will also need to register {@code IdDeserializer} with Gson as follows:
  *
  * <pre>
  * Gson gson = new GsonBuilder().registerTypeAdapter(Id.class, new IdDeserializer()).create();
  * </pre>
  *
- * <p>Deserializers should be stateless and thread-safe, otherwise the thread-safety
- * guarantees of {@link Gson} might not apply.
+ * <p>Deserializers should be stateless and thread-safe, otherwise the thread-safety guarantees of
+ * {@link Gson} might not apply.
  *
- * <p>New applications should prefer {@link TypeAdapter}, whose streaming API
- * is more efficient than this interface's tree API.
+ * <p>New applications should prefer {@link TypeAdapter}, whose streaming API is more efficient than
+ * this interface's tree API.
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
- *
  * @param <T> type for which the deserializer is being registered. It is possible that a
- * deserializer may be asked to deserialize a specific generic type of the T.
+ *     deserializer may be asked to deserialize a specific generic type of the T.
  */
 public interface JsonDeserializer<T> {
 
   /**
    * Gson invokes this call-back method during deserialization when it encounters a field of the
    * specified type.
-   * <p>In the implementation of this call-back method, you should consider invoking
-   * {@link JsonDeserializationContext#deserialize(JsonElement, Type)} method to create objects
-   * for any non-trivial field of the returned object. However, you should never invoke it on the
-   * same type passing {@code json} since that will cause an infinite loop (Gson will call your
-   * call-back method again).
+   *
+   * <p>In the implementation of this call-back method, you should consider invoking {@link
+   * JsonDeserializationContext#deserialize(JsonElement, Type)} method to create objects for any
+   * non-trivial field of the returned object. However, you should never invoke it on the same type
+   * passing {@code json} since that will cause an infinite loop (Gson will call your call-back
+   * method again).
    *
    * @param json The Json data being deserialized
    * @param typeOfT The type of the Object to deserialize to

--- a/gson/src/main/java/com/google/gson/JsonElement.java
+++ b/gson/src/main/java/com/google/gson/JsonElement.java
@@ -25,25 +25,24 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 
 /**
- * A class representing an element of JSON. It could either be a {@link JsonObject}, a
- * {@link JsonArray}, a {@link JsonPrimitive} or a {@link JsonNull}.
+ * A class representing an element of JSON. It could either be a {@link JsonObject}, a {@link
+ * JsonArray}, a {@link JsonPrimitive} or a {@link JsonNull}.
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
  */
 public abstract class JsonElement {
   /**
-   * @deprecated Creating custom {@code JsonElement} subclasses is highly discouraged
-   *   and can lead to undefined behavior.<br>
-   *   This constructor is only kept for backward compatibility.
+   * @deprecated Creating custom {@code JsonElement} subclasses is highly discouraged and can lead
+   *     to undefined behavior.<br>
+   *     This constructor is only kept for backward compatibility.
    */
   @Deprecated
-  public JsonElement() {
-  }
+  public JsonElement() {}
 
   /**
-   * Returns a deep copy of this element. Immutable elements like primitives
-   * and nulls are not copied.
+   * Returns a deep copy of this element. Immutable elements like primitives and nulls are not
+   * copied.
    *
    * @since 2.8.2
    */
@@ -103,10 +102,9 @@ public abstract class JsonElement {
   }
 
   /**
-   * Convenience method to get this element as a {@link JsonArray}. If this element is of some
-   * other type, an {@link IllegalStateException} will result. Hence it is best to use this method
-   * after ensuring that this element is of the desired type by calling {@link #isJsonArray()}
-   * first.
+   * Convenience method to get this element as a {@link JsonArray}. If this element is of some other
+   * type, an {@link IllegalStateException} will result. Hence it is best to use this method after
+   * ensuring that this element is of the desired type by calling {@link #isJsonArray()} first.
    *
    * @return this element as a {@link JsonArray}.
    * @throws IllegalStateException if this element is of another type.
@@ -135,10 +133,9 @@ public abstract class JsonElement {
   }
 
   /**
-   * Convenience method to get this element as a {@link JsonNull}. If this element is of some
-   * other type, an {@link IllegalStateException} will result. Hence it is best to use this method
-   * after ensuring that this element is of the desired type by calling {@link #isJsonNull()}
-   * first.
+   * Convenience method to get this element as a {@link JsonNull}. If this element is of some other
+   * type, an {@link IllegalStateException} will result. Hence it is best to use this method after
+   * ensuring that this element is of the desired type by calling {@link #isJsonNull()} first.
    *
    * @return this element as a {@link JsonNull}.
    * @throws IllegalStateException if this element is of another type.
@@ -156,9 +153,10 @@ public abstract class JsonElement {
    * Convenience method to get this element as a boolean value.
    *
    * @return this element as a primitive boolean value.
-   * @throws UnsupportedOperationException if this element is not a {@link JsonPrimitive} or {@link JsonArray}.
+   * @throws UnsupportedOperationException if this element is not a {@link JsonPrimitive} or {@link
+   *     JsonArray}.
    * @throws IllegalStateException if this element is of the type {@link JsonArray} but contains
-   * more than a single element.
+   *     more than a single element.
    */
   public boolean getAsBoolean() {
     throw new UnsupportedOperationException(getClass().getSimpleName());
@@ -168,10 +166,10 @@ public abstract class JsonElement {
    * Convenience method to get this element as a {@link Number}.
    *
    * @return this element as a {@link Number}.
-   * @throws UnsupportedOperationException if this element is not a {@link JsonPrimitive} or {@link JsonArray},
-   * or cannot be converted to a number.
+   * @throws UnsupportedOperationException if this element is not a {@link JsonPrimitive} or {@link
+   *     JsonArray}, or cannot be converted to a number.
    * @throws IllegalStateException if this element is of the type {@link JsonArray} but contains
-   * more than a single element.
+   *     more than a single element.
    */
   public Number getAsNumber() {
     throw new UnsupportedOperationException(getClass().getSimpleName());
@@ -181,9 +179,10 @@ public abstract class JsonElement {
    * Convenience method to get this element as a string value.
    *
    * @return this element as a string value.
-   * @throws UnsupportedOperationException if this element is not a {@link JsonPrimitive} or {@link JsonArray}.
+   * @throws UnsupportedOperationException if this element is not a {@link JsonPrimitive} or {@link
+   *     JsonArray}.
    * @throws IllegalStateException if this element is of the type {@link JsonArray} but contains
-   * more than a single element.
+   *     more than a single element.
    */
   public String getAsString() {
     throw new UnsupportedOperationException(getClass().getSimpleName());
@@ -193,10 +192,11 @@ public abstract class JsonElement {
    * Convenience method to get this element as a primitive double value.
    *
    * @return this element as a primitive double value.
-   * @throws UnsupportedOperationException if this element is not a {@link JsonPrimitive} or {@link JsonArray}.
+   * @throws UnsupportedOperationException if this element is not a {@link JsonPrimitive} or {@link
+   *     JsonArray}.
    * @throws NumberFormatException if the value contained is not a valid double.
    * @throws IllegalStateException if this element is of the type {@link JsonArray} but contains
-   * more than a single element.
+   *     more than a single element.
    */
   public double getAsDouble() {
     throw new UnsupportedOperationException(getClass().getSimpleName());
@@ -206,10 +206,11 @@ public abstract class JsonElement {
    * Convenience method to get this element as a primitive float value.
    *
    * @return this element as a primitive float value.
-   * @throws UnsupportedOperationException if this element is not a {@link JsonPrimitive} or {@link JsonArray}.
+   * @throws UnsupportedOperationException if this element is not a {@link JsonPrimitive} or {@link
+   *     JsonArray}.
    * @throws NumberFormatException if the value contained is not a valid float.
    * @throws IllegalStateException if this element is of the type {@link JsonArray} but contains
-   * more than a single element.
+   *     more than a single element.
    */
   public float getAsFloat() {
     throw new UnsupportedOperationException(getClass().getSimpleName());
@@ -219,10 +220,11 @@ public abstract class JsonElement {
    * Convenience method to get this element as a primitive long value.
    *
    * @return this element as a primitive long value.
-   * @throws UnsupportedOperationException if this element is not a {@link JsonPrimitive} or {@link JsonArray}.
+   * @throws UnsupportedOperationException if this element is not a {@link JsonPrimitive} or {@link
+   *     JsonArray}.
    * @throws NumberFormatException if the value contained is not a valid long.
    * @throws IllegalStateException if this element is of the type {@link JsonArray} but contains
-   * more than a single element.
+   *     more than a single element.
    */
   public long getAsLong() {
     throw new UnsupportedOperationException(getClass().getSimpleName());
@@ -232,10 +234,11 @@ public abstract class JsonElement {
    * Convenience method to get this element as a primitive integer value.
    *
    * @return this element as a primitive integer value.
-   * @throws UnsupportedOperationException if this element is not a {@link JsonPrimitive} or {@link JsonArray}.
+   * @throws UnsupportedOperationException if this element is not a {@link JsonPrimitive} or {@link
+   *     JsonArray}.
    * @throws NumberFormatException if the value contained is not a valid integer.
    * @throws IllegalStateException if this element is of the type {@link JsonArray} but contains
-   * more than a single element.
+   *     more than a single element.
    */
   public int getAsInt() {
     throw new UnsupportedOperationException(getClass().getSimpleName());
@@ -245,10 +248,11 @@ public abstract class JsonElement {
    * Convenience method to get this element as a primitive byte value.
    *
    * @return this element as a primitive byte value.
-   * @throws UnsupportedOperationException if this element is not a {@link JsonPrimitive} or {@link JsonArray}.
+   * @throws UnsupportedOperationException if this element is not a {@link JsonPrimitive} or {@link
+   *     JsonArray}.
    * @throws NumberFormatException if the value contained is not a valid byte.
    * @throws IllegalStateException if this element is of the type {@link JsonArray} but contains
-   * more than a single element.
+   *     more than a single element.
    * @since 1.3
    */
   public byte getAsByte() {
@@ -259,13 +263,13 @@ public abstract class JsonElement {
    * Convenience method to get the first character of the string value of this element.
    *
    * @return the first character of the string value.
-   * @throws UnsupportedOperationException if this element is not a {@link JsonPrimitive} or {@link JsonArray},
-   * or if its string value is empty.
+   * @throws UnsupportedOperationException if this element is not a {@link JsonPrimitive} or {@link
+   *     JsonArray}, or if its string value is empty.
    * @throws IllegalStateException if this element is of the type {@link JsonArray} but contains
-   * more than a single element.
+   *     more than a single element.
    * @since 1.3
    * @deprecated This method is misleading, as it does not get this element as a char but rather as
-   * a string's first character.
+   *     a string's first character.
    */
   @Deprecated
   public char getAsCharacter() {
@@ -276,10 +280,11 @@ public abstract class JsonElement {
    * Convenience method to get this element as a {@link BigDecimal}.
    *
    * @return this element as a {@link BigDecimal}.
-   * @throws UnsupportedOperationException if this element is not a {@link JsonPrimitive} or {@link JsonArray}.
+   * @throws UnsupportedOperationException if this element is not a {@link JsonPrimitive} or {@link
+   *     JsonArray}.
    * @throws NumberFormatException if this element is not a valid {@link BigDecimal}.
    * @throws IllegalStateException if this element is of the type {@link JsonArray} but contains
-   * more than a single element.
+   *     more than a single element.
    * @since 1.2
    */
   public BigDecimal getAsBigDecimal() {
@@ -290,10 +295,11 @@ public abstract class JsonElement {
    * Convenience method to get this element as a {@link BigInteger}.
    *
    * @return this element as a {@link BigInteger}.
-   * @throws UnsupportedOperationException if this element is not a {@link JsonPrimitive} or {@link JsonArray}.
+   * @throws UnsupportedOperationException if this element is not a {@link JsonPrimitive} or {@link
+   *     JsonArray}.
    * @throws NumberFormatException if this element is not a valid {@link BigInteger}.
    * @throws IllegalStateException if this element is of the type {@link JsonArray} but contains
-   * more than a single element.
+   *     more than a single element.
    * @since 1.2
    */
   public BigInteger getAsBigInteger() {
@@ -304,24 +310,24 @@ public abstract class JsonElement {
    * Convenience method to get this element as a primitive short value.
    *
    * @return this element as a primitive short value.
-   * @throws UnsupportedOperationException if this element is not a {@link JsonPrimitive} or {@link JsonArray}.
+   * @throws UnsupportedOperationException if this element is not a {@link JsonPrimitive} or {@link
+   *     JsonArray}.
    * @throws NumberFormatException if the value contained is not a valid short.
    * @throws IllegalStateException if this element is of the type {@link JsonArray} but contains
-   * more than a single element.
+   *     more than a single element.
    */
   public short getAsShort() {
     throw new UnsupportedOperationException(getClass().getSimpleName());
   }
 
-  /**
-   * Returns a String representation of this element.
-   */
+  /** Returns a String representation of this element. */
   @Override
   public String toString() {
     try {
       StringWriter stringWriter = new StringWriter();
       JsonWriter jsonWriter = new JsonWriter(stringWriter);
-      // Make writer lenient because toString() must not fail, even if for example JsonPrimitive contains NaN
+      // Make writer lenient because toString() must not fail, even if for example JsonPrimitive
+      // contains NaN
       jsonWriter.setStrictness(Strictness.LENIENT);
       Streams.write(this, jsonWriter);
       return stringWriter.toString();

--- a/gson/src/main/java/com/google/gson/JsonIOException.java
+++ b/gson/src/main/java/com/google/gson/JsonIOException.java
@@ -16,9 +16,8 @@
 package com.google.gson;
 
 /**
- * This exception is raised when Gson was unable to read an input stream
- * or write to one.
- * 
+ * This exception is raised when Gson was unable to read an input stream or write to one.
+ *
  * @author Inderjeet Singh
  * @author Joel Leitch
  */
@@ -34,8 +33,8 @@ public final class JsonIOException extends JsonParseException {
   }
 
   /**
-   * Creates exception with the specified cause. Consider using
-   * {@link #JsonIOException(String, Throwable)} instead if you can describe what happened.
+   * Creates exception with the specified cause. Consider using {@link #JsonIOException(String,
+   * Throwable)} instead if you can describe what happened.
    *
    * @param cause root exception that caused this exception to be thrown.
    */

--- a/gson/src/main/java/com/google/gson/JsonNull.java
+++ b/gson/src/main/java/com/google/gson/JsonNull.java
@@ -51,17 +51,13 @@ public final class JsonNull extends JsonElement {
     return INSTANCE;
   }
 
-  /**
-   * All instances of {@code JsonNull} have the same hash code since they are indistinguishable.
-   */
+  /** All instances of {@code JsonNull} have the same hash code since they are indistinguishable. */
   @Override
   public int hashCode() {
     return JsonNull.class.hashCode();
   }
 
-  /**
-   * All instances of {@code JsonNull} are considered equal.
-   */
+  /** All instances of {@code JsonNull} are considered equal. */
   @Override
   public boolean equals(Object other) {
     return other instanceof JsonNull;

--- a/gson/src/main/java/com/google/gson/JsonObject.java
+++ b/gson/src/main/java/com/google/gson/JsonObject.java
@@ -25,11 +25,11 @@ import java.util.Set;
  * A class representing an object type in Json. An object consists of name-value pairs where names
  * are strings, and values are any other type of {@link JsonElement}. This allows for a creating a
  * tree of JsonElements. The member elements of this object are maintained in order they were added.
- * This class does not support {@code null} values. If {@code null} is provided as value argument
- * to any of the methods, it is converted to a {@link JsonNull}.
+ * This class does not support {@code null} values. If {@code null} is provided as value argument to
+ * any of the methods, it is converted to a {@link JsonNull}.
  *
- * <p>{@code JsonObject} does not implement the {@link Map} interface, but a {@code Map} view
- * of it can be obtained with {@link #asMap()}.
+ * <p>{@code JsonObject} does not implement the {@link Map} interface, but a {@code Map} view of it
+ * can be obtained with {@link #asMap()}.
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
@@ -37,12 +37,9 @@ import java.util.Set;
 public final class JsonObject extends JsonElement {
   private final LinkedTreeMap<String, JsonElement> members = new LinkedTreeMap<>(false);
 
-  /**
-   * Creates an empty JsonObject.
-   */
+  /** Creates an empty JsonObject. */
   @SuppressWarnings("deprecation") // superclass constructor
-  public JsonObject() {
-  }
+  public JsonObject() {}
 
   /**
    * Creates a deep copy of this element and all its children.
@@ -60,8 +57,8 @@ public final class JsonObject extends JsonElement {
 
   /**
    * Adds a member, which is a name-value pair, to self. The name must be a String, but the value
-   * can be an arbitrary {@link JsonElement}, thereby allowing you to build a full tree of JsonElements
-   * rooted at this node.
+   * can be an arbitrary {@link JsonElement}, thereby allowing you to build a full tree of
+   * JsonElements rooted at this node.
    *
    * @param property name of the member.
    * @param value the member object.
@@ -74,8 +71,8 @@ public final class JsonObject extends JsonElement {
    * Removes the {@code property} from this object.
    *
    * @param property name of the member that should be removed.
-   * @return the {@link JsonElement} object that is being removed, or {@code null} if no
-   *   member with this name exists.
+   * @return the {@link JsonElement} object that is being removed, or {@code null} if no member with
+   *     this name exists.
    * @since 1.3
    */
   @CanIgnoreReturnValue
@@ -84,8 +81,8 @@ public final class JsonObject extends JsonElement {
   }
 
   /**
-   * Convenience method to add a string member. The specified value is converted to a
-   * {@link JsonPrimitive} of String.
+   * Convenience method to add a string member. The specified value is converted to a {@link
+   * JsonPrimitive} of String.
    *
    * @param property name of the member.
    * @param value the string value associated with the member.
@@ -95,8 +92,8 @@ public final class JsonObject extends JsonElement {
   }
 
   /**
-   * Convenience method to add a number member. The specified value is converted to a
-   * {@link JsonPrimitive} of Number.
+   * Convenience method to add a number member. The specified value is converted to a {@link
+   * JsonPrimitive} of Number.
    *
    * @param property name of the member.
    * @param value the number value associated with the member.
@@ -106,8 +103,8 @@ public final class JsonObject extends JsonElement {
   }
 
   /**
-   * Convenience method to add a boolean member. The specified value is converted to a
-   * {@link JsonPrimitive} of Boolean.
+   * Convenience method to add a boolean member. The specified value is converted to a {@link
+   * JsonPrimitive} of Boolean.
    *
    * @param property name of the member.
    * @param value the boolean value associated with the member.
@@ -117,8 +114,8 @@ public final class JsonObject extends JsonElement {
   }
 
   /**
-   * Convenience method to add a char member. The specified value is converted to a
-   * {@link JsonPrimitive} of Character.
+   * Convenience method to add a char member. The specified value is converted to a {@link
+   * JsonPrimitive} of Character.
    *
    * @param property name of the member.
    * @param value the char value associated with the member.
@@ -192,7 +189,7 @@ public final class JsonObject extends JsonElement {
    *
    * @param memberName name of the member being requested.
    * @return the {@code JsonPrimitive} corresponding to the specified member, or {@code null} if no
-   *   member with this name exists.
+   *     member with this name exists.
    * @throws ClassCastException if the member is not of type {@code JsonPrimitive}.
    */
   public JsonPrimitive getAsJsonPrimitive(String memberName) {
@@ -204,7 +201,7 @@ public final class JsonObject extends JsonElement {
    *
    * @param memberName name of the member being requested.
    * @return the {@code JsonArray} corresponding to the specified member, or {@code null} if no
-   *   member with this name exists.
+   *     member with this name exists.
    * @throws ClassCastException if the member is not of type {@code JsonArray}.
    */
   public JsonArray getAsJsonArray(String memberName) {
@@ -216,7 +213,7 @@ public final class JsonObject extends JsonElement {
    *
    * @param memberName name of the member being requested.
    * @return the {@code JsonObject} corresponding to the specified member, or {@code null} if no
-   *   member with this name exists.
+   *     member with this name exists.
    * @throws ClassCastException if the member is not of type {@code JsonObject}.
    */
   public JsonObject getAsJsonObject(String memberName) {
@@ -224,12 +221,12 @@ public final class JsonObject extends JsonElement {
   }
 
   /**
-   * Returns a mutable {@link Map} view of this {@code JsonObject}. Changes to the {@code Map}
-   * are visible in this {@code JsonObject} and the other way around.
+   * Returns a mutable {@link Map} view of this {@code JsonObject}. Changes to the {@code Map} are
+   * visible in this {@code JsonObject} and the other way around.
    *
    * <p>The {@code Map} does not permit {@code null} keys or values. Unlike {@code JsonObject}'s
-   * {@code null} handling, a {@link NullPointerException} is thrown when trying to add {@code null}.
-   * Use {@link JsonNull} for JSON null values.
+   * {@code null} handling, a {@link NullPointerException} is thrown when trying to add {@code
+   * null}. Use {@link JsonNull} for JSON null values.
    *
    * @return mutable {@code Map} view
    * @since 2.10
@@ -240,19 +237,17 @@ public final class JsonObject extends JsonElement {
   }
 
   /**
-   * Returns whether the other object is equal to this. This method only considers
-   * the other object to be equal if it is an instance of {@code JsonObject} and has
-   * equal members, ignoring order.
+   * Returns whether the other object is equal to this. This method only considers the other object
+   * to be equal if it is an instance of {@code JsonObject} and has equal members, ignoring order.
    */
   @Override
   public boolean equals(Object o) {
-    return (o == this) || (o instanceof JsonObject
-        && ((JsonObject) o).members.equals(members));
+    return (o == this) || (o instanceof JsonObject && ((JsonObject) o).members.equals(members));
   }
 
   /**
-   * Returns the hash code of this object. This method calculates the hash code based
-   * on the members of this object, ignoring order.
+   * Returns the hash code of this object. This method calculates the hash code based on the members
+   * of this object, ignoring order.
    */
   @Override
   public int hashCode() {

--- a/gson/src/main/java/com/google/gson/JsonParseException.java
+++ b/gson/src/main/java/com/google/gson/JsonParseException.java
@@ -17,14 +17,14 @@
 package com.google.gson;
 
 /**
- * This exception is raised if there is a serious issue that occurs during parsing of a Json
- * string. One of the main usages for this class is for the Gson infrastructure. If the incoming
- * Json is bad/malicious, an instance of this exception is raised.
+ * This exception is raised if there is a serious issue that occurs during parsing of a Json string.
+ * One of the main usages for this class is for the Gson infrastructure. If the incoming Json is
+ * bad/malicious, an instance of this exception is raised.
  *
  * <p>This exception is a {@link RuntimeException} because it is exposed to the client. Using a
  * {@link RuntimeException} avoids bad coding practices on the client side where they catch the
  * exception and do nothing. It is often the case that you want to blow up if there is a parsing
- * error (i.e. often clients do not know how to recover from a {@link JsonParseException}.</p>
+ * error (i.e. often clients do not know how to recover from a {@link JsonParseException}.
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
@@ -53,8 +53,8 @@ public class JsonParseException extends RuntimeException {
   }
 
   /**
-   * Creates exception with the specified cause. Consider using
-   * {@link #JsonParseException(String, Throwable)} instead if you can describe what happened.
+   * Creates exception with the specified cause. Consider using {@link #JsonParseException(String,
+   * Throwable)} instead if you can describe what happened.
    *
    * @param cause root exception that caused this exception to be thrown.
    */

--- a/gson/src/main/java/com/google/gson/JsonParser.java
+++ b/gson/src/main/java/com/google/gson/JsonParser.java
@@ -32,14 +32,15 @@ import java.io.StringReader;
  * @since 1.3
  */
 public final class JsonParser {
-  /** @deprecated No need to instantiate this class, use the static methods instead. */
+  /**
+   * @deprecated No need to instantiate this class, use the static methods instead.
+   */
   @Deprecated
   public JsonParser() {}
 
   /**
-   * Parses the specified JSON string into a parse tree.
-   * An exception is thrown if the JSON string has multiple top-level JSON elements,
-   * or if there is trailing data.
+   * Parses the specified JSON string into a parse tree. An exception is thrown if the JSON string
+   * has multiple top-level JSON elements, or if there is trailing data.
    *
    * <p>The JSON string is parsed in {@linkplain JsonReader#setStrictness(Strictness) lenient mode}.
    *
@@ -53,16 +54,15 @@ public final class JsonParser {
   }
 
   /**
-   * Parses the complete JSON string provided by the reader into a parse tree.
-   * An exception is thrown if the JSON string has multiple top-level JSON elements,
-   * or if there is trailing data.
+   * Parses the complete JSON string provided by the reader into a parse tree. An exception is
+   * thrown if the JSON string has multiple top-level JSON elements, or if there is trailing data.
    *
    * <p>The JSON data is parsed in {@linkplain JsonReader#setStrictness(Strictness) lenient mode}.
    *
    * @param reader JSON text
    * @return a parse tree of {@link JsonElement}s corresponding to the specified JSON
-   * @throws JsonParseException if there is an IOException or if the specified
-   *     text is not valid JSON
+   * @throws JsonParseException if there is an IOException or if the specified text is not valid
+   *     JSON
    * @since 2.8.6
    */
   public static JsonElement parseReader(Reader reader) throws JsonIOException, JsonSyntaxException {
@@ -83,16 +83,16 @@ public final class JsonParser {
   }
 
   /**
-   * Returns the next value from the JSON stream as a parse tree.
-   * Unlike the other {@code parse} methods, no exception is thrown if the JSON data has
-   * multiple top-level JSON elements, or if there is trailing data.
+   * Returns the next value from the JSON stream as a parse tree. Unlike the other {@code parse}
+   * methods, no exception is thrown if the JSON data has multiple top-level JSON elements, or if
+   * there is trailing data.
    *
    * <p>The JSON data is parsed in {@linkplain JsonReader#setStrictness(Strictness) lenient mode},
-   * regardless of the strictness setting of the provided reader. The strictness setting
-   * of the reader is restored once this method returns.
+   * regardless of the strictness setting of the provided reader. The strictness setting of the
+   * reader is restored once this method returns.
    *
-   * @throws JsonParseException if there is an IOException or if the specified
-   *     text is not valid JSON
+   * @throws JsonParseException if there is an IOException or if the specified text is not valid
+   *     JSON
    * @since 2.8.6
    */
   public static JsonElement parseReader(JsonReader reader)
@@ -110,21 +110,27 @@ public final class JsonParser {
     }
   }
 
-  /** @deprecated Use {@link JsonParser#parseString} */
+  /**
+   * @deprecated Use {@link JsonParser#parseString}
+   */
   @Deprecated
   @InlineMe(replacement = "JsonParser.parseString(json)", imports = "com.google.gson.JsonParser")
   public JsonElement parse(String json) throws JsonSyntaxException {
     return parseString(json);
   }
 
-  /** @deprecated Use {@link JsonParser#parseReader(Reader)} */
+  /**
+   * @deprecated Use {@link JsonParser#parseReader(Reader)}
+   */
   @Deprecated
   @InlineMe(replacement = "JsonParser.parseReader(json)", imports = "com.google.gson.JsonParser")
   public JsonElement parse(Reader json) throws JsonIOException, JsonSyntaxException {
     return parseReader(json);
   }
 
-  /** @deprecated Use {@link JsonParser#parseReader(JsonReader)} */
+  /**
+   * @deprecated Use {@link JsonParser#parseReader(JsonReader)}
+   */
   @Deprecated
   @InlineMe(replacement = "JsonParser.parseReader(json)", imports = "com.google.gson.JsonParser")
   public JsonElement parse(JsonReader json) throws JsonIOException, JsonSyntaxException {

--- a/gson/src/main/java/com/google/gson/JsonPrimitive.java
+++ b/gson/src/main/java/com/google/gson/JsonPrimitive.java
@@ -23,9 +23,8 @@ import java.math.BigInteger;
 import java.util.Objects;
 
 /**
- * A class representing a JSON primitive value. A primitive value
- * is either a String, a Java primitive, or a Java primitive
- * wrapper type.
+ * A class representing a JSON primitive value. A primitive value is either a String, a Java
+ * primitive, or a Java primitive wrapper type.
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
@@ -97,10 +96,10 @@ public final class JsonPrimitive extends JsonElement {
   }
 
   /**
-   * Convenience method to get this element as a boolean value.
-   * If this primitive {@linkplain #isBoolean() is not a boolean}, the string value
-   * is parsed using {@link Boolean#parseBoolean(String)}. This means {@code "true"} (ignoring
-   * case) is considered {@code true} and any other value is considered {@code false}.
+   * Convenience method to get this element as a boolean value. If this primitive {@linkplain
+   * #isBoolean() is not a boolean}, the string value is parsed using {@link
+   * Boolean#parseBoolean(String)}. This means {@code "true"} (ignoring case) is considered {@code
+   * true} and any other value is considered {@code false}.
    */
   @Override
   public boolean getAsBoolean() {
@@ -121,10 +120,9 @@ public final class JsonPrimitive extends JsonElement {
   }
 
   /**
-   * Convenience method to get this element as a {@link Number}.
-   * If this primitive {@linkplain #isString() is a string}, a lazily parsed {@code Number}
-   * is constructed which parses the string when any of its methods are called (which can
-   * lead to a {@link NumberFormatException}).
+   * Convenience method to get this element as a {@link Number}. If this primitive {@linkplain
+   * #isString() is a string}, a lazily parsed {@code Number} is constructed which parses the string
+   * when any of its methods are called (which can lead to a {@link NumberFormatException}).
    *
    * @throws UnsupportedOperationException if this primitive is neither a number nor a string.
    */
@@ -173,7 +171,9 @@ public final class JsonPrimitive extends JsonElement {
    */
   @Override
   public BigDecimal getAsBigDecimal() {
-    return value instanceof BigDecimal ? (BigDecimal) value : NumberLimits.parseBigDecimal(getAsString());
+    return value instanceof BigDecimal
+        ? (BigDecimal) value
+        : NumberLimits.parseBigDecimal(getAsString());
   }
 
   /**
@@ -215,9 +215,9 @@ public final class JsonPrimitive extends JsonElement {
     return isNumber() ? getAsNumber().shortValue() : Short.parseShort(getAsString());
   }
 
- /**
-  * @throws NumberFormatException {@inheritDoc}
-  */
+  /**
+   * @throws NumberFormatException {@inheritDoc}
+   */
   @Override
   public int getAsInt() {
     return isNumber() ? getAsNumber().intValue() : Integer.parseInt(getAsString());
@@ -232,10 +232,9 @@ public final class JsonPrimitive extends JsonElement {
   }
 
   /**
-   * @throws UnsupportedOperationException if the string value of this
-   * primitive is empty.
+   * @throws UnsupportedOperationException if the string value of this primitive is empty.
    * @deprecated This method is misleading, as it does not get this element as a char but rather as
-   * a string's first character.
+   *     a string's first character.
    */
   @Deprecated
   @Override
@@ -248,9 +247,7 @@ public final class JsonPrimitive extends JsonElement {
     }
   }
 
-  /**
-   * Returns the hash code of this object.
-   */
+  /** Returns the hash code of this object. */
   @Override
   public int hashCode() {
     if (value == null) {
@@ -269,9 +266,8 @@ public final class JsonPrimitive extends JsonElement {
   }
 
   /**
-   * Returns whether the other object is equal to this. This method only considers
-   * the other object to be equal if it is an instance of {@code JsonPrimitive} and
-   * has an equal value.
+   * Returns whether the other object is equal to this. This method only considers the other object
+   * to be equal if it is an instance of {@code JsonPrimitive} and has an equal value.
    */
   @Override
   public boolean equals(Object obj) {
@@ -281,7 +277,7 @@ public final class JsonPrimitive extends JsonElement {
     if (obj == null || getClass() != obj.getClass()) {
       return false;
     }
-    JsonPrimitive other = (JsonPrimitive)obj;
+    JsonPrimitive other = (JsonPrimitive) obj;
     if (value == null) {
       return other.value == null;
     }
@@ -301,14 +297,17 @@ public final class JsonPrimitive extends JsonElement {
   }
 
   /**
-   * Returns true if the specified number is an integral type
-   * (Long, Integer, Short, Byte, BigInteger)
+   * Returns true if the specified number is an integral type (Long, Integer, Short, Byte,
+   * BigInteger)
    */
   private static boolean isIntegral(JsonPrimitive primitive) {
     if (primitive.value instanceof Number) {
       Number number = (Number) primitive.value;
-      return number instanceof BigInteger || number instanceof Long || number instanceof Integer
-          || number instanceof Short || number instanceof Byte;
+      return number instanceof BigInteger
+          || number instanceof Long
+          || number instanceof Integer
+          || number instanceof Short
+          || number instanceof Byte;
     }
     return false;
   }

--- a/gson/src/main/java/com/google/gson/JsonSerializationContext.java
+++ b/gson/src/main/java/com/google/gson/JsonSerializationContext.java
@@ -19,8 +19,8 @@ package com.google.gson;
 import java.lang.reflect.Type;
 
 /**
- * Context for serialization that is passed to a custom serializer during invocation of its
- * {@link JsonSerializer#serialize(Object, Type, JsonSerializationContext)} method.
+ * Context for serialization that is passed to a custom serializer during invocation of its {@link
+ * JsonSerializer#serialize(Object, Type, JsonSerializationContext)} method.
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
@@ -36,10 +36,10 @@ public interface JsonSerializationContext {
   public JsonElement serialize(Object src);
 
   /**
-   * Invokes default serialization on the specified object passing the specific type information.
-   * It should never be invoked on the element received as a parameter of the
-   * {@link JsonSerializer#serialize(Object, Type, JsonSerializationContext)} method. Doing
-   * so will result in an infinite loop since Gson will in-turn call the custom serializer again.
+   * Invokes default serialization on the specified object passing the specific type information. It
+   * should never be invoked on the element received as a parameter of the {@link
+   * JsonSerializer#serialize(Object, Type, JsonSerializationContext)} method. Doing so will result
+   * in an infinite loop since Gson will in-turn call the custom serializer again.
    *
    * @param src the object that needs to be serialized.
    * @param typeOfSrc the actual genericized type of src object.

--- a/gson/src/main/java/com/google/gson/JsonSerializer.java
+++ b/gson/src/main/java/com/google/gson/JsonSerializer.java
@@ -19,12 +19,12 @@ package com.google.gson;
 import java.lang.reflect.Type;
 
 /**
- * Interface representing a custom serializer for JSON. You should write a custom serializer, if
- * you are not happy with the default serialization done by Gson. You will also need to register
- * this serializer through {@link com.google.gson.GsonBuilder#registerTypeAdapter(Type, Object)}.
+ * Interface representing a custom serializer for JSON. You should write a custom serializer, if you
+ * are not happy with the default serialization done by Gson. You will also need to register this
+ * serializer through {@link com.google.gson.GsonBuilder#registerTypeAdapter(Type, Object)}.
  *
  * <p>Let us look at example where defining a serializer will be useful. The {@code Id} class
- * defined below has two fields: {@code clazz} and {@code value}.</p>
+ * defined below has two fields: {@code clazz} and {@code value}.
  *
  * <pre>
  * public class Id&lt;T&gt; {
@@ -42,10 +42,9 @@ import java.lang.reflect.Type;
  * }
  * </pre>
  *
- * <p>The default serialization of {@code Id(com.foo.MyObject.class, 20L)} will be
- * <code>{"clazz":"com.foo.MyObject","value":20}</code>. Suppose, you just want the output to be
- * the value instead, which is {@code 20} in this case. You can achieve that by writing a custom
- * serializer:</p>
+ * <p>The default serialization of {@code Id(com.foo.MyObject.class, 20L)} will be <code>
+ * {"clazz":"com.foo.MyObject","value":20}</code>. Suppose, you just want the output to be the value
+ * instead, which is {@code 20} in this case. You can achieve that by writing a custom serializer:
  *
  * <pre>
  * class IdSerializer implements JsonSerializer&lt;Id&gt; {
@@ -55,22 +54,22 @@ import java.lang.reflect.Type;
  * }
  * </pre>
  *
- * <p>You will also need to register {@code IdSerializer} with Gson as follows:</p>
+ * <p>You will also need to register {@code IdSerializer} with Gson as follows:
+ *
  * <pre>
  * Gson gson = new GsonBuilder().registerTypeAdapter(Id.class, new IdSerializer()).create();
  * </pre>
  *
- * <p>Serializers should be stateless and thread-safe, otherwise the thread-safety
- * guarantees of {@link Gson} might not apply.
+ * <p>Serializers should be stateless and thread-safe, otherwise the thread-safety guarantees of
+ * {@link Gson} might not apply.
  *
- * <p>New applications should prefer {@link TypeAdapter}, whose streaming API
- * is more efficient than this interface's tree API.
+ * <p>New applications should prefer {@link TypeAdapter}, whose streaming API is more efficient than
+ * this interface's tree API.
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
- *
  * @param <T> type for which the serializer is being registered. It is possible that a serializer
- *        may be asked to serialize a specific generic type of the T.
+ *     may be asked to serialize a specific generic type of the T.
  */
 public interface JsonSerializer<T> {
 
@@ -78,11 +77,11 @@ public interface JsonSerializer<T> {
    * Gson invokes this call-back method during serialization when it encounters a field of the
    * specified type.
    *
-   * <p>In the implementation of this call-back method, you should consider invoking
-   * {@link JsonSerializationContext#serialize(Object, Type)} method to create JsonElements for any
-   * non-trivial field of the {@code src} object. However, you should never invoke it on the
-   * {@code src} object itself since that will cause an infinite loop (Gson will call your
-   * call-back method again).</p>
+   * <p>In the implementation of this call-back method, you should consider invoking {@link
+   * JsonSerializationContext#serialize(Object, Type)} method to create JsonElements for any
+   * non-trivial field of the {@code src} object. However, you should never invoke it on the {@code
+   * src} object itself since that will cause an infinite loop (Gson will call your call-back method
+   * again).
    *
    * @param src the object that needs to be converted to Json.
    * @param typeOfSrc the actual type (fully genericized version) of the source object.

--- a/gson/src/main/java/com/google/gson/JsonStreamParser.java
+++ b/gson/src/main/java/com/google/gson/JsonStreamParser.java
@@ -27,8 +27,8 @@ import java.util.NoSuchElementException;
 
 /**
  * A streaming parser that allows reading of multiple {@link JsonElement}s from the specified reader
- * asynchronously. The JSON data is parsed in lenient mode, see also
- * {@link JsonReader#setStrictness(Strictness)}.
+ * asynchronously. The JSON data is parsed in lenient mode, see also {@link
+ * JsonReader#setStrictness(Strictness)}.
  *
  * <p>This class is conditionally thread-safe (see Item 70, Effective Java second edition). To
  * properly use this class across multiple threads, you will need to add some external
@@ -71,8 +71,8 @@ public final class JsonStreamParser implements Iterator<JsonElement> {
   }
 
   /**
-   * Returns the next available {@link JsonElement} on the reader. Throws a
-   * {@link NoSuchElementException} if no element is available.
+   * Returns the next available {@link JsonElement} on the reader. Throws a {@link
+   * NoSuchElementException} if no element is available.
    *
    * @return the next available {@code JsonElement} on the reader.
    * @throws JsonParseException if the incoming stream is malformed JSON.
@@ -96,6 +96,7 @@ public final class JsonStreamParser implements Iterator<JsonElement> {
 
   /**
    * Returns true if a {@link JsonElement} is available on the input for consumption
+   *
    * @return true if a {@link JsonElement} is available on the input, false otherwise
    * @throws JsonParseException if the incoming stream is malformed JSON.
    * @since 1.4
@@ -116,6 +117,7 @@ public final class JsonStreamParser implements Iterator<JsonElement> {
   /**
    * This optional {@link Iterator} method is not relevant for stream parsing and hence is not
    * implemented.
+   *
    * @since 1.4
    */
   @Override

--- a/gson/src/main/java/com/google/gson/JsonSyntaxException.java
+++ b/gson/src/main/java/com/google/gson/JsonSyntaxException.java
@@ -16,8 +16,7 @@
 package com.google.gson;
 
 /**
- * This exception is raised when Gson attempts to read (or write) a malformed
- * JSON element.
+ * This exception is raised when Gson attempts to read (or write) a malformed JSON element.
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
@@ -35,9 +34,8 @@ public final class JsonSyntaxException extends JsonParseException {
   }
 
   /**
-   * Creates exception with the specified cause. Consider using
-   * {@link #JsonSyntaxException(String, Throwable)} instead if you can
-   * describe what actually happened.
+   * Creates exception with the specified cause. Consider using {@link #JsonSyntaxException(String,
+   * Throwable)} instead if you can describe what actually happened.
    *
    * @param cause root exception that caused this exception to be thrown.
    */

--- a/gson/src/main/java/com/google/gson/LongSerializationPolicy.java
+++ b/gson/src/main/java/com/google/gson/LongSerializationPolicy.java
@@ -20,7 +20,6 @@ package com.google.gson;
  * Defines the expected format for a {@code long} or {@code Long} type when it is serialized.
  *
  * @since 1.3
- *
  * @author Inderjeet Singh
  * @author Joel Leitch
  */
@@ -28,36 +27,36 @@ public enum LongSerializationPolicy {
   /**
    * This is the "default" serialization policy that will output a {@code Long} object as a JSON
    * number. For example, assume an object has a long field named "f" then the serialized output
-   * would be:
-   * {@code {"f":123}}
+   * would be: {@code {"f":123}}
    *
    * <p>A {@code null} value is serialized as {@link JsonNull}.
    */
   DEFAULT() {
-    @Override public JsonElement serialize(Long value) {
+    @Override
+    public JsonElement serialize(Long value) {
       if (value == null) {
         return JsonNull.INSTANCE;
       }
       return new JsonPrimitive(value);
     }
   },
-  
+
   /**
-   * Serializes a long value as a quoted string. For example, assume an object has a long field 
-   * named "f" then the serialized output would be:
-   * {@code {"f":"123"}}
+   * Serializes a long value as a quoted string. For example, assume an object has a long field
+   * named "f" then the serialized output would be: {@code {"f":"123"}}
    *
    * <p>A {@code null} value is serialized as {@link JsonNull}.
    */
   STRING() {
-    @Override public JsonElement serialize(Long value) {
+    @Override
+    public JsonElement serialize(Long value) {
       if (value == null) {
         return JsonNull.INSTANCE;
       }
       return new JsonPrimitive(value.toString());
     }
   };
-  
+
   /**
    * Serialize this {@code value} using this serialization policy.
    *

--- a/gson/src/main/java/com/google/gson/ReflectionAccessFilter.java
+++ b/gson/src/main/java/com/google/gson/ReflectionAccessFilter.java
@@ -20,27 +20,24 @@ import com.google.gson.internal.ReflectionAccessFilterHelper;
 import java.lang.reflect.AccessibleObject;
 
 /**
- * Filter for determining whether reflection based serialization and
- * deserialization is allowed for a class.
+ * Filter for determining whether reflection based serialization and deserialization is allowed for
+ * a class.
  *
- * <p>A filter can be useful in multiple scenarios, for example when
- * upgrading to newer Java versions which use the Java Platform Module
- * System (JPMS). A filter then allows to {@linkplain FilterResult#BLOCK_INACCESSIBLE
- * prevent making inaccessible members accessible}, even if the used
- * Java version might still allow illegal access (but logs a warning),
- * or if {@code java} command line arguments are used to open the inaccessible
- * packages to other parts of the application. This interface defines some
- * convenience filters for this task, such as {@link #BLOCK_INACCESSIBLE_JAVA}.
+ * <p>A filter can be useful in multiple scenarios, for example when upgrading to newer Java
+ * versions which use the Java Platform Module System (JPMS). A filter then allows to {@linkplain
+ * FilterResult#BLOCK_INACCESSIBLE prevent making inaccessible members accessible}, even if the used
+ * Java version might still allow illegal access (but logs a warning), or if {@code java} command
+ * line arguments are used to open the inaccessible packages to other parts of the application. This
+ * interface defines some convenience filters for this task, such as {@link
+ * #BLOCK_INACCESSIBLE_JAVA}.
  *
- * <p>A filter can also be useful to prevent mixing model classes of a
- * project with other non-model classes; the filter could
- * {@linkplain FilterResult#BLOCK_ALL block all reflective access} to
+ * <p>A filter can also be useful to prevent mixing model classes of a project with other non-model
+ * classes; the filter could {@linkplain FilterResult#BLOCK_ALL block all reflective access} to
  * non-model classes.
  *
- * <p>A reflection access filter is similar to an {@link ExclusionStrategy}
- * with the major difference that a filter will cause an exception to be
- * thrown when access is disallowed while an exclusion strategy just skips
- * fields and classes.
+ * <p>A reflection access filter is similar to an {@link ExclusionStrategy} with the major
+ * difference that a filter will cause an exception to be thrown when access is disallowed while an
+ * exclusion strategy just skips fields and classes.
  *
  * @see GsonBuilder#addReflectionAccessFilter(ReflectionAccessFilter)
  * @since 2.9.1
@@ -55,158 +52,157 @@ public interface ReflectionAccessFilter {
     /**
      * Reflection access for the class is allowed.
      *
-     * <p>Note that this does not affect the Java access checks in any way,
-     * it only permits Gson to try using reflection for a class. The Java
-     * runtime might still deny such access.
+     * <p>Note that this does not affect the Java access checks in any way, it only permits Gson to
+     * try using reflection for a class. The Java runtime might still deny such access.
      */
     ALLOW,
     /**
-     * The filter is indecisive whether reflection access should be allowed.
-     * The next registered filter will be consulted to get the result. If
-     * there is no next filter, this result acts like {@link #ALLOW}.
+     * The filter is indecisive whether reflection access should be allowed. The next registered
+     * filter will be consulted to get the result. If there is no next filter, this result acts like
+     * {@link #ALLOW}.
      */
     INDECISIVE,
     /**
-     * Blocks reflection access if a member of the class is not accessible
-     * by default and would have to be made accessible. This is unaffected
-     * by any {@code java} command line arguments being used to make packages
-     * accessible, or by module declaration directives which <i>open</i> the
-     * complete module or certain packages for reflection and will consider
-     * such packages inaccessible.
+     * Blocks reflection access if a member of the class is not accessible by default and would have
+     * to be made accessible. This is unaffected by any {@code java} command line arguments being
+     * used to make packages accessible, or by module declaration directives which <i>open</i> the
+     * complete module or certain packages for reflection and will consider such packages
+     * inaccessible.
      *
-     * <p>Note that this <b>only works for Java 9 and higher</b>, for older
-     * Java versions its functionality will be limited and it might behave like
-     * {@link #ALLOW}. Access checks are only performed as defined by the Java
-     * Language Specification (<a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-6.html#jls-6.6">JLS 11 &sect;6.6</a>),
-     * restrictions imposed by a {@link SecurityManager} are not considered.
+     * <p>Note that this <b>only works for Java 9 and higher</b>, for older Java versions its
+     * functionality will be limited and it might behave like {@link #ALLOW}. Access checks are only
+     * performed as defined by the Java Language Specification (<a
+     * href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-6.html#jls-6.6">JLS 11
+     * &sect;6.6</a>), restrictions imposed by a {@link SecurityManager} are not considered.
      *
-     * <p>This result type is mainly intended to help enforce the access checks of
-     * the Java Platform Module System. It allows detecting illegal access, even if
-     * the used Java version would only log a warning, or is configured to open
-     * packages for reflection using command line arguments.
+     * <p>This result type is mainly intended to help enforce the access checks of the Java Platform
+     * Module System. It allows detecting illegal access, even if the used Java version would only
+     * log a warning, or is configured to open packages for reflection using command line arguments.
      *
      * @see AccessibleObject#canAccess(Object)
      */
     BLOCK_INACCESSIBLE,
     /**
-     * Blocks all reflection access for the class. Other means for serializing
-     * and deserializing the class, such as a {@link TypeAdapter}, have to
-     * be used.
+     * Blocks all reflection access for the class. Other means for serializing and deserializing the
+     * class, such as a {@link TypeAdapter}, have to be used.
      */
     BLOCK_ALL
   }
 
   /**
-   * Blocks all reflection access to members of standard Java classes which are
-   * not accessible by default. However, reflection access is still allowed for
-   * classes for which all fields are accessible and which have an accessible
-   * no-args constructor (or for which an {@link InstanceCreator} has been registered).
+   * Blocks all reflection access to members of standard Java classes which are not accessible by
+   * default. However, reflection access is still allowed for classes for which all fields are
+   * accessible and which have an accessible no-args constructor (or for which an {@link
+   * InstanceCreator} has been registered).
    *
-   * <p>If this filter encounters a class other than a standard Java class it
-   * returns {@link FilterResult#INDECISIVE}.
+   * <p>If this filter encounters a class other than a standard Java class it returns {@link
+   * FilterResult#INDECISIVE}.
    *
-   * <p>This filter is mainly intended to help enforcing the access checks of
-   * Java Platform Module System. It allows detecting illegal access, even if
-   * the used Java version would only log a warning, or is configured to open
-   * packages for reflection. However, this filter <b>only works for Java 9 and
-   * higher</b>, when using an older Java version its functionality will be
-   * limited.
+   * <p>This filter is mainly intended to help enforcing the access checks of Java Platform Module
+   * System. It allows detecting illegal access, even if the used Java version would only log a
+   * warning, or is configured to open packages for reflection. However, this filter <b>only works
+   * for Java 9 and higher</b>, when using an older Java version its functionality will be limited.
    *
-   * <p>Note that this filter might not cover all standard Java classes. Currently
-   * only classes in a {@code java.*} or {@code javax.*} package are considered. The
-   * set of detected classes might be expanded in the future without prior notice.
+   * <p>Note that this filter might not cover all standard Java classes. Currently only classes in a
+   * {@code java.*} or {@code javax.*} package are considered. The set of detected classes might be
+   * expanded in the future without prior notice.
    *
    * @see FilterResult#BLOCK_INACCESSIBLE
    */
-  ReflectionAccessFilter BLOCK_INACCESSIBLE_JAVA = new ReflectionAccessFilter() {
-    @Override public FilterResult check(Class<?> rawClass) {
-      return ReflectionAccessFilterHelper.isJavaType(rawClass)
-        ? FilterResult.BLOCK_INACCESSIBLE
-        : FilterResult.INDECISIVE;
-    }
-  };
+  ReflectionAccessFilter BLOCK_INACCESSIBLE_JAVA =
+      new ReflectionAccessFilter() {
+        @Override
+        public FilterResult check(Class<?> rawClass) {
+          return ReflectionAccessFilterHelper.isJavaType(rawClass)
+              ? FilterResult.BLOCK_INACCESSIBLE
+              : FilterResult.INDECISIVE;
+        }
+      };
 
   /**
    * Blocks all reflection access to members of standard Java classes.
    *
-   * <p>If this filter encounters a class other than a standard Java class it
-   * returns {@link FilterResult#INDECISIVE}.
+   * <p>If this filter encounters a class other than a standard Java class it returns {@link
+   * FilterResult#INDECISIVE}.
    *
-   * <p>This filter is mainly intended to prevent depending on implementation
-   * details of the Java platform and to help applications prepare for upgrading
-   * to the Java Platform Module System.
+   * <p>This filter is mainly intended to prevent depending on implementation details of the Java
+   * platform and to help applications prepare for upgrading to the Java Platform Module System.
    *
-   * <p>Note that this filter might not cover all standard Java classes. Currently
-   * only classes in a {@code java.*} or {@code javax.*} package are considered. The
-   * set of detected classes might be expanded in the future without prior notice.
+   * <p>Note that this filter might not cover all standard Java classes. Currently only classes in a
+   * {@code java.*} or {@code javax.*} package are considered. The set of detected classes might be
+   * expanded in the future without prior notice.
    *
    * @see #BLOCK_INACCESSIBLE_JAVA
    * @see FilterResult#BLOCK_ALL
    */
-  ReflectionAccessFilter BLOCK_ALL_JAVA = new ReflectionAccessFilter() {
-    @Override public FilterResult check(Class<?> rawClass) {
-      return ReflectionAccessFilterHelper.isJavaType(rawClass)
-        ? FilterResult.BLOCK_ALL
-        : FilterResult.INDECISIVE;
-    }
-  };
+  ReflectionAccessFilter BLOCK_ALL_JAVA =
+      new ReflectionAccessFilter() {
+        @Override
+        public FilterResult check(Class<?> rawClass) {
+          return ReflectionAccessFilterHelper.isJavaType(rawClass)
+              ? FilterResult.BLOCK_ALL
+              : FilterResult.INDECISIVE;
+        }
+      };
 
   /**
    * Blocks all reflection access to members of standard Android classes.
    *
-   * <p>If this filter encounters a class other than a standard Android class it
-   * returns {@link FilterResult#INDECISIVE}.
+   * <p>If this filter encounters a class other than a standard Android class it returns {@link
+   * FilterResult#INDECISIVE}.
    *
-   * <p>This filter is mainly intended to prevent depending on implementation
-   * details of the Android platform.
+   * <p>This filter is mainly intended to prevent depending on implementation details of the Android
+   * platform.
    *
-   * <p>Note that this filter might not cover all standard Android classes. Currently
-   * only classes in an {@code android.*} or {@code androidx.*} package, and standard
-   * Java classes in a {@code java.*} or {@code javax.*} package are considered. The
-   * set of detected classes might be expanded in the future without prior notice.
+   * <p>Note that this filter might not cover all standard Android classes. Currently only classes
+   * in an {@code android.*} or {@code androidx.*} package, and standard Java classes in a {@code
+   * java.*} or {@code javax.*} package are considered. The set of detected classes might be
+   * expanded in the future without prior notice.
    *
    * @see FilterResult#BLOCK_ALL
    */
-  ReflectionAccessFilter BLOCK_ALL_ANDROID = new ReflectionAccessFilter() {
-    @Override public FilterResult check(Class<?> rawClass) {
-      return ReflectionAccessFilterHelper.isAndroidType(rawClass)
-        ? FilterResult.BLOCK_ALL
-        : FilterResult.INDECISIVE;
-    }
-  };
+  ReflectionAccessFilter BLOCK_ALL_ANDROID =
+      new ReflectionAccessFilter() {
+        @Override
+        public FilterResult check(Class<?> rawClass) {
+          return ReflectionAccessFilterHelper.isAndroidType(rawClass)
+              ? FilterResult.BLOCK_ALL
+              : FilterResult.INDECISIVE;
+        }
+      };
 
   /**
-   * Blocks all reflection access to members of classes belonging to programming
-   * language platforms, such as Java, Android, Kotlin or Scala.
+   * Blocks all reflection access to members of classes belonging to programming language platforms,
+   * such as Java, Android, Kotlin or Scala.
    *
-   * <p>If this filter encounters a class other than a standard platform class it
-   * returns {@link FilterResult#INDECISIVE}.
+   * <p>If this filter encounters a class other than a standard platform class it returns {@link
+   * FilterResult#INDECISIVE}.
    *
-   * <p>This filter is mainly intended to prevent depending on implementation
-   * details of the platform classes.
+   * <p>This filter is mainly intended to prevent depending on implementation details of the
+   * platform classes.
    *
-   * <p>Note that this filter might not cover all platform classes. Currently it
-   * combines the filters {@link #BLOCK_ALL_JAVA} and {@link #BLOCK_ALL_ANDROID},
-   * and checks for other language-specific platform classes like {@code kotlin.*}.
-   * The set of detected classes might be expanded in the future without prior notice.
+   * <p>Note that this filter might not cover all platform classes. Currently it combines the
+   * filters {@link #BLOCK_ALL_JAVA} and {@link #BLOCK_ALL_ANDROID}, and checks for other
+   * language-specific platform classes like {@code kotlin.*}. The set of detected classes might be
+   * expanded in the future without prior notice.
    *
    * @see FilterResult#BLOCK_ALL
    */
-  ReflectionAccessFilter BLOCK_ALL_PLATFORM = new ReflectionAccessFilter() {
-    @Override public FilterResult check(Class<?> rawClass) {
-      return ReflectionAccessFilterHelper.isAnyPlatformType(rawClass)
-        ? FilterResult.BLOCK_ALL
-        : FilterResult.INDECISIVE;
-    }
-  };
+  ReflectionAccessFilter BLOCK_ALL_PLATFORM =
+      new ReflectionAccessFilter() {
+        @Override
+        public FilterResult check(Class<?> rawClass) {
+          return ReflectionAccessFilterHelper.isAnyPlatformType(rawClass)
+              ? FilterResult.BLOCK_ALL
+              : FilterResult.INDECISIVE;
+        }
+      };
 
   /**
    * Checks if reflection access should be allowed for a class.
    *
-   * @param rawClass
-   *    Class to check
-   * @return
-   *    Result indicating whether reflection access is allowed
+   * @param rawClass Class to check
+   * @return Result indicating whether reflection access is allowed
    */
   FilterResult check(Class<?> rawClass);
 }

--- a/gson/src/main/java/com/google/gson/Strictness.java
+++ b/gson/src/main/java/com/google/gson/Strictness.java
@@ -4,26 +4,25 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
 /**
- * Modes that indicate how strictly a JSON {@linkplain JsonReader reader} or
- * {@linkplain JsonWriter writer} follows the syntax laid out in the
- * <a href="https://www.ietf.org/rfc/rfc8259.txt">RFC 8259 JSON specification</a>.
+ * Modes that indicate how strictly a JSON {@linkplain JsonReader reader} or {@linkplain JsonWriter
+ * writer} follows the syntax laid out in the <a href="https://www.ietf.org/rfc/rfc8259.txt">RFC
+ * 8259 JSON specification</a>.
  *
- * <p>You can look at {@link JsonReader#setStrictness(Strictness)} to see how the strictness
- * affects the {@link JsonReader} and you can look at
- * {@link JsonWriter#setStrictness(Strictness)} to see how the strictness
- * affects the {@link JsonWriter}.</p>
+ * <p>You can look at {@link JsonReader#setStrictness(Strictness)} to see how the strictness affects
+ * the {@link JsonReader} and you can look at {@link JsonWriter#setStrictness(Strictness)} to see
+ * how the strictness affects the {@link JsonWriter}.
  *
  * @see JsonReader#setStrictness(Strictness)
  * @see JsonWriter#setStrictness(Strictness)
  * @since $next-version$
  */
 public enum Strictness {
-    /** Allow large deviations from the JSON specification. */
-    LENIENT,
+  /** Allow large deviations from the JSON specification. */
+  LENIENT,
 
-    /** Allow certain small deviations from the JSON specification for legacy reasons. */
-    LEGACY_STRICT,
+  /** Allow certain small deviations from the JSON specification for legacy reasons. */
+  LEGACY_STRICT,
 
-    /** Strict compliance with the JSON specification. */
-    STRICT
+  /** Strict compliance with the JSON specification. */
+  STRICT
 }

--- a/gson/src/main/java/com/google/gson/ToNumberPolicy.java
+++ b/gson/src/main/java/com/google/gson/ToNumberPolicy.java
@@ -24,9 +24,9 @@ import java.io.IOException;
 import java.math.BigDecimal;
 
 /**
- * An enumeration that defines two standard number reading strategies and a couple of
- * strategies to overcome some historical Gson limitations while deserializing numbers as
- * {@link Object} and {@link Number}.
+ * An enumeration that defines two standard number reading strategies and a couple of strategies to
+ * overcome some historical Gson limitations while deserializing numbers as {@link Object} and
+ * {@link Number}.
  *
  * @see ToNumberStrategy
  * @since 2.8.9
@@ -34,37 +34,39 @@ import java.math.BigDecimal;
 public enum ToNumberPolicy implements ToNumberStrategy {
 
   /**
-   * Using this policy will ensure that numbers will be read as {@link Double} values.
-   * This is the default strategy used during deserialization of numbers as {@link Object}.
+   * Using this policy will ensure that numbers will be read as {@link Double} values. This is the
+   * default strategy used during deserialization of numbers as {@link Object}.
    */
   DOUBLE {
-    @Override public Double readNumber(JsonReader in) throws IOException {
+    @Override
+    public Double readNumber(JsonReader in) throws IOException {
       return in.nextDouble();
     }
   },
 
   /**
-   * Using this policy will ensure that numbers will be read as a lazily parsed number backed
-   * by a string. This is the default strategy used during deserialization of numbers as
-   * {@link Number}.
+   * Using this policy will ensure that numbers will be read as a lazily parsed number backed by a
+   * string. This is the default strategy used during deserialization of numbers as {@link Number}.
    */
   LAZILY_PARSED_NUMBER {
-    @Override public Number readNumber(JsonReader in) throws IOException {
+    @Override
+    public Number readNumber(JsonReader in) throws IOException {
       return new LazilyParsedNumber(in.nextString());
     }
   },
 
   /**
    * Using this policy will ensure that numbers will be read as {@link Long} or {@link Double}
-   * values depending on how JSON numbers are represented: {@code Long} if the JSON number can
-   * be parsed as a {@code Long} value, or otherwise {@code Double} if it can be parsed as a
-   * {@code Double} value. If the parsed double-precision number results in a positive or negative
-   * infinity ({@link Double#isInfinite()}) or a NaN ({@link Double#isNaN()}) value and the
-   * {@code JsonReader} is not {@link JsonReader#isLenient() lenient}, a {@link MalformedJsonException}
-   * is thrown.
+   * values depending on how JSON numbers are represented: {@code Long} if the JSON number can be
+   * parsed as a {@code Long} value, or otherwise {@code Double} if it can be parsed as a {@code
+   * Double} value. If the parsed double-precision number results in a positive or negative infinity
+   * ({@link Double#isInfinite()}) or a NaN ({@link Double#isNaN()}) value and the {@code
+   * JsonReader} is not {@link JsonReader#isLenient() lenient}, a {@link MalformedJsonException} is
+   * thrown.
    */
   LONG_OR_DOUBLE {
-    @Override public Number readNumber(JsonReader in) throws IOException, JsonParseException {
+    @Override
+    public Number readNumber(JsonReader in) throws IOException, JsonParseException {
       String value = in.nextString();
       try {
         return Long.parseLong(value);
@@ -72,29 +74,32 @@ public enum ToNumberPolicy implements ToNumberStrategy {
         try {
           Double d = Double.valueOf(value);
           if ((d.isInfinite() || d.isNaN()) && !in.isLenient()) {
-            throw new MalformedJsonException("JSON forbids NaN and infinities: " + d + "; at path " + in.getPreviousPath());
+            throw new MalformedJsonException(
+                "JSON forbids NaN and infinities: " + d + "; at path " + in.getPreviousPath());
           }
           return d;
         } catch (NumberFormatException doubleE) {
-          throw new JsonParseException("Cannot parse " + value + "; at path " + in.getPreviousPath(), doubleE);
+          throw new JsonParseException(
+              "Cannot parse " + value + "; at path " + in.getPreviousPath(), doubleE);
         }
       }
     }
   },
 
   /**
-   * Using this policy will ensure that numbers will be read as numbers of arbitrary length
-   * using {@link BigDecimal}.
+   * Using this policy will ensure that numbers will be read as numbers of arbitrary length using
+   * {@link BigDecimal}.
    */
   BIG_DECIMAL {
-    @Override public BigDecimal readNumber(JsonReader in) throws IOException {
+    @Override
+    public BigDecimal readNumber(JsonReader in) throws IOException {
       String value = in.nextString();
       try {
         return NumberLimits.parseBigDecimal(value);
       } catch (NumberFormatException e) {
-        throw new JsonParseException("Cannot parse " + value + "; at path " + in.getPreviousPath(), e);
+        throw new JsonParseException(
+            "Cannot parse " + value + "; at path " + in.getPreviousPath(), e);
       }
     }
   }
-
 }

--- a/gson/src/main/java/com/google/gson/ToNumberStrategy.java
+++ b/gson/src/main/java/com/google/gson/ToNumberStrategy.java
@@ -20,20 +20,20 @@ import com.google.gson.stream.JsonReader;
 import java.io.IOException;
 
 /**
- * A strategy that is used to control how numbers should be deserialized for {@link Object} and {@link Number}
- * when a concrete type of the deserialized number is unknown in advance. By default, Gson uses the following
- * deserialization strategies:
+ * A strategy that is used to control how numbers should be deserialized for {@link Object} and
+ * {@link Number} when a concrete type of the deserialized number is unknown in advance. By default,
+ * Gson uses the following deserialization strategies:
  *
  * <ul>
- * <li>{@link Double} values are returned for JSON numbers if the deserialization type is declared as
- * {@code Object}, see {@link ToNumberPolicy#DOUBLE};</li>
- * <li>Lazily parsed number values are returned if the deserialization type is declared as {@code Number},
- * see {@link ToNumberPolicy#LAZILY_PARSED_NUMBER}.</li>
+ *   <li>{@link Double} values are returned for JSON numbers if the deserialization type is declared
+ *       as {@code Object}, see {@link ToNumberPolicy#DOUBLE};
+ *   <li>Lazily parsed number values are returned if the deserialization type is declared as {@code
+ *       Number}, see {@link ToNumberPolicy#LAZILY_PARSED_NUMBER}.
  * </ul>
  *
  * <p>For historical reasons, Gson does not support deserialization of arbitrary-length numbers for
- * {@code Object} and {@code Number} by default, potentially causing precision loss. However,
- * <a href="https://tools.ietf.org/html/rfc8259#section-6">RFC 8259</a> permits this:
+ * {@code Object} and {@code Number} by default, potentially causing precision loss. However, <a
+ * href="https://tools.ietf.org/html/rfc8259#section-6">RFC 8259</a> permits this:
  *
  * <pre>
  *   This specification allows implementations to set limits on the range
@@ -50,7 +50,7 @@ import java.io.IOException;
  * </pre>
  *
  * <p>To overcome the precision loss, use for example {@link ToNumberPolicy#LONG_OR_DOUBLE} or
- * {@link ToNumberPolicy#BIG_DECIMAL}.</p>
+ * {@link ToNumberPolicy#BIG_DECIMAL}.
  *
  * @see ToNumberPolicy
  * @see GsonBuilder#setObjectToNumberStrategy(ToNumberStrategy)
@@ -60,8 +60,8 @@ import java.io.IOException;
 public interface ToNumberStrategy {
 
   /**
-   * Reads a number from the given JSON reader. A strategy is supposed to read a single value from the
-   * reader, and the read value is guaranteed never to be {@code null}.
+   * Reads a number from the given JSON reader. A strategy is supposed to read a single value from
+   * the reader, and the read value is guaranteed never to be {@code null}.
    *
    * @param in JSON reader to read a number from
    * @return number read from the JSON reader.

--- a/gson/src/main/java/com/google/gson/TypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/TypeAdapter.java
@@ -31,66 +31,69 @@ import java.io.Writer;
  * Converts Java objects to and from JSON.
  *
  * <h2>Defining a type's JSON form</h2>
- * By default Gson converts application classes to JSON using its built-in type
- * adapters. If Gson's default JSON conversion isn't appropriate for a type,
- * extend this class to customize the conversion. Here's an example of a type
- * adapter for an (X,Y) coordinate point: <pre>{@code
- *   public class PointAdapter extends TypeAdapter<Point> {
- *     public Point read(JsonReader reader) throws IOException {
- *       if (reader.peek() == JsonToken.NULL) {
- *         reader.nextNull();
- *         return null;
- *       }
- *       String xy = reader.nextString();
- *       String[] parts = xy.split(",");
- *       int x = Integer.parseInt(parts[0]);
- *       int y = Integer.parseInt(parts[1]);
- *       return new Point(x, y);
+ *
+ * By default Gson converts application classes to JSON using its built-in type adapters. If Gson's
+ * default JSON conversion isn't appropriate for a type, extend this class to customize the
+ * conversion. Here's an example of a type adapter for an (X,Y) coordinate point:
+ *
+ * <pre>{@code
+ * public class PointAdapter extends TypeAdapter<Point> {
+ *   public Point read(JsonReader reader) throws IOException {
+ *     if (reader.peek() == JsonToken.NULL) {
+ *       reader.nextNull();
+ *       return null;
  *     }
- *     public void write(JsonWriter writer, Point value) throws IOException {
- *       if (value == null) {
- *         writer.nullValue();
- *         return;
- *       }
- *       String xy = value.getX() + "," + value.getY();
- *       writer.value(xy);
+ *     String xy = reader.nextString();
+ *     String[] parts = xy.split(",");
+ *     int x = Integer.parseInt(parts[0]);
+ *     int y = Integer.parseInt(parts[1]);
+ *     return new Point(x, y);
+ *   }
+ *   public void write(JsonWriter writer, Point value) throws IOException {
+ *     if (value == null) {
+ *       writer.nullValue();
+ *       return;
  *     }
- *   }}</pre>
- * With this type adapter installed, Gson will convert {@code Points} to JSON as
- * strings like {@code "5,8"} rather than objects like {@code {"x":5,"y":8}}. In
- * this case the type adapter binds a rich Java class to a compact JSON value.
+ *     String xy = value.getX() + "," + value.getY();
+ *     writer.value(xy);
+ *   }
+ * }
+ * }</pre>
  *
- * <p>The {@link #read(JsonReader) read()} method must read exactly one value
- * and {@link #write(JsonWriter,Object) write()} must write exactly one value.
- * For primitive types this is means readers should make exactly one call to
- * {@code nextBoolean()}, {@code nextDouble()}, {@code nextInt()}, {@code
- * nextLong()}, {@code nextString()} or {@code nextNull()}. Writers should make
- * exactly one call to one of <code>value()</code> or <code>nullValue()</code>.
- * For arrays, type adapters should start with a call to {@code beginArray()},
- * convert all elements, and finish with a call to {@code endArray()}. For
- * objects, they should start with {@code beginObject()}, convert the object,
- * and finish with {@code endObject()}. Failing to convert a value or converting
- * too many values may cause the application to crash.
+ * With this type adapter installed, Gson will convert {@code Points} to JSON as strings like {@code
+ * "5,8"} rather than objects like {@code {"x":5,"y":8}}. In this case the type adapter binds a rich
+ * Java class to a compact JSON value.
  *
- * <p>Type adapters should be prepared to read null from the stream and write it
- * to the stream. Alternatively, they should use {@link #nullSafe()} method while
- * registering the type adapter with Gson. If your {@code Gson} instance
- * has been configured to {@link GsonBuilder#serializeNulls()}, these nulls will be
- * written to the final document. Otherwise the value (and the corresponding name
- * when writing to a JSON object) will be omitted automatically. In either case
- * your type adapter must handle null.
+ * <p>The {@link #read(JsonReader) read()} method must read exactly one value and {@link
+ * #write(JsonWriter,Object) write()} must write exactly one value. For primitive types this is
+ * means readers should make exactly one call to {@code nextBoolean()}, {@code nextDouble()}, {@code
+ * nextInt()}, {@code nextLong()}, {@code nextString()} or {@code nextNull()}. Writers should make
+ * exactly one call to one of <code>value()</code> or <code>nullValue()</code>. For arrays, type
+ * adapters should start with a call to {@code beginArray()}, convert all elements, and finish with
+ * a call to {@code endArray()}. For objects, they should start with {@code beginObject()}, convert
+ * the object, and finish with {@code endObject()}. Failing to convert a value or converting too
+ * many values may cause the application to crash.
  *
- * <p>Type adapters should be stateless and thread-safe, otherwise the thread-safety
- * guarantees of {@link Gson} might not apply.
+ * <p>Type adapters should be prepared to read null from the stream and write it to the stream.
+ * Alternatively, they should use {@link #nullSafe()} method while registering the type adapter with
+ * Gson. If your {@code Gson} instance has been configured to {@link GsonBuilder#serializeNulls()},
+ * these nulls will be written to the final document. Otherwise the value (and the corresponding
+ * name when writing to a JSON object) will be omitted automatically. In either case your type
+ * adapter must handle null.
  *
- * <p>To use a custom type adapter with Gson, you must <i>register</i> it with a
- * {@link GsonBuilder}: <pre>{@code
- *   GsonBuilder builder = new GsonBuilder();
- *   builder.registerTypeAdapter(Point.class, new PointAdapter());
- *   // if PointAdapter didn't check for nulls in its read/write methods, you should instead use
- *   // builder.registerTypeAdapter(Point.class, new PointAdapter().nullSafe());
- *   ...
- *   Gson gson = builder.create();
+ * <p>Type adapters should be stateless and thread-safe, otherwise the thread-safety guarantees of
+ * {@link Gson} might not apply.
+ *
+ * <p>To use a custom type adapter with Gson, you must <i>register</i> it with a {@link
+ * GsonBuilder}:
+ *
+ * <pre>{@code
+ * GsonBuilder builder = new GsonBuilder();
+ * builder.registerTypeAdapter(Point.class, new PointAdapter());
+ * // if PointAdapter didn't check for nulls in its read/write methods, you should instead use
+ * // builder.registerTypeAdapter(Point.class, new PointAdapter().nullSafe());
+ * ...
+ * Gson gson = builder.create();
  * }</pre>
  *
  * @since 2.1
@@ -117,12 +120,10 @@ import java.io.Writer;
 //
 public abstract class TypeAdapter<T> {
 
-  public TypeAdapter() {
-  }
+  public TypeAdapter() {}
 
   /**
-   * Writes one JSON value (an array, object, string, number, boolean or null)
-   * for {@code value}.
+   * Writes one JSON value (an array, object, string, number, boolean or null) for {@code value}.
    *
    * @param value the Java object to write. May be null.
    */
@@ -131,9 +132,9 @@ public abstract class TypeAdapter<T> {
   /**
    * Converts {@code value} to a JSON document and writes it to {@code out}.
    *
-   * <p>A {@link JsonWriter} with default configuration is used for writing the
-   * JSON data. To customize this behavior, create a {@link JsonWriter}, configure
-   * it and then use {@link #write(JsonWriter, Object)} instead.
+   * <p>A {@link JsonWriter} with default configuration is used for writing the JSON data. To
+   * customize this behavior, create a {@link JsonWriter}, configure it and then use {@link
+   * #write(JsonWriter, Object)} instead.
    *
    * @param value the Java object to convert. May be {@code null}.
    * @since 2.2
@@ -144,9 +145,9 @@ public abstract class TypeAdapter<T> {
   }
 
   /**
-   * This wrapper method is used to make a type adapter null tolerant. In general, a
-   * type adapter is required to handle nulls in write and read methods. Here is how this
-   * is typically done:<br>
+   * This wrapper method is used to make a type adapter null tolerant. In general, a type adapter is
+   * required to handle nulls in write and read methods. Here is how this is typically done:<br>
+   *
    * <pre>{@code
    * Gson gson = new GsonBuilder().registerTypeAdapter(Foo.class,
    *   new TypeAdapter<Foo>() {
@@ -166,8 +167,10 @@ public abstract class TypeAdapter<T> {
    *     }
    *   }).create();
    * }</pre>
-   * You can avoid this boilerplate handling of nulls by wrapping your type adapter with
-   * this method. Here is how we will rewrite the above example:
+   *
+   * You can avoid this boilerplate handling of nulls by wrapping your type adapter with this
+   * method. Here is how we will rewrite the above example:
+   *
    * <pre>{@code
    * Gson gson = new GsonBuilder().registerTypeAdapter(Foo.class,
    *   new TypeAdapter<Foo>() {
@@ -179,18 +182,22 @@ public abstract class TypeAdapter<T> {
    *     }
    *   }.nullSafe()).create();
    * }</pre>
+   *
    * Note that we didn't need to check for nulls in our type adapter after we used nullSafe.
    */
   public final TypeAdapter<T> nullSafe() {
     return new TypeAdapter<T>() {
-      @Override public void write(JsonWriter out, T value) throws IOException {
+      @Override
+      public void write(JsonWriter out, T value) throws IOException {
         if (value == null) {
           out.nullValue();
         } else {
           TypeAdapter.this.write(out, value);
         }
       }
-      @Override public T read(JsonReader reader) throws IOException {
+
+      @Override
+      public T read(JsonReader reader) throws IOException {
         if (reader.peek() == JsonToken.NULL) {
           reader.nextNull();
           return null;
@@ -203,11 +210,12 @@ public abstract class TypeAdapter<T> {
   /**
    * Converts {@code value} to a JSON document.
    *
-   * <p>A {@link JsonWriter} with default configuration is used for writing the
-   * JSON data. To customize this behavior, create a {@link JsonWriter}, configure
-   * it and then use {@link #write(JsonWriter, Object)} instead.
+   * <p>A {@link JsonWriter} with default configuration is used for writing the JSON data. To
+   * customize this behavior, create a {@link JsonWriter}, configure it and then use {@link
+   * #write(JsonWriter, Object)} instead.
    *
-   * @throws JsonIOException wrapping {@code IOException}s thrown by {@link #write(JsonWriter, Object)}
+   * @throws JsonIOException wrapping {@code IOException}s thrown by {@link #write(JsonWriter,
+   *     Object)}
    * @param value the Java object to convert. May be {@code null}.
    * @since 2.2
    */
@@ -226,7 +234,8 @@ public abstract class TypeAdapter<T> {
    *
    * @param value the Java object to convert. May be {@code null}.
    * @return the converted JSON tree. May be {@link JsonNull}.
-   * @throws JsonIOException wrapping {@code IOException}s thrown by {@link #write(JsonWriter, Object)}
+   * @throws JsonIOException wrapping {@code IOException}s thrown by {@link #write(JsonWriter,
+   *     Object)}
    * @since 2.2
    */
   public final JsonElement toJsonTree(T value) {
@@ -240,8 +249,8 @@ public abstract class TypeAdapter<T> {
   }
 
   /**
-   * Reads one JSON value (an array, object, string, number, boolean or null)
-   * and converts it to a Java object. Returns the converted object.
+   * Reads one JSON value (an array, object, string, number, boolean or null) and converts it to a
+   * Java object. Returns the converted object.
    *
    * @return the converted Java object. May be {@code null}.
    */
@@ -250,13 +259,13 @@ public abstract class TypeAdapter<T> {
   /**
    * Converts the JSON document in {@code in} to a Java object.
    *
-   * <p>A {@link JsonReader} with default configuration (that is with
-   * {@link Strictness#LEGACY_STRICT} as strictness) is used for reading the JSON data.
-   * To customize this behavior, create a {@link JsonReader}, configure it and then
-   * use {@link #read(JsonReader)} instead.
+   * <p>A {@link JsonReader} with default configuration (that is with {@link
+   * Strictness#LEGACY_STRICT} as strictness) is used for reading the JSON data. To customize this
+   * behavior, create a {@link JsonReader}, configure it and then use {@link #read(JsonReader)}
+   * instead.
    *
-   * <p>No exception is thrown if the JSON data has multiple top-level JSON elements,
-   * or if there is trailing data.
+   * <p>No exception is thrown if the JSON data has multiple top-level JSON elements, or if there is
+   * trailing data.
    *
    * @return the converted Java object. May be {@code null}.
    * @since 2.2
@@ -269,13 +278,13 @@ public abstract class TypeAdapter<T> {
   /**
    * Converts the JSON document in {@code json} to a Java object.
    *
-   * <p>A {@link JsonReader} with default configuration (that is with
-   * {@link Strictness#LEGACY_STRICT} as strictness) is used for reading the JSON data.
-   * To customize this behavior, create a {@link JsonReader}, configure it and then
-   * use {@link #read(JsonReader)} instead.
+   * <p>A {@link JsonReader} with default configuration (that is with {@link
+   * Strictness#LEGACY_STRICT} as strictness) is used for reading the JSON data. To customize this
+   * behavior, create a {@link JsonReader}, configure it and then use {@link #read(JsonReader)}
+   * instead.
    *
-   * <p>No exception is thrown if the JSON data has multiple top-level JSON elements,
-   * or if there is trailing data.
+   * <p>No exception is thrown if the JSON data has multiple top-level JSON elements, or if there is
+   * trailing data.
    *
    * @return the converted Java object. May be {@code null}.
    * @since 2.2

--- a/gson/src/main/java/com/google/gson/TypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/TypeAdapterFactory.java
@@ -19,153 +19,152 @@ package com.google.gson;
 import com.google.gson.reflect.TypeToken;
 
 /**
- * Creates type adapters for set of related types. Type adapter factories are
- * most useful when several types share similar structure in their JSON form.
+ * Creates type adapters for set of related types. Type adapter factories are most useful when
+ * several types share similar structure in their JSON form.
  *
  * <h2>Examples</h2>
+ *
  * <h3>Example: Converting enums to lowercase</h3>
- * In this example, we implement a factory that creates type adapters for all
- * enums. The type adapters will write enums in lowercase, despite the fact
- * that they're defined in {@code CONSTANT_CASE} in the corresponding Java
- * model: <pre>   {@code
  *
- *   public class LowercaseEnumTypeAdapterFactory implements TypeAdapterFactory {
- *     public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
- *       Class<T> rawType = (Class<T>) type.getRawType();
- *       if (!rawType.isEnum()) {
- *         return null;
- *       }
+ * In this example, we implement a factory that creates type adapters for all enums. The type
+ * adapters will write enums in lowercase, despite the fact that they're defined in {@code
+ * CONSTANT_CASE} in the corresponding Java model:
  *
- *       final Map<String, T> lowercaseToConstant = new HashMap<>();
- *       for (T constant : rawType.getEnumConstants()) {
- *         lowercaseToConstant.put(toLowercase(constant), constant);
- *       }
- *
- *       return new TypeAdapter<T>() {
- *         public void write(JsonWriter out, T value) throws IOException {
- *           if (value == null) {
- *             out.nullValue();
- *           } else {
- *             out.value(toLowercase(value));
- *           }
- *         }
- *
- *         public T read(JsonReader reader) throws IOException {
- *           if (reader.peek() == JsonToken.NULL) {
- *             reader.nextNull();
- *             return null;
- *           } else {
- *             return lowercaseToConstant.get(reader.nextString());
- *           }
- *         }
- *       };
+ * <pre>{@code
+ * public class LowercaseEnumTypeAdapterFactory implements TypeAdapterFactory {
+ *   public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+ *     Class<T> rawType = (Class<T>) type.getRawType();
+ *     if (!rawType.isEnum()) {
+ *       return null;
  *     }
  *
- *     private String toLowercase(Object o) {
- *       return o.toString().toLowerCase(Locale.US);
+ *     final Map<String, T> lowercaseToConstant = new HashMap<>();
+ *     for (T constant : rawType.getEnumConstants()) {
+ *       lowercaseToConstant.put(toLowercase(constant), constant);
  *     }
+ *
+ *     return new TypeAdapter<T>() {
+ *       public void write(JsonWriter out, T value) throws IOException {
+ *         if (value == null) {
+ *           out.nullValue();
+ *         } else {
+ *           out.value(toLowercase(value));
+ *         }
+ *       }
+ *
+ *       public T read(JsonReader reader) throws IOException {
+ *         if (reader.peek() == JsonToken.NULL) {
+ *           reader.nextNull();
+ *           return null;
+ *         } else {
+ *           return lowercaseToConstant.get(reader.nextString());
+ *         }
+ *       }
+ *     };
  *   }
+ *
+ *   private String toLowercase(Object o) {
+ *     return o.toString().toLowerCase(Locale.US);
+ *   }
+ * }
  * }</pre>
  *
- * <p>Type adapter factories select which types they provide type adapters
- * for. If a factory cannot support a given type, it must return null when
- * that type is passed to {@link #create}. Factories should expect {@code
- * create()} to be called on them for many types and should return null for
- * most of those types. In the above example the factory returns null for
- * calls to {@code create()} where {@code type} is not an enum.
+ * <p>Type adapter factories select which types they provide type adapters for. If a factory cannot
+ * support a given type, it must return null when that type is passed to {@link #create}. Factories
+ * should expect {@code create()} to be called on them for many types and should return null for
+ * most of those types. In the above example the factory returns null for calls to {@code create()}
+ * where {@code type} is not an enum.
  *
- * <p>A factory is typically called once per type, but the returned type
- * adapter may be used many times. It is most efficient to do expensive work
- * like reflection in {@code create()} so that the type adapter's {@code
- * read()} and {@code write()} methods can be very fast. In this example the
+ * <p>A factory is typically called once per type, but the returned type adapter may be used many
+ * times. It is most efficient to do expensive work like reflection in {@code create()} so that the
+ * type adapter's {@code read()} and {@code write()} methods can be very fast. In this example the
  * mapping from lowercase name to enum value is computed eagerly.
  *
  * <p>As with type adapters, factories must be <i>registered</i> with a {@link
- * com.google.gson.GsonBuilder} for them to take effect: <pre>   {@code
+ * com.google.gson.GsonBuilder} for them to take effect:
  *
- *  GsonBuilder builder = new GsonBuilder();
- *  builder.registerTypeAdapterFactory(new LowercaseEnumTypeAdapterFactory());
- *  ...
- *  Gson gson = builder.create();
+ * <pre>{@code
+ * GsonBuilder builder = new GsonBuilder();
+ * builder.registerTypeAdapterFactory(new LowercaseEnumTypeAdapterFactory());
+ * ...
+ * Gson gson = builder.create();
  * }</pre>
- * If multiple factories support the same type, the factory registered earlier
- * takes precedence.
+ *
+ * If multiple factories support the same type, the factory registered earlier takes precedence.
  *
  * <h3>Example: Composing other type adapters</h3>
- * In this example we implement a factory for Guava's {@code Multiset}
- * collection type. The factory can be used to create type adapters for
- * multisets of any element type: the type adapter for {@code
- * Multiset<String>} is different from the type adapter for {@code
- * Multiset<URL>}.
  *
- * <p>The type adapter <i>delegates</i> to another type adapter for the
- * multiset elements. It figures out the element type by reflecting on the
- * multiset's type token. A {@code Gson} is passed in to {@code create} for
- * just this purpose: <pre>   {@code
+ * In this example we implement a factory for Guava's {@code Multiset} collection type. The factory
+ * can be used to create type adapters for multisets of any element type: the type adapter for
+ * {@code Multiset<String>} is different from the type adapter for {@code Multiset<URL>}.
  *
- *   public class MultisetTypeAdapterFactory implements TypeAdapterFactory {
- *     public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
- *       Type type = typeToken.getType();
- *       if (typeToken.getRawType() != Multiset.class
- *           || !(type instanceof ParameterizedType)) {
- *         return null;
+ * <p>The type adapter <i>delegates</i> to another type adapter for the multiset elements. It
+ * figures out the element type by reflecting on the multiset's type token. A {@code Gson} is passed
+ * in to {@code create} for just this purpose:
+ *
+ * <pre>{@code
+ * public class MultisetTypeAdapterFactory implements TypeAdapterFactory {
+ *   public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
+ *     Type type = typeToken.getType();
+ *     if (typeToken.getRawType() != Multiset.class
+ *         || !(type instanceof ParameterizedType)) {
+ *       return null;
+ *     }
+ *
+ *     Type elementType = ((ParameterizedType) type).getActualTypeArguments()[0];
+ *     TypeAdapter<?> elementAdapter = gson.getAdapter(TypeToken.get(elementType));
+ *     return (TypeAdapter<T>) newMultisetAdapter(elementAdapter);
+ *   }
+ *
+ *   private <E> TypeAdapter<Multiset<E>> newMultisetAdapter(
+ *       final TypeAdapter<E> elementAdapter) {
+ *     return new TypeAdapter<Multiset<E>>() {
+ *       public void write(JsonWriter out, Multiset<E> value) throws IOException {
+ *         if (value == null) {
+ *           out.nullValue();
+ *           return;
+ *         }
+ *
+ *         out.beginArray();
+ *         for (Multiset.Entry<E> entry : value.entrySet()) {
+ *           out.value(entry.getCount());
+ *           elementAdapter.write(out, entry.getElement());
+ *         }
+ *         out.endArray();
  *       }
  *
- *       Type elementType = ((ParameterizedType) type).getActualTypeArguments()[0];
- *       TypeAdapter<?> elementAdapter = gson.getAdapter(TypeToken.get(elementType));
- *       return (TypeAdapter<T>) newMultisetAdapter(elementAdapter);
- *     }
- *
- *     private <E> TypeAdapter<Multiset<E>> newMultisetAdapter(
- *         final TypeAdapter<E> elementAdapter) {
- *       return new TypeAdapter<Multiset<E>>() {
- *         public void write(JsonWriter out, Multiset<E> value) throws IOException {
- *           if (value == null) {
- *             out.nullValue();
- *             return;
- *           }
- *
- *           out.beginArray();
- *           for (Multiset.Entry<E> entry : value.entrySet()) {
- *             out.value(entry.getCount());
- *             elementAdapter.write(out, entry.getElement());
- *           }
- *           out.endArray();
+ *       public Multiset<E> read(JsonReader in) throws IOException {
+ *         if (in.peek() == JsonToken.NULL) {
+ *           in.nextNull();
+ *           return null;
  *         }
  *
- *         public Multiset<E> read(JsonReader in) throws IOException {
- *           if (in.peek() == JsonToken.NULL) {
- *             in.nextNull();
- *             return null;
- *           }
- *
- *           Multiset<E> result = LinkedHashMultiset.create();
- *           in.beginArray();
- *           while (in.hasNext()) {
- *             int count = in.nextInt();
- *             E element = elementAdapter.read(in);
- *             result.add(element, count);
- *           }
- *           in.endArray();
- *           return result;
+ *         Multiset<E> result = LinkedHashMultiset.create();
+ *         in.beginArray();
+ *         while (in.hasNext()) {
+ *           int count = in.nextInt();
+ *           E element = elementAdapter.read(in);
+ *           result.add(element, count);
  *         }
- *       };
- *     }
+ *         in.endArray();
+ *         return result;
+ *       }
+ *     };
  *   }
+ * }
  * }</pre>
- * Delegating from one type adapter to another is extremely powerful; it's
- * the foundation of how Gson converts Java objects and collections. Whenever
- * possible your factory should retrieve its delegate type adapter in the
- * {@code create()} method; this ensures potentially-expensive type adapter
- * creation happens only once.
+ *
+ * Delegating from one type adapter to another is extremely powerful; it's the foundation of how
+ * Gson converts Java objects and collections. Whenever possible your factory should retrieve its
+ * delegate type adapter in the {@code create()} method; this ensures potentially-expensive type
+ * adapter creation happens only once.
  *
  * @since 2.1
  */
 public interface TypeAdapterFactory {
 
   /**
-   * Returns a type adapter for {@code type}, or null if this factory doesn't
-   * support {@code type}.
+   * Returns a type adapter for {@code type}, or null if this factory doesn't support {@code type}.
    */
   <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type);
 }

--- a/gson/src/main/java/com/google/gson/annotations/Expose.java
+++ b/gson/src/main/java/com/google/gson/annotations/Expose.java
@@ -23,15 +23,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * An annotation that indicates this member should be exposed for JSON
- * serialization or deserialization.
+ * An annotation that indicates this member should be exposed for JSON serialization or
+ * deserialization.
  *
- * <p>This annotation has no effect unless you build {@link com.google.gson.Gson}
- * with a {@link com.google.gson.GsonBuilder} and invoke
- * {@link com.google.gson.GsonBuilder#excludeFieldsWithoutExposeAnnotation()}
- * method.</p>
+ * <p>This annotation has no effect unless you build {@link com.google.gson.Gson} with a {@link
+ * com.google.gson.GsonBuilder} and invoke {@link
+ * com.google.gson.GsonBuilder#excludeFieldsWithoutExposeAnnotation()} method.
  *
  * <p>Here is an example of how this annotation is meant to be used:
+ *
  * <pre>
  * public class User {
  *   &#64;Expose private String firstName;
@@ -40,20 +40,21 @@ import java.lang.annotation.Target;
  *   private String password;
  * }
  * </pre>
- * If you created Gson with {@code new Gson()}, the {@code toJson()} and {@code fromJson()}
- * methods will use the {@code password} field along-with {@code firstName}, {@code lastName},
- * and {@code emailAddress} for serialization and deserialization. However, if you created Gson
- * with {@code Gson gson = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create()}
- * then the {@code toJson()} and {@code fromJson()} methods of Gson will exclude the
- * {@code password} field. This is because the {@code password} field is not marked with the
- * {@code @Expose} annotation. Gson will also exclude {@code lastName} and {@code emailAddress}
- * from serialization since {@code serialize} is set to {@code false}. Similarly, Gson will
- * exclude {@code emailAddress} from deserialization since {@code deserialize} is set to false.
  *
- * <p>Note that another way to achieve the same effect would have been to just mark the
- * {@code password} field as {@code transient}, and Gson would have excluded it even with default
- * settings. The {@code @Expose} annotation is useful in a style of programming where you want to
- * explicitly specify all fields that should get considered for serialization or deserialization.
+ * If you created Gson with {@code new Gson()}, the {@code toJson()} and {@code fromJson()} methods
+ * will use the {@code password} field along-with {@code firstName}, {@code lastName}, and {@code
+ * emailAddress} for serialization and deserialization. However, if you created Gson with {@code
+ * Gson gson = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create()} then the {@code
+ * toJson()} and {@code fromJson()} methods of Gson will exclude the {@code password} field. This is
+ * because the {@code password} field is not marked with the {@code @Expose} annotation. Gson will
+ * also exclude {@code lastName} and {@code emailAddress} from serialization since {@code serialize}
+ * is set to {@code false}. Similarly, Gson will exclude {@code emailAddress} from deserialization
+ * since {@code deserialize} is set to false.
+ *
+ * <p>Note that another way to achieve the same effect would have been to just mark the {@code
+ * password} field as {@code transient}, and Gson would have excluded it even with default settings.
+ * The {@code @Expose} annotation is useful in a style of programming where you want to explicitly
+ * specify all fields that should get considered for serialization or deserialization.
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
@@ -62,19 +63,21 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface Expose {
-  
+
   /**
    * If {@code true}, the field marked with this annotation is written out in the JSON while
    * serializing. If {@code false}, the field marked with this annotation is skipped from the
    * serialized output. Defaults to {@code true}.
+   *
    * @since 1.4
    */
   public boolean serialize() default true;
 
   /**
-   * If {@code true}, the field marked with this annotation is deserialized from the JSON.
-   * If {@code false}, the field marked with this annotation is skipped during deserialization. 
-   * Defaults to {@code true}.
+   * If {@code true}, the field marked with this annotation is deserialized from the JSON. If {@code
+   * false}, the field marked with this annotation is skipped during deserialization. Defaults to
+   * {@code true}.
+   *
    * @since 1.4
    */
   public boolean deserialize() default true;

--- a/gson/src/main/java/com/google/gson/annotations/JsonAdapter.java
+++ b/gson/src/main/java/com/google/gson/annotations/JsonAdapter.java
@@ -29,10 +29,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * An annotation that indicates the Gson {@link TypeAdapter} to use with a class
- * or field.
+ * An annotation that indicates the Gson {@link TypeAdapter} to use with a class or field.
  *
- * <p>Here is an example of how this annotation is used:</p>
+ * <p>Here is an example of how this annotation is used:
+ *
  * <pre>
  * &#64;JsonAdapter(UserJsonAdapter.class)
  * public class User {
@@ -68,6 +68,7 @@ import java.lang.annotation.Target;
  * annotation, it will automatically be invoked to serialize/deserialize {@code User} instances.
  *
  * <p>Here is an example of how to apply this annotation to a field.
+ *
  * <pre>
  * private static final class Gadget {
  *   &#64;JsonAdapter(UserJsonAdapter.class)
@@ -79,39 +80,34 @@ import java.lang.annotation.Target;
  * }
  * </pre>
  *
- * It's possible to specify different type adapters on a field, that
- * field's type, and in the {@link GsonBuilder}. Field annotations
- * take precedence over {@code GsonBuilder}-registered type
+ * It's possible to specify different type adapters on a field, that field's type, and in the {@link
+ * GsonBuilder}. Field annotations take precedence over {@code GsonBuilder}-registered type
  * adapters, which in turn take precedence over annotated types.
  *
- * <p>The class referenced by this annotation must be either a {@link
- * TypeAdapter} or a {@link TypeAdapterFactory}, or must implement one
- * or both of {@link JsonDeserializer} or {@link JsonSerializer}.
- * Using {@link TypeAdapterFactory} makes it possible to delegate
- * to the enclosing {@link Gson} instance. By default the specified
- * adapter will not be called for {@code null} values; set {@link #nullSafe()}
- * to {@code false} to let the adapter handle {@code null} values itself.
+ * <p>The class referenced by this annotation must be either a {@link TypeAdapter} or a {@link
+ * TypeAdapterFactory}, or must implement one or both of {@link JsonDeserializer} or {@link
+ * JsonSerializer}. Using {@link TypeAdapterFactory} makes it possible to delegate to the enclosing
+ * {@link Gson} instance. By default the specified adapter will not be called for {@code null}
+ * values; set {@link #nullSafe()} to {@code false} to let the adapter handle {@code null} values
+ * itself.
  *
- * <p>The type adapter is created in the same way Gson creates instances of
- * custom classes during deserialization, that means:
+ * <p>The type adapter is created in the same way Gson creates instances of custom classes during
+ * deserialization, that means:
+ *
  * <ol>
- *   <li>If a custom {@link InstanceCreator} has been registered for the
- *       adapter class, it will be used to create the instance
- *   <li>Otherwise, if the adapter class has a no-args constructor
- *       (regardless of which visibility), it will be invoked to create
- *       the instance
- *   <li>Otherwise, JDK {@code Unsafe} will be used to create the instance;
- *       see {@link GsonBuilder#disableJdkUnsafe()} for the unexpected
- *       side-effects this might have
+ *   <li>If a custom {@link InstanceCreator} has been registered for the adapter class, it will be
+ *       used to create the instance
+ *   <li>Otherwise, if the adapter class has a no-args constructor (regardless of which visibility),
+ *       it will be invoked to create the instance
+ *   <li>Otherwise, JDK {@code Unsafe} will be used to create the instance; see {@link
+ *       GsonBuilder#disableJdkUnsafe()} for the unexpected side-effects this might have
  * </ol>
  *
- * <p>{@code Gson} instances might cache the adapter they create for
- * a {@code @JsonAdapter} annotation. It is not guaranteed that a new
- * adapter is created every time the annotated class or field is serialized
- * or deserialized.
+ * <p>{@code Gson} instances might cache the adapter they create for a {@code @JsonAdapter}
+ * annotation. It is not guaranteed that a new adapter is created every time the annotated class or
+ * field is serialized or deserialized.
  *
  * @since 2.3
- *
  * @author Inderjeet Singh
  * @author Joel Leitch
  * @author Jesse Wilson
@@ -121,16 +117,19 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE, ElementType.FIELD})
 public @interface JsonAdapter {
 
-  /** Either a {@link TypeAdapter} or {@link TypeAdapterFactory}, or one or both of {@link JsonDeserializer} or {@link JsonSerializer}. */
+  /**
+   * Either a {@link TypeAdapter} or {@link TypeAdapterFactory}, or one or both of {@link
+   * JsonDeserializer} or {@link JsonSerializer}.
+   */
   Class<?> value();
 
   /**
-   * Whether the adapter referenced by {@link #value()} should be made {@linkplain TypeAdapter#nullSafe() null-safe}.
+   * Whether the adapter referenced by {@link #value()} should be made {@linkplain
+   * TypeAdapter#nullSafe() null-safe}.
    *
-   * <p>If {@code true} (the default), it will be made null-safe and Gson will handle {@code null} Java objects
-   * on serialization and JSON {@code null} on deserialization without calling the adapter. If {@code false},
-   * the adapter will have to handle the {@code null} values.
+   * <p>If {@code true} (the default), it will be made null-safe and Gson will handle {@code null}
+   * Java objects on serialization and JSON {@code null} on deserialization without calling the
+   * adapter. If {@code false}, the adapter will have to handle the {@code null} values.
    */
   boolean nullSafe() default true;
-
 }

--- a/gson/src/main/java/com/google/gson/annotations/SerializedName.java
+++ b/gson/src/main/java/com/google/gson/annotations/SerializedName.java
@@ -23,16 +23,17 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * An annotation that indicates this member should be serialized to JSON with
- * the provided name value as its field name.
+ * An annotation that indicates this member should be serialized to JSON with the provided name
+ * value as its field name.
  *
- * <p>This annotation will override any {@link com.google.gson.FieldNamingPolicy}, including
- * the default field naming policy, that may have been set on the {@link com.google.gson.Gson}
- * instance. A different naming policy can set using the {@code GsonBuilder} class. See
- * {@link com.google.gson.GsonBuilder#setFieldNamingPolicy(com.google.gson.FieldNamingPolicy)}
- * for more information.</p>
+ * <p>This annotation will override any {@link com.google.gson.FieldNamingPolicy}, including the
+ * default field naming policy, that may have been set on the {@link com.google.gson.Gson} instance.
+ * A different naming policy can set using the {@code GsonBuilder} class. See {@link
+ * com.google.gson.GsonBuilder#setFieldNamingPolicy(com.google.gson.FieldNamingPolicy)} for more
+ * information.
  *
- * <p>Here is an example of how this annotation is meant to be used:</p>
+ * <p>Here is an example of how this annotation is meant to be used:
+ *
  * <pre>
  * public class MyClass {
  *   &#64;SerializedName("name") String a;
@@ -47,8 +48,9 @@ import java.lang.annotation.Target;
  * }
  * </pre>
  *
- * <p>The following shows the output that is generated when serializing an instance of the
- * above example class:</p>
+ * <p>The following shows the output that is generated when serializing an instance of the above
+ * example class:
+ *
  * <pre>
  * MyClass target = new MyClass("v1", "v2", "v3");
  * Gson gson = new Gson();
@@ -59,9 +61,10 @@ import java.lang.annotation.Target;
  * {"name":"v1","name1":"v2","c":"v3"}
  * </pre>
  *
- * <p>NOTE: The value you specify in this annotation must be a valid JSON field name.</p>
- * While deserializing, all values specified in the annotation will be deserialized into the field.
- * For example:
+ * <p>NOTE: The value you specify in this annotation must be a valid JSON field name. While
+ * deserializing, all values specified in the annotation will be deserialized into the field. For
+ * example:
+ *
  * <pre>
  *   MyClass target = gson.fromJson("{'name1':'v1'}", MyClass.class);
  *   assertEquals("v1", target.b);
@@ -70,10 +73,10 @@ import java.lang.annotation.Target;
  *   target = gson.fromJson("{'name3':'v3'}", MyClass.class);
  *   assertEquals("v3", target.b);
  * </pre>
+ *
  * Note that MyClass.b is now deserialized from either name1, name2 or name3.
  *
  * @see com.google.gson.FieldNamingPolicy
- *
  * @author Inderjeet Singh
  * @author Joel Leitch
  */
@@ -88,6 +91,7 @@ public @interface SerializedName {
    * @return the desired name of the field when it is serialized or deserialized
    */
   String value();
+
   /**
    * The alternative names of the field when it is deserialized
    *

--- a/gson/src/main/java/com/google/gson/annotations/Since.java
+++ b/gson/src/main/java/com/google/gson/annotations/Since.java
@@ -24,14 +24,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * An annotation that indicates the version number since a member or a type has been present.
- * This annotation is useful to manage versioning of your JSON classes for a web-service.
+ * An annotation that indicates the version number since a member or a type has been present. This
+ * annotation is useful to manage versioning of your JSON classes for a web-service.
  *
- * <p>
- * This annotation has no effect unless you build {@link com.google.gson.Gson} with a
- * {@code GsonBuilder} and invoke the {@link GsonBuilder#setVersion(double)} method.
+ * <p>This annotation has no effect unless you build {@link com.google.gson.Gson} with a {@code
+ * GsonBuilder} and invoke the {@link GsonBuilder#setVersion(double)} method.
  *
- * <p>Here is an example of how this annotation is meant to be used:</p>
+ * <p>Here is an example of how this annotation is meant to be used:
+ *
  * <pre>
  * public class User {
  *   private String firstName;
@@ -44,9 +44,9 @@ import java.lang.annotation.Target;
  *
  * <p>If you created Gson with {@code new Gson()}, the {@code toJson()} and {@code fromJson()}
  * methods will use all the fields for serialization and deserialization. However, if you created
- * Gson with {@code Gson gson = new GsonBuilder().setVersion(1.0).create()} then the
- * {@code toJson()} and {@code fromJson()} methods of Gson will exclude the {@code address} field
- * since it's version number is set to {@code 1.1}.</p>
+ * Gson with {@code Gson gson = new GsonBuilder().setVersion(1.0).create()} then the {@code
+ * toJson()} and {@code fromJson()} methods of Gson will exclude the {@code address} field since
+ * it's version number is set to {@code 1.1}.
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
@@ -58,8 +58,8 @@ import java.lang.annotation.Target;
 @Target({ElementType.FIELD, ElementType.TYPE})
 public @interface Since {
   /**
-   * The value indicating a version number since this member or type has been present.
-   * The number is inclusive; annotated elements will be included if {@code gsonVersion >= value}.
+   * The value indicating a version number since this member or type has been present. The number is
+   * inclusive; annotated elements will be included if {@code gsonVersion >= value}.
    */
   double value();
 }

--- a/gson/src/main/java/com/google/gson/annotations/Until.java
+++ b/gson/src/main/java/com/google/gson/annotations/Until.java
@@ -25,15 +25,15 @@ import java.lang.annotation.Target;
 
 /**
  * An annotation that indicates the version number until a member or a type should be present.
- * Basically, if Gson is created with a version number that is equal to or exceeds the value
- * stored in the {@code Until} annotation then the field will be ignored from the JSON output.
- * This annotation is useful to manage versioning of your JSON classes for a web-service.
+ * Basically, if Gson is created with a version number that is equal to or exceeds the value stored
+ * in the {@code Until} annotation then the field will be ignored from the JSON output. This
+ * annotation is useful to manage versioning of your JSON classes for a web-service.
  *
- * <p>
- * This annotation has no effect unless you build {@link com.google.gson.Gson} with a
- * {@code GsonBuilder} and invoke the {@link GsonBuilder#setVersion(double)} method.
+ * <p>This annotation has no effect unless you build {@link com.google.gson.Gson} with a {@code
+ * GsonBuilder} and invoke the {@link GsonBuilder#setVersion(double)} method.
  *
- * <p>Here is an example of how this annotation is meant to be used:</p>
+ * <p>Here is an example of how this annotation is meant to be used:
+ *
  * <pre>
  * public class User {
  *   private String firstName;
@@ -45,11 +45,11 @@ import java.lang.annotation.Target;
  *
  * <p>If you created Gson with {@code new Gson()}, the {@code toJson()} and {@code fromJson()}
  * methods will use all the fields for serialization and deserialization. However, if you created
- * Gson with {@code Gson gson = new GsonBuilder().setVersion(1.2).create()} then the
- * {@code toJson()} and {@code fromJson()} methods of Gson will exclude the {@code emailAddress}
- * and {@code password} fields from the example above, because the version number passed to the
- * GsonBuilder, {@code 1.2}, exceeds the version number set on the {@code Until} annotation,
- * {@code 1.1}, for those fields.
+ * Gson with {@code Gson gson = new GsonBuilder().setVersion(1.2).create()} then the {@code
+ * toJson()} and {@code fromJson()} methods of Gson will exclude the {@code emailAddress} and {@code
+ * password} fields from the example above, because the version number passed to the GsonBuilder,
+ * {@code 1.2}, exceeds the version number set on the {@code Until} annotation, {@code 1.1}, for
+ * those fields.
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
@@ -63,8 +63,8 @@ import java.lang.annotation.Target;
 public @interface Until {
 
   /**
-   * The value indicating a version number until this member or type should be included.
-   * The number is exclusive; annotated elements will be included if {@code gsonVersion < value}.
+   * The value indicating a version number until this member or type should be included. The number
+   * is exclusive; annotated elements will be included if {@code gsonVersion < value}.
    */
   double value();
 }

--- a/gson/src/main/java/com/google/gson/annotations/package-info.java
+++ b/gson/src/main/java/com/google/gson/annotations/package-info.java
@@ -16,7 +16,7 @@
 
 /**
  * This package provides annotations that can be used with {@link com.google.gson.Gson}.
- * 
+ *
  * @author Inderjeet Singh, Joel Leitch
  */
 package com.google.gson.annotations;

--- a/gson/src/main/java/com/google/gson/internal/$Gson$Preconditions.java
+++ b/gson/src/main/java/com/google/gson/internal/$Gson$Preconditions.java
@@ -37,8 +37,8 @@ public final class $Gson$Preconditions {
   }
 
   /**
-   * @deprecated
-   * This is an internal Gson method. Use {@link Objects#requireNonNull(Object)} instead.
+   * @deprecated This is an internal Gson method. Use {@link Objects#requireNonNull(Object)}
+   *     instead.
    */
   // Only deprecated for now because external projects might be using this by accident
   @Deprecated

--- a/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
+++ b/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
@@ -1,19 +1,16 @@
 /**
  * Copyright (C) 2008 Google Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.google.gson.internal;
 
 import static com.google.gson.internal.$Gson$Preconditions.checkArgument;
@@ -50,8 +47,8 @@ public final class $Gson$Types {
   }
 
   /**
-   * Returns a new parameterized type, applying {@code typeArguments} to
-   * {@code rawType} and enclosed by {@code ownerType}.
+   * Returns a new parameterized type, applying {@code typeArguments} to {@code rawType} and
+   * enclosed by {@code ownerType}.
    *
    * @return a {@link java.io.Serializable serializable} parameterized type.
    */
@@ -61,8 +58,7 @@ public final class $Gson$Types {
   }
 
   /**
-   * Returns an array type whose elements are all instances of
-   * {@code componentType}.
+   * Returns an array type whose elements are all instances of {@code componentType}.
    *
    * @return a {@link java.io.Serializable serializable} generic array type.
    */
@@ -71,40 +67,38 @@ public final class $Gson$Types {
   }
 
   /**
-   * Returns a type that represents an unknown type that extends {@code bound}.
-   * For example, if {@code bound} is {@code CharSequence.class}, this returns
-   * {@code ? extends CharSequence}. If {@code bound} is {@code Object.class},
-   * this returns {@code ?}, which is shorthand for {@code ? extends Object}.
+   * Returns a type that represents an unknown type that extends {@code bound}. For example, if
+   * {@code bound} is {@code CharSequence.class}, this returns {@code ? extends CharSequence}. If
+   * {@code bound} is {@code Object.class}, this returns {@code ?}, which is shorthand for {@code ?
+   * extends Object}.
    */
   public static WildcardType subtypeOf(Type bound) {
     Type[] upperBounds;
     if (bound instanceof WildcardType) {
       upperBounds = ((WildcardType) bound).getUpperBounds();
     } else {
-      upperBounds = new Type[] { bound };
+      upperBounds = new Type[] {bound};
     }
     return new WildcardTypeImpl(upperBounds, EMPTY_TYPE_ARRAY);
   }
 
   /**
-   * Returns a type that represents an unknown supertype of {@code bound}. For
-   * example, if {@code bound} is {@code String.class}, this returns {@code ?
-   * super String}.
+   * Returns a type that represents an unknown supertype of {@code bound}. For example, if {@code
+   * bound} is {@code String.class}, this returns {@code ? super String}.
    */
   public static WildcardType supertypeOf(Type bound) {
     Type[] lowerBounds;
     if (bound instanceof WildcardType) {
       lowerBounds = ((WildcardType) bound).getLowerBounds();
     } else {
-      lowerBounds = new Type[] { bound };
+      lowerBounds = new Type[] {bound};
     }
-    return new WildcardTypeImpl(new Type[] { Object.class }, lowerBounds);
+    return new WildcardTypeImpl(new Type[] {Object.class}, lowerBounds);
   }
 
   /**
-   * Returns a type that is functionally equal but not necessarily equal
-   * according to {@link Object#equals(Object) Object.equals()}. The returned
-   * type is {@link java.io.Serializable}.
+   * Returns a type that is functionally equal but not necessarily equal according to {@link
+   * Object#equals(Object) Object.equals()}. The returned type is {@link java.io.Serializable}.
    */
   public static Type canonicalize(Type type) {
     if (type instanceof Class) {
@@ -113,8 +107,8 @@ public final class $Gson$Types {
 
     } else if (type instanceof ParameterizedType) {
       ParameterizedType p = (ParameterizedType) type;
-      return new ParameterizedTypeImpl(p.getOwnerType(),
-          p.getRawType(), p.getActualTypeArguments());
+      return new ParameterizedTypeImpl(
+          p.getOwnerType(), p.getRawType(), p.getActualTypeArguments());
 
     } else if (type instanceof GenericArrayType) {
       GenericArrayType g = (GenericArrayType) type;
@@ -145,7 +139,7 @@ public final class $Gson$Types {
       return (Class<?>) rawType;
 
     } else if (type instanceof GenericArrayType) {
-      Type componentType = ((GenericArrayType)type).getGenericComponentType();
+      Type componentType = ((GenericArrayType) type).getGenericComponentType();
       return Array.newInstance(getRawType(componentType), 0).getClass();
 
     } else if (type instanceof TypeVariable) {
@@ -161,8 +155,12 @@ public final class $Gson$Types {
 
     } else {
       String className = type == null ? "null" : type.getClass().getName();
-      throw new IllegalArgumentException("Expected a Class, ParameterizedType, or "
-          + "GenericArrayType, but <" + type + "> is of type " + className);
+      throw new IllegalArgumentException(
+          "Expected a Class, ParameterizedType, or "
+              + "GenericArrayType, but <"
+              + type
+              + "> is of type "
+              + className);
     }
   }
 
@@ -170,9 +168,7 @@ public final class $Gson$Types {
     return Objects.equals(a, b);
   }
 
-  /**
-   * Returns true if {@code a} and {@code b} are equal.
-   */
+  /** Returns true if {@code a} and {@code b} are equal. */
   public static boolean equals(Type a, Type b) {
     if (a == b) {
       // also handles (a == null && b == null)
@@ -280,19 +276,23 @@ public final class $Gson$Types {
    */
   private static Type getSupertype(Type context, Class<?> contextRawType, Class<?> supertype) {
     if (context instanceof WildcardType) {
-      // wildcards are useless for resolving supertypes. As the upper bound has the same raw type, use it instead
-      Type[] bounds = ((WildcardType)context).getUpperBounds();
+      // Wildcards are useless for resolving supertypes. As the upper bound has the same raw type,
+      // use it instead
+      Type[] bounds = ((WildcardType) context).getUpperBounds();
       // Currently the JLS only permits one bound for wildcards so using first bound is safe
       assert bounds.length == 1;
       context = bounds[0];
     }
     checkArgument(supertype.isAssignableFrom(contextRawType));
-    return resolve(context, contextRawType,
+    return resolve(
+        context,
+        contextRawType,
         $Gson$Types.getGenericSupertype(context, contextRawType, supertype));
   }
 
   /**
    * Returns the component type of this array type.
+   *
    * @throws ClassCastException if this type is not an array.
    */
   public static Type getArrayComponentType(Type array) {
@@ -303,6 +303,7 @@ public final class $Gson$Types {
 
   /**
    * Returns the element type of this collection type.
+   *
    * @throws IllegalArgumentException if this type is not a collection.
    */
   public static Type getCollectionElementType(Type context, Class<?> contextRawType) {
@@ -315,8 +316,8 @@ public final class $Gson$Types {
   }
 
   /**
-   * Returns a two element array containing this map's key and value types in
-   * positions 0 and 1 respectively.
+   * Returns a two element array containing this map's key and value types in positions 0 and 1
+   * respectively.
    */
   public static Type[] getMapKeyAndValueTypes(Type context, Class<?> contextRawType) {
     /*
@@ -325,7 +326,7 @@ public final class $Gson$Types {
      * extend Hashtable<Object, Object>.
      */
     if (context == Properties.class) {
-      return new Type[] { String.class, String.class }; // TODO: test subclasses of Properties!
+      return new Type[] {String.class, String.class}; // TODO: test subclasses of Properties!
     }
 
     Type mapType = getSupertype(context, contextRawType, Map.class);
@@ -334,7 +335,7 @@ public final class $Gson$Types {
       ParameterizedType mapParameterizedType = (ParameterizedType) mapType;
       return mapParameterizedType.getActualTypeArguments();
     }
-    return new Type[] { Object.class, Object.class };
+    return new Type[] {Object.class, Object.class};
   }
 
   public static Type resolve(Type context, Class<?> contextRawType, Type toResolve) {
@@ -342,8 +343,11 @@ public final class $Gson$Types {
     return resolve(context, contextRawType, toResolve, new HashMap<TypeVariable<?>, Type>());
   }
 
-  private static Type resolve(Type context, Class<?> contextRawType, Type toResolve,
-                              Map<TypeVariable<?>, Type> visitedTypeVariables) {
+  private static Type resolve(
+      Type context,
+      Class<?> contextRawType,
+      Type toResolve,
+      Map<TypeVariable<?>, Type> visitedTypeVariables) {
     // this implementation is made a little more complicated in an attempt to avoid object-creation
     TypeVariable<?> resolving = null;
     while (true) {
@@ -369,19 +373,17 @@ public final class $Gson$Types {
       } else if (toResolve instanceof Class && ((Class<?>) toResolve).isArray()) {
         Class<?> original = (Class<?>) toResolve;
         Type componentType = original.getComponentType();
-        Type newComponentType = resolve(context, contextRawType, componentType, visitedTypeVariables);
-        toResolve = equal(componentType, newComponentType)
-            ? original
-            : arrayOf(newComponentType);
+        Type newComponentType =
+            resolve(context, contextRawType, componentType, visitedTypeVariables);
+        toResolve = equal(componentType, newComponentType) ? original : arrayOf(newComponentType);
         break;
 
       } else if (toResolve instanceof GenericArrayType) {
         GenericArrayType original = (GenericArrayType) toResolve;
         Type componentType = original.getGenericComponentType();
-        Type newComponentType = resolve(context, contextRawType, componentType, visitedTypeVariables);
-        toResolve = equal(componentType, newComponentType)
-            ? original
-            : arrayOf(newComponentType);
+        Type newComponentType =
+            resolve(context, contextRawType, componentType, visitedTypeVariables);
+        toResolve = equal(componentType, newComponentType) ? original : arrayOf(newComponentType);
         break;
 
       } else if (toResolve instanceof ParameterizedType) {
@@ -392,7 +394,8 @@ public final class $Gson$Types {
 
         Type[] args = original.getActualTypeArguments();
         for (int t = 0, length = args.length; t < length; t++) {
-          Type resolvedTypeArgument = resolve(context, contextRawType, args[t], visitedTypeVariables);
+          Type resolvedTypeArgument =
+              resolve(context, contextRawType, args[t], visitedTypeVariables);
           if (!equal(resolvedTypeArgument, args[t])) {
             if (!changed) {
               args = args.clone();
@@ -402,9 +405,10 @@ public final class $Gson$Types {
           }
         }
 
-        toResolve = changed
-            ? newParameterizedTypeWithOwner(newOwnerType, original.getRawType(), args)
-            : original;
+        toResolve =
+            changed
+                ? newParameterizedTypeWithOwner(newOwnerType, original.getRawType(), args)
+                : original;
         break;
 
       } else if (toResolve instanceof WildcardType) {
@@ -413,13 +417,15 @@ public final class $Gson$Types {
         Type[] originalUpperBound = original.getUpperBounds();
 
         if (originalLowerBound.length == 1) {
-          Type lowerBound = resolve(context, contextRawType, originalLowerBound[0], visitedTypeVariables);
+          Type lowerBound =
+              resolve(context, contextRawType, originalLowerBound[0], visitedTypeVariables);
           if (lowerBound != originalLowerBound[0]) {
             toResolve = supertypeOf(lowerBound);
             break;
           }
         } else if (originalUpperBound.length == 1) {
-          Type upperBound = resolve(context, contextRawType, originalUpperBound[0], visitedTypeVariables);
+          Type upperBound =
+              resolve(context, contextRawType, originalUpperBound[0], visitedTypeVariables);
           if (upperBound != originalUpperBound[0]) {
             toResolve = subtypeOf(upperBound);
             break;
@@ -439,7 +445,8 @@ public final class $Gson$Types {
     return toResolve;
   }
 
-  private static Type resolveTypeVariable(Type context, Class<?> contextRawType, TypeVariable<?> unknown) {
+  private static Type resolveTypeVariable(
+      Type context, Class<?> contextRawType, TypeVariable<?> unknown) {
     Class<?> declaredByRaw = declaringClassOf(unknown);
 
     // we can't reduce this further
@@ -471,9 +478,7 @@ public final class $Gson$Types {
    */
   private static Class<?> declaringClassOf(TypeVariable<?> typeVariable) {
     GenericDeclaration genericDeclaration = typeVariable.getGenericDeclaration();
-    return genericDeclaration instanceof Class
-        ? (Class<?>) genericDeclaration
-        : null;
+    return genericDeclaration instanceof Class ? (Class<?>) genericDeclaration : null;
   }
 
   static void checkNotPrimitive(Type type) {
@@ -503,8 +508,10 @@ public final class $Gson$Types {
   private static final class ParameterizedTypeImpl implements ParameterizedType, Serializable {
     @SuppressWarnings("serial")
     private final Type ownerType;
+
     @SuppressWarnings("serial")
     private final Type rawType;
+
     @SuppressWarnings("serial")
     private final Type[] typeArguments;
 
@@ -526,19 +533,23 @@ public final class $Gson$Types {
       }
     }
 
-    @Override public Type[] getActualTypeArguments() {
+    @Override
+    public Type[] getActualTypeArguments() {
       return typeArguments.clone();
     }
 
-    @Override public Type getRawType() {
+    @Override
+    public Type getRawType() {
       return rawType;
     }
 
-    @Override public Type getOwnerType() {
+    @Override
+    public Type getOwnerType() {
       return ownerType;
     }
 
-    @Override public boolean equals(Object other) {
+    @Override
+    public boolean equals(Object other) {
       return other instanceof ParameterizedType
           && $Gson$Types.equals(this, (ParameterizedType) other);
     }
@@ -547,20 +558,23 @@ public final class $Gson$Types {
       return o != null ? o.hashCode() : 0;
     }
 
-    @Override public int hashCode() {
-      return Arrays.hashCode(typeArguments)
-          ^ rawType.hashCode()
-          ^ hashCodeOrZero(ownerType);
+    @Override
+    public int hashCode() {
+      return Arrays.hashCode(typeArguments) ^ rawType.hashCode() ^ hashCodeOrZero(ownerType);
     }
 
-    @Override public String toString() {
+    @Override
+    public String toString() {
       int length = typeArguments.length;
       if (length == 0) {
         return typeToString(rawType);
       }
 
       StringBuilder stringBuilder = new StringBuilder(30 * (length + 1));
-      stringBuilder.append(typeToString(rawType)).append("<").append(typeToString(typeArguments[0]));
+      stringBuilder
+          .append(typeToString(rawType))
+          .append("<")
+          .append(typeToString(typeArguments[0]));
       for (int i = 1; i < length; i++) {
         stringBuilder.append(", ").append(typeToString(typeArguments[i]));
       }
@@ -579,20 +593,23 @@ public final class $Gson$Types {
       this.componentType = canonicalize(componentType);
     }
 
-    @Override public Type getGenericComponentType() {
+    @Override
+    public Type getGenericComponentType() {
       return componentType;
     }
 
-    @Override public boolean equals(Object o) {
-      return o instanceof GenericArrayType
-          && $Gson$Types.equals(this, (GenericArrayType) o);
+    @Override
+    public boolean equals(Object o) {
+      return o instanceof GenericArrayType && $Gson$Types.equals(this, (GenericArrayType) o);
     }
 
-    @Override public int hashCode() {
+    @Override
+    public int hashCode() {
       return componentType.hashCode();
     }
 
-    @Override public String toString() {
+    @Override
+    public String toString() {
       return typeToString(componentType) + "[]";
     }
 
@@ -600,14 +617,15 @@ public final class $Gson$Types {
   }
 
   /**
-   * The WildcardType interface supports multiple upper bounds and multiple
-   * lower bounds. We only support what the target Java version supports - at most one
-   * bound, see also https://bugs.openjdk.java.net/browse/JDK-8250660. If a lower bound
-   * is set, the upper bound must be Object.class.
+   * The WildcardType interface supports multiple upper bounds and multiple lower bounds. We only
+   * support what the target Java version supports - at most one bound, see also
+   * https://bugs.openjdk.java.net/browse/JDK-8250660. If a lower bound is set, the upper bound must
+   * be Object.class.
    */
   private static final class WildcardTypeImpl implements WildcardType, Serializable {
     @SuppressWarnings("serial")
     private final Type upperBound;
+
     @SuppressWarnings("serial")
     private final Type lowerBound;
 
@@ -630,26 +648,29 @@ public final class $Gson$Types {
       }
     }
 
-    @Override public Type[] getUpperBounds() {
-      return new Type[] { upperBound };
+    @Override
+    public Type[] getUpperBounds() {
+      return new Type[] {upperBound};
     }
 
-    @Override public Type[] getLowerBounds() {
-      return lowerBound != null ? new Type[] { lowerBound } : EMPTY_TYPE_ARRAY;
+    @Override
+    public Type[] getLowerBounds() {
+      return lowerBound != null ? new Type[] {lowerBound} : EMPTY_TYPE_ARRAY;
     }
 
-    @Override public boolean equals(Object other) {
-      return other instanceof WildcardType
-          && $Gson$Types.equals(this, (WildcardType) other);
+    @Override
+    public boolean equals(Object other) {
+      return other instanceof WildcardType && $Gson$Types.equals(this, (WildcardType) other);
     }
 
-    @Override public int hashCode() {
+    @Override
+    public int hashCode() {
       // this equals Arrays.hashCode(getLowerBounds()) ^ Arrays.hashCode(getUpperBounds());
-      return (lowerBound != null ? 31 + lowerBound.hashCode() : 1)
-          ^ (31 + upperBound.hashCode());
+      return (lowerBound != null ? 31 + lowerBound.hashCode() : 1) ^ (31 + upperBound.hashCode());
     }
 
-    @Override public String toString() {
+    @Override
+    public String toString() {
       if (lowerBound != null) {
         return "? super " + typeToString(lowerBound);
       } else if (upperBound == Object.class) {

--- a/gson/src/main/java/com/google/gson/internal/Excluder.java
+++ b/gson/src/main/java/com/google/gson/internal/Excluder.java
@@ -35,14 +35,12 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * This class selects which fields and types to omit. It is configurable,
- * supporting version attributes {@link Since} and {@link Until}, modifiers,
- * synthetic fields, anonymous and local classes, inner classes, and fields with
- * the {@link Expose} annotation.
+ * This class selects which fields and types to omit. It is configurable, supporting version
+ * attributes {@link Since} and {@link Until}, modifiers, synthetic fields, anonymous and local
+ * classes, inner classes, and fields with the {@link Expose} annotation.
  *
- * <p>This class is a type adapter factory; types that are excluded will be
- * adapted to null. It may delegate to another type adapter if only one
- * direction is excluded.
+ * <p>This class is a type adapter factory; types that are excluded will be adapted to null. It may
+ * delegate to another type adapter if only one direction is excluded.
  *
  * @author Joel Leitch
  * @author Jesse Wilson
@@ -58,7 +56,8 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
   private List<ExclusionStrategy> serializationStrategies = Collections.emptyList();
   private List<ExclusionStrategy> deserializationStrategies = Collections.emptyList();
 
-  @Override protected Excluder clone() {
+  @Override
+  protected Excluder clone() {
     try {
       return (Excluder) super.clone();
     } catch (CloneNotSupportedException e) {
@@ -93,8 +92,8 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
     return result;
   }
 
-  public Excluder withExclusionStrategy(ExclusionStrategy exclusionStrategy,
-      boolean serialization, boolean deserialization) {
+  public Excluder withExclusionStrategy(
+      ExclusionStrategy exclusionStrategy, boolean serialization, boolean deserialization) {
     Excluder result = clone();
     if (serialization) {
       result.serializationStrategies = new ArrayList<>(serializationStrategies);
@@ -107,12 +106,13 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
     return result;
   }
 
-  @Override public <T> TypeAdapter<T> create(final Gson gson, final TypeToken<T> type) {
+  @Override
+  public <T> TypeAdapter<T> create(final Gson gson, final TypeToken<T> type) {
     Class<?> rawType = type.getRawType();
     boolean excludeClass = excludeClassChecks(rawType);
 
     final boolean skipSerialize = excludeClass || excludeClassInStrategy(rawType, true);
-    final boolean skipDeserialize = excludeClass ||  excludeClassInStrategy(rawType, false);
+    final boolean skipDeserialize = excludeClass || excludeClassInStrategy(rawType, false);
 
     if (!skipSerialize && !skipDeserialize) {
       return null;
@@ -122,7 +122,8 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
       /** The delegate is lazily created because it may not be needed, and creating it may fail. */
       private TypeAdapter<T> delegate;
 
-      @Override public T read(JsonReader in) throws IOException {
+      @Override
+      public T read(JsonReader in) throws IOException {
         if (skipDeserialize) {
           in.skipValue();
           return null;
@@ -130,7 +131,8 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
         return delegate().read(in);
       }
 
-      @Override public void write(JsonWriter out, T value) throws IOException {
+      @Override
+      public void write(JsonWriter out, T value) throws IOException {
         if (skipSerialize) {
           out.nullValue();
           return;
@@ -140,9 +142,7 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
 
       private TypeAdapter<T> delegate() {
         TypeAdapter<T> d = delegate;
-        return d != null
-            ? d
-            : (delegate = gson.getDelegateAdapter(Excluder.this, type));
+        return d != null ? d : (delegate = gson.getDelegateAdapter(Excluder.this, type));
       }
     };
   }
@@ -190,34 +190,35 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
   }
 
   private boolean excludeClassChecks(Class<?> clazz) {
-      if (version != Excluder.IGNORE_VERSIONS && !isValidVersion(clazz.getAnnotation(Since.class), clazz.getAnnotation(Until.class))) {
-          return true;
-      }
+    if (version != Excluder.IGNORE_VERSIONS
+        && !isValidVersion(clazz.getAnnotation(Since.class), clazz.getAnnotation(Until.class))) {
+      return true;
+    }
 
-      if (!serializeInnerClasses && isInnerClass(clazz)) {
-          return true;
-      }
+    if (!serializeInnerClasses && isInnerClass(clazz)) {
+      return true;
+    }
 
-      return isAnonymousOrNonStaticLocal(clazz);
+    return isAnonymousOrNonStaticLocal(clazz);
   }
 
   public boolean excludeClass(Class<?> clazz, boolean serialize) {
-      return excludeClassChecks(clazz) ||
-              excludeClassInStrategy(clazz, serialize);
+    return excludeClassChecks(clazz) || excludeClassInStrategy(clazz, serialize);
   }
 
   private boolean excludeClassInStrategy(Class<?> clazz, boolean serialize) {
-      List<ExclusionStrategy> list = serialize ? serializationStrategies : deserializationStrategies;
-      for (ExclusionStrategy exclusionStrategy : list) {
-          if (exclusionStrategy.shouldSkipClass(clazz)) {
-              return true;
-          }
+    List<ExclusionStrategy> list = serialize ? serializationStrategies : deserializationStrategies;
+    for (ExclusionStrategy exclusionStrategy : list) {
+      if (exclusionStrategy.shouldSkipClass(clazz)) {
+        return true;
       }
-      return false;
+    }
+    return false;
   }
 
   private boolean isAnonymousOrNonStaticLocal(Class<?> clazz) {
-    return !Enum.class.isAssignableFrom(clazz) && !isStatic(clazz)
+    return !Enum.class.isAssignableFrom(clazz)
+        && !isStatic(clazz)
         && (clazz.isAnonymousClass() || clazz.isLocalClass());
   }
 

--- a/gson/src/main/java/com/google/gson/internal/JavaVersion.java
+++ b/gson/src/main/java/com/google/gson/internal/JavaVersion.java
@@ -16,12 +16,12 @@
 
 package com.google.gson.internal;
 
-/**
- * Utility to check the major Java version of the current JVM.
- */
+/** Utility to check the major Java version of the current JVM. */
 public final class JavaVersion {
-  // Oracle defines naming conventions at http://www.oracle.com/technetwork/java/javase/versioning-naming-139433.html
-  // However, many alternate implementations differ. For example, Debian used 9-debian as the version string
+  // Oracle defines naming conventions at
+  // http://www.oracle.com/technetwork/java/javase/versioning-naming-139433.html
+  // However, many alternate implementations differ. For example, Debian used 9-debian as the
+  // version string
 
   private static final int majorJavaVersion = determineMajorJavaVersion();
 
@@ -37,12 +37,12 @@ public final class JavaVersion {
       version = extractBeginningInt(javaVersion);
     }
     if (version == -1) {
-      return 6;  // Choose minimum supported JDK version as default
+      return 6; // Choose a minimum supported JDK version as default
     }
     return version;
   }
 
-  // Parses both legacy 1.8 style and newer 9.0.4 style 
+  // Parses both legacy 1.8 style and newer 9.0.4 style
   private static int parseDotted(String javaVersion) {
     try {
       String[] parts = javaVersion.split("[._]", 3);
@@ -86,11 +86,12 @@ public final class JavaVersion {
   /**
    * Gets a boolean value depending if the application is running on Java 9 or later
    *
-   * @return {@code true} if the application is running on Java 9 or later; and {@code false} otherwise.
+   * @return {@code true} if the application is running on Java 9 or later; and {@code false}
+   *     otherwise.
    */
   public static boolean isJava9OrLater() {
     return majorJavaVersion >= 9;
   }
 
-  private JavaVersion() { }
+  private JavaVersion() {}
 }

--- a/gson/src/main/java/com/google/gson/internal/JsonReaderInternalAccess.java
+++ b/gson/src/main/java/com/google/gson/internal/JsonReaderInternalAccess.java
@@ -19,14 +19,10 @@ package com.google.gson.internal;
 import com.google.gson.stream.JsonReader;
 import java.io.IOException;
 
-/**
- * Internal-only APIs of JsonReader available only to other classes in Gson.
- */
+/** Internal-only APIs of JsonReader available only to other classes in Gson. */
 public abstract class JsonReaderInternalAccess {
   public static JsonReaderInternalAccess INSTANCE;
 
-  /**
-   * Changes the type of the current property name token to a string value.
-   */
+  /** Changes the type of the current property name token to a string value. */
   public abstract void promoteNameToValue(JsonReader reader) throws IOException;
 }

--- a/gson/src/main/java/com/google/gson/internal/LazilyParsedNumber.java
+++ b/gson/src/main/java/com/google/gson/internal/LazilyParsedNumber.java
@@ -30,7 +30,9 @@ import java.math.BigDecimal;
 public final class LazilyParsedNumber extends Number {
   private final String value;
 
-  /** @param value must not be null */
+  /**
+   * @param value must not be null
+   */
   public LazilyParsedNumber(String value) {
     this.value = value;
   }
@@ -77,16 +79,16 @@ public final class LazilyParsedNumber extends Number {
   }
 
   /**
-   * If somebody is unlucky enough to have to serialize one of these, serialize
-   * it as a BigDecimal so that they won't need Gson on the other side to
-   * deserialize it.
+   * If somebody is unlucky enough to have to serialize one of these, serialize it as a BigDecimal
+   * so that they won't need Gson on the other side to deserialize it.
    */
   private Object writeReplace() throws ObjectStreamException {
     return asBigDecimal();
   }
 
   private void readObject(ObjectInputStream in) throws IOException {
-    // Don't permit directly deserializing this class; writeReplace() should have written a replacement
+    // Don't permit directly deserializing this class; writeReplace() should have written a
+    // replacement
     throw new InvalidObjectException("Deserialization is unsupported");
   }
 

--- a/gson/src/main/java/com/google/gson/internal/LinkedTreeMap.java
+++ b/gson/src/main/java/com/google/gson/internal/LinkedTreeMap.java
@@ -30,24 +30,26 @@ import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.NoSuchElementException;
-import java.util.Set;
 import java.util.Objects;
+import java.util.Set;
 
 /**
- * A map of comparable keys to values. Unlike {@code TreeMap}, this class uses
- * insertion order for iteration order. Comparison order is only used as an
- * optimization for efficient insertion and removal.
+ * A map of comparable keys to values. Unlike {@code TreeMap}, this class uses insertion order for
+ * iteration order. Comparison order is only used as an optimization for efficient insertion and
+ * removal.
  *
  * <p>This implementation was derived from Android 4.1's TreeMap class.
  */
 @SuppressWarnings("serial") // ignore warning about missing serialVersionUID
 public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Serializable {
-  @SuppressWarnings({ "unchecked", "rawtypes" }) // to avoid Comparable<Comparable<Comparable<...>>>
-  private static final Comparator<Comparable> NATURAL_ORDER = new Comparator<Comparable>() {
-    @Override public int compare(Comparable a, Comparable b) {
-      return a.compareTo(b);
-    }
-  };
+  @SuppressWarnings({"unchecked", "rawtypes"}) // to avoid Comparable<Comparable<Comparable<...>>>
+  private static final Comparator<Comparable> NATURAL_ORDER =
+      new Comparator<Comparable>() {
+        @Override
+        public int compare(Comparable a, Comparable b) {
+          return a.compareTo(b);
+        }
+      };
 
   private final Comparator<? super K> comparator;
   private final boolean allowNullValues;
@@ -59,8 +61,8 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
   final Node<K, V> header;
 
   /**
-   * Create a natural order, empty tree map whose keys must be mutually
-   * comparable and non-null, and whose values can be {@code null}.
+   * Create a natural order, empty tree map whose keys must be mutually comparable and non-null, and
+   * whose values can be {@code null}.
    */
   @SuppressWarnings("unchecked") // unsafe! this assumes K is comparable
   public LinkedTreeMap() {
@@ -68,8 +70,7 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
   }
 
   /**
-   * Create a natural order, empty tree map whose keys must be mutually
-   * comparable and non-null.
+   * Create a natural order, empty tree map whose keys must be mutually comparable and non-null.
    *
    * @param allowNullValues whether {@code null} is allowed as entry value
    */
@@ -79,37 +80,40 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
   }
 
   /**
-   * Create a tree map ordered by {@code comparator}. This map's keys may only
-   * be null if {@code comparator} permits.
+   * Create a tree map ordered by {@code comparator}. This map's keys may only be null if {@code
+   * comparator} permits.
    *
-   * @param comparator the comparator to order elements with, or {@code null} to
-   *     use the natural ordering.
+   * @param comparator the comparator to order elements with, or {@code null} to use the natural
+   *     ordering.
    * @param allowNullValues whether {@code null} is allowed as entry value
    */
-  @SuppressWarnings({ "unchecked", "rawtypes" }) // unsafe! if comparator is null, this assumes K is comparable
+  // unsafe! if comparator is null, this assumes K is comparable
+  @SuppressWarnings({"unchecked", "rawtypes"})
   public LinkedTreeMap(Comparator<? super K> comparator, boolean allowNullValues) {
-    this.comparator = comparator != null
-        ? comparator
-        : (Comparator) NATURAL_ORDER;
+    this.comparator = comparator != null ? comparator : (Comparator) NATURAL_ORDER;
     this.allowNullValues = allowNullValues;
     this.header = new Node<>(allowNullValues);
   }
 
-  @Override public int size() {
+  @Override
+  public int size() {
     return size;
   }
 
-  @Override public V get(Object key) {
+  @Override
+  public V get(Object key) {
     Node<K, V> node = findByObject(key);
     return node != null ? node.value : null;
   }
 
-  @Override public boolean containsKey(Object key) {
+  @Override
+  public boolean containsKey(Object key) {
     return findByObject(key) != null;
   }
 
   @CanIgnoreReturnValue
-  @Override public V put(K key, V value) {
+  @Override
+  public V put(K key, V value) {
     if (key == null) {
       throw new NullPointerException("key == null");
     }
@@ -122,7 +126,8 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
     return result;
   }
 
-  @Override public void clear() {
+  @Override
+  public void clear() {
     root = null;
     size = 0;
     modCount++;
@@ -132,7 +137,8 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
     header.next = header.prev = header;
   }
 
-  @Override public V remove(Object key) {
+  @Override
+  public V remove(Object key) {
     Node<K, V> node = removeInternalByKey(key);
     return node != null ? node.value : null;
   }
@@ -140,8 +146,7 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
   /**
    * Returns the node at or adjacent to the given key, creating it if requested.
    *
-   * @throws ClassCastException if {@code key} and the tree's keys aren't
-   *     mutually comparable.
+   * @throws ClassCastException if {@code key} and the tree's keys aren't mutually comparable.
    */
   Node<K, V> find(K key, boolean create) {
     Comparator<? super K> comparator = this.comparator;
@@ -151,14 +156,14 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
     if (nearest != null) {
       // Micro-optimization: avoid polymorphic calls to Comparator.compare().
       @SuppressWarnings("unchecked") // Throws a ClassCastException below if there's trouble.
-          Comparable<Object> comparableKey = (comparator == NATURAL_ORDER)
-          ? (Comparable<Object>) key
-          : null;
+      Comparable<Object> comparableKey =
+          (comparator == NATURAL_ORDER) ? (Comparable<Object>) key : null;
 
       while (true) {
-        comparison = (comparableKey != null)
-            ? comparableKey.compareTo(nearest.key)
-            : comparator.compare(key, nearest.key);
+        comparison =
+            (comparableKey != null)
+                ? comparableKey.compareTo(nearest.key)
+                : comparator.compare(key, nearest.key);
 
         // We found the requested key.
         if (comparison == 0) {
@@ -215,13 +220,12 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
   }
 
   /**
-   * Returns this map's entry that has the same key and value as {@code
-   * entry}, or null if this map has no such entry.
+   * Returns this map's entry that has the same key and value as {@code entry}, or null if this map
+   * has no such entry.
    *
-   * <p>This method uses the comparator for key equality rather than {@code
-   * equals}. If this map's comparator isn't consistent with equals (such as
-   * {@code String.CASE_INSENSITIVE_ORDER}), then {@code remove()} and {@code
-   * contains()} will violate the collections API.
+   * <p>This method uses the comparator for key equality rather than {@code equals}. If this map's
+   * comparator isn't consistent with equals (such as {@code String.CASE_INSENSITIVE_ORDER}), then
+   * {@code remove()} and {@code contains()} will violate the collections API.
    */
   Node<K, V> findByEntry(Entry<?, ?> entry) {
     Node<K, V> mine = findByObject(entry.getKey());
@@ -234,8 +238,7 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
   }
 
   /**
-   * Removes {@code node} from this tree, rearranging the tree's structure as
-   * necessary.
+   * Removes {@code node} from this tree, rearranging the tree's structure as necessary.
    *
    * @param unlink true to also unlink this node from the iteration linked list.
    */
@@ -327,11 +330,10 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
   }
 
   /**
-   * Rebalances the tree by making any AVL rotations necessary between the
-   * newly-unbalanced node and the tree's root.
+   * Rebalances the tree by making any AVL rotations necessary between the newly-unbalanced node and
+   * the tree's root.
    *
-   * @param insert true if the node was unbalanced by an insert; false if it
-   *     was by a removal.
+   * @param insert true if the node was unbalanced by an insert; false if it was by a removal.
    */
   private void rebalance(Node<K, V> unbalanced, boolean insert) {
     for (Node<K, V> node = unbalanced; node != null; node = node.parent) {
@@ -393,9 +395,7 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
     }
   }
 
-  /**
-   * Rotates the subtree so that its root's right child is the new root.
-   */
+  /** Rotates the subtree so that its root's right child is the new root. */
   private void rotateLeft(Node<K, V> root) {
     Node<K, V> left = root.left;
     Node<K, V> pivot = root.right;
@@ -415,15 +415,12 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
     root.parent = pivot;
 
     // fix heights
-    root.height = Math.max(left != null ? left.height : 0,
-        pivotLeft != null ? pivotLeft.height : 0) + 1;
-    pivot.height = Math.max(root.height,
-        pivotRight != null ? pivotRight.height : 0) + 1;
+    root.height =
+        Math.max(left != null ? left.height : 0, pivotLeft != null ? pivotLeft.height : 0) + 1;
+    pivot.height = Math.max(root.height, pivotRight != null ? pivotRight.height : 0) + 1;
   }
 
-  /**
-   * Rotates the subtree so that its root's left child is the new root.
-   */
+  /** Rotates the subtree so that its root's left child is the new root. */
   private void rotateRight(Node<K, V> root) {
     Node<K, V> pivot = root.left;
     Node<K, V> right = root.right;
@@ -443,21 +440,22 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
     root.parent = pivot;
 
     // fixup heights
-    root.height = Math.max(right != null ? right.height : 0,
-        pivotRight != null ? pivotRight.height : 0) + 1;
-    pivot.height = Math.max(root.height,
-        pivotLeft != null ? pivotLeft.height : 0) + 1;
+    root.height =
+        Math.max(right != null ? right.height : 0, pivotRight != null ? pivotRight.height : 0) + 1;
+    pivot.height = Math.max(root.height, pivotLeft != null ? pivotLeft.height : 0) + 1;
   }
 
   private EntrySet entrySet;
   private KeySet keySet;
 
-  @Override public Set<Entry<K, V>> entrySet() {
+  @Override
+  public Set<Entry<K, V>> entrySet() {
     EntrySet result = entrySet;
     return result != null ? result : (entrySet = new EntrySet());
   }
 
-  @Override public Set<K> keySet() {
+  @Override
+  public Set<K> keySet() {
     KeySet result = keySet;
     return result != null ? result : (keySet = new KeySet());
   }
@@ -492,15 +490,18 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
       next.prev = this;
     }
 
-    @Override public K getKey() {
+    @Override
+    public K getKey() {
       return key;
     }
 
-    @Override public V getValue() {
+    @Override
+    public V getValue() {
       return value;
     }
 
-    @Override public V setValue(V value) {
+    @Override
+    public V setValue(V value) {
       if (value == null && !allowNullValue) {
         throw new NullPointerException("value == null");
       }
@@ -509,7 +510,8 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
       return oldValue;
     }
 
-    @Override public boolean equals(Object o) {
+    @Override
+    public boolean equals(Object o) {
       if (o instanceof Entry) {
         Entry<?, ?> other = (Entry<?, ?>) o;
         return (key == null ? other.getKey() == null : key.equals(other.getKey()))
@@ -518,18 +520,17 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
       return false;
     }
 
-    @Override public int hashCode() {
-      return (key == null ? 0 : key.hashCode())
-          ^ (value == null ? 0 : value.hashCode());
+    @Override
+    public int hashCode() {
+      return (key == null ? 0 : key.hashCode()) ^ (value == null ? 0 : value.hashCode());
     }
 
-    @Override public String toString() {
+    @Override
+    public String toString() {
       return key + "=" + value;
     }
 
-    /**
-     * Returns the first node in this subtree.
-     */
+    /** Returns the first node in this subtree. */
     public Node<K, V> first() {
       Node<K, V> node = this;
       Node<K, V> child = node.left;
@@ -540,9 +541,7 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
       return node;
     }
 
-    /**
-     * Returns the last node in this subtree.
-     */
+    /** Returns the last node in this subtree. */
     public Node<K, V> last() {
       Node<K, V> node = this;
       Node<K, V> child = node.right;
@@ -559,8 +558,7 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
     Node<K, V> lastReturned = null;
     int expectedModCount = modCount;
 
-    LinkedTreeMapIterator() {
-    }
+    LinkedTreeMapIterator() {}
 
     @Override
     @SuppressWarnings("ReferenceEquality")
@@ -581,7 +579,8 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
       return lastReturned = e;
     }
 
-    @Override public final void remove() {
+    @Override
+    public final void remove() {
       if (lastReturned == null) {
         throw new IllegalStateException();
       }
@@ -592,23 +591,28 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
   }
 
   class EntrySet extends AbstractSet<Entry<K, V>> {
-    @Override public int size() {
+    @Override
+    public int size() {
       return size;
     }
 
-    @Override public Iterator<Entry<K, V>> iterator() {
+    @Override
+    public Iterator<Entry<K, V>> iterator() {
       return new LinkedTreeMapIterator<Entry<K, V>>() {
-        @Override public Entry<K, V> next() {
+        @Override
+        public Entry<K, V> next() {
           return nextNode();
         }
       };
     }
 
-    @Override public boolean contains(Object o) {
+    @Override
+    public boolean contains(Object o) {
       return o instanceof Entry && findByEntry((Entry<?, ?>) o) != null;
     }
 
-    @Override public boolean remove(Object o) {
+    @Override
+    public boolean remove(Object o) {
       if (!(o instanceof Entry)) {
         return false;
       }
@@ -621,49 +625,56 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
       return true;
     }
 
-    @Override public void clear() {
+    @Override
+    public void clear() {
       LinkedTreeMap.this.clear();
     }
   }
 
   final class KeySet extends AbstractSet<K> {
-    @Override public int size() {
+    @Override
+    public int size() {
       return size;
     }
 
-    @Override public Iterator<K> iterator() {
+    @Override
+    public Iterator<K> iterator() {
       return new LinkedTreeMapIterator<K>() {
-        @Override public K next() {
+        @Override
+        public K next() {
           return nextNode().key;
         }
       };
     }
 
-    @Override public boolean contains(Object o) {
+    @Override
+    public boolean contains(Object o) {
       return containsKey(o);
     }
 
-    @Override public boolean remove(Object key) {
+    @Override
+    public boolean remove(Object key) {
       return removeInternalByKey(key) != null;
     }
 
-    @Override public void clear() {
+    @Override
+    public void clear() {
       LinkedTreeMap.this.clear();
     }
   }
 
   /**
-   * If somebody is unlucky enough to have to serialize one of these, serialize
-   * it as a LinkedHashMap so that they won't need Gson on the other side to
-   * deserialize it. Using serialization defeats our DoS defence, so most apps
-   * shouldn't use it.
+   * If somebody is unlucky enough to have to serialize one of these, serialize it as a
+   * LinkedHashMap so that they won't need Gson on the other side to deserialize it. Using
+   * serialization defeats our DoS defence, so most apps shouldn't use it.
    */
   private Object writeReplace() throws ObjectStreamException {
     return new LinkedHashMap<>(this);
   }
 
   private void readObject(ObjectInputStream in) throws IOException {
-    // Don't permit directly deserializing this class; writeReplace() should have written a replacement
+    // Don't permit directly deserializing this class; writeReplace() should have written a
+    // replacement
     throw new InvalidObjectException("Deserialization is unsupported");
   }
 }

--- a/gson/src/main/java/com/google/gson/internal/NonNullElementWrapperList.java
+++ b/gson/src/main/java/com/google/gson/internal/NonNullElementWrapperList.java
@@ -24,10 +24,9 @@ import java.util.Objects;
 import java.util.RandomAccess;
 
 /**
- * {@link List} which wraps another {@code List} but prevents insertion of
- * {@code null} elements. Methods which only perform checks with the element
- * argument (e.g. {@link #contains(Object)}) do not throw exceptions for
- * {@code null} arguments.
+ * {@link List} which wraps another {@code List} but prevents insertion of {@code null} elements.
+ * Methods which only perform checks with the element argument (e.g. {@link #contains(Object)}) do
+ * not throw exceptions for {@code null} arguments.
  */
 public class NonNullElementWrapperList<E> extends AbstractList<E> implements RandomAccess {
   // Explicitly specify ArrayList as type to guarantee that delegate implements RandomAccess
@@ -38,11 +37,13 @@ public class NonNullElementWrapperList<E> extends AbstractList<E> implements Ran
     this.delegate = Objects.requireNonNull(delegate);
   }
 
-  @Override public E get(int index) {
+  @Override
+  public E get(int index) {
     return delegate.get(index);
   }
 
-  @Override public int size() {
+  @Override
+  public int size() {
     return delegate.size();
   }
 
@@ -53,61 +54,75 @@ public class NonNullElementWrapperList<E> extends AbstractList<E> implements Ran
     return element;
   }
 
-  @Override public E set(int index, E element) {
+  @Override
+  public E set(int index, E element) {
     return delegate.set(index, nonNull(element));
   }
 
-  @Override public void add(int index, E element) {
+  @Override
+  public void add(int index, E element) {
     delegate.add(index, nonNull(element));
   }
 
-  @Override public E remove(int index) {
+  @Override
+  public E remove(int index) {
     return delegate.remove(index);
   }
 
   /* The following methods are overridden because their default implementation is inefficient */
 
-  @Override public void clear() {
+  @Override
+  public void clear() {
     delegate.clear();
   }
 
-  @Override public boolean remove(Object o) {
+  @Override
+  public boolean remove(Object o) {
     return delegate.remove(o);
   }
 
-  @Override public boolean removeAll(Collection<?> c) {
+  @Override
+  public boolean removeAll(Collection<?> c) {
     return delegate.removeAll(c);
   }
 
-  @Override public boolean retainAll(Collection<?> c) {
+  @Override
+  public boolean retainAll(Collection<?> c) {
     return delegate.retainAll(c);
   }
 
-  @Override public boolean contains(Object o) {
+  @Override
+  public boolean contains(Object o) {
     return delegate.contains(o);
   }
 
-  @Override public int indexOf(Object o) {
+  @Override
+  public int indexOf(Object o) {
     return delegate.indexOf(o);
   }
 
-  @Override public int lastIndexOf(Object o) {
+  @Override
+  public int lastIndexOf(Object o) {
     return delegate.lastIndexOf(o);
   }
 
-  @Override public Object[] toArray() {
+  @Override
+  public Object[] toArray() {
     return delegate.toArray();
   }
 
-  @Override public <T> T[] toArray(T[] a) {
+  @Override
+  public <T> T[] toArray(T[] a) {
     return delegate.toArray(a);
   }
 
-  @Override public boolean equals(Object o) {
+  @Override
+  public boolean equals(Object o) {
     return delegate.equals(o);
   }
 
-  @Override public int hashCode() {
+  @Override
+  public int hashCode() {
     return delegate.hashCode();
   }
 

--- a/gson/src/main/java/com/google/gson/internal/NumberLimits.java
+++ b/gson/src/main/java/com/google/gson/internal/NumberLimits.java
@@ -4,12 +4,11 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 
 /**
- * This class enforces limits on numbers parsed from JSON to avoid potential performance
- * problems when extremely large numbers are used.
+ * This class enforces limits on numbers parsed from JSON to avoid potential performance problems
+ * when extremely large numbers are used.
  */
 public class NumberLimits {
-  private NumberLimits() {
-  }
+  private NumberLimits() {}
 
   private static final int MAX_NUMBER_STRING_LENGTH = 10_000;
 

--- a/gson/src/main/java/com/google/gson/internal/ObjectConstructor.java
+++ b/gson/src/main/java/com/google/gson/internal/ObjectConstructor.java
@@ -17,17 +17,15 @@
 package com.google.gson.internal;
 
 /**
- * Defines a generic object construction factory.  The purpose of this class
- * is to construct a default instance of a class that can be used for object
- * navigation while deserialization from its JSON representation.
+ * Defines a generic object construction factory. The purpose of this class is to construct a
+ * default instance of a class that can be used for object navigation while deserialization from its
+ * JSON representation.
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
  */
 public interface ObjectConstructor<T> {
 
-  /**
-   * Returns a new instance.
-   */
+  /** Returns a new instance. */
   public T construct();
 }

--- a/gson/src/main/java/com/google/gson/internal/PreJava9DateFormatProvider.java
+++ b/gson/src/main/java/com/google/gson/internal/PreJava9DateFormatProvider.java
@@ -19,68 +19,68 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Locale;
 
-/**
- * Provides DateFormats for US locale with patterns which were the default ones before Java 9.
- */
+/** Provides DateFormats for US locale with patterns which were the default ones before Java 9. */
 public class PreJava9DateFormatProvider {
 
   /**
-   * Returns the same DateFormat as {@code DateFormat.getDateInstance(style, Locale.US)} in Java 8 or below.
+   * Returns the same DateFormat as {@code DateFormat.getDateInstance(style, Locale.US)} in Java 8
+   * or below.
    */
   public static DateFormat getUSDateFormat(int style) {
     return new SimpleDateFormat(getDateFormatPattern(style), Locale.US);
   }
 
   /**
-   * Returns the same DateFormat as {@code DateFormat.getDateTimeInstance(dateStyle, timeStyle, Locale.US)}
-   * in Java 8 or below.
+   * Returns the same DateFormat as {@code DateFormat.getDateTimeInstance(dateStyle, timeStyle,
+   * Locale.US)} in Java 8 or below.
    */
   public static DateFormat getUSDateTimeFormat(int dateStyle, int timeStyle) {
-    String pattern = getDatePartOfDateTimePattern(dateStyle) + " " + getTimePartOfDateTimePattern(timeStyle);
+    String pattern =
+        getDatePartOfDateTimePattern(dateStyle) + " " + getTimePartOfDateTimePattern(timeStyle);
     return new SimpleDateFormat(pattern, Locale.US);
   }
 
   private static String getDateFormatPattern(int style) {
     switch (style) {
-    case DateFormat.SHORT:
-      return "M/d/yy";
-    case DateFormat.MEDIUM:
-      return "MMM d, y";
-    case DateFormat.LONG:
-      return "MMMM d, y";
-    case DateFormat.FULL:
-      return "EEEE, MMMM d, y";
-    default:
-      throw new IllegalArgumentException("Unknown DateFormat style: " + style);
+      case DateFormat.SHORT:
+        return "M/d/yy";
+      case DateFormat.MEDIUM:
+        return "MMM d, y";
+      case DateFormat.LONG:
+        return "MMMM d, y";
+      case DateFormat.FULL:
+        return "EEEE, MMMM d, y";
+      default:
+        throw new IllegalArgumentException("Unknown DateFormat style: " + style);
     }
   }
 
   private static String getDatePartOfDateTimePattern(int dateStyle) {
     switch (dateStyle) {
-    case DateFormat.SHORT:
-      return "M/d/yy";
-    case DateFormat.MEDIUM:
-      return "MMM d, yyyy";
-    case DateFormat.LONG:
-      return "MMMM d, yyyy";
-    case DateFormat.FULL:
-      return "EEEE, MMMM d, yyyy";
-    default:
-      throw new IllegalArgumentException("Unknown DateFormat style: " + dateStyle);
+      case DateFormat.SHORT:
+        return "M/d/yy";
+      case DateFormat.MEDIUM:
+        return "MMM d, yyyy";
+      case DateFormat.LONG:
+        return "MMMM d, yyyy";
+      case DateFormat.FULL:
+        return "EEEE, MMMM d, yyyy";
+      default:
+        throw new IllegalArgumentException("Unknown DateFormat style: " + dateStyle);
     }
   }
 
   private static String getTimePartOfDateTimePattern(int timeStyle) {
     switch (timeStyle) {
-    case DateFormat.SHORT:
-      return "h:mm a";
-    case DateFormat.MEDIUM:
-      return "h:mm:ss a";
-    case DateFormat.FULL:
-    case DateFormat.LONG:
-      return "h:mm:ss a z";
-    default:
-      throw new IllegalArgumentException("Unknown DateFormat style: " + timeStyle);
+      case DateFormat.SHORT:
+        return "h:mm a";
+      case DateFormat.MEDIUM:
+        return "h:mm:ss a";
+      case DateFormat.FULL:
+      case DateFormat.LONG:
+        return "h:mm:ss a z";
+      default:
+        throw new IllegalArgumentException("Unknown DateFormat style: " + timeStyle);
     }
   }
 }

--- a/gson/src/main/java/com/google/gson/internal/Primitives.java
+++ b/gson/src/main/java/com/google/gson/internal/Primitives.java
@@ -19,24 +19,22 @@ package com.google.gson.internal;
 import java.lang.reflect.Type;
 
 /**
- * Contains static utility methods pertaining to primitive types and their
- * corresponding wrapper types.
+ * Contains static utility methods pertaining to primitive types and their corresponding wrapper
+ * types.
  *
  * @author Kevin Bourrillion
  */
 public final class Primitives {
   private Primitives() {}
 
-  /**
-   * Returns true if this type is a primitive.
-   */
+  /** Returns true if this type is a primitive. */
   public static boolean isPrimitive(Type type) {
     return type instanceof Class<?> && ((Class<?>) type).isPrimitive();
   }
 
   /**
-   * Returns {@code true} if {@code type} is one of the nine
-   * primitive-wrapper types, such as {@link Integer}.
+   * Returns {@code true} if {@code type} is one of the nine primitive-wrapper types, such as {@link
+   * Integer}.
    *
    * @see Class#isPrimitive
    */
@@ -53,8 +51,9 @@ public final class Primitives {
   }
 
   /**
-   * Returns the corresponding wrapper type of {@code type} if it is a primitive
-   * type; otherwise returns {@code type} itself. Idempotent.
+   * Returns the corresponding wrapper type of {@code type} if it is a primitive type; otherwise
+   * returns {@code type} itself. Idempotent.
+   *
    * <pre>
    *     wrap(int.class) == Integer.class
    *     wrap(Integer.class) == Integer.class
@@ -76,8 +75,9 @@ public final class Primitives {
   }
 
   /**
-   * Returns the corresponding primitive type of {@code type} if it is a
-   * wrapper type; otherwise returns {@code type} itself. Idempotent.
+   * Returns the corresponding primitive type of {@code type} if it is a wrapper type; otherwise
+   * returns {@code type} itself. Idempotent.
+   *
    * <pre>
    *     unwrap(Integer.class) == int.class
    *     unwrap(int.class) == int.class

--- a/gson/src/main/java/com/google/gson/internal/Streams.java
+++ b/gson/src/main/java/com/google/gson/internal/Streams.java
@@ -31,17 +31,13 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.Objects;
 
-/**
- * Reads and writes GSON parse trees over streams.
- */
+/** Reads and writes GSON parse trees over streams. */
 public final class Streams {
   private Streams() {
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * Takes a reader in any state and returns the next value as a JsonElement.
-   */
+  /** Takes a reader in any state and returns the next value as a JsonElement. */
   public static JsonElement parse(JsonReader reader) throws JsonParseException {
     boolean isEmpty = true;
     try {
@@ -67,9 +63,7 @@ public final class Streams {
     }
   }
 
-  /**
-   * Writes the JSON element to the writer, recursively.
-   */
+  /** Writes the JSON element to the writer, recursively. */
   public static void write(JsonElement element, JsonWriter writer) throws IOException {
     TypeAdapters.JSON_ELEMENT.write(writer, element);
   }
@@ -78,10 +72,7 @@ public final class Streams {
     return appendable instanceof Writer ? (Writer) appendable : new AppendableWriter(appendable);
   }
 
-  /**
-   * Adapts an {@link Appendable} so it can be passed anywhere a {@link Writer}
-   * is used.
-   */
+  /** Adapts an {@link Appendable} so it can be passed anywhere a {@link Writer} is used. */
   private static final class AppendableWriter extends Writer {
     private final Appendable appendable;
     private final CurrentWrite currentWrite = new CurrentWrite();
@@ -90,40 +81,46 @@ public final class Streams {
       this.appendable = appendable;
     }
 
-    @Override public void write(char[] chars, int offset, int length) throws IOException {
+    @Override
+    public void write(char[] chars, int offset, int length) throws IOException {
       currentWrite.setChars(chars);
       appendable.append(currentWrite, offset, offset + length);
     }
 
-    @Override public void flush() {}
-    @Override public void close() {}
+    @Override
+    public void flush() {}
+
+    @Override
+    public void close() {}
 
     // Override these methods for better performance
     // They would otherwise unnecessarily create Strings or char arrays
 
-    @Override public void write(int i) throws IOException {
+    @Override
+    public void write(int i) throws IOException {
       appendable.append((char) i);
     }
 
-    @Override public void write(String str, int off, int len) throws IOException {
+    @Override
+    public void write(String str, int off, int len) throws IOException {
       // Appendable.append turns null -> "null", which is not desired here
       Objects.requireNonNull(str);
       appendable.append(str, off, off + len);
     }
 
-    @Override public Writer append(CharSequence csq) throws IOException {
+    @Override
+    public Writer append(CharSequence csq) throws IOException {
       appendable.append(csq);
       return this;
     }
 
-    @Override public Writer append(CharSequence csq, int start, int end) throws IOException {
+    @Override
+    public Writer append(CharSequence csq, int start, int end) throws IOException {
       appendable.append(csq, start, end);
       return this;
     }
 
-    /**
-     * A mutable char sequence pointing at a single char[].
-     */
+    /** A mutable char sequence pointing at a single char[]. */
     private static class CurrentWrite implements CharSequence {
       private char[] chars;
       private String cachedString;
@@ -133,18 +130,24 @@ public final class Streams {
         this.cachedString = null;
       }
 
-      @Override public int length() {
+      @Override
+      public int length() {
         return chars.length;
       }
-      @Override public char charAt(int i) {
+
+      @Override
+      public char charAt(int i) {
         return chars[i];
       }
-      @Override public CharSequence subSequence(int start, int end) {
+
+      @Override
+      public CharSequence subSequence(int start, int end) {
         return new String(chars, start, end - start);
       }
 
       // Must return string representation to satisfy toString() contract
-      @Override public String toString() {
+      @Override
+      public String toString() {
         if (cachedString == null) {
           cachedString = new String(chars);
         }

--- a/gson/src/main/java/com/google/gson/internal/TroubleshootingGuide.java
+++ b/gson/src/main/java/com/google/gson/internal/TroubleshootingGuide.java
@@ -3,9 +3,7 @@ package com.google.gson.internal;
 public class TroubleshootingGuide {
   private TroubleshootingGuide() {}
 
-  /**
-   * Creates a URL referring to the specified troubleshooting section.
-   */
+  /** Creates a URL referring to the specified troubleshooting section. */
   public static String createUrl(String id) {
     return "https://github.com/google/gson/blob/main/Troubleshooting.md#" + id;
   }

--- a/gson/src/main/java/com/google/gson/internal/UnsafeAllocator.java
+++ b/gson/src/main/java/com/google/gson/internal/UnsafeAllocator.java
@@ -31,14 +31,15 @@ public abstract class UnsafeAllocator {
   public abstract <T> T newInstance(Class<T> c) throws Exception;
 
   /**
-   * Asserts that the class is instantiable. This check should have already occurred
-   * in {@link ConstructorConstructor}; this check here acts as safeguard since trying
-   * to use Unsafe for non-instantiable classes might crash the JVM on some devices.
+   * Asserts that the class is instantiable. This check should have already occurred in {@link
+   * ConstructorConstructor}; this check here acts as safeguard since trying to use Unsafe for
+   * non-instantiable classes might crash the JVM on some devices.
    */
   private static void assertInstantiable(Class<?> c) {
     String exceptionMessage = ConstructorConstructor.checkInstantiable(c);
     if (exceptionMessage != null) {
-      throw new AssertionError("UnsafeAllocator is used for non-instantiable type: " + exceptionMessage);
+      throw new AssertionError(
+          "UnsafeAllocator is used for non-instantiable type: " + exceptionMessage);
     }
   }
 
@@ -73,12 +74,12 @@ public abstract class UnsafeAllocator {
     //   private static native Object newInstance(Class<?> instantiationClass, int methodId);
     // }
     try {
-      Method getConstructorId = ObjectStreamClass.class
-          .getDeclaredMethod("getConstructorId", Class.class);
+      Method getConstructorId =
+          ObjectStreamClass.class.getDeclaredMethod("getConstructorId", Class.class);
       getConstructorId.setAccessible(true);
       final int constructorId = (Integer) getConstructorId.invoke(null, Object.class);
-      final Method newInstance = ObjectStreamClass.class
-          .getDeclaredMethod("newInstance", Class.class, int.class);
+      final Method newInstance =
+          ObjectStreamClass.class.getDeclaredMethod("newInstance", Class.class, int.class);
       newInstance.setAccessible(true);
       return new UnsafeAllocator() {
         @Override
@@ -98,8 +99,8 @@ public abstract class UnsafeAllocator {
     //     Class<?> instantiationClass, Class<?> constructorClass);
     // }
     try {
-      final Method newInstance = ObjectInputStream.class
-          .getDeclaredMethod("newInstance", Class.class, Class.class);
+      final Method newInstance =
+          ObjectInputStream.class.getDeclaredMethod("newInstance", Class.class, Class.class);
       newInstance.setAccessible(true);
       return new UnsafeAllocator() {
         @Override
@@ -117,8 +118,11 @@ public abstract class UnsafeAllocator {
     return new UnsafeAllocator() {
       @Override
       public <T> T newInstance(Class<T> c) {
-        throw new UnsupportedOperationException("Cannot allocate " + c + ". Usage of JDK sun.misc.Unsafe is enabled, "
-            + "but it could not be used. Make sure your runtime is configured correctly.");
+        throw new UnsupportedOperationException(
+            "Cannot allocate "
+                + c
+                + ". Usage of JDK sun.misc.Unsafe is enabled, "
+                + "but it could not be used. Make sure your runtime is configured correctly.");
       }
     };
   }

--- a/gson/src/main/java/com/google/gson/internal/bind/ArrayTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ArrayTypeAdapter.java
@@ -30,37 +30,41 @@ import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 
-/**
- * Adapt an array of objects.
- */
+/** Adapt an array of objects. */
 public final class ArrayTypeAdapter<E> extends TypeAdapter<Object> {
-  public static final TypeAdapterFactory FACTORY = new TypeAdapterFactory() {
-    @Override public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
-      Type type = typeToken.getType();
-      if (!(type instanceof GenericArrayType || (type instanceof Class && ((Class<?>) type).isArray()))) {
-        return null;
-      }
+  public static final TypeAdapterFactory FACTORY =
+      new TypeAdapterFactory() {
+        @Override
+        public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
+          Type type = typeToken.getType();
+          if (!(type instanceof GenericArrayType
+              || (type instanceof Class && ((Class<?>) type).isArray()))) {
+            return null;
+          }
 
-      Type componentType = $Gson$Types.getArrayComponentType(type);
-      TypeAdapter<?> componentTypeAdapter = gson.getAdapter(TypeToken.get(componentType));
+          Type componentType = $Gson$Types.getArrayComponentType(type);
+          TypeAdapter<?> componentTypeAdapter = gson.getAdapter(TypeToken.get(componentType));
 
-      @SuppressWarnings({"unchecked", "rawtypes"})
-      TypeAdapter<T> arrayAdapter = new ArrayTypeAdapter(
-              gson, componentTypeAdapter, $Gson$Types.getRawType(componentType));
-      return arrayAdapter;
-    }
-  };
+          @SuppressWarnings({"unchecked", "rawtypes"})
+          TypeAdapter<T> arrayAdapter =
+              new ArrayTypeAdapter(
+                  gson, componentTypeAdapter, $Gson$Types.getRawType(componentType));
+          return arrayAdapter;
+        }
+      };
 
   private final Class<E> componentType;
   private final TypeAdapter<E> componentTypeAdapter;
 
-  public ArrayTypeAdapter(Gson context, TypeAdapter<E> componentTypeAdapter, Class<E> componentType) {
+  public ArrayTypeAdapter(
+      Gson context, TypeAdapter<E> componentTypeAdapter, Class<E> componentType) {
     this.componentTypeAdapter =
-      new TypeAdapterRuntimeTypeWrapper<>(context, componentTypeAdapter, componentType);
+        new TypeAdapterRuntimeTypeWrapper<>(context, componentTypeAdapter, componentType);
     this.componentType = componentType;
   }
 
-  @Override public Object read(JsonReader in) throws IOException {
+  @Override
+  public Object read(JsonReader in) throws IOException {
     if (in.peek() == JsonToken.NULL) {
       in.nextNull();
       return null;
@@ -91,7 +95,8 @@ public final class ArrayTypeAdapter<E> extends TypeAdapter<Object> {
     }
   }
 
-  @Override public void write(JsonWriter out, Object array) throws IOException {
+  @Override
+  public void write(JsonWriter out, Object array) throws IOException {
     if (array == null) {
       out.nullValue();
       return;

--- a/gson/src/main/java/com/google/gson/internal/bind/CollectionTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/CollectionTypeAdapterFactory.java
@@ -30,9 +30,7 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.Collection;
 
-/**
- * Adapt a homogeneous collection of objects.
- */
+/** Adapt a homogeneous collection of objects. */
 public final class CollectionTypeAdapterFactory implements TypeAdapterFactory {
   private final ConstructorConstructor constructorConstructor;
 
@@ -62,7 +60,9 @@ public final class CollectionTypeAdapterFactory implements TypeAdapterFactory {
     private final TypeAdapter<E> elementTypeAdapter;
     private final ObjectConstructor<? extends Collection<E>> constructor;
 
-    public Adapter(Gson context, Type elementType,
+    public Adapter(
+        Gson context,
+        Type elementType,
         TypeAdapter<E> elementTypeAdapter,
         ObjectConstructor<? extends Collection<E>> constructor) {
       this.elementTypeAdapter =
@@ -70,7 +70,8 @@ public final class CollectionTypeAdapterFactory implements TypeAdapterFactory {
       this.constructor = constructor;
     }
 
-    @Override public Collection<E> read(JsonReader in) throws IOException {
+    @Override
+    public Collection<E> read(JsonReader in) throws IOException {
       if (in.peek() == JsonToken.NULL) {
         in.nextNull();
         return null;
@@ -86,7 +87,8 @@ public final class CollectionTypeAdapterFactory implements TypeAdapterFactory {
       return collection;
     }
 
-    @Override public void write(JsonWriter out, Collection<E> collection) throws IOException {
+    @Override
+    public void write(JsonWriter out, Collection<E> collection) throws IOException {
       if (collection == null) {
         out.nullValue();
         return;

--- a/gson/src/main/java/com/google/gson/internal/bind/DateTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/DateTypeAdapter.java
@@ -27,7 +27,6 @@ import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
-
 import java.io.IOException;
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -38,36 +37,42 @@ import java.util.List;
 import java.util.Locale;
 
 /**
- * Adapter for Date. Although this class appears stateless, it is not.
- * DateFormat captures its time zone and locale when it is created, which gives
- * this class state. DateFormat isn't thread safe either, so this class has
- * to synchronize its read and write methods.
+ * Adapter for Date. Although this class appears stateless, it is not. DateFormat captures its time
+ * zone and locale when it is created, which gives this class state. DateFormat isn't thread safe
+ * either, so this class has to synchronize its read and write methods.
  */
 public final class DateTypeAdapter extends TypeAdapter<Date> {
-  public static final TypeAdapterFactory FACTORY = new TypeAdapterFactory() {
-    @SuppressWarnings("unchecked") // we use a runtime check to make sure the 'T's equal
-    @Override public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
-      return typeToken.getRawType() == Date.class ? (TypeAdapter<T>) new DateTypeAdapter() : null;
-    }
-  };
+  public static final TypeAdapterFactory FACTORY =
+      new TypeAdapterFactory() {
+        @SuppressWarnings("unchecked") // we use a runtime check to make sure the 'T's equal
+        @Override
+        public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
+          return typeToken.getRawType() == Date.class
+              ? (TypeAdapter<T>) new DateTypeAdapter()
+              : null;
+        }
+      };
 
   /**
-   * List of 1 or more different date formats used for de-serialization attempts.
-   * The first of them (default US format) is used for serialization as well.
+   * List of 1 or more different date formats used for de-serialization attempts. The first of them
+   * (default US format) is used for serialization as well.
    */
   private final List<DateFormat> dateFormats = new ArrayList<>();
 
   public DateTypeAdapter() {
-    dateFormats.add(DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.DEFAULT, Locale.US));
+    dateFormats.add(
+        DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.DEFAULT, Locale.US));
     if (!Locale.getDefault().equals(Locale.US)) {
       dateFormats.add(DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.DEFAULT));
     }
     if (JavaVersion.isJava9OrLater()) {
-      dateFormats.add(PreJava9DateFormatProvider.getUSDateTimeFormat(DateFormat.DEFAULT, DateFormat.DEFAULT));
+      dateFormats.add(
+          PreJava9DateFormatProvider.getUSDateTimeFormat(DateFormat.DEFAULT, DateFormat.DEFAULT));
     }
   }
 
-  @Override public Date read(JsonReader in) throws IOException {
+  @Override
+  public Date read(JsonReader in) throws IOException {
     if (in.peek() == JsonToken.NULL) {
       in.nextNull();
       return null;
@@ -89,11 +94,13 @@ public final class DateTypeAdapter extends TypeAdapter<Date> {
     try {
       return ISO8601Utils.parse(s, new ParsePosition(0));
     } catch (ParseException e) {
-      throw new JsonSyntaxException("Failed parsing '" + s + "' as Date; at path " + in.getPreviousPath(), e);
+      throw new JsonSyntaxException(
+          "Failed parsing '" + s + "' as Date; at path " + in.getPreviousPath(), e);
     }
   }
 
-  @Override public void write(JsonWriter out, Date value) throws IOException {
+  @Override
+  public void write(JsonWriter out, Date value) throws IOException {
     if (value == null) {
       out.nullValue();
       return;

--- a/gson/src/main/java/com/google/gson/internal/bind/DefaultDateTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/DefaultDateTypeAdapter.java
@@ -37,9 +37,8 @@ import java.util.Locale;
 import java.util.Objects;
 
 /**
- * This type adapter supports subclasses of date by defining a
- * {@link DefaultDateTypeAdapter.DateType} and then using its {@code createAdapterFactory}
- * methods.
+ * This type adapter supports subclasses of date by defining a {@link
+ * DefaultDateTypeAdapter.DateType} and then using its {@code createAdapterFactory} methods.
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
@@ -47,12 +46,14 @@ import java.util.Objects;
 public final class DefaultDateTypeAdapter<T extends Date> extends TypeAdapter<T> {
   private static final String SIMPLE_NAME = "DefaultDateTypeAdapter";
 
-  public static abstract class DateType<T extends Date> {
-    public static final DateType<Date> DATE = new DateType<Date>(Date.class) {
-      @Override protected Date deserialize(Date date) {
-        return date;
-      }
-    };
+  public abstract static class DateType<T extends Date> {
+    public static final DateType<Date> DATE =
+        new DateType<Date>(Date.class) {
+          @Override
+          protected Date deserialize(Date date) {
+            return date;
+          }
+        };
 
     private final Class<T> dateClass;
 
@@ -79,15 +80,16 @@ public final class DefaultDateTypeAdapter<T extends Date> extends TypeAdapter<T>
     }
 
     public final TypeAdapterFactory createDefaultsAdapterFactory() {
-      return createFactory(new DefaultDateTypeAdapter<>(this, DateFormat.DEFAULT, DateFormat.DEFAULT));
+      return createFactory(
+          new DefaultDateTypeAdapter<>(this, DateFormat.DEFAULT, DateFormat.DEFAULT));
     }
   }
 
   private final DateType<T> dateType;
 
   /**
-   * List of 1 or more different date formats used for de-serialization attempts.
-   * The first of them is used for serialization as well.
+   * List of 1 or more different date formats used for de-serialization attempts. The first of them
+   * is used for serialization as well.
    */
   private final List<DateFormat> dateFormats = new ArrayList<>();
 
@@ -163,7 +165,8 @@ public final class DefaultDateTypeAdapter<T extends Date> extends TypeAdapter<T>
     try {
       return ISO8601Utils.parse(s, new ParsePosition(0));
     } catch (ParseException e) {
-      throw new JsonSyntaxException("Failed parsing '" + s + "' as Date; at path " + in.getPreviousPath(), e);
+      throw new JsonSyntaxException(
+          "Failed parsing '" + s + "' as Date; at path " + in.getPreviousPath(), e);
     }
   }
 

--- a/gson/src/main/java/com/google/gson/internal/bind/JsonAdapterAnnotationTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonAdapterAnnotationTypeAdapterFactory.java
@@ -36,29 +36,26 @@ import java.util.concurrent.ConcurrentMap;
  */
 public final class JsonAdapterAnnotationTypeAdapterFactory implements TypeAdapterFactory {
   private static class DummyTypeAdapterFactory implements TypeAdapterFactory {
-    @Override public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
       throw new AssertionError("Factory should not be used");
     }
   }
 
-  /**
-   * Factory used for {@link TreeTypeAdapter}s created for {@code @JsonAdapter}
-   * on a class.
-   */
-  private static final TypeAdapterFactory TREE_TYPE_CLASS_DUMMY_FACTORY = new DummyTypeAdapterFactory();
+  /** Factory used for {@link TreeTypeAdapter}s created for {@code @JsonAdapter} on a class. */
+  private static final TypeAdapterFactory TREE_TYPE_CLASS_DUMMY_FACTORY =
+      new DummyTypeAdapterFactory();
 
-  /**
-   * Factory used for {@link TreeTypeAdapter}s created for {@code @JsonAdapter}
-   * on a field.
-   */
-  private static final TypeAdapterFactory TREE_TYPE_FIELD_DUMMY_FACTORY = new DummyTypeAdapterFactory();
+  /** Factory used for {@link TreeTypeAdapter}s created for {@code @JsonAdapter} on a field. */
+  private static final TypeAdapterFactory TREE_TYPE_FIELD_DUMMY_FACTORY =
+      new DummyTypeAdapterFactory();
 
   private final ConstructorConstructor constructorConstructor;
 
   /**
-   * For a class, if it is annotated with {@code @JsonAdapter} and refers to a {@link TypeAdapterFactory},
-   * stores the factory instance in case it has been requested already.
-   * Has to be a {@link ConcurrentMap} because {@link Gson} guarantees to be thread-safe.
+   * For a class, if it is annotated with {@code @JsonAdapter} and refers to a {@link
+   * TypeAdapterFactory}, stores the factory instance in case it has been requested already. Has to
+   * be a {@link ConcurrentMap} because {@link Gson} guarantees to be thread-safe.
    */
   // Note: In case these strong reference to TypeAdapterFactory instances are considered
   // a memory leak in the future, could consider switching to WeakReference<TypeAdapterFactory>
@@ -74,7 +71,8 @@ public final class JsonAdapterAnnotationTypeAdapterFactory implements TypeAdapte
     return rawType.getAnnotation(JsonAdapter.class);
   }
 
-  @SuppressWarnings("unchecked") // this is not safe; requires that user has specified correct adapter class for @JsonAdapter
+  // this is not safe; requires that user has specified correct adapter class for  @JsonAdapter
+  @SuppressWarnings("unchecked")
   @Override
   public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> targetType) {
     Class<? super T> rawType = targetType.getRawType();
@@ -82,13 +80,16 @@ public final class JsonAdapterAnnotationTypeAdapterFactory implements TypeAdapte
     if (annotation == null) {
       return null;
     }
-    return (TypeAdapter<T>) getTypeAdapter(constructorConstructor, gson, targetType, annotation, true);
+    return (TypeAdapter<T>)
+        getTypeAdapter(constructorConstructor, gson, targetType, annotation, true);
   }
 
   // Separate helper method to make sure callers create adapter in a consistent way
-  private static Object createAdapter(ConstructorConstructor constructorConstructor, Class<?> adapterClass) {
-    // TODO: The exception messages created by ConstructorConstructor are currently written in the context of
-    // deserialization and for example suggest usage of TypeAdapter, which would not work for @JsonAdapter usage
+  private static Object createAdapter(
+      ConstructorConstructor constructorConstructor, Class<?> adapterClass) {
+    // TODO: The exception messages created by ConstructorConstructor are currently written in the
+    // context of deserialization and for example suggest usage of TypeAdapter, which would not work
+    // for @JsonAdapter usage
     return constructorConstructor.get(TypeToken.get(adapterClass)).construct();
   }
 
@@ -98,8 +99,12 @@ public final class JsonAdapterAnnotationTypeAdapterFactory implements TypeAdapte
     return existingFactory != null ? existingFactory : factory;
   }
 
-  TypeAdapter<?> getTypeAdapter(ConstructorConstructor constructorConstructor, Gson gson,
-      TypeToken<?> type, JsonAdapter annotation, boolean isClassAnnotation) {
+  TypeAdapter<?> getTypeAdapter(
+      ConstructorConstructor constructorConstructor,
+      Gson gson,
+      TypeToken<?> type,
+      JsonAdapter annotation,
+      boolean isClassAnnotation) {
     Object instance = createAdapter(constructorConstructor, annotation.value());
 
     TypeAdapter<?> typeAdapter;
@@ -115,32 +120,35 @@ public final class JsonAdapterAnnotationTypeAdapterFactory implements TypeAdapte
 
       typeAdapter = factory.create(gson, type);
     } else if (instance instanceof JsonSerializer || instance instanceof JsonDeserializer) {
-      JsonSerializer<?> serializer = instance instanceof JsonSerializer
-          ? (JsonSerializer<?>) instance
-          : null;
-      JsonDeserializer<?> deserializer = instance instanceof JsonDeserializer
-          ? (JsonDeserializer<?>) instance
-          : null;
+      JsonSerializer<?> serializer =
+          instance instanceof JsonSerializer ? (JsonSerializer<?>) instance : null;
+      JsonDeserializer<?> deserializer =
+          instance instanceof JsonDeserializer ? (JsonDeserializer<?>) instance : null;
 
-      // Uses dummy factory instances because TreeTypeAdapter needs a 'skipPast' factory for `Gson.getDelegateAdapter`
-      // call and has to differentiate there whether TreeTypeAdapter was created for @JsonAdapter on class or field
+      // Uses dummy factory instances because TreeTypeAdapter needs a 'skipPast' factory for
+      // `Gson.getDelegateAdapter` call and has to differentiate there whether TreeTypeAdapter was
+      // created for @JsonAdapter on class or field
       TypeAdapterFactory skipPast;
       if (isClassAnnotation) {
         skipPast = TREE_TYPE_CLASS_DUMMY_FACTORY;
       } else {
         skipPast = TREE_TYPE_FIELD_DUMMY_FACTORY;
       }
-      @SuppressWarnings({ "unchecked", "rawtypes" })
-      TypeAdapter<?> tempAdapter = new TreeTypeAdapter(serializer, deserializer, gson, type, skipPast, nullSafe);
+      @SuppressWarnings({"unchecked", "rawtypes"})
+      TypeAdapter<?> tempAdapter =
+          new TreeTypeAdapter(serializer, deserializer, gson, type, skipPast, nullSafe);
       typeAdapter = tempAdapter;
 
       // TreeTypeAdapter handles nullSafe; don't additionally call `nullSafe()`
       nullSafe = false;
     } else {
-      throw new IllegalArgumentException("Invalid attempt to bind an instance of "
-          + instance.getClass().getName() + " as a @JsonAdapter for " + type.toString()
-          + ". @JsonAdapter value must be a TypeAdapter, TypeAdapterFactory,"
-          + " JsonSerializer or JsonDeserializer.");
+      throw new IllegalArgumentException(
+          "Invalid attempt to bind an instance of "
+              + instance.getClass().getName()
+              + " as a @JsonAdapter for "
+              + type.toString()
+              + ". @JsonAdapter value must be a TypeAdapter, TypeAdapterFactory,"
+              + " JsonSerializer or JsonDeserializer.");
     }
 
     if (typeAdapter != null && nullSafe) {
@@ -173,8 +181,8 @@ public final class JsonAdapterAnnotationTypeAdapterFactory implements TypeAdapte
 
     // If no factory has been created for the type yet check manually for a @JsonAdapter annotation
     // which specifies a TypeAdapterFactory
-    // Otherwise behavior would not be consistent, depending on whether or not adapter had been requested
-    // before call to `isClassJsonAdapterFactory` was made
+    // Otherwise behavior would not be consistent, depending on whether or not adapter had been
+    // requested before call to `isClassJsonAdapterFactory` was made
     JsonAdapter annotation = getAnnotation(rawType);
     if (annotation == null) {
       return false;

--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
@@ -32,20 +32,23 @@ import java.util.Iterator;
 import java.util.Map;
 
 /**
- * This reader walks the elements of a JsonElement as if it was coming from a
- * character stream.
+ * This reader walks the elements of a JsonElement as if it was coming from a character stream.
  *
  * @author Jesse Wilson
  */
 public final class JsonTreeReader extends JsonReader {
-  private static final Reader UNREADABLE_READER = new Reader() {
-    @Override public int read(char[] buffer, int offset, int count) {
-      throw new AssertionError();
-    }
-    @Override public void close() {
-      throw new AssertionError();
-    }
-  };
+  private static final Reader UNREADABLE_READER =
+      new Reader() {
+        @Override
+        public int read(char[] buffer, int offset, int count) {
+          throw new AssertionError();
+        }
+
+        @Override
+        public void close() {
+          throw new AssertionError();
+        }
+      };
   private static final Object SENTINEL_CLOSED = new Object();
 
   /*
@@ -70,14 +73,16 @@ public final class JsonTreeReader extends JsonReader {
     push(element);
   }
 
-  @Override public void beginArray() throws IOException {
+  @Override
+  public void beginArray() throws IOException {
     expect(JsonToken.BEGIN_ARRAY);
     JsonArray array = (JsonArray) peekStack();
     push(array.iterator());
     pathIndices[stackSize - 1] = 0;
   }
 
-  @Override public void endArray() throws IOException {
+  @Override
+  public void endArray() throws IOException {
     expect(JsonToken.END_ARRAY);
     popStack(); // empty iterator
     popStack(); // array
@@ -86,13 +91,15 @@ public final class JsonTreeReader extends JsonReader {
     }
   }
 
-  @Override public void beginObject() throws IOException {
+  @Override
+  public void beginObject() throws IOException {
     expect(JsonToken.BEGIN_OBJECT);
     JsonObject object = (JsonObject) peekStack();
     push(object.entrySet().iterator());
   }
 
-  @Override public void endObject() throws IOException {
+  @Override
+  public void endObject() throws IOException {
     expect(JsonToken.END_OBJECT);
     pathNames[stackSize - 1] = null; // Free the last path name so that it can be garbage collected
     popStack(); // empty iterator
@@ -102,12 +109,16 @@ public final class JsonTreeReader extends JsonReader {
     }
   }
 
-  @Override public boolean hasNext() throws IOException {
+  @Override
+  public boolean hasNext() throws IOException {
     JsonToken token = peek();
-    return token != JsonToken.END_OBJECT && token != JsonToken.END_ARRAY && token != JsonToken.END_DOCUMENT;
+    return token != JsonToken.END_OBJECT
+        && token != JsonToken.END_ARRAY
+        && token != JsonToken.END_DOCUMENT;
   }
 
-  @Override public JsonToken peek() throws IOException {
+  @Override
+  public JsonToken peek() throws IOException {
     if (stackSize == 0) {
       return JsonToken.END_DOCUMENT;
     }
@@ -146,7 +157,8 @@ public final class JsonTreeReader extends JsonReader {
     } else if (o == SENTINEL_CLOSED) {
       throw new IllegalStateException("JsonReader is closed");
     } else {
-      throw new MalformedJsonException("Custom JsonElement subclass " + o.getClass().getName() + " is not supported");
+      throw new MalformedJsonException(
+          "Custom JsonElement subclass " + o.getClass().getName() + " is not supported");
     }
   }
 
@@ -178,11 +190,13 @@ public final class JsonTreeReader extends JsonReader {
     return result;
   }
 
-  @Override public String nextName() throws IOException {
+  @Override
+  public String nextName() throws IOException {
     return nextName(false);
   }
 
-  @Override public String nextString() throws IOException {
+  @Override
+  public String nextString() throws IOException {
     JsonToken token = peek();
     if (token != JsonToken.STRING && token != JsonToken.NUMBER) {
       throw new IllegalStateException(
@@ -195,7 +209,8 @@ public final class JsonTreeReader extends JsonReader {
     return result;
   }
 
-  @Override public boolean nextBoolean() throws IOException {
+  @Override
+  public boolean nextBoolean() throws IOException {
     expect(JsonToken.BOOLEAN);
     boolean result = ((JsonPrimitive) popStack()).getAsBoolean();
     if (stackSize > 0) {
@@ -204,7 +219,8 @@ public final class JsonTreeReader extends JsonReader {
     return result;
   }
 
-  @Override public void nextNull() throws IOException {
+  @Override
+  public void nextNull() throws IOException {
     expect(JsonToken.NULL);
     popStack();
     if (stackSize > 0) {
@@ -212,7 +228,8 @@ public final class JsonTreeReader extends JsonReader {
     }
   }
 
-  @Override public double nextDouble() throws IOException {
+  @Override
+  public double nextDouble() throws IOException {
     JsonToken token = peek();
     if (token != JsonToken.NUMBER && token != JsonToken.STRING) {
       throw new IllegalStateException(
@@ -229,7 +246,8 @@ public final class JsonTreeReader extends JsonReader {
     return result;
   }
 
-  @Override public long nextLong() throws IOException {
+  @Override
+  public long nextLong() throws IOException {
     JsonToken token = peek();
     if (token != JsonToken.NUMBER && token != JsonToken.STRING) {
       throw new IllegalStateException(
@@ -243,7 +261,8 @@ public final class JsonTreeReader extends JsonReader {
     return result;
   }
 
-  @Override public int nextInt() throws IOException {
+  @Override
+  public int nextInt() throws IOException {
     JsonToken token = peek();
     if (token != JsonToken.NUMBER && token != JsonToken.STRING) {
       throw new IllegalStateException(
@@ -270,12 +289,14 @@ public final class JsonTreeReader extends JsonReader {
     return element;
   }
 
-  @Override public void close() throws IOException {
-    stack = new Object[] { SENTINEL_CLOSED };
+  @Override
+  public void close() throws IOException {
+    stack = new Object[] {SENTINEL_CLOSED};
     stackSize = 1;
   }
 
-  @Override public void skipValue() throws IOException {
+  @Override
+  public void skipValue() throws IOException {
     JsonToken peeked = peek();
     switch (peeked) {
       case NAME:
@@ -300,7 +321,8 @@ public final class JsonTreeReader extends JsonReader {
     }
   }
 
-  @Override public String toString() {
+  @Override
+  public String toString() {
     return getClass().getSimpleName() + locationString();
   }
 
@@ -348,11 +370,13 @@ public final class JsonTreeReader extends JsonReader {
     return result.toString();
   }
 
-  @Override public String getPreviousPath() {
+  @Override
+  public String getPreviousPath() {
     return getPath(true);
   }
 
-  @Override public String getPath() {
+  @Override
+  public String getPath() {
     return getPath(false);
   }
 

--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeWriter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeWriter.java
@@ -29,21 +29,26 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-/**
- * This writer creates a JsonElement.
- */
+/** This writer creates a JsonElement. */
 public final class JsonTreeWriter extends JsonWriter {
-  private static final Writer UNWRITABLE_WRITER = new Writer() {
-    @Override public void write(char[] buffer, int offset, int counter) {
-      throw new AssertionError();
-    }
-    @Override public void flush() {
-      throw new AssertionError();
-    }
-    @Override public void close() {
-      throw new AssertionError();
-    }
-  };
+  private static final Writer UNWRITABLE_WRITER =
+      new Writer() {
+        @Override
+        public void write(char[] buffer, int offset, int counter) {
+          throw new AssertionError();
+        }
+
+        @Override
+        public void flush() {
+          throw new AssertionError();
+        }
+
+        @Override
+        public void close() {
+          throw new AssertionError();
+        }
+      };
+
   /** Added to the top of the stack when this writer is closed to cause following ops to fail. */
   private static final JsonPrimitive SENTINEL_CLOSED = new JsonPrimitive("closed");
 
@@ -60,9 +65,7 @@ public final class JsonTreeWriter extends JsonWriter {
     super(UNWRITABLE_WRITER);
   }
 
-  /**
-   * Returns the top level object produced by this writer.
-   */
+  /** Returns the top level object produced by this writer. */
   public JsonElement get() {
     if (!stack.isEmpty()) {
       throw new IllegalStateException("Expected one JSON element but was " + stack);
@@ -94,7 +97,8 @@ public final class JsonTreeWriter extends JsonWriter {
   }
 
   @CanIgnoreReturnValue
-  @Override public JsonWriter beginArray() throws IOException {
+  @Override
+  public JsonWriter beginArray() throws IOException {
     JsonArray array = new JsonArray();
     put(array);
     stack.add(array);
@@ -102,7 +106,8 @@ public final class JsonTreeWriter extends JsonWriter {
   }
 
   @CanIgnoreReturnValue
-  @Override public JsonWriter endArray() throws IOException {
+  @Override
+  public JsonWriter endArray() throws IOException {
     if (stack.isEmpty() || pendingName != null) {
       throw new IllegalStateException();
     }
@@ -115,7 +120,8 @@ public final class JsonTreeWriter extends JsonWriter {
   }
 
   @CanIgnoreReturnValue
-  @Override public JsonWriter beginObject() throws IOException {
+  @Override
+  public JsonWriter beginObject() throws IOException {
     JsonObject object = new JsonObject();
     put(object);
     stack.add(object);
@@ -123,7 +129,8 @@ public final class JsonTreeWriter extends JsonWriter {
   }
 
   @CanIgnoreReturnValue
-  @Override public JsonWriter endObject() throws IOException {
+  @Override
+  public JsonWriter endObject() throws IOException {
     if (stack.isEmpty() || pendingName != null) {
       throw new IllegalStateException();
     }
@@ -136,7 +143,8 @@ public final class JsonTreeWriter extends JsonWriter {
   }
 
   @CanIgnoreReturnValue
-  @Override public JsonWriter name(String name) throws IOException {
+  @Override
+  public JsonWriter name(String name) throws IOException {
     Objects.requireNonNull(name, "name == null");
     if (stack.isEmpty() || pendingName != null) {
       throw new IllegalStateException("Did not expect a name");
@@ -150,7 +158,8 @@ public final class JsonTreeWriter extends JsonWriter {
   }
 
   @CanIgnoreReturnValue
-  @Override public JsonWriter value(String value) throws IOException {
+  @Override
+  public JsonWriter value(String value) throws IOException {
     if (value == null) {
       return nullValue();
     }
@@ -158,24 +167,28 @@ public final class JsonTreeWriter extends JsonWriter {
     return this;
   }
 
-  @Override public JsonWriter jsonValue(String value) throws IOException {
+  @Override
+  public JsonWriter jsonValue(String value) throws IOException {
     throw new UnsupportedOperationException();
   }
 
   @CanIgnoreReturnValue
-  @Override public JsonWriter nullValue() throws IOException {
+  @Override
+  public JsonWriter nullValue() throws IOException {
     put(JsonNull.INSTANCE);
     return this;
   }
 
   @CanIgnoreReturnValue
-  @Override public JsonWriter value(boolean value) throws IOException {
+  @Override
+  public JsonWriter value(boolean value) throws IOException {
     put(new JsonPrimitive(value));
     return this;
   }
 
   @CanIgnoreReturnValue
-  @Override public JsonWriter value(Boolean value) throws IOException {
+  @Override
+  public JsonWriter value(Boolean value) throws IOException {
     if (value == null) {
       return nullValue();
     }
@@ -184,7 +197,8 @@ public final class JsonTreeWriter extends JsonWriter {
   }
 
   @CanIgnoreReturnValue
-  @Override public JsonWriter value(float value) throws IOException {
+  @Override
+  public JsonWriter value(float value) throws IOException {
     if (!isLenient() && (Float.isNaN(value) || Float.isInfinite(value))) {
       throw new IllegalArgumentException("JSON forbids NaN and infinities: " + value);
     }
@@ -193,7 +207,8 @@ public final class JsonTreeWriter extends JsonWriter {
   }
 
   @CanIgnoreReturnValue
-  @Override public JsonWriter value(double value) throws IOException {
+  @Override
+  public JsonWriter value(double value) throws IOException {
     if (!isLenient() && (Double.isNaN(value) || Double.isInfinite(value))) {
       throw new IllegalArgumentException("JSON forbids NaN and infinities: " + value);
     }
@@ -202,13 +217,15 @@ public final class JsonTreeWriter extends JsonWriter {
   }
 
   @CanIgnoreReturnValue
-  @Override public JsonWriter value(long value) throws IOException {
+  @Override
+  public JsonWriter value(long value) throws IOException {
     put(new JsonPrimitive(value));
     return this;
   }
 
   @CanIgnoreReturnValue
-  @Override public JsonWriter value(Number value) throws IOException {
+  @Override
+  public JsonWriter value(Number value) throws IOException {
     if (value == null) {
       return nullValue();
     }
@@ -224,10 +241,11 @@ public final class JsonTreeWriter extends JsonWriter {
     return this;
   }
 
-  @Override public void flush() throws IOException {
-  }
+  @Override
+  public void flush() throws IOException {}
 
-  @Override public void close() throws IOException {
+  @Override
+  public void close() throws IOException {
     if (!stack.isEmpty()) {
       throw new IOException("Incomplete document");
     }

--- a/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
@@ -41,78 +41,89 @@ import java.util.Map;
  * Adapts maps to either JSON objects or JSON arrays.
  *
  * <h2>Maps as JSON objects</h2>
- * For primitive keys or when complex map key serialization is not enabled, this
- * converts Java {@link Map Maps} to JSON Objects. This requires that map keys
- * can be serialized as strings; this is insufficient for some key types. For
- * example, consider a map whose keys are points on a grid. The default JSON
- * form encodes reasonably: <pre>   {@code
- *   Map<Point, String> original = new LinkedHashMap<>();
- *   original.put(new Point(5, 6), "a");
- *   original.put(new Point(8, 8), "b");
- *   System.out.println(gson.toJson(original, type));
+ *
+ * For primitive keys or when complex map key serialization is not enabled, this converts Java
+ * {@link Map Maps} to JSON Objects. This requires that map keys can be serialized as strings; this
+ * is insufficient for some key types. For example, consider a map whose keys are points on a grid.
+ * The default JSON form encodes reasonably:
+ *
+ * <pre>{@code
+ * Map<Point, String> original = new LinkedHashMap<>();
+ * original.put(new Point(5, 6), "a");
+ * original.put(new Point(8, 8), "b");
+ * System.out.println(gson.toJson(original, type));
  * }</pre>
- * The above code prints this JSON object:<pre>   {@code
- *   {
- *     "(5,6)": "a",
- *     "(8,8)": "b"
- *   }
+ *
+ * The above code prints this JSON object:
+ *
+ * <pre>{@code
+ * {
+ *   "(5,6)": "a",
+ *   "(8,8)": "b"
+ * }
  * }</pre>
- * But GSON is unable to deserialize this value because the JSON string name is
- * just the {@link Object#toString() toString()} of the map key. Attempting to
- * convert the above JSON to an object fails with a parse exception:
+ *
+ * But GSON is unable to deserialize this value because the JSON string name is just the {@link
+ * Object#toString() toString()} of the map key. Attempting to convert the above JSON to an object
+ * fails with a parse exception:
+ *
  * <pre>com.google.gson.JsonParseException: Expecting object found: "(5,6)"
  *   at com.google.gson.JsonObjectDeserializationVisitor.visitFieldUsingCustomHandler
  *   at com.google.gson.ObjectNavigator.navigateClassFields
  *   ...</pre>
  *
  * <h2>Maps as JSON arrays</h2>
- * An alternative approach taken by this type adapter when it is required and
- * complex map key serialization is enabled is to encode maps as arrays of map
- * entries. Each map entry is a two element array containing a key and a value.
- * This approach is more flexible because any type can be used as the map's key;
- * not just strings. But it's also less portable because the receiver of such
- * JSON must be aware of the map entry convention.
+ *
+ * An alternative approach taken by this type adapter when it is required and complex map key
+ * serialization is enabled is to encode maps as arrays of map entries. Each map entry is a two
+ * element array containing a key and a value. This approach is more flexible because any type can
+ * be used as the map's key; not just strings. But it's also less portable because the receiver of
+ * such JSON must be aware of the map entry convention.
  *
  * <p>Register this adapter when you are creating your GSON instance.
- * <pre>   {@code
- *   Gson gson = new GsonBuilder()
- *     .registerTypeAdapter(Map.class, new MapAsArrayTypeAdapter())
- *     .create();
+ *
+ * <pre>{@code
+ * Gson gson = new GsonBuilder()
+ *   .registerTypeAdapter(Map.class, new MapAsArrayTypeAdapter())
+ *   .create();
  * }</pre>
- * This will change the structure of the JSON emitted by the code above. Now we
- * get an array. In this case the arrays elements are map entries:
- * <pre>   {@code
+ *
+ * This will change the structure of the JSON emitted by the code above. Now we get an array. In
+ * this case the arrays elements are map entries:
+ *
+ * <pre>{@code
+ * [
  *   [
- *     [
- *       {
- *         "x": 5,
- *         "y": 6
- *       },
- *       "a",
- *     ],
- *     [
- *       {
- *         "x": 8,
- *         "y": 8
- *       },
- *       "b"
- *     ]
+ *     {
+ *       "x": 5,
+ *       "y": 6
+ *     },
+ *     "a",
+ *   ],
+ *   [
+ *     {
+ *       "x": 8,
+ *       "y": 8
+ *     },
+ *     "b"
  *   ]
+ * ]
  * }</pre>
- * This format will serialize and deserialize just fine as long as this adapter
- * is registered.
+ *
+ * This format will serialize and deserialize just fine as long as this adapter is registered.
  */
 public final class MapTypeAdapterFactory implements TypeAdapterFactory {
   private final ConstructorConstructor constructorConstructor;
   final boolean complexMapKeySerialization;
 
-  public MapTypeAdapterFactory(ConstructorConstructor constructorConstructor,
-      boolean complexMapKeySerialization) {
+  public MapTypeAdapterFactory(
+      ConstructorConstructor constructorConstructor, boolean complexMapKeySerialization) {
     this.constructorConstructor = constructorConstructor;
     this.complexMapKeySerialization = complexMapKeySerialization;
   }
 
-  @Override public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
+  @Override
+  public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
     Type type = typeToken.getType();
 
     Class<? super T> rawType = typeToken.getRawType();
@@ -127,14 +138,13 @@ public final class MapTypeAdapterFactory implements TypeAdapterFactory {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     // we don't define a type parameter for the key or value types
-    TypeAdapter<T> result = new Adapter(gson, keyAndValueTypes[0], keyAdapter,
-        keyAndValueTypes[1], valueAdapter, constructor);
+    TypeAdapter<T> result =
+        new Adapter(
+            gson, keyAndValueTypes[0], keyAdapter, keyAndValueTypes[1], valueAdapter, constructor);
     return result;
   }
 
-  /**
-   * Returns a type adapter that writes the value as a string.
-   */
+  /** Returns a type adapter that writes the value as a string. */
   private TypeAdapter<?> getKeyAdapter(Gson context, Type keyType) {
     return (keyType == boolean.class || keyType == Boolean.class)
         ? TypeAdapters.BOOLEAN_AS_STRING
@@ -146,17 +156,21 @@ public final class MapTypeAdapterFactory implements TypeAdapterFactory {
     private final TypeAdapter<V> valueTypeAdapter;
     private final ObjectConstructor<? extends Map<K, V>> constructor;
 
-    public Adapter(Gson context, Type keyType, TypeAdapter<K> keyTypeAdapter,
-        Type valueType, TypeAdapter<V> valueTypeAdapter,
+    public Adapter(
+        Gson context,
+        Type keyType,
+        TypeAdapter<K> keyTypeAdapter,
+        Type valueType,
+        TypeAdapter<V> valueTypeAdapter,
         ObjectConstructor<? extends Map<K, V>> constructor) {
-      this.keyTypeAdapter =
-        new TypeAdapterRuntimeTypeWrapper<>(context, keyTypeAdapter, keyType);
+      this.keyTypeAdapter = new TypeAdapterRuntimeTypeWrapper<>(context, keyTypeAdapter, keyType);
       this.valueTypeAdapter =
-        new TypeAdapterRuntimeTypeWrapper<>(context, valueTypeAdapter, valueType);
+          new TypeAdapterRuntimeTypeWrapper<>(context, valueTypeAdapter, valueType);
       this.constructor = constructor;
     }
 
-    @Override public Map<K, V> read(JsonReader in) throws IOException {
+    @Override
+    public Map<K, V> read(JsonReader in) throws IOException {
       JsonToken peek = in.peek();
       if (peek == JsonToken.NULL) {
         in.nextNull();
@@ -194,7 +208,8 @@ public final class MapTypeAdapterFactory implements TypeAdapterFactory {
       return map;
     }
 
-    @Override public void write(JsonWriter out, Map<K, V> map) throws IOException {
+    @Override
+    public void write(JsonWriter out, Map<K, V> map) throws IOException {
       if (map == null) {
         out.nullValue();
         return;

--- a/gson/src/main/java/com/google/gson/internal/bind/NumberTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/NumberTypeAdapter.java
@@ -18,25 +18,21 @@ package com.google.gson.internal.bind;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
-import com.google.gson.ToNumberStrategy;
 import com.google.gson.ToNumberPolicy;
+import com.google.gson.ToNumberStrategy;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
-
 import java.io.IOException;
 
-/**
- * Type adapter for {@link Number}.
- */
+/** Type adapter for {@link Number}. */
 public final class NumberTypeAdapter extends TypeAdapter<Number> {
-  /**
-   * Gson default factory using {@link ToNumberPolicy#LAZILY_PARSED_NUMBER}.
-   */
-  private static final TypeAdapterFactory LAZILY_PARSED_NUMBER_FACTORY = newFactory(ToNumberPolicy.LAZILY_PARSED_NUMBER);
+  /** Gson default factory using {@link ToNumberPolicy#LAZILY_PARSED_NUMBER}. */
+  private static final TypeAdapterFactory LAZILY_PARSED_NUMBER_FACTORY =
+      newFactory(ToNumberPolicy.LAZILY_PARSED_NUMBER);
 
   private final ToNumberStrategy toNumberStrategy;
 
@@ -48,7 +44,8 @@ public final class NumberTypeAdapter extends TypeAdapter<Number> {
     final NumberTypeAdapter adapter = new NumberTypeAdapter(toNumberStrategy);
     return new TypeAdapterFactory() {
       @SuppressWarnings("unchecked")
-      @Override public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+      @Override
+      public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
         return type.getRawType() == Number.class ? (TypeAdapter<T>) adapter : null;
       }
     };
@@ -62,21 +59,24 @@ public final class NumberTypeAdapter extends TypeAdapter<Number> {
     }
   }
 
-  @Override public Number read(JsonReader in) throws IOException {
+  @Override
+  public Number read(JsonReader in) throws IOException {
     JsonToken jsonToken = in.peek();
     switch (jsonToken) {
-    case NULL:
-      in.nextNull();
-      return null;
-    case NUMBER:
-    case STRING:
-      return toNumberStrategy.readNumber(in);
-    default:
-      throw new JsonSyntaxException("Expecting number, got: " + jsonToken + "; at path " + in.getPath());
+      case NULL:
+        in.nextNull();
+        return null;
+      case NUMBER:
+      case STRING:
+        return toNumberStrategy.readNumber(in);
+      default:
+        throw new JsonSyntaxException(
+            "Expecting number, got: " + jsonToken + "; at path " + in.getPath());
     }
   }
 
-  @Override public void write(JsonWriter out, Number value) throws IOException {
+  @Override
+  public void write(JsonWriter out, Number value) throws IOException {
     out.value(value);
   }
 }

--- a/gson/src/main/java/com/google/gson/internal/bind/ObjectTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ObjectTypeAdapter.java
@@ -34,13 +34,11 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Adapts types whose static type is only 'Object'. Uses getClass() on
- * serialization and a primitive/Map/List on deserialization.
+ * Adapts types whose static type is only 'Object'. Uses getClass() on serialization and a
+ * primitive/Map/List on deserialization.
  */
 public final class ObjectTypeAdapter extends TypeAdapter<Object> {
-  /**
-   * Gson default factory using {@link ToNumberPolicy#DOUBLE}.
-   */
+  /** Gson default factory using {@link ToNumberPolicy#DOUBLE}. */
   private static final TypeAdapterFactory DOUBLE_FACTORY = newFactory(ToNumberPolicy.DOUBLE);
 
   private final Gson gson;
@@ -54,7 +52,8 @@ public final class ObjectTypeAdapter extends TypeAdapter<Object> {
   private static TypeAdapterFactory newFactory(final ToNumberStrategy toNumberStrategy) {
     return new TypeAdapterFactory() {
       @SuppressWarnings("unchecked")
-      @Override public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+      @Override
+      public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
         if (type.getRawType() == Object.class) {
           return (TypeAdapter<T>) new ObjectTypeAdapter(gson, toNumberStrategy);
         }
@@ -72,8 +71,8 @@ public final class ObjectTypeAdapter extends TypeAdapter<Object> {
   }
 
   /**
-   * Tries to begin reading a JSON array or JSON object, returning {@code null} if
-   * the next element is neither of those.
+   * Tries to begin reading a JSON array or JSON object, returning {@code null} if the next element
+   * is neither of those.
    */
   private Object tryBeginNesting(JsonReader in, JsonToken peeked) throws IOException {
     switch (peeked) {
@@ -106,7 +105,8 @@ public final class ObjectTypeAdapter extends TypeAdapter<Object> {
     }
   }
 
-  @Override public Object read(JsonReader in) throws IOException {
+  @Override
+  public Object read(JsonReader in) throws IOException {
     // Either List or Map
     Object current;
     JsonToken peeked = in.peek();
@@ -166,7 +166,8 @@ public final class ObjectTypeAdapter extends TypeAdapter<Object> {
     }
   }
 
-  @Override public void write(JsonWriter out, Object value) throws IOException {
+  @Override
+  public void write(JsonWriter out, Object value) throws IOException {
     if (value == null) {
       out.nullValue();
       return;

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -56,9 +56,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-/**
- * Type adapter that reflects over the fields and methods of a class.
- */
+/** Type adapter that reflects over the fields and methods of a class. */
 public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
   private final ConstructorConstructor constructorConstructor;
   private final FieldNamingStrategy fieldNamingPolicy;
@@ -66,8 +64,10 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
   private final JsonAdapterAnnotationTypeAdapterFactory jsonAdapterFactory;
   private final List<ReflectionAccessFilter> reflectionFilters;
 
-  public ReflectiveTypeAdapterFactory(ConstructorConstructor constructorConstructor,
-      FieldNamingStrategy fieldNamingPolicy, Excluder excluder,
+  public ReflectiveTypeAdapterFactory(
+      ConstructorConstructor constructorConstructor,
+      FieldNamingStrategy fieldNamingPolicy,
+      Excluder excluder,
       JsonAdapterAnnotationTypeAdapterFactory jsonAdapterFactory,
       List<ReflectionAccessFilter> reflectionFilters) {
     this.constructorConstructor = constructorConstructor;
@@ -114,36 +114,49 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
         ReflectionAccessFilterHelper.getFilterResult(reflectionFilters, raw);
     if (filterResult == FilterResult.BLOCK_ALL) {
       throw new JsonIOException(
-          "ReflectionAccessFilter does not permit using reflection for " + raw
-          + ". Register a TypeAdapter for this type or adjust the access filter.");
+          "ReflectionAccessFilter does not permit using reflection for "
+              + raw
+              + ". Register a TypeAdapter for this type or adjust the access filter.");
     }
     boolean blockInaccessible = filterResult == FilterResult.BLOCK_INACCESSIBLE;
 
-    // If the type is actually a Java Record, we need to use the RecordAdapter instead. This will always be false
-    // on JVMs that do not support records.
+    // If the type is actually a Java Record, we need to use the RecordAdapter instead. This will
+    // always be false on JVMs that do not support records.
     if (ReflectionHelper.isRecord(raw)) {
       @SuppressWarnings("unchecked")
-      TypeAdapter<T> adapter = (TypeAdapter<T>) new RecordAdapter<>(raw,
-          getBoundFields(gson, type, raw, blockInaccessible, true), blockInaccessible);
+      TypeAdapter<T> adapter =
+          (TypeAdapter<T>)
+              new RecordAdapter<>(
+                  raw, getBoundFields(gson, type, raw, blockInaccessible, true), blockInaccessible);
       return adapter;
     }
 
     ObjectConstructor<T> constructor = constructorConstructor.get(type);
-    return new FieldReflectionAdapter<>(constructor, getBoundFields(gson, type, raw, blockInaccessible, false));
+    return new FieldReflectionAdapter<>(
+        constructor, getBoundFields(gson, type, raw, blockInaccessible, false));
   }
 
-  private static <M extends AccessibleObject & Member> void checkAccessible(Object object, M member) {
-    if (!ReflectionAccessFilterHelper.canAccess(member, Modifier.isStatic(member.getModifiers()) ? null : object)) {
+  private static <M extends AccessibleObject & Member> void checkAccessible(
+      Object object, M member) {
+    if (!ReflectionAccessFilterHelper.canAccess(
+        member, Modifier.isStatic(member.getModifiers()) ? null : object)) {
       String memberDescription = ReflectionHelper.getAccessibleObjectDescription(member, true);
-      throw new JsonIOException(memberDescription + " is not accessible and ReflectionAccessFilter does not"
-          + " permit making it accessible. Register a TypeAdapter for the declaring type, adjust the"
-          + " access filter or increase the visibility of the element and its declaring type.");
+      throw new JsonIOException(
+          memberDescription
+              + " is not accessible and ReflectionAccessFilter does not permit making it"
+              + " accessible. Register a TypeAdapter for the declaring type, adjust the access"
+              + " filter or increase the visibility of the element and its declaring type.");
     }
   }
 
   private BoundField createBoundField(
-      final Gson context, final Field field, final Method accessor, final String serializedName,
-      final TypeToken<?> fieldType, final boolean serialize, final boolean blockInaccessible) {
+      final Gson context,
+      final Field field,
+      final Method accessor,
+      final String serializedName,
+      final TypeToken<?> fieldType,
+      final boolean serialize,
+      final boolean blockInaccessible) {
 
     final boolean isPrimitive = Primitives.isPrimitive(fieldType.getRawType());
 
@@ -154,8 +167,9 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
     TypeAdapter<?> mapped = null;
     if (annotation != null) {
       // This is not safe; requires that user has specified correct adapter class for @JsonAdapter
-      mapped = jsonAdapterFactory.getTypeAdapter(
-          constructorConstructor, context, fieldType, annotation, false);
+      mapped =
+          jsonAdapterFactory.getTypeAdapter(
+              constructorConstructor, context, fieldType, annotation, false);
     }
     final boolean jsonAdapterPresent = mapped != null;
     if (mapped == null) mapped = context.getAdapter(fieldType);
@@ -164,15 +178,17 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
     final TypeAdapter<Object> typeAdapter = (TypeAdapter<Object>) mapped;
     final TypeAdapter<Object> writeTypeAdapter;
     if (serialize) {
-      writeTypeAdapter = jsonAdapterPresent ? typeAdapter
-          : new TypeAdapterRuntimeTypeWrapper<>(context, typeAdapter, fieldType.getType());
+      writeTypeAdapter =
+          jsonAdapterPresent
+              ? typeAdapter
+              : new TypeAdapterRuntimeTypeWrapper<>(context, typeAdapter, fieldType.getType());
     } else {
       // Will never actually be used, but we set it to avoid confusing nullness-analysis tools
       writeTypeAdapter = typeAdapter;
     }
     return new BoundField(serializedName, field) {
-      @Override void write(JsonWriter writer, Object source)
-          throws IOException, IllegalAccessException {
+      @Override
+      void write(JsonWriter writer, Object source) throws IOException, IllegalAccessException {
         if (blockInaccessible) {
           if (accessor == null) {
             checkAccessible(source, field);
@@ -188,8 +204,10 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
           try {
             fieldValue = accessor.invoke(source);
           } catch (InvocationTargetException e) {
-            String accessorDescription = ReflectionHelper.getAccessibleObjectDescription(accessor, false);
-            throw new JsonIOException("Accessor " + accessorDescription + " threw exception", e.getCause());
+            String accessorDescription =
+                ReflectionHelper.getAccessibleObjectDescription(accessor, false);
+            throw new JsonIOException(
+                "Accessor " + accessorDescription + " threw exception", e.getCause());
           }
         } else {
           fieldValue = field.get(source);
@@ -203,11 +221,16 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
       }
 
       @Override
-      void readIntoArray(JsonReader reader, int index, Object[] target) throws IOException, JsonParseException {
+      void readIntoArray(JsonReader reader, int index, Object[] target)
+          throws IOException, JsonParseException {
         Object fieldValue = typeAdapter.read(reader);
         if (fieldValue == null && isPrimitive) {
-          throw new JsonParseException("null is not allowed as value for record component '" + fieldName + "'"
-              + " of primitive type; at path " + reader.getPath());
+          throw new JsonParseException(
+              "null is not allowed as value for record component '"
+                  + fieldName
+                  + "'"
+                  + " of primitive type; at path "
+                  + reader.getPath());
         }
         target[index] = fieldValue;
       }
@@ -220,8 +243,9 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
           if (blockInaccessible) {
             checkAccessible(target, field);
           } else if (isStaticFinalField) {
-            // Reflection does not permit setting value of `static final` field, even after calling `setAccessible`
-            // Handle this here to avoid causing IllegalAccessException when calling `Field.set`
+            // Reflection does not permit setting value of `static final` field, even after calling
+            // `setAccessible` Handle this here to avoid causing IllegalAccessException when calling
+            // `Field.set`
             String fieldDescription = ReflectionHelper.getAccessibleObjectDescription(field, false);
             throw new JsonIOException("Cannot set value of 'static final' " + fieldDescription);
           }
@@ -232,32 +256,47 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
   }
 
   private static class FieldsData {
-    public static final FieldsData EMPTY = new FieldsData(Collections.<String, BoundField>emptyMap(), Collections.<BoundField>emptyList());
+    public static final FieldsData EMPTY =
+        new FieldsData(
+            Collections.<String, BoundField>emptyMap(), Collections.<BoundField>emptyList());
 
     /** Maps from JSON member name to field */
     public final Map<String, BoundField> deserializedFields;
+
     public final List<BoundField> serializedFields;
 
-    public FieldsData(Map<String, BoundField> deserializedFields, List<BoundField> serializedFields) {
+    public FieldsData(
+        Map<String, BoundField> deserializedFields, List<BoundField> serializedFields) {
       this.deserializedFields = deserializedFields;
       this.serializedFields = serializedFields;
     }
   }
 
-  private static IllegalArgumentException createDuplicateFieldException(Class<?> declaringType, String duplicateName, Field field1, Field field2) {
-    throw new IllegalArgumentException("Class " + declaringType.getName()
-        + " declares multiple JSON fields named '" + duplicateName + "'; conflict is caused"
-        + " by fields " + ReflectionHelper.fieldToString(field1) + " and " + ReflectionHelper.fieldToString(field2)
-        + "\nSee " + TroubleshootingGuide.createUrl("duplicate-fields"));
+  private static IllegalArgumentException createDuplicateFieldException(
+      Class<?> declaringType, String duplicateName, Field field1, Field field2) {
+    throw new IllegalArgumentException(
+        "Class "
+            + declaringType.getName()
+            + " declares multiple JSON fields named '"
+            + duplicateName
+            + "'; conflict is caused"
+            + " by fields "
+            + ReflectionHelper.fieldToString(field1)
+            + " and "
+            + ReflectionHelper.fieldToString(field2)
+            + "\nSee "
+            + TroubleshootingGuide.createUrl("duplicate-fields"));
   }
 
-  private FieldsData getBoundFields(Gson context, TypeToken<?> type, Class<?> raw, boolean blockInaccessible, boolean isRecord) {
+  private FieldsData getBoundFields(
+      Gson context, TypeToken<?> type, Class<?> raw, boolean blockInaccessible, boolean isRecord) {
     if (raw.isInterface()) {
       return FieldsData.EMPTY;
     }
 
     Map<String, BoundField> deserializedFields = new LinkedHashMap<>();
-    // For serialized fields use a Map to track duplicate field names; otherwise this could be a List<BoundField> instead
+    // For serialized fields use a Map to track duplicate field names; otherwise this could be a
+    // List<BoundField> instead
     Map<String, BoundField> serializedFields = new LinkedHashMap<>();
 
     Class<?> originalRaw = raw;
@@ -266,11 +305,16 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
 
       // For inherited fields, check if access to their declaring class is allowed
       if (raw != originalRaw && fields.length > 0) {
-        FilterResult filterResult = ReflectionAccessFilterHelper.getFilterResult(reflectionFilters, raw);
+        FilterResult filterResult =
+            ReflectionAccessFilterHelper.getFilterResult(reflectionFilters, raw);
         if (filterResult == FilterResult.BLOCK_ALL) {
-          throw new JsonIOException("ReflectionAccessFilter does not permit using reflection for " + raw
-              + " (supertype of " + originalRaw + "). Register a TypeAdapter for this type"
-              + " or adjust the access filter.");
+          throw new JsonIOException(
+              "ReflectionAccessFilter does not permit using reflection for "
+                  + raw
+                  + " (supertype of "
+                  + originalRaw
+                  + "). Register a TypeAdapter for this type"
+                  + " or adjust the access filter.");
         }
         blockInaccessible = filterResult == FilterResult.BLOCK_INACCESSIBLE;
       }
@@ -281,13 +325,16 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
         if (!serialize && !deserialize) {
           continue;
         }
-        // The accessor method is only used for records. If the type is a record, we will read out values
-        // via its accessor method instead of via reflection. This way we will bypass the accessible restrictions
+        // The accessor method is only used for records. If the type is a record, we will read out
+        // values via its accessor method instead of via reflection. This way we will bypass the
+        // accessible restrictions
         Method accessor = null;
         if (isRecord) {
-          // If there is a static field on a record, there will not be an accessor. Instead we will use the default
-          // field serialization logic, but for deserialization the field is excluded for simplicity. Note that Gson
-          // ignores static fields by default, but GsonBuilder.excludeFieldsWithModifiers can overwrite this.
+          // If there is a static field on a record, there will not be an accessor. Instead we will
+          // use the default field serialization logic, but for deserialization the field is
+          // excluded for simplicity.
+          // Note that Gson ignores static fields by default, but
+          // GsonBuilder.excludeFieldsWithModifiers can overwrite this.
           if (Modifier.isStatic(field.getModifiers())) {
             deserialize = false;
           } else {
@@ -298,12 +345,15 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
             }
 
             // @SerializedName can be placed on accessor method, but it is not supported there
-            // If field and method have annotation it is not easily possible to determine if accessor method
-            // is implicit and has inherited annotation, or if it is explicitly declared with custom annotation
+            // If field and method have annotation it is not easily possible to determine if
+            // accessor method is implicit and has inherited annotation, or if it is explicitly
+            // declared with custom annotation
             if (accessor.getAnnotation(SerializedName.class) != null
                 && field.getAnnotation(SerializedName.class) == null) {
-              String methodDescription = ReflectionHelper.getAccessibleObjectDescription(accessor, false);
-              throw new JsonIOException("@SerializedName on " + methodDescription + " is not supported");
+              String methodDescription =
+                  ReflectionHelper.getAccessibleObjectDescription(accessor, false);
+              throw new JsonIOException(
+                  "@SerializedName on " + methodDescription + " is not supported");
             }
           }
         }
@@ -317,8 +367,15 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
         Type fieldType = $Gson$Types.resolve(type.getType(), raw, field.getGenericType());
         List<String> fieldNames = getFieldNames(field);
         String serializedName = fieldNames.get(0);
-        BoundField boundField = createBoundField(context, field, accessor, serializedName,
-            TypeToken.get(fieldType), serialize, blockInaccessible);
+        BoundField boundField =
+            createBoundField(
+                context,
+                field,
+                accessor,
+                serializedName,
+                TypeToken.get(fieldType),
+                serialize,
+                blockInaccessible);
 
         if (deserialize) {
           for (String name : fieldNames) {
@@ -343,10 +400,12 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
     return new FieldsData(deserializedFields, new ArrayList<>(serializedFields.values()));
   }
 
-  static abstract class BoundField {
+  abstract static class BoundField {
     /** Name used for serialization (but not for deserialization) */
     final String serializedName;
+
     final Field field;
+
     /** Name of the underlying field */
     final String fieldName;
 
@@ -357,13 +416,19 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
     }
 
     /** Read this field value from the source, and append its JSON value to the writer */
-    abstract void write(JsonWriter writer, Object source) throws IOException, IllegalAccessException;
+    abstract void write(JsonWriter writer, Object source)
+        throws IOException, IllegalAccessException;
 
     /** Read the value into the target array, used to provide constructor arguments for records */
-    abstract void readIntoArray(JsonReader reader, int index, Object[] target) throws IOException, JsonParseException;
+    abstract void readIntoArray(JsonReader reader, int index, Object[] target)
+        throws IOException, JsonParseException;
 
-    /** Read the value from the reader, and set it on the corresponding field on target via reflection */
-    abstract void readIntoField(JsonReader reader, Object target) throws IOException, IllegalAccessException;
+    /**
+     * Read the value from the reader, and set it on the corresponding field on target via
+     * reflection
+     */
+    abstract void readIntoField(JsonReader reader, Object target)
+        throws IOException, IllegalAccessException;
   }
 
   /**
@@ -372,15 +437,16 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
    * <p>The {@link RecordAdapter} is a special case to handle records for JVMs that support it, for
    * all other types we use the {@link FieldReflectionAdapter}. This class encapsulates the common
    * logic for serialization and deserialization. During deserialization, we construct an
-   * accumulator A, which we use to accumulate values from the source JSON. After the object has been read in
-   * full, the {@link #finalize(Object)} method is used to convert the accumulator to an instance
-   * of T.
+   * accumulator A, which we use to accumulate values from the source JSON. After the object has
+   * been read in full, the {@link #finalize(Object)} method is used to convert the accumulator to
+   * an instance of T.
    *
    * @param <T> type of objects that this Adapter creates.
    * @param <A> type of accumulator used to build the deserialization result.
    */
-  // This class is public because external projects check for this class with `instanceof` (even though it is internal)
-  public static abstract class Adapter<T, A> extends TypeAdapter<T> {
+  // This class is public because external projects check for this class with `instanceof` (even
+  // though it is internal)
+  public abstract static class Adapter<T, A> extends TypeAdapter<T> {
     private final FieldsData fieldsData;
 
     Adapter(FieldsData fieldsData) {
@@ -437,12 +503,14 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
 
     /** Create the Object that will be used to collect each field value */
     abstract A createAccumulator();
+
     /**
-     * Read a single BoundField into the accumulator. The JsonReader will be pointed at the
-     * start of the value for the BoundField to read from.
+     * Read a single BoundField into the accumulator. The JsonReader will be pointed at the start of
+     * the value for the BoundField to read from.
      */
     abstract void readField(A accumulator, JsonReader in, BoundField field)
         throws IllegalAccessException, IOException;
+
     /** Convert the accumulator to a final instance of T. */
     abstract T finalize(A accumulator);
   }
@@ -499,8 +567,9 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
       }
       Class<?>[] parameterTypes = constructor.getParameterTypes();
 
-      // We need to ensure that we are passing non-null values to primitive fields in the constructor. To do this,
-      // we create an Object[] where all primitives are initialized to non-null values.
+      // We need to ensure that we are passing non-null values to primitive fields in the
+      // constructor. To do this, we create an Object[] where all primitives are initialized to
+      // non-null values.
       constructorArgsDefaults = new Object[parameterTypes.length];
       for (int i = 0; i < parameterTypes.length; i++) {
         // This will correctly be null for non-primitive types:
@@ -532,12 +601,16 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
       Integer componentIndex = componentIndices.get(field.fieldName);
       if (componentIndex == null) {
         throw new IllegalStateException(
-            "Could not find the index in the constructor '" + ReflectionHelper.constructorToString(constructor) + "'"
-                + " for field with name '" + field.fieldName + "',"
-                + " unable to determine which argument in the constructor the field corresponds"
+            "Could not find the index in the constructor '"
+                + ReflectionHelper.constructorToString(constructor)
+                + "'"
+                + " for field with name '"
+                + field.fieldName
+                + "', unable to determine which argument in the constructor the field corresponds"
                 + " to. This is unexpected behavior, as we expect the RecordComponents to have the"
                 + " same names as the fields in the Java class, and that the order of the"
-                + " RecordComponents is the same as the order of the canonical constructor parameters.");
+                + " RecordComponents is the same as the order of the canonical constructor"
+                + " parameters.");
       }
       field.readIntoArray(in, componentIndex, accumulator);
     }
@@ -550,17 +623,25 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
         throw ReflectionHelper.createExceptionForUnexpectedIllegalAccess(e);
       }
       // Note: InstantiationException should be impossible because record class is not abstract;
-      //  IllegalArgumentException should not be possible unless a bad adapter returns objects of the wrong type
+      //  IllegalArgumentException should not be possible unless a bad adapter returns objects of
+      // the wrong type
       catch (InstantiationException | IllegalArgumentException e) {
         throw new RuntimeException(
-            "Failed to invoke constructor '" + ReflectionHelper.constructorToString(constructor) + "'"
-            + " with args " + Arrays.toString(accumulator), e);
-      }
-      catch (InvocationTargetException e) {
+            "Failed to invoke constructor '"
+                + ReflectionHelper.constructorToString(constructor)
+                + "'"
+                + " with args "
+                + Arrays.toString(accumulator),
+            e);
+      } catch (InvocationTargetException e) {
         // TODO: JsonParseException ?
         throw new RuntimeException(
-            "Failed to invoke constructor '" + ReflectionHelper.constructorToString(constructor) + "'"
-            + " with args " + Arrays.toString(accumulator), e.getCause());
+            "Failed to invoke constructor '"
+                + ReflectionHelper.constructorToString(constructor)
+                + "'"
+                + " with args "
+                + Arrays.toString(accumulator),
+            e.getCause());
       }
     }
   }

--- a/gson/src/main/java/com/google/gson/internal/bind/SerializationDelegatingTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/SerializationDelegatingTypeAdapter.java
@@ -18,13 +18,11 @@ package com.google.gson.internal.bind;
 
 import com.google.gson.TypeAdapter;
 
-/**
- * Type adapter which might delegate serialization to another adapter.
- */
+/** Type adapter which might delegate serialization to another adapter. */
 public abstract class SerializationDelegatingTypeAdapter<T> extends TypeAdapter<T> {
   /**
-   * Returns the adapter used for serialization, might be {@code this} or another adapter.
-   * That other adapter might itself also be a {@code SerializationDelegatingTypeAdapter}.
+   * Returns the adapter used for serialization, might be {@code this} or another adapter. That
+   * other adapter might itself also be a {@code SerializationDelegatingTypeAdapter}.
    */
   public abstract TypeAdapter<T> getSerializationDelegate();
 }

--- a/gson/src/main/java/com/google/gson/internal/bind/TreeTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TreeTypeAdapter.java
@@ -34,31 +34,38 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 
 /**
- * Adapts a Gson 1.x tree-style adapter as a streaming TypeAdapter. Since the
- * tree adapter may be serialization-only or deserialization-only, this class
- * has a facility to look up a delegate type adapter on demand.
+ * Adapts a Gson 1.x tree-style adapter as a streaming TypeAdapter. Since the tree adapter may be
+ * serialization-only or deserialization-only, this class has a facility to look up a delegate type
+ * adapter on demand.
  */
 public final class TreeTypeAdapter<T> extends SerializationDelegatingTypeAdapter<T> {
   private final JsonSerializer<T> serializer;
   private final JsonDeserializer<T> deserializer;
   final Gson gson;
   private final TypeToken<T> typeToken;
+
   /**
-   * Only intended as {@code skipPast} for {@link Gson#getDelegateAdapter(TypeAdapterFactory, TypeToken)},
-   * must not be used in any other way.
+   * Only intended as {@code skipPast} for {@link Gson#getDelegateAdapter(TypeAdapterFactory,
+   * TypeToken)}, must not be used in any other way.
    */
   private final TypeAdapterFactory skipPastForGetDelegateAdapter;
+
   private final GsonContextImpl context = new GsonContextImpl();
   private final boolean nullSafe;
 
   /**
-   * The delegate is lazily created because it may not be needed, and creating it may fail.
-   * Field has to be {@code volatile} because {@link Gson} guarantees to be thread-safe.
+   * The delegate is lazily created because it may not be needed, and creating it may fail. Field
+   * has to be {@code volatile} because {@link Gson} guarantees to be thread-safe.
    */
   private volatile TypeAdapter<T> delegate;
 
-  public TreeTypeAdapter(JsonSerializer<T> serializer, JsonDeserializer<T> deserializer,
-      Gson gson, TypeToken<T> typeToken, TypeAdapterFactory skipPast, boolean nullSafe) {
+  public TreeTypeAdapter(
+      JsonSerializer<T> serializer,
+      JsonDeserializer<T> deserializer,
+      Gson gson,
+      TypeToken<T> typeToken,
+      TypeAdapterFactory skipPast,
+      boolean nullSafe) {
     this.serializer = serializer;
     this.deserializer = deserializer;
     this.gson = gson;
@@ -67,12 +74,17 @@ public final class TreeTypeAdapter<T> extends SerializationDelegatingTypeAdapter
     this.nullSafe = nullSafe;
   }
 
-  public TreeTypeAdapter(JsonSerializer<T> serializer, JsonDeserializer<T> deserializer,
-                         Gson gson, TypeToken<T> typeToken, TypeAdapterFactory skipPast) {
+  public TreeTypeAdapter(
+      JsonSerializer<T> serializer,
+      JsonDeserializer<T> deserializer,
+      Gson gson,
+      TypeToken<T> typeToken,
+      TypeAdapterFactory skipPast) {
     this(serializer, deserializer, gson, typeToken, skipPast, true);
   }
 
-  @Override public T read(JsonReader in) throws IOException {
+  @Override
+  public T read(JsonReader in) throws IOException {
     if (deserializer == null) {
       return delegate().read(in);
     }
@@ -83,7 +95,8 @@ public final class TreeTypeAdapter<T> extends SerializationDelegatingTypeAdapter
     return deserializer.deserialize(value, typeToken.getType(), context);
   }
 
-  @Override public void write(JsonWriter out, T value) throws IOException {
+  @Override
+  public void write(JsonWriter out, T value) throws IOException {
     if (serializer == null) {
       delegate().write(out, value);
       return;
@@ -97,7 +110,8 @@ public final class TreeTypeAdapter<T> extends SerializationDelegatingTypeAdapter
   }
 
   private TypeAdapter<T> delegate() {
-    // A race might lead to `delegate` being assigned by multiple threads but the last assignment will stick
+    // A race might lead to `delegate` being assigned by multiple threads but the last assignment
+    // will stick
     TypeAdapter<T> d = delegate;
     return d != null
         ? d
@@ -105,25 +119,20 @@ public final class TreeTypeAdapter<T> extends SerializationDelegatingTypeAdapter
   }
 
   /**
-   * Returns the type adapter which is used for serialization. Returns {@code this}
-   * if this {@code TreeTypeAdapter} has a {@link #serializer}; otherwise returns
-   * the delegate.
+   * Returns the type adapter which is used for serialization. Returns {@code this} if this {@code
+   * TreeTypeAdapter} has a {@link #serializer}; otherwise returns the delegate.
    */
-  @Override public TypeAdapter<T> getSerializationDelegate() {
+  @Override
+  public TypeAdapter<T> getSerializationDelegate() {
     return serializer != null ? this : delegate();
   }
 
-  /**
-   * Returns a new factory that will match each type against {@code exactType}.
-   */
+  /** Returns a new factory that will match each type against {@code exactType}. */
   public static TypeAdapterFactory newFactory(TypeToken<?> exactType, Object typeAdapter) {
     return new SingleTypeFactory(typeAdapter, exactType, false, null);
   }
 
-  /**
-   * Returns a new factory that will match each type and its raw type against
-   * {@code exactType}.
-   */
+  /** Returns a new factory that will match each type and its raw type against {@code exactType}. */
   public static TypeAdapterFactory newFactoryWithMatchRawType(
       TypeToken<?> exactType, Object typeAdapter) {
     // only bother matching raw types if exact type is a raw type
@@ -132,8 +141,8 @@ public final class TreeTypeAdapter<T> extends SerializationDelegatingTypeAdapter
   }
 
   /**
-   * Returns a new factory that will match each type's raw type for assignability
-   * to {@code hierarchyType}.
+   * Returns a new factory that will match each type's raw type for assignability to {@code
+   * hierarchyType}.
    */
   public static TypeAdapterFactory newTypeHierarchyFactory(
       Class<?> hierarchyType, Object typeAdapter) {
@@ -147,14 +156,11 @@ public final class TreeTypeAdapter<T> extends SerializationDelegatingTypeAdapter
     private final JsonSerializer<?> serializer;
     private final JsonDeserializer<?> deserializer;
 
-    SingleTypeFactory(Object typeAdapter, TypeToken<?> exactType, boolean matchRawType,
-        Class<?> hierarchyType) {
-      serializer = typeAdapter instanceof JsonSerializer
-          ? (JsonSerializer<?>) typeAdapter
-          : null;
-      deserializer = typeAdapter instanceof JsonDeserializer
-          ? (JsonDeserializer<?>) typeAdapter
-          : null;
+    SingleTypeFactory(
+        Object typeAdapter, TypeToken<?> exactType, boolean matchRawType, Class<?> hierarchyType) {
+      serializer = typeAdapter instanceof JsonSerializer ? (JsonSerializer<?>) typeAdapter : null;
+      deserializer =
+          typeAdapter instanceof JsonDeserializer ? (JsonDeserializer<?>) typeAdapter : null;
       $Gson$Preconditions.checkArgument(serializer != null || deserializer != null);
       this.exactType = exactType;
       this.matchRawType = matchRawType;
@@ -164,23 +170,29 @@ public final class TreeTypeAdapter<T> extends SerializationDelegatingTypeAdapter
     @SuppressWarnings("unchecked") // guarded by typeToken.equals() call
     @Override
     public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
-      boolean matches = exactType != null
-          ? exactType.equals(type) || (matchRawType && exactType.getType() == type.getRawType())
-          : hierarchyType.isAssignableFrom(type.getRawType());
+      boolean matches =
+          exactType != null
+              ? exactType.equals(type) || (matchRawType && exactType.getType() == type.getRawType())
+              : hierarchyType.isAssignableFrom(type.getRawType());
       return matches
-          ? new TreeTypeAdapter<>((JsonSerializer<T>) serializer,
-              (JsonDeserializer<T>) deserializer, gson, type, this)
+          ? new TreeTypeAdapter<>(
+              (JsonSerializer<T>) serializer, (JsonDeserializer<T>) deserializer, gson, type, this)
           : null;
     }
   }
 
-  private final class GsonContextImpl implements JsonSerializationContext, JsonDeserializationContext {
-    @Override public JsonElement serialize(Object src) {
+  private final class GsonContextImpl
+      implements JsonSerializationContext, JsonDeserializationContext {
+    @Override
+    public JsonElement serialize(Object src) {
       return gson.toJsonTree(src);
     }
-    @Override public JsonElement serialize(Object src, Type typeOfSrc) {
+
+    @Override
+    public JsonElement serialize(Object src, Type typeOfSrc) {
       return gson.toJsonTree(src, typeOfSrc);
     }
+
     @Override
     @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
     public <R> R deserialize(JsonElement json, Type typeOfT) throws JsonParseException {

--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapterRuntimeTypeWrapper.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapterRuntimeTypeWrapper.java
@@ -45,16 +45,19 @@ final class TypeAdapterRuntimeTypeWrapper<T> extends TypeAdapter<T> {
     // Order of preference for choosing type adapters
     // First preference: a type adapter registered for the runtime type
     // Second preference: a type adapter registered for the declared type
-    // Third preference: reflective type adapter for the runtime type (if it is a subclass of the declared type)
+    // Third preference: reflective type adapter for the runtime type (if it is a subclass of the
+    // declared type)
     // Fourth preference: reflective type adapter for the declared type
 
     TypeAdapter<T> chosen = delegate;
     Type runtimeType = getRuntimeTypeIfMoreSpecific(type, value);
     if (runtimeType != type) {
       @SuppressWarnings("unchecked")
-      TypeAdapter<T> runtimeTypeAdapter = (TypeAdapter<T>) context.getAdapter(TypeToken.get(runtimeType));
-      // For backward compatibility only check ReflectiveTypeAdapterFactory.Adapter here but not any other
-      // wrapping adapters, see https://github.com/google/gson/pull/1787#issuecomment-1222175189
+      TypeAdapter<T> runtimeTypeAdapter =
+          (TypeAdapter<T>) context.getAdapter(TypeToken.get(runtimeType));
+      // For backward compatibility only check ReflectiveTypeAdapterFactory.Adapter here but not any
+      // other wrapping adapters, see
+      // https://github.com/google/gson/pull/1787#issuecomment-1222175189
       if (!(runtimeTypeAdapter instanceof ReflectiveTypeAdapterFactory.Adapter)) {
         // The user registered a type adapter for the runtime type, so we will use that
         chosen = runtimeTypeAdapter;
@@ -78,7 +81,8 @@ final class TypeAdapterRuntimeTypeWrapper<T> extends TypeAdapter<T> {
   private static boolean isReflective(TypeAdapter<?> typeAdapter) {
     // Run this in loop in case multiple delegating adapters are nested
     while (typeAdapter instanceof SerializationDelegatingTypeAdapter) {
-      TypeAdapter<?> delegate = ((SerializationDelegatingTypeAdapter<?>) typeAdapter).getSerializationDelegate();
+      TypeAdapter<?> delegate =
+          ((SerializationDelegatingTypeAdapter<?>) typeAdapter).getSerializationDelegate();
       // Break if adapter does not delegate serialization
       if (delegate == typeAdapter) {
         break;
@@ -89,9 +93,7 @@ final class TypeAdapterRuntimeTypeWrapper<T> extends TypeAdapter<T> {
     return typeAdapter instanceof ReflectiveTypeAdapterFactory.Adapter;
   }
 
-  /**
-   * Finds a compatible runtime type if it is more specific
-   */
+  /** Finds a compatible runtime type if it is more specific */
   private static Type getRuntimeTypeIfMoreSpecific(Type type, Object value) {
     if (value != null && (type instanceof Class<?> || type instanceof TypeVariable<?>)) {
       type = value.getClass();

--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -62,807 +62,887 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 
-/**
- * Type adapters for basic types.
- */
+/** Type adapters for basic types. */
 public final class TypeAdapters {
   private TypeAdapters() {
     throw new UnsupportedOperationException();
   }
 
   @SuppressWarnings("rawtypes")
-  public static final TypeAdapter<Class> CLASS = new TypeAdapter<Class>() {
-    @Override
-    public void write(JsonWriter out, Class value) throws IOException {
-      throw new UnsupportedOperationException("Attempted to serialize java.lang.Class: "
-          + value.getName() + ". Forgot to register a type adapter?"
-          + "\nSee " + TroubleshootingGuide.createUrl("java-lang-class-unsupported"));
-    }
-    @Override
-    public Class read(JsonReader in) throws IOException {
-      throw new UnsupportedOperationException(
-          "Attempted to deserialize a java.lang.Class. Forgot to register a type adapter?"
-          + "\nSee " + TroubleshootingGuide.createUrl("java-lang-class-unsupported"));
-    }
-  }.nullSafe();
+  public static final TypeAdapter<Class> CLASS =
+      new TypeAdapter<Class>() {
+        @Override
+        public void write(JsonWriter out, Class value) throws IOException {
+          throw new UnsupportedOperationException(
+              "Attempted to serialize java.lang.Class: "
+                  + value.getName()
+                  + ". Forgot to register a type adapter?"
+                  + "\nSee "
+                  + TroubleshootingGuide.createUrl("java-lang-class-unsupported"));
+        }
+
+        @Override
+        public Class read(JsonReader in) throws IOException {
+          throw new UnsupportedOperationException(
+              "Attempted to deserialize a java.lang.Class. Forgot to register a type adapter?"
+                  + "\nSee "
+                  + TroubleshootingGuide.createUrl("java-lang-class-unsupported"));
+        }
+      }.nullSafe();
 
   public static final TypeAdapterFactory CLASS_FACTORY = newFactory(Class.class, CLASS);
 
-  public static final TypeAdapter<BitSet> BIT_SET = new TypeAdapter<BitSet>() {
-    @Override public BitSet read(JsonReader in) throws IOException {
-      BitSet bitset = new BitSet();
-      in.beginArray();
-      int i = 0;
-      JsonToken tokenType = in.peek();
-      while (tokenType != JsonToken.END_ARRAY) {
-        boolean set;
-        switch (tokenType) {
-        case NUMBER:
-        case STRING:
-          int intValue = in.nextInt();
-          if (intValue == 0) {
-            set = false;
-          } else if (intValue == 1) {
-            set = true;
-          } else {
-            throw new JsonSyntaxException("Invalid bitset value " + intValue + ", expected 0 or 1; at path " + in.getPreviousPath());
+  public static final TypeAdapter<BitSet> BIT_SET =
+      new TypeAdapter<BitSet>() {
+        @Override
+        public BitSet read(JsonReader in) throws IOException {
+          BitSet bitset = new BitSet();
+          in.beginArray();
+          int i = 0;
+          JsonToken tokenType = in.peek();
+          while (tokenType != JsonToken.END_ARRAY) {
+            boolean set;
+            switch (tokenType) {
+              case NUMBER:
+              case STRING:
+                int intValue = in.nextInt();
+                if (intValue == 0) {
+                  set = false;
+                } else if (intValue == 1) {
+                  set = true;
+                } else {
+                  throw new JsonSyntaxException(
+                      "Invalid bitset value "
+                          + intValue
+                          + ", expected 0 or 1; at path "
+                          + in.getPreviousPath());
+                }
+                break;
+              case BOOLEAN:
+                set = in.nextBoolean();
+                break;
+              default:
+                throw new JsonSyntaxException(
+                    "Invalid bitset value type: " + tokenType + "; at path " + in.getPath());
+            }
+            if (set) {
+              bitset.set(i);
+            }
+            ++i;
+            tokenType = in.peek();
           }
-          break;
-        case BOOLEAN:
-          set = in.nextBoolean();
-          break;
-        default:
-          throw new JsonSyntaxException("Invalid bitset value type: " + tokenType + "; at path " + in.getPath());
+          in.endArray();
+          return bitset;
         }
-        if (set) {
-          bitset.set(i);
-        }
-        ++i;
-        tokenType = in.peek();
-      }
-      in.endArray();
-      return bitset;
-    }
 
-    @Override public void write(JsonWriter out, BitSet src) throws IOException {
-      out.beginArray();
-      for (int i = 0, length = src.length(); i < length; i++) {
-        int value = src.get(i) ? 1 : 0;
-        out.value(value);
-      }
-      out.endArray();
-    }
-  }.nullSafe();
+        @Override
+        public void write(JsonWriter out, BitSet src) throws IOException {
+          out.beginArray();
+          for (int i = 0, length = src.length(); i < length; i++) {
+            int value = src.get(i) ? 1 : 0;
+            out.value(value);
+          }
+          out.endArray();
+        }
+      }.nullSafe();
 
   public static final TypeAdapterFactory BIT_SET_FACTORY = newFactory(BitSet.class, BIT_SET);
 
-  public static final TypeAdapter<Boolean> BOOLEAN = new TypeAdapter<Boolean>() {
-    @Override
-    public Boolean read(JsonReader in) throws IOException {
-      JsonToken peek = in.peek();
-      if (peek == JsonToken.NULL) {
-        in.nextNull();
-        return null;
-      } else if (peek == JsonToken.STRING) {
-        // support strings for compatibility with GSON 1.7
-        return Boolean.parseBoolean(in.nextString());
-      }
-      return in.nextBoolean();
-    }
-    @Override
-    public void write(JsonWriter out, Boolean value) throws IOException {
-      out.value(value);
-    }
-  };
+  public static final TypeAdapter<Boolean> BOOLEAN =
+      new TypeAdapter<Boolean>() {
+        @Override
+        public Boolean read(JsonReader in) throws IOException {
+          JsonToken peek = in.peek();
+          if (peek == JsonToken.NULL) {
+            in.nextNull();
+            return null;
+          } else if (peek == JsonToken.STRING) {
+            // support strings for compatibility with GSON 1.7
+            return Boolean.parseBoolean(in.nextString());
+          }
+          return in.nextBoolean();
+        }
+
+        @Override
+        public void write(JsonWriter out, Boolean value) throws IOException {
+          out.value(value);
+        }
+      };
 
   /**
-   * Writes a boolean as a string. Useful for map keys, where booleans aren't
-   * otherwise permitted.
+   * Writes a boolean as a string. Useful for map keys, where booleans aren't otherwise permitted.
    */
-  public static final TypeAdapter<Boolean> BOOLEAN_AS_STRING = new TypeAdapter<Boolean>() {
-    @Override public Boolean read(JsonReader in) throws IOException {
-      if (in.peek() == JsonToken.NULL) {
-        in.nextNull();
-        return null;
-      }
-      return Boolean.valueOf(in.nextString());
-    }
+  public static final TypeAdapter<Boolean> BOOLEAN_AS_STRING =
+      new TypeAdapter<Boolean>() {
+        @Override
+        public Boolean read(JsonReader in) throws IOException {
+          if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return null;
+          }
+          return Boolean.valueOf(in.nextString());
+        }
 
-    @Override public void write(JsonWriter out, Boolean value) throws IOException {
-      out.value(value == null ? "null" : value.toString());
-    }
-  };
+        @Override
+        public void write(JsonWriter out, Boolean value) throws IOException {
+          out.value(value == null ? "null" : value.toString());
+        }
+      };
 
-  public static final TypeAdapterFactory BOOLEAN_FACTORY
-      = newFactory(boolean.class, Boolean.class, BOOLEAN);
+  public static final TypeAdapterFactory BOOLEAN_FACTORY =
+      newFactory(boolean.class, Boolean.class, BOOLEAN);
 
-  public static final TypeAdapter<Number> BYTE = new TypeAdapter<Number>() {
-    @Override
-    public Number read(JsonReader in) throws IOException {
-      if (in.peek() == JsonToken.NULL) {
-        in.nextNull();
-        return null;
-      }
+  public static final TypeAdapter<Number> BYTE =
+      new TypeAdapter<Number>() {
+        @Override
+        public Number read(JsonReader in) throws IOException {
+          if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return null;
+          }
 
-      int intValue;
-      try {
-        intValue = in.nextInt();
-      } catch (NumberFormatException e) {
-        throw new JsonSyntaxException(e);
-      }
-      // Allow up to 255 to support unsigned values
-      if (intValue > 255 || intValue < Byte.MIN_VALUE) {
-        throw new JsonSyntaxException("Lossy conversion from " + intValue + " to byte; at path " + in.getPreviousPath());
-      }
-      return (byte) intValue;
-    }
-    @Override
-    public void write(JsonWriter out, Number value) throws IOException {
-      if (value == null) {
-        out.nullValue();
-      } else {
-        out.value(value.byteValue());
-      }
-    }
-  };
-
-  public static final TypeAdapterFactory BYTE_FACTORY
-      = newFactory(byte.class, Byte.class, BYTE);
-
-  public static final TypeAdapter<Number> SHORT = new TypeAdapter<Number>() {
-    @Override
-    public Number read(JsonReader in) throws IOException {
-      if (in.peek() == JsonToken.NULL) {
-        in.nextNull();
-        return null;
-      }
-
-      int intValue;
-      try {
-        intValue = in.nextInt();
-      } catch (NumberFormatException e) {
-        throw new JsonSyntaxException(e);
-      }
-      // Allow up to 65535 to support unsigned values
-      if (intValue > 65535 || intValue < Short.MIN_VALUE) {
-        throw new JsonSyntaxException("Lossy conversion from " + intValue + " to short; at path " + in.getPreviousPath());
-      }
-      return (short) intValue;
-    }
-    @Override
-    public void write(JsonWriter out, Number value) throws IOException {
-      if (value == null) {
-        out.nullValue();
-      } else {
-        out.value(value.shortValue());
-      }
-    }
-  };
-
-  public static final TypeAdapterFactory SHORT_FACTORY
-      = newFactory(short.class, Short.class, SHORT);
-
-  public static final TypeAdapter<Number> INTEGER = new TypeAdapter<Number>() {
-    @Override
-    public Number read(JsonReader in) throws IOException {
-      if (in.peek() == JsonToken.NULL) {
-        in.nextNull();
-        return null;
-      }
-      try {
-        return in.nextInt();
-      } catch (NumberFormatException e) {
-        throw new JsonSyntaxException(e);
-      }
-    }
-    @Override
-    public void write(JsonWriter out, Number value) throws IOException {
-      if (value == null) {
-        out.nullValue();
-      } else {
-        out.value(value.intValue());
-      }
-    }
-  };
-  public static final TypeAdapterFactory INTEGER_FACTORY
-      = newFactory(int.class, Integer.class, INTEGER);
-
-  public static final TypeAdapter<AtomicInteger> ATOMIC_INTEGER = new TypeAdapter<AtomicInteger>() {
-    @Override public AtomicInteger read(JsonReader in) throws IOException {
-      try {
-        return new AtomicInteger(in.nextInt());
-      } catch (NumberFormatException e) {
-        throw new JsonSyntaxException(e);
-      }
-    }
-    @Override public void write(JsonWriter out, AtomicInteger value) throws IOException {
-      out.value(value.get());
-    }
-  }.nullSafe();
-  public static final TypeAdapterFactory ATOMIC_INTEGER_FACTORY =
-      newFactory(AtomicInteger.class, TypeAdapters.ATOMIC_INTEGER);
-
-  public static final TypeAdapter<AtomicBoolean> ATOMIC_BOOLEAN = new TypeAdapter<AtomicBoolean>() {
-    @Override public AtomicBoolean read(JsonReader in) throws IOException {
-      return new AtomicBoolean(in.nextBoolean());
-    }
-    @Override public void write(JsonWriter out, AtomicBoolean value) throws IOException {
-      out.value(value.get());
-    }
-  }.nullSafe();
-  public static final TypeAdapterFactory ATOMIC_BOOLEAN_FACTORY =
-      newFactory(AtomicBoolean.class, TypeAdapters.ATOMIC_BOOLEAN);
-
-  public static final TypeAdapter<AtomicIntegerArray> ATOMIC_INTEGER_ARRAY = new TypeAdapter<AtomicIntegerArray>() {
-    @Override public AtomicIntegerArray read(JsonReader in) throws IOException {
-        List<Integer> list = new ArrayList<>();
-        in.beginArray();
-        while (in.hasNext()) {
+          int intValue;
           try {
-            int integer = in.nextInt();
-            list.add(integer);
+            intValue = in.nextInt();
+          } catch (NumberFormatException e) {
+            throw new JsonSyntaxException(e);
+          }
+          // Allow up to 255 to support unsigned values
+          if (intValue > 255 || intValue < Byte.MIN_VALUE) {
+            throw new JsonSyntaxException(
+                "Lossy conversion from " + intValue + " to byte; at path " + in.getPreviousPath());
+          }
+          return (byte) intValue;
+        }
+
+        @Override
+        public void write(JsonWriter out, Number value) throws IOException {
+          if (value == null) {
+            out.nullValue();
+          } else {
+            out.value(value.byteValue());
+          }
+        }
+      };
+
+  public static final TypeAdapterFactory BYTE_FACTORY = newFactory(byte.class, Byte.class, BYTE);
+
+  public static final TypeAdapter<Number> SHORT =
+      new TypeAdapter<Number>() {
+        @Override
+        public Number read(JsonReader in) throws IOException {
+          if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return null;
+          }
+
+          int intValue;
+          try {
+            intValue = in.nextInt();
+          } catch (NumberFormatException e) {
+            throw new JsonSyntaxException(e);
+          }
+          // Allow up to 65535 to support unsigned values
+          if (intValue > 65535 || intValue < Short.MIN_VALUE) {
+            throw new JsonSyntaxException(
+                "Lossy conversion from " + intValue + " to short; at path " + in.getPreviousPath());
+          }
+          return (short) intValue;
+        }
+
+        @Override
+        public void write(JsonWriter out, Number value) throws IOException {
+          if (value == null) {
+            out.nullValue();
+          } else {
+            out.value(value.shortValue());
+          }
+        }
+      };
+
+  public static final TypeAdapterFactory SHORT_FACTORY =
+      newFactory(short.class, Short.class, SHORT);
+
+  public static final TypeAdapter<Number> INTEGER =
+      new TypeAdapter<Number>() {
+        @Override
+        public Number read(JsonReader in) throws IOException {
+          if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return null;
+          }
+          try {
+            return in.nextInt();
           } catch (NumberFormatException e) {
             throw new JsonSyntaxException(e);
           }
         }
-        in.endArray();
-        int length = list.size();
-        AtomicIntegerArray array = new AtomicIntegerArray(length);
-        for (int i = 0; i < length; ++i) {
-          array.set(i, list.get(i));
+
+        @Override
+        public void write(JsonWriter out, Number value) throws IOException {
+          if (value == null) {
+            out.nullValue();
+          } else {
+            out.value(value.intValue());
+          }
         }
-        return array;
-    }
-    @Override public void write(JsonWriter out, AtomicIntegerArray value) throws IOException {
-      out.beginArray();
-      for (int i = 0, length = value.length(); i < length; i++) {
-        out.value(value.get(i));
-      }
-      out.endArray();
-    }
-  }.nullSafe();
+      };
+  public static final TypeAdapterFactory INTEGER_FACTORY =
+      newFactory(int.class, Integer.class, INTEGER);
+
+  public static final TypeAdapter<AtomicInteger> ATOMIC_INTEGER =
+      new TypeAdapter<AtomicInteger>() {
+        @Override
+        public AtomicInteger read(JsonReader in) throws IOException {
+          try {
+            return new AtomicInteger(in.nextInt());
+          } catch (NumberFormatException e) {
+            throw new JsonSyntaxException(e);
+          }
+        }
+
+        @Override
+        public void write(JsonWriter out, AtomicInteger value) throws IOException {
+          out.value(value.get());
+        }
+      }.nullSafe();
+  public static final TypeAdapterFactory ATOMIC_INTEGER_FACTORY =
+      newFactory(AtomicInteger.class, TypeAdapters.ATOMIC_INTEGER);
+
+  public static final TypeAdapter<AtomicBoolean> ATOMIC_BOOLEAN =
+      new TypeAdapter<AtomicBoolean>() {
+        @Override
+        public AtomicBoolean read(JsonReader in) throws IOException {
+          return new AtomicBoolean(in.nextBoolean());
+        }
+
+        @Override
+        public void write(JsonWriter out, AtomicBoolean value) throws IOException {
+          out.value(value.get());
+        }
+      }.nullSafe();
+  public static final TypeAdapterFactory ATOMIC_BOOLEAN_FACTORY =
+      newFactory(AtomicBoolean.class, TypeAdapters.ATOMIC_BOOLEAN);
+
+  public static final TypeAdapter<AtomicIntegerArray> ATOMIC_INTEGER_ARRAY =
+      new TypeAdapter<AtomicIntegerArray>() {
+        @Override
+        public AtomicIntegerArray read(JsonReader in) throws IOException {
+          List<Integer> list = new ArrayList<>();
+          in.beginArray();
+          while (in.hasNext()) {
+            try {
+              int integer = in.nextInt();
+              list.add(integer);
+            } catch (NumberFormatException e) {
+              throw new JsonSyntaxException(e);
+            }
+          }
+          in.endArray();
+          int length = list.size();
+          AtomicIntegerArray array = new AtomicIntegerArray(length);
+          for (int i = 0; i < length; ++i) {
+            array.set(i, list.get(i));
+          }
+          return array;
+        }
+
+        @Override
+        public void write(JsonWriter out, AtomicIntegerArray value) throws IOException {
+          out.beginArray();
+          for (int i = 0, length = value.length(); i < length; i++) {
+            out.value(value.get(i));
+          }
+          out.endArray();
+        }
+      }.nullSafe();
   public static final TypeAdapterFactory ATOMIC_INTEGER_ARRAY_FACTORY =
       newFactory(AtomicIntegerArray.class, TypeAdapters.ATOMIC_INTEGER_ARRAY);
 
-  public static final TypeAdapter<Number> LONG = new TypeAdapter<Number>() {
-    @Override
-    public Number read(JsonReader in) throws IOException {
-      if (in.peek() == JsonToken.NULL) {
-        in.nextNull();
-        return null;
-      }
-      try {
-        return in.nextLong();
-      } catch (NumberFormatException e) {
-        throw new JsonSyntaxException(e);
-      }
-    }
-    @Override
-    public void write(JsonWriter out, Number value) throws IOException {
-      if (value == null) {
-        out.nullValue();
-      } else {
-        out.value(value.longValue());
-      }
-    }
-  };
+  public static final TypeAdapter<Number> LONG =
+      new TypeAdapter<Number>() {
+        @Override
+        public Number read(JsonReader in) throws IOException {
+          if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return null;
+          }
+          try {
+            return in.nextLong();
+          } catch (NumberFormatException e) {
+            throw new JsonSyntaxException(e);
+          }
+        }
 
-  public static final TypeAdapter<Number> FLOAT = new TypeAdapter<Number>() {
-    @Override
-    public Number read(JsonReader in) throws IOException {
-      if (in.peek() == JsonToken.NULL) {
-        in.nextNull();
-        return null;
-      }
-      return (float) in.nextDouble();
-    }
-    @Override
-    public void write(JsonWriter out, Number value) throws IOException {
-      if (value == null) {
-        out.nullValue();
-      } else {
-        // For backward compatibility don't call `JsonWriter.value(float)` because that method has
-        // been newly added and not all custom JsonWriter implementations might override it yet
-        Number floatNumber = value instanceof Float ? value : value.floatValue();
-        out.value(floatNumber);
-      }
-    }
-  };
+        @Override
+        public void write(JsonWriter out, Number value) throws IOException {
+          if (value == null) {
+            out.nullValue();
+          } else {
+            out.value(value.longValue());
+          }
+        }
+      };
 
-  public static final TypeAdapter<Number> DOUBLE = new TypeAdapter<Number>() {
-    @Override
-    public Number read(JsonReader in) throws IOException {
-      if (in.peek() == JsonToken.NULL) {
-        in.nextNull();
-        return null;
-      }
-      return in.nextDouble();
-    }
-    @Override
-    public void write(JsonWriter out, Number value) throws IOException {
-      if (value == null) {
-        out.nullValue();
-      } else {
-        out.value(value.doubleValue());
-      }
-    }
-  };
+  public static final TypeAdapter<Number> FLOAT =
+      new TypeAdapter<Number>() {
+        @Override
+        public Number read(JsonReader in) throws IOException {
+          if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return null;
+          }
+          return (float) in.nextDouble();
+        }
 
-  public static final TypeAdapter<Character> CHARACTER = new TypeAdapter<Character>() {
-    @Override
-    public Character read(JsonReader in) throws IOException {
-      if (in.peek() == JsonToken.NULL) {
-        in.nextNull();
-        return null;
-      }
-      String str = in.nextString();
-      if (str.length() != 1) {
-        throw new JsonSyntaxException("Expecting character, got: " + str + "; at " + in.getPreviousPath());
-      }
-      return str.charAt(0);
-    }
-    @Override
-    public void write(JsonWriter out, Character value) throws IOException {
-      out.value(value == null ? null : String.valueOf(value));
-    }
-  };
+        @Override
+        public void write(JsonWriter out, Number value) throws IOException {
+          if (value == null) {
+            out.nullValue();
+          } else {
+            // For backward compatibility don't call `JsonWriter.value(float)` because that method
+            // has
+            // been newly added and not all custom JsonWriter implementations might override it yet
+            Number floatNumber = value instanceof Float ? value : value.floatValue();
+            out.value(floatNumber);
+          }
+        }
+      };
 
-  public static final TypeAdapterFactory CHARACTER_FACTORY
-      = newFactory(char.class, Character.class, CHARACTER);
+  public static final TypeAdapter<Number> DOUBLE =
+      new TypeAdapter<Number>() {
+        @Override
+        public Number read(JsonReader in) throws IOException {
+          if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return null;
+          }
+          return in.nextDouble();
+        }
 
-  public static final TypeAdapter<String> STRING = new TypeAdapter<String>() {
-    @Override
-    public String read(JsonReader in) throws IOException {
-      JsonToken peek = in.peek();
-      if (peek == JsonToken.NULL) {
-        in.nextNull();
-        return null;
-      }
-      /* coerce booleans to strings for backwards compatibility */
-      if (peek == JsonToken.BOOLEAN) {
-        return Boolean.toString(in.nextBoolean());
-      }
-      return in.nextString();
-    }
-    @Override
-    public void write(JsonWriter out, String value) throws IOException {
-      out.value(value);
-    }
-  };
+        @Override
+        public void write(JsonWriter out, Number value) throws IOException {
+          if (value == null) {
+            out.nullValue();
+          } else {
+            out.value(value.doubleValue());
+          }
+        }
+      };
 
-  public static final TypeAdapter<BigDecimal> BIG_DECIMAL = new TypeAdapter<BigDecimal>() {
-    @Override public BigDecimal read(JsonReader in) throws IOException {
-      if (in.peek() == JsonToken.NULL) {
-        in.nextNull();
-        return null;
-      }
-      String s = in.nextString();
-      try {
-        return NumberLimits.parseBigDecimal(s);
-      } catch (NumberFormatException e) {
-        throw new JsonSyntaxException("Failed parsing '" + s + "' as BigDecimal; at path " + in.getPreviousPath(), e);
-      }
-    }
+  public static final TypeAdapter<Character> CHARACTER =
+      new TypeAdapter<Character>() {
+        @Override
+        public Character read(JsonReader in) throws IOException {
+          if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return null;
+          }
+          String str = in.nextString();
+          if (str.length() != 1) {
+            throw new JsonSyntaxException(
+                "Expecting character, got: " + str + "; at " + in.getPreviousPath());
+          }
+          return str.charAt(0);
+        }
 
-    @Override public void write(JsonWriter out, BigDecimal value) throws IOException {
-      out.value(value);
-    }
-  };
+        @Override
+        public void write(JsonWriter out, Character value) throws IOException {
+          out.value(value == null ? null : String.valueOf(value));
+        }
+      };
 
-  public static final TypeAdapter<BigInteger> BIG_INTEGER = new TypeAdapter<BigInteger>() {
-    @Override public BigInteger read(JsonReader in) throws IOException {
-      if (in.peek() == JsonToken.NULL) {
-        in.nextNull();
-        return null;
-      }
-      String s = in.nextString();
-      try {
-        return NumberLimits.parseBigInteger(s);
-      } catch (NumberFormatException e) {
-        throw new JsonSyntaxException("Failed parsing '" + s + "' as BigInteger; at path " + in.getPreviousPath(), e);
-      }
-    }
+  public static final TypeAdapterFactory CHARACTER_FACTORY =
+      newFactory(char.class, Character.class, CHARACTER);
 
-    @Override public void write(JsonWriter out, BigInteger value) throws IOException {
-      out.value(value);
-    }
-  };
+  public static final TypeAdapter<String> STRING =
+      new TypeAdapter<String>() {
+        @Override
+        public String read(JsonReader in) throws IOException {
+          JsonToken peek = in.peek();
+          if (peek == JsonToken.NULL) {
+            in.nextNull();
+            return null;
+          }
+          /* coerce booleans to strings for backwards compatibility */
+          if (peek == JsonToken.BOOLEAN) {
+            return Boolean.toString(in.nextBoolean());
+          }
+          return in.nextString();
+        }
 
-  public static final TypeAdapter<LazilyParsedNumber> LAZILY_PARSED_NUMBER = new TypeAdapter<LazilyParsedNumber>() {
-    // Normally users should not be able to access and deserialize LazilyParsedNumber because
-    // it is an internal type, but implement this nonetheless in case there are legit corner
-    // cases where this is possible
-    @Override public LazilyParsedNumber read(JsonReader in) throws IOException {
-      if (in.peek() == JsonToken.NULL) {
-        in.nextNull();
-        return null;
-      }
-      return new LazilyParsedNumber(in.nextString());
-    }
+        @Override
+        public void write(JsonWriter out, String value) throws IOException {
+          out.value(value);
+        }
+      };
 
-    @Override public void write(JsonWriter out, LazilyParsedNumber value) throws IOException {
-      out.value(value);
-    }
-  };
+  public static final TypeAdapter<BigDecimal> BIG_DECIMAL =
+      new TypeAdapter<BigDecimal>() {
+        @Override
+        public BigDecimal read(JsonReader in) throws IOException {
+          if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return null;
+          }
+          String s = in.nextString();
+          try {
+            return NumberLimits.parseBigDecimal(s);
+          } catch (NumberFormatException e) {
+            throw new JsonSyntaxException(
+                "Failed parsing '" + s + "' as BigDecimal; at path " + in.getPreviousPath(), e);
+          }
+        }
+
+        @Override
+        public void write(JsonWriter out, BigDecimal value) throws IOException {
+          out.value(value);
+        }
+      };
+
+  public static final TypeAdapter<BigInteger> BIG_INTEGER =
+      new TypeAdapter<BigInteger>() {
+        @Override
+        public BigInteger read(JsonReader in) throws IOException {
+          if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return null;
+          }
+          String s = in.nextString();
+          try {
+            return NumberLimits.parseBigInteger(s);
+          } catch (NumberFormatException e) {
+            throw new JsonSyntaxException(
+                "Failed parsing '" + s + "' as BigInteger; at path " + in.getPreviousPath(), e);
+          }
+        }
+
+        @Override
+        public void write(JsonWriter out, BigInteger value) throws IOException {
+          out.value(value);
+        }
+      };
+
+  public static final TypeAdapter<LazilyParsedNumber> LAZILY_PARSED_NUMBER =
+      new TypeAdapter<LazilyParsedNumber>() {
+        // Normally users should not be able to access and deserialize LazilyParsedNumber because
+        // it is an internal type, but implement this nonetheless in case there are legit corner
+        // cases where this is possible
+        @Override
+        public LazilyParsedNumber read(JsonReader in) throws IOException {
+          if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return null;
+          }
+          return new LazilyParsedNumber(in.nextString());
+        }
+
+        @Override
+        public void write(JsonWriter out, LazilyParsedNumber value) throws IOException {
+          out.value(value);
+        }
+      };
 
   public static final TypeAdapterFactory STRING_FACTORY = newFactory(String.class, STRING);
 
-  public static final TypeAdapter<StringBuilder> STRING_BUILDER = new TypeAdapter<StringBuilder>() {
-    @Override
-    public StringBuilder read(JsonReader in) throws IOException {
-      if (in.peek() == JsonToken.NULL) {
-        in.nextNull();
-        return null;
-      }
-      return new StringBuilder(in.nextString());
-    }
-    @Override
-    public void write(JsonWriter out, StringBuilder value) throws IOException {
-      out.value(value == null ? null : value.toString());
-    }
-  };
+  public static final TypeAdapter<StringBuilder> STRING_BUILDER =
+      new TypeAdapter<StringBuilder>() {
+        @Override
+        public StringBuilder read(JsonReader in) throws IOException {
+          if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return null;
+          }
+          return new StringBuilder(in.nextString());
+        }
+
+        @Override
+        public void write(JsonWriter out, StringBuilder value) throws IOException {
+          out.value(value == null ? null : value.toString());
+        }
+      };
 
   public static final TypeAdapterFactory STRING_BUILDER_FACTORY =
-    newFactory(StringBuilder.class, STRING_BUILDER);
+      newFactory(StringBuilder.class, STRING_BUILDER);
 
-  public static final TypeAdapter<StringBuffer> STRING_BUFFER = new TypeAdapter<StringBuffer>() {
-    @Override
-    public StringBuffer read(JsonReader in) throws IOException {
-      if (in.peek() == JsonToken.NULL) {
-        in.nextNull();
-        return null;
-      }
-      return new StringBuffer(in.nextString());
-    }
-    @Override
-    public void write(JsonWriter out, StringBuffer value) throws IOException {
-      out.value(value == null ? null : value.toString());
-    }
-  };
+  public static final TypeAdapter<StringBuffer> STRING_BUFFER =
+      new TypeAdapter<StringBuffer>() {
+        @Override
+        public StringBuffer read(JsonReader in) throws IOException {
+          if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return null;
+          }
+          return new StringBuffer(in.nextString());
+        }
+
+        @Override
+        public void write(JsonWriter out, StringBuffer value) throws IOException {
+          out.value(value == null ? null : value.toString());
+        }
+      };
 
   public static final TypeAdapterFactory STRING_BUFFER_FACTORY =
-    newFactory(StringBuffer.class, STRING_BUFFER);
+      newFactory(StringBuffer.class, STRING_BUFFER);
 
-  public static final TypeAdapter<URL> URL = new TypeAdapter<URL>() {
-    @Override
-    public URL read(JsonReader in) throws IOException {
-      if (in.peek() == JsonToken.NULL) {
-        in.nextNull();
-        return null;
-      }
-      String nextString = in.nextString();
-      return "null".equals(nextString) ? null : new URL(nextString);
-    }
-    @Override
-    public void write(JsonWriter out, URL value) throws IOException {
-      out.value(value == null ? null : value.toExternalForm());
-    }
-  };
+  public static final TypeAdapter<URL> URL =
+      new TypeAdapter<URL>() {
+        @Override
+        public URL read(JsonReader in) throws IOException {
+          if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return null;
+          }
+          String nextString = in.nextString();
+          return "null".equals(nextString) ? null : new URL(nextString);
+        }
+
+        @Override
+        public void write(JsonWriter out, URL value) throws IOException {
+          out.value(value == null ? null : value.toExternalForm());
+        }
+      };
 
   public static final TypeAdapterFactory URL_FACTORY = newFactory(URL.class, URL);
 
-  public static final TypeAdapter<URI> URI = new TypeAdapter<URI>() {
-    @Override
-    public URI read(JsonReader in) throws IOException {
-      if (in.peek() == JsonToken.NULL) {
-        in.nextNull();
-        return null;
-      }
-      try {
-        String nextString = in.nextString();
-        return "null".equals(nextString) ? null : new URI(nextString);
-      } catch (URISyntaxException e) {
-        throw new JsonIOException(e);
-      }
-    }
-    @Override
-    public void write(JsonWriter out, URI value) throws IOException {
-      out.value(value == null ? null : value.toASCIIString());
-    }
-  };
+  public static final TypeAdapter<URI> URI =
+      new TypeAdapter<URI>() {
+        @Override
+        public URI read(JsonReader in) throws IOException {
+          if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return null;
+          }
+          try {
+            String nextString = in.nextString();
+            return "null".equals(nextString) ? null : new URI(nextString);
+          } catch (URISyntaxException e) {
+            throw new JsonIOException(e);
+          }
+        }
+
+        @Override
+        public void write(JsonWriter out, URI value) throws IOException {
+          out.value(value == null ? null : value.toASCIIString());
+        }
+      };
 
   public static final TypeAdapterFactory URI_FACTORY = newFactory(URI.class, URI);
 
-  public static final TypeAdapter<InetAddress> INET_ADDRESS = new TypeAdapter<InetAddress>() {
-    @Override
-    public InetAddress read(JsonReader in) throws IOException {
-      if (in.peek() == JsonToken.NULL) {
-        in.nextNull();
-        return null;
-      }
-      // regrettably, this should have included both the host name and the host address
-      // For compatibility, we use InetAddress.getByName rather than the possibly-better
-      // .getAllByName
-      @SuppressWarnings("AddressSelection")
-      InetAddress addr = InetAddress.getByName(in.nextString());
-      return addr;
-    }
-    @Override
-    public void write(JsonWriter out, InetAddress value) throws IOException {
-      out.value(value == null ? null : value.getHostAddress());
-    }
-  };
+  public static final TypeAdapter<InetAddress> INET_ADDRESS =
+      new TypeAdapter<InetAddress>() {
+        @Override
+        public InetAddress read(JsonReader in) throws IOException {
+          if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return null;
+          }
+          // regrettably, this should have included both the host name and the host address
+          // For compatibility, we use InetAddress.getByName rather than the possibly-better
+          // .getAllByName
+          @SuppressWarnings("AddressSelection")
+          InetAddress addr = InetAddress.getByName(in.nextString());
+          return addr;
+        }
+
+        @Override
+        public void write(JsonWriter out, InetAddress value) throws IOException {
+          out.value(value == null ? null : value.getHostAddress());
+        }
+      };
 
   public static final TypeAdapterFactory INET_ADDRESS_FACTORY =
-    newTypeHierarchyFactory(InetAddress.class, INET_ADDRESS);
+      newTypeHierarchyFactory(InetAddress.class, INET_ADDRESS);
 
-  public static final TypeAdapter<UUID> UUID = new TypeAdapter<UUID>() {
-    @Override
-    public UUID read(JsonReader in) throws IOException {
-      if (in.peek() == JsonToken.NULL) {
-        in.nextNull();
-        return null;
-      }
-      String s = in.nextString();
-      try {
-        return java.util.UUID.fromString(s);
-      } catch (IllegalArgumentException e) {
-        throw new JsonSyntaxException("Failed parsing '" + s + "' as UUID; at path " + in.getPreviousPath(), e);
-      }
-    }
-    @Override
-    public void write(JsonWriter out, UUID value) throws IOException {
-      out.value(value == null ? null : value.toString());
-    }
-  };
+  public static final TypeAdapter<UUID> UUID =
+      new TypeAdapter<UUID>() {
+        @Override
+        public UUID read(JsonReader in) throws IOException {
+          if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return null;
+          }
+          String s = in.nextString();
+          try {
+            return java.util.UUID.fromString(s);
+          } catch (IllegalArgumentException e) {
+            throw new JsonSyntaxException(
+                "Failed parsing '" + s + "' as UUID; at path " + in.getPreviousPath(), e);
+          }
+        }
+
+        @Override
+        public void write(JsonWriter out, UUID value) throws IOException {
+          out.value(value == null ? null : value.toString());
+        }
+      };
 
   public static final TypeAdapterFactory UUID_FACTORY = newFactory(UUID.class, UUID);
 
-  public static final TypeAdapter<Currency> CURRENCY = new TypeAdapter<Currency>() {
-    @Override
-    public Currency read(JsonReader in) throws IOException {
-      String s = in.nextString();
-      try {
-        return Currency.getInstance(s);
-      } catch (IllegalArgumentException e) {
-        throw new JsonSyntaxException("Failed parsing '" + s + "' as Currency; at path " + in.getPreviousPath(), e);
-      }
-    }
-    @Override
-    public void write(JsonWriter out, Currency value) throws IOException {
-      out.value(value.getCurrencyCode());
-    }
-  }.nullSafe();
+  public static final TypeAdapter<Currency> CURRENCY =
+      new TypeAdapter<Currency>() {
+        @Override
+        public Currency read(JsonReader in) throws IOException {
+          String s = in.nextString();
+          try {
+            return Currency.getInstance(s);
+          } catch (IllegalArgumentException e) {
+            throw new JsonSyntaxException(
+                "Failed parsing '" + s + "' as Currency; at path " + in.getPreviousPath(), e);
+          }
+        }
+
+        @Override
+        public void write(JsonWriter out, Currency value) throws IOException {
+          out.value(value.getCurrencyCode());
+        }
+      }.nullSafe();
   public static final TypeAdapterFactory CURRENCY_FACTORY = newFactory(Currency.class, CURRENCY);
 
-  public static final TypeAdapter<Calendar> CALENDAR = new TypeAdapter<Calendar>() {
-    private static final String YEAR = "year";
-    private static final String MONTH = "month";
-    private static final String DAY_OF_MONTH = "dayOfMonth";
-    private static final String HOUR_OF_DAY = "hourOfDay";
-    private static final String MINUTE = "minute";
-    private static final String SECOND = "second";
+  public static final TypeAdapter<Calendar> CALENDAR =
+      new TypeAdapter<Calendar>() {
+        private static final String YEAR = "year";
+        private static final String MONTH = "month";
+        private static final String DAY_OF_MONTH = "dayOfMonth";
+        private static final String HOUR_OF_DAY = "hourOfDay";
+        private static final String MINUTE = "minute";
+        private static final String SECOND = "second";
 
-    @Override
-    public Calendar read(JsonReader in) throws IOException {
-      if (in.peek() == JsonToken.NULL) {
-        in.nextNull();
-        return  null;
-      }
-      in.beginObject();
-      int year = 0;
-      int month = 0;
-      int dayOfMonth = 0;
-      int hourOfDay = 0;
-      int minute = 0;
-      int second = 0;
-      while (in.peek() != JsonToken.END_OBJECT) {
-        String name = in.nextName();
-        int value = in.nextInt();
-        if (YEAR.equals(name)) {
-          year = value;
-        } else if (MONTH.equals(name)) {
-          month = value;
-        } else if (DAY_OF_MONTH.equals(name)) {
-          dayOfMonth = value;
-        } else if (HOUR_OF_DAY.equals(name)) {
-          hourOfDay = value;
-        } else if (MINUTE.equals(name)) {
-          minute = value;
-        } else if (SECOND.equals(name)) {
-          second = value;
+        @Override
+        public Calendar read(JsonReader in) throws IOException {
+          if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return null;
+          }
+          in.beginObject();
+          int year = 0;
+          int month = 0;
+          int dayOfMonth = 0;
+          int hourOfDay = 0;
+          int minute = 0;
+          int second = 0;
+          while (in.peek() != JsonToken.END_OBJECT) {
+            String name = in.nextName();
+            int value = in.nextInt();
+            if (YEAR.equals(name)) {
+              year = value;
+            } else if (MONTH.equals(name)) {
+              month = value;
+            } else if (DAY_OF_MONTH.equals(name)) {
+              dayOfMonth = value;
+            } else if (HOUR_OF_DAY.equals(name)) {
+              hourOfDay = value;
+            } else if (MINUTE.equals(name)) {
+              minute = value;
+            } else if (SECOND.equals(name)) {
+              second = value;
+            }
+          }
+          in.endObject();
+          return new GregorianCalendar(year, month, dayOfMonth, hourOfDay, minute, second);
         }
-      }
-      in.endObject();
-      return new GregorianCalendar(year, month, dayOfMonth, hourOfDay, minute, second);
-    }
 
-    @Override
-    public void write(JsonWriter out, Calendar value) throws IOException {
-      if (value == null) {
-        out.nullValue();
-        return;
-      }
-      out.beginObject();
-      out.name(YEAR);
-      out.value(value.get(Calendar.YEAR));
-      out.name(MONTH);
-      out.value(value.get(Calendar.MONTH));
-      out.name(DAY_OF_MONTH);
-      out.value(value.get(Calendar.DAY_OF_MONTH));
-      out.name(HOUR_OF_DAY);
-      out.value(value.get(Calendar.HOUR_OF_DAY));
-      out.name(MINUTE);
-      out.value(value.get(Calendar.MINUTE));
-      out.name(SECOND);
-      out.value(value.get(Calendar.SECOND));
-      out.endObject();
-    }
-  };
+        @Override
+        public void write(JsonWriter out, Calendar value) throws IOException {
+          if (value == null) {
+            out.nullValue();
+            return;
+          }
+          out.beginObject();
+          out.name(YEAR);
+          out.value(value.get(Calendar.YEAR));
+          out.name(MONTH);
+          out.value(value.get(Calendar.MONTH));
+          out.name(DAY_OF_MONTH);
+          out.value(value.get(Calendar.DAY_OF_MONTH));
+          out.name(HOUR_OF_DAY);
+          out.value(value.get(Calendar.HOUR_OF_DAY));
+          out.name(MINUTE);
+          out.value(value.get(Calendar.MINUTE));
+          out.name(SECOND);
+          out.value(value.get(Calendar.SECOND));
+          out.endObject();
+        }
+      };
 
   public static final TypeAdapterFactory CALENDAR_FACTORY =
-    newFactoryForMultipleTypes(Calendar.class, GregorianCalendar.class, CALENDAR);
+      newFactoryForMultipleTypes(Calendar.class, GregorianCalendar.class, CALENDAR);
 
-  public static final TypeAdapter<Locale> LOCALE = new TypeAdapter<Locale>() {
-    @Override
-    public Locale read(JsonReader in) throws IOException {
-      if (in.peek() == JsonToken.NULL) {
-        in.nextNull();
-        return null;
-      }
-      String locale = in.nextString();
-      StringTokenizer tokenizer = new StringTokenizer(locale, "_");
-      String language = null;
-      String country = null;
-      String variant = null;
-      if (tokenizer.hasMoreElements()) {
-        language = tokenizer.nextToken();
-      }
-      if (tokenizer.hasMoreElements()) {
-        country = tokenizer.nextToken();
-      }
-      if (tokenizer.hasMoreElements()) {
-        variant = tokenizer.nextToken();
-      }
-      if (country == null && variant == null) {
-        return new Locale(language);
-      } else if (variant == null) {
-        return new Locale(language, country);
-      } else {
-        return new Locale(language, country, variant);
-      }
-    }
-    @Override
-    public void write(JsonWriter out, Locale value) throws IOException {
-      out.value(value == null ? null : value.toString());
-    }
-  };
+  public static final TypeAdapter<Locale> LOCALE =
+      new TypeAdapter<Locale>() {
+        @Override
+        public Locale read(JsonReader in) throws IOException {
+          if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return null;
+          }
+          String locale = in.nextString();
+          StringTokenizer tokenizer = new StringTokenizer(locale, "_");
+          String language = null;
+          String country = null;
+          String variant = null;
+          if (tokenizer.hasMoreElements()) {
+            language = tokenizer.nextToken();
+          }
+          if (tokenizer.hasMoreElements()) {
+            country = tokenizer.nextToken();
+          }
+          if (tokenizer.hasMoreElements()) {
+            variant = tokenizer.nextToken();
+          }
+          if (country == null && variant == null) {
+            return new Locale(language);
+          } else if (variant == null) {
+            return new Locale(language, country);
+          } else {
+            return new Locale(language, country, variant);
+          }
+        }
+
+        @Override
+        public void write(JsonWriter out, Locale value) throws IOException {
+          out.value(value == null ? null : value.toString());
+        }
+      };
 
   public static final TypeAdapterFactory LOCALE_FACTORY = newFactory(Locale.class, LOCALE);
 
-  public static final TypeAdapter<JsonElement> JSON_ELEMENT = new TypeAdapter<JsonElement>() {
-    /**
-     * Tries to begin reading a JSON array or JSON object, returning {@code null} if
-     * the next element is neither of those.
-     */
-    private JsonElement tryBeginNesting(JsonReader in, JsonToken peeked) throws IOException {
-      switch (peeked) {
-        case BEGIN_ARRAY:
-          in.beginArray();
-          return new JsonArray();
-        case BEGIN_OBJECT:
-          in.beginObject();
-          return new JsonObject();
-        default:
-          return null;
-      }
-    }
+  public static final TypeAdapter<JsonElement> JSON_ELEMENT =
+      new TypeAdapter<JsonElement>() {
+        /**
+         * Tries to begin reading a JSON array or JSON object, returning {@code null} if the next
+         * element is neither of those.
+         */
+        private JsonElement tryBeginNesting(JsonReader in, JsonToken peeked) throws IOException {
+          switch (peeked) {
+            case BEGIN_ARRAY:
+              in.beginArray();
+              return new JsonArray();
+            case BEGIN_OBJECT:
+              in.beginObject();
+              return new JsonObject();
+            default:
+              return null;
+          }
+        }
 
-    /** Reads a {@link JsonElement} which cannot have any nested elements */
-    private JsonElement readTerminal(JsonReader in, JsonToken peeked) throws IOException {
-      switch (peeked) {
-        case STRING:
-          return new JsonPrimitive(in.nextString());
-        case NUMBER:
-          String number = in.nextString();
-          return new JsonPrimitive(new LazilyParsedNumber(number));
-        case BOOLEAN:
-          return new JsonPrimitive(in.nextBoolean());
-        case NULL:
-          in.nextNull();
-          return JsonNull.INSTANCE;
-        default:
-          // When read(JsonReader) is called with JsonReader in invalid state
-          throw new IllegalStateException("Unexpected token: " + peeked);
-      }
-    }
+        /** Reads a {@link JsonElement} which cannot have any nested elements */
+        private JsonElement readTerminal(JsonReader in, JsonToken peeked) throws IOException {
+          switch (peeked) {
+            case STRING:
+              return new JsonPrimitive(in.nextString());
+            case NUMBER:
+              String number = in.nextString();
+              return new JsonPrimitive(new LazilyParsedNumber(number));
+            case BOOLEAN:
+              return new JsonPrimitive(in.nextBoolean());
+            case NULL:
+              in.nextNull();
+              return JsonNull.INSTANCE;
+            default:
+              // When read(JsonReader) is called with JsonReader in invalid state
+              throw new IllegalStateException("Unexpected token: " + peeked);
+          }
+        }
 
-    @Override public JsonElement read(JsonReader in) throws IOException {
-      if (in instanceof JsonTreeReader) {
-        return ((JsonTreeReader) in).nextJsonElement();
-      }
-
-      // Either JsonArray or JsonObject
-      JsonElement current;
-      JsonToken peeked = in.peek();
-
-      current = tryBeginNesting(in, peeked);
-      if (current == null) {
-        return readTerminal(in, peeked);
-      }
-
-      Deque<JsonElement> stack = new ArrayDeque<>();
-
-      while (true) {
-        while (in.hasNext()) {
-          String name = null;
-          // Name is only used for JSON object members
-          if (current instanceof JsonObject) {
-            name = in.nextName();
+        @Override
+        public JsonElement read(JsonReader in) throws IOException {
+          if (in instanceof JsonTreeReader) {
+            return ((JsonTreeReader) in).nextJsonElement();
           }
 
-          peeked = in.peek();
-          JsonElement value = tryBeginNesting(in, peeked);
-          boolean isNesting = value != null;
+          // Either JsonArray or JsonObject
+          JsonElement current;
+          JsonToken peeked = in.peek();
 
-          if (value == null) {
-            value = readTerminal(in, peeked);
+          current = tryBeginNesting(in, peeked);
+          if (current == null) {
+            return readTerminal(in, peeked);
           }
 
-          if (current instanceof JsonArray) {
-            ((JsonArray) current).add(value);
+          Deque<JsonElement> stack = new ArrayDeque<>();
+
+          while (true) {
+            while (in.hasNext()) {
+              String name = null;
+              // Name is only used for JSON object members
+              if (current instanceof JsonObject) {
+                name = in.nextName();
+              }
+
+              peeked = in.peek();
+              JsonElement value = tryBeginNesting(in, peeked);
+              boolean isNesting = value != null;
+
+              if (value == null) {
+                value = readTerminal(in, peeked);
+              }
+
+              if (current instanceof JsonArray) {
+                ((JsonArray) current).add(value);
+              } else {
+                ((JsonObject) current).add(name, value);
+              }
+
+              if (isNesting) {
+                stack.addLast(current);
+                current = value;
+              }
+            }
+
+            // End current element
+            if (current instanceof JsonArray) {
+              in.endArray();
+            } else {
+              in.endObject();
+            }
+
+            if (stack.isEmpty()) {
+              return current;
+            } else {
+              // Continue with enclosing element
+              current = stack.removeLast();
+            }
+          }
+        }
+
+        @Override
+        public void write(JsonWriter out, JsonElement value) throws IOException {
+          if (value == null || value.isJsonNull()) {
+            out.nullValue();
+          } else if (value.isJsonPrimitive()) {
+            JsonPrimitive primitive = value.getAsJsonPrimitive();
+            if (primitive.isNumber()) {
+              out.value(primitive.getAsNumber());
+            } else if (primitive.isBoolean()) {
+              out.value(primitive.getAsBoolean());
+            } else {
+              out.value(primitive.getAsString());
+            }
+
+          } else if (value.isJsonArray()) {
+            out.beginArray();
+            for (JsonElement e : value.getAsJsonArray()) {
+              write(out, e);
+            }
+            out.endArray();
+
+          } else if (value.isJsonObject()) {
+            out.beginObject();
+            for (Map.Entry<String, JsonElement> e : value.getAsJsonObject().entrySet()) {
+              out.name(e.getKey());
+              write(out, e.getValue());
+            }
+            out.endObject();
+
           } else {
-            ((JsonObject) current).add(name, value);
-          }
-
-          if (isNesting) {
-            stack.addLast(current);
-            current = value;
+            throw new IllegalArgumentException("Couldn't write " + value.getClass());
           }
         }
+      };
 
-        // End current element
-        if (current instanceof JsonArray) {
-          in.endArray();
-        } else {
-          in.endObject();
-        }
-
-        if (stack.isEmpty()) {
-          return current;
-        } else {
-          // Continue with enclosing element
-          current = stack.removeLast();
-        }
-      }
-    }
-
-    @Override public void write(JsonWriter out, JsonElement value) throws IOException {
-      if (value == null || value.isJsonNull()) {
-        out.nullValue();
-      } else if (value.isJsonPrimitive()) {
-        JsonPrimitive primitive = value.getAsJsonPrimitive();
-        if (primitive.isNumber()) {
-          out.value(primitive.getAsNumber());
-        } else if (primitive.isBoolean()) {
-          out.value(primitive.getAsBoolean());
-        } else {
-          out.value(primitive.getAsString());
-        }
-
-      } else if (value.isJsonArray()) {
-        out.beginArray();
-        for (JsonElement e : value.getAsJsonArray()) {
-          write(out, e);
-        }
-        out.endArray();
-
-      } else if (value.isJsonObject()) {
-        out.beginObject();
-        for (Map.Entry<String, JsonElement> e : value.getAsJsonObject().entrySet()) {
-          out.name(e.getKey());
-          write(out, e.getValue());
-        }
-        out.endObject();
-
-      } else {
-        throw new IllegalArgumentException("Couldn't write " + value.getClass());
-      }
-    }
-  };
-
-  public static final TypeAdapterFactory JSON_ELEMENT_FACTORY
-      = newTypeHierarchyFactory(JsonElement.class, JSON_ELEMENT);
+  public static final TypeAdapterFactory JSON_ELEMENT_FACTORY =
+      newTypeHierarchyFactory(JsonElement.class, JSON_ELEMENT);
 
   private static final class EnumTypeAdapter<T extends Enum<T>> extends TypeAdapter<T> {
     private final Map<String, T> nameToConstant = new HashMap<>();
@@ -871,24 +951,28 @@ public final class TypeAdapters {
 
     public EnumTypeAdapter(final Class<T> classOfT) {
       try {
-        // Uses reflection to find enum constants to work around name mismatches for obfuscated classes
-        // Reflection access might throw SecurityException, therefore run this in privileged context;
-        // should be acceptable because this only retrieves enum constants, but does not expose anything else
-        Field[] constantFields = AccessController.doPrivileged(new PrivilegedAction<Field[]>() {
-          @Override public Field[] run() {
-            Field[] fields = classOfT.getDeclaredFields();
-            ArrayList<Field> constantFieldsList = new ArrayList<>(fields.length);
-            for (Field f : fields) {
-              if (f.isEnumConstant()) {
-                constantFieldsList.add(f);
-              }
-            }
+        // Uses reflection to find enum constants to work around name mismatches for obfuscated
+        // classes Reflection access might throw SecurityException, therefore run this in privileged
+        // context; should be acceptable because this only retrieves enum constants, but does not
+        // expose anything else
+        Field[] constantFields =
+            AccessController.doPrivileged(
+                new PrivilegedAction<Field[]>() {
+                  @Override
+                  public Field[] run() {
+                    Field[] fields = classOfT.getDeclaredFields();
+                    ArrayList<Field> constantFieldsList = new ArrayList<>(fields.length);
+                    for (Field f : fields) {
+                      if (f.isEnumConstant()) {
+                        constantFieldsList.add(f);
+                      }
+                    }
 
-            Field[] constantFields = constantFieldsList.toArray(new Field[0]);
-            AccessibleObject.setAccessible(constantFields, true);
-            return constantFields;
-          }
-        });
+                    Field[] constantFields = constantFieldsList.toArray(new Field[0]);
+                    AccessibleObject.setAccessible(constantFields, true);
+                    return constantFields;
+                  }
+                });
         for (Field constantField : constantFields) {
           @SuppressWarnings("unchecked")
           T constant = (T) constantField.get(null);
@@ -910,7 +994,9 @@ public final class TypeAdapters {
         throw new AssertionError(e);
       }
     }
-    @Override public T read(JsonReader in) throws IOException {
+
+    @Override
+    public T read(JsonReader in) throws IOException {
       if (in.peek() == JsonToken.NULL) {
         in.nextNull();
         return null;
@@ -920,31 +1006,35 @@ public final class TypeAdapters {
       return (constant == null) ? stringToConstant.get(key) : constant;
     }
 
-    @Override public void write(JsonWriter out, T value) throws IOException {
+    @Override
+    public void write(JsonWriter out, T value) throws IOException {
       out.value(value == null ? null : constantToName.get(value));
     }
   }
 
-  public static final TypeAdapterFactory ENUM_FACTORY = new TypeAdapterFactory() {
-    @Override public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
-      Class<? super T> rawType = typeToken.getRawType();
-      if (!Enum.class.isAssignableFrom(rawType) || rawType == Enum.class) {
-        return null;
-      }
-      if (!rawType.isEnum()) {
-        rawType = rawType.getSuperclass(); // handle anonymous subclasses
-      }
-      @SuppressWarnings({"rawtypes", "unchecked"})
-      TypeAdapter<T> adapter = (TypeAdapter<T>) new EnumTypeAdapter(rawType);
-      return adapter;
-    }
-  };
+  public static final TypeAdapterFactory ENUM_FACTORY =
+      new TypeAdapterFactory() {
+        @Override
+        public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
+          Class<? super T> rawType = typeToken.getRawType();
+          if (!Enum.class.isAssignableFrom(rawType) || rawType == Enum.class) {
+            return null;
+          }
+          if (!rawType.isEnum()) {
+            rawType = rawType.getSuperclass(); // handle anonymous subclasses
+          }
+          @SuppressWarnings({"rawtypes", "unchecked"})
+          TypeAdapter<T> adapter = (TypeAdapter<T>) new EnumTypeAdapter(rawType);
+          return adapter;
+        }
+      };
 
   public static <TT> TypeAdapterFactory newFactory(
       final TypeToken<TT> type, final TypeAdapter<TT> typeAdapter) {
     return new TypeAdapterFactory() {
       @SuppressWarnings("unchecked") // we use a runtime check to make sure the 'T's equal
-      @Override public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
+      @Override
+      public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
         return typeToken.equals(type) ? (TypeAdapter<T>) typeAdapter : null;
       }
     };
@@ -954,10 +1044,13 @@ public final class TypeAdapters {
       final Class<TT> type, final TypeAdapter<TT> typeAdapter) {
     return new TypeAdapterFactory() {
       @SuppressWarnings("unchecked") // we use a runtime check to make sure the 'T's equal
-      @Override public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
+      @Override
+      public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
         return typeToken.getRawType() == type ? (TypeAdapter<T>) typeAdapter : null;
       }
-      @Override public String toString() {
+
+      @Override
+      public String toString() {
         return "Factory[type=" + type.getName() + ",adapter=" + typeAdapter + "]";
       }
     };
@@ -967,28 +1060,46 @@ public final class TypeAdapters {
       final Class<TT> unboxed, final Class<TT> boxed, final TypeAdapter<? super TT> typeAdapter) {
     return new TypeAdapterFactory() {
       @SuppressWarnings("unchecked") // we use a runtime check to make sure the 'T's equal
-      @Override public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
+      @Override
+      public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
         Class<? super T> rawType = typeToken.getRawType();
         return (rawType == unboxed || rawType == boxed) ? (TypeAdapter<T>) typeAdapter : null;
       }
-      @Override public String toString() {
-        return "Factory[type=" + boxed.getName()
-            + "+" + unboxed.getName() + ",adapter=" + typeAdapter + "]";
+
+      @Override
+      public String toString() {
+        return "Factory[type="
+            + boxed.getName()
+            + "+"
+            + unboxed.getName()
+            + ",adapter="
+            + typeAdapter
+            + "]";
       }
     };
   }
 
-  public static <TT> TypeAdapterFactory newFactoryForMultipleTypes(final Class<TT> base,
-      final Class<? extends TT> sub, final TypeAdapter<? super TT> typeAdapter) {
+  public static <TT> TypeAdapterFactory newFactoryForMultipleTypes(
+      final Class<TT> base,
+      final Class<? extends TT> sub,
+      final TypeAdapter<? super TT> typeAdapter) {
     return new TypeAdapterFactory() {
       @SuppressWarnings("unchecked") // we use a runtime check to make sure the 'T's equal
-      @Override public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
+      @Override
+      public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
         Class<? super T> rawType = typeToken.getRawType();
         return (rawType == base || rawType == sub) ? (TypeAdapter<T>) typeAdapter : null;
       }
-      @Override public String toString() {
-        return "Factory[type=" + base.getName()
-            + "+" + sub.getName() + ",adapter=" + typeAdapter + "]";
+
+      @Override
+      public String toString() {
+        return "Factory[type="
+            + base.getName()
+            + "+"
+            + sub.getName()
+            + ",adapter="
+            + typeAdapter
+            + "]";
       }
     };
   }
@@ -1001,27 +1112,38 @@ public final class TypeAdapters {
       final Class<T1> clazz, final TypeAdapter<T1> typeAdapter) {
     return new TypeAdapterFactory() {
       @SuppressWarnings("unchecked")
-      @Override public <T2> TypeAdapter<T2> create(Gson gson, TypeToken<T2> typeToken) {
+      @Override
+      public <T2> TypeAdapter<T2> create(Gson gson, TypeToken<T2> typeToken) {
         final Class<? super T2> requestedType = typeToken.getRawType();
         if (!clazz.isAssignableFrom(requestedType)) {
           return null;
         }
-        return (TypeAdapter<T2>) new TypeAdapter<T1>() {
-          @Override public void write(JsonWriter out, T1 value) throws IOException {
-            typeAdapter.write(out, value);
-          }
+        return (TypeAdapter<T2>)
+            new TypeAdapter<T1>() {
+              @Override
+              public void write(JsonWriter out, T1 value) throws IOException {
+                typeAdapter.write(out, value);
+              }
 
-          @Override public T1 read(JsonReader in) throws IOException {
-            T1 result = typeAdapter.read(in);
-            if (result != null && !requestedType.isInstance(result)) {
-              throw new JsonSyntaxException("Expected a " + requestedType.getName()
-                  + " but was " + result.getClass().getName() + "; at path " + in.getPreviousPath());
-            }
-            return result;
-          }
-        };
+              @Override
+              public T1 read(JsonReader in) throws IOException {
+                T1 result = typeAdapter.read(in);
+                if (result != null && !requestedType.isInstance(result)) {
+                  throw new JsonSyntaxException(
+                      "Expected a "
+                          + requestedType.getName()
+                          + " but was "
+                          + result.getClass().getName()
+                          + "; at path "
+                          + in.getPreviousPath());
+                }
+                return result;
+              }
+            };
       }
-      @Override public String toString() {
+
+      @Override
+      public String toString() {
         return "Factory[typeHierarchy=" + clazz.getName() + ",adapter=" + typeAdapter + "]";
       }
     };

--- a/gson/src/main/java/com/google/gson/internal/bind/util/ISO8601Utils.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/util/ISO8601Utils.java
@@ -25,349 +25,357 @@ import java.util.Locale;
 import java.util.TimeZone;
 
 /**
- * Utilities methods for manipulating dates in iso8601 format. This is much faster and GC friendly than using SimpleDateFormat so
- * highly suitable if you (un)serialize lots of date objects.
- * 
- * Supported parse format: [yyyy-MM-dd|yyyyMMdd][T(hh:mm[:ss[.sss]]|hhmm[ss[.sss]])]?[Z|[+-]hh[:]mm]]
- * 
+ * Utilities methods for manipulating dates in iso8601 format. This is much faster and GC friendly
+ * than using SimpleDateFormat so highly suitable if you (un)serialize lots of date objects.
+ *
+ * <p>Supported parse format:
+ * [yyyy-MM-dd|yyyyMMdd][T(hh:mm[:ss[.sss]]|hhmm[ss[.sss]])]?[Z|[+-]hh[:]mm]]
+ *
  * @see <a href="http://www.w3.org/TR/NOTE-datetime">this specification</a>
  */
 // Date parsing code from Jackson databind ISO8601Utils.java
 // https://github.com/FasterXML/jackson-databind/blob/2.8/src/main/java/com/fasterxml/jackson/databind/util/ISO8601Utils.java
-public class ISO8601Utils
-{
-    /**
-     * ID to represent the 'UTC' string, default timezone since Jackson 2.7
-     * 
-     * @since 2.7
-     */
-    private static final String UTC_ID = "UTC";
-    /**
-     * The UTC timezone, prefetched to avoid more lookups.
-     * 
-     * @since 2.7
-     */
-    private static final TimeZone TIMEZONE_UTC = TimeZone.getTimeZone(UTC_ID);
+public class ISO8601Utils {
+  /**
+   * ID to represent the 'UTC' string, default timezone since Jackson 2.7
+   *
+   * @since 2.7
+   */
+  private static final String UTC_ID = "UTC";
 
-    /*
-    /**********************************************************
-    /* Formatting
-    /**********************************************************
-     */
+  /**
+   * The UTC timezone, prefetched to avoid more lookups.
+   *
+   * @since 2.7
+   */
+  private static final TimeZone TIMEZONE_UTC = TimeZone.getTimeZone(UTC_ID);
 
-    /**
-     * Format a date into 'yyyy-MM-ddThh:mm:ssZ' (default timezone, no milliseconds precision)
-     * 
-     * @param date the date to format
-     * @return the date formatted as 'yyyy-MM-ddThh:mm:ssZ'
-     */
-    public static String format(Date date) {
-        return format(date, false, TIMEZONE_UTC);
+  /*
+  /**********************************************************
+  /* Formatting
+  /**********************************************************
+   */
+
+  /**
+   * Format a date into 'yyyy-MM-ddThh:mm:ssZ' (default timezone, no milliseconds precision)
+   *
+   * @param date the date to format
+   * @return the date formatted as 'yyyy-MM-ddThh:mm:ssZ'
+   */
+  public static String format(Date date) {
+    return format(date, false, TIMEZONE_UTC);
+  }
+
+  /**
+   * Format a date into 'yyyy-MM-ddThh:mm:ss[.sss]Z' (GMT timezone)
+   *
+   * @param date the date to format
+   * @param millis true to include millis precision otherwise false
+   * @return the date formatted as 'yyyy-MM-ddThh:mm:ss[.sss]Z'
+   */
+  public static String format(Date date, boolean millis) {
+    return format(date, millis, TIMEZONE_UTC);
+  }
+
+  /**
+   * Format date into yyyy-MM-ddThh:mm:ss[.sss][Z|[+-]hh:mm]
+   *
+   * @param date the date to format
+   * @param millis true to include millis precision otherwise false
+   * @param tz timezone to use for the formatting (UTC will produce 'Z')
+   * @return the date formatted as yyyy-MM-ddThh:mm:ss[.sss][Z|[+-]hh:mm]
+   */
+  public static String format(Date date, boolean millis, TimeZone tz) {
+    Calendar calendar = new GregorianCalendar(tz, Locale.US);
+    calendar.setTime(date);
+
+    // estimate capacity of buffer as close as we can (yeah, that's pedantic ;)
+    int capacity = "yyyy-MM-ddThh:mm:ss".length();
+    capacity += millis ? ".sss".length() : 0;
+    capacity += tz.getRawOffset() == 0 ? "Z".length() : "+hh:mm".length();
+    StringBuilder formatted = new StringBuilder(capacity);
+
+    padInt(formatted, calendar.get(Calendar.YEAR), "yyyy".length());
+    formatted.append('-');
+    padInt(formatted, calendar.get(Calendar.MONTH) + 1, "MM".length());
+    formatted.append('-');
+    padInt(formatted, calendar.get(Calendar.DAY_OF_MONTH), "dd".length());
+    formatted.append('T');
+    padInt(formatted, calendar.get(Calendar.HOUR_OF_DAY), "hh".length());
+    formatted.append(':');
+    padInt(formatted, calendar.get(Calendar.MINUTE), "mm".length());
+    formatted.append(':');
+    padInt(formatted, calendar.get(Calendar.SECOND), "ss".length());
+    if (millis) {
+      formatted.append('.');
+      padInt(formatted, calendar.get(Calendar.MILLISECOND), "sss".length());
     }
 
-    /**
-     * Format a date into 'yyyy-MM-ddThh:mm:ss[.sss]Z' (GMT timezone)
-     * 
-     * @param date the date to format
-     * @param millis true to include millis precision otherwise false
-     * @return the date formatted as 'yyyy-MM-ddThh:mm:ss[.sss]Z'
-     */
-    public static String format(Date date, boolean millis) {
-        return format(date, millis, TIMEZONE_UTC);
+    int offset = tz.getOffset(calendar.getTimeInMillis());
+    if (offset != 0) {
+      int hours = Math.abs((offset / (60 * 1000)) / 60);
+      int minutes = Math.abs((offset / (60 * 1000)) % 60);
+      formatted.append(offset < 0 ? '-' : '+');
+      padInt(formatted, hours, "hh".length());
+      formatted.append(':');
+      padInt(formatted, minutes, "mm".length());
+    } else {
+      formatted.append('Z');
     }
 
-    /**
-     * Format date into yyyy-MM-ddThh:mm:ss[.sss][Z|[+-]hh:mm]
-     * 
-     * @param date the date to format
-     * @param millis true to include millis precision otherwise false
-     * @param tz timezone to use for the formatting (UTC will produce 'Z')
-     * @return the date formatted as yyyy-MM-ddThh:mm:ss[.sss][Z|[+-]hh:mm]
-     */
-    public static String format(Date date, boolean millis, TimeZone tz) {
-        Calendar calendar = new GregorianCalendar(tz, Locale.US);
-        calendar.setTime(date);
+    return formatted.toString();
+  }
 
-        // estimate capacity of buffer as close as we can (yeah, that's pedantic ;)
-        int capacity = "yyyy-MM-ddThh:mm:ss".length();
-        capacity += millis ? ".sss".length() : 0;
-        capacity += tz.getRawOffset() == 0 ? "Z".length() : "+hh:mm".length();
-        StringBuilder formatted = new StringBuilder(capacity);
+  /*
+  /**********************************************************
+  /* Parsing
+  /**********************************************************
+   */
 
-        padInt(formatted, calendar.get(Calendar.YEAR), "yyyy".length());
-        formatted.append('-');
-        padInt(formatted, calendar.get(Calendar.MONTH) + 1, "MM".length());
-        formatted.append('-');
-        padInt(formatted, calendar.get(Calendar.DAY_OF_MONTH), "dd".length());
-        formatted.append('T');
-        padInt(formatted, calendar.get(Calendar.HOUR_OF_DAY), "hh".length());
-        formatted.append(':');
-        padInt(formatted, calendar.get(Calendar.MINUTE), "mm".length());
-        formatted.append(':');
-        padInt(formatted, calendar.get(Calendar.SECOND), "ss".length());
-        if (millis) {
-            formatted.append('.');
-            padInt(formatted, calendar.get(Calendar.MILLISECOND), "sss".length());
+  /**
+   * Parse a date from ISO-8601 formatted string. It expects a format
+   * [yyyy-MM-dd|yyyyMMdd][T(hh:mm[:ss[.sss]]|hhmm[ss[.sss]])]?[Z|[+-]hh[:mm]]]
+   *
+   * @param date ISO string to parse in the appropriate format.
+   * @param pos The position to start parsing from, updated to where parsing stopped.
+   * @return the parsed date
+   * @throws ParseException if the date is not in the appropriate format
+   */
+  public static Date parse(String date, ParsePosition pos) throws ParseException {
+    Exception fail = null;
+    try {
+      int offset = pos.getIndex();
+
+      // extract year
+      int year = parseInt(date, offset, offset += 4);
+      if (checkOffset(date, offset, '-')) {
+        offset += 1;
+      }
+
+      // extract month
+      int month = parseInt(date, offset, offset += 2);
+      if (checkOffset(date, offset, '-')) {
+        offset += 1;
+      }
+
+      // extract day
+      int day = parseInt(date, offset, offset += 2);
+      // default time value
+      int hour = 0;
+      int minutes = 0;
+      int seconds = 0;
+      int milliseconds =
+          0; // always use 0 otherwise returned date will include millis of current time
+
+      // if the value has no time component (and no time zone), we are done
+      boolean hasT = checkOffset(date, offset, 'T');
+
+      if (!hasT && (date.length() <= offset)) {
+        Calendar calendar = new GregorianCalendar(year, month - 1, day);
+        calendar.setLenient(false);
+
+        pos.setIndex(offset);
+        return calendar.getTime();
+      }
+
+      if (hasT) {
+
+        // extract hours, minutes, seconds and milliseconds
+        hour = parseInt(date, offset += 1, offset += 2);
+        if (checkOffset(date, offset, ':')) {
+          offset += 1;
         }
 
-        int offset = tz.getOffset(calendar.getTimeInMillis());
-        if (offset != 0) {
-            int hours = Math.abs((offset / (60 * 1000)) / 60);
-            int minutes = Math.abs((offset / (60 * 1000)) % 60);
-            formatted.append(offset < 0 ? '-' : '+');
-            padInt(formatted, hours, "hh".length());
-            formatted.append(':');
-            padInt(formatted, minutes, "mm".length());
+        minutes = parseInt(date, offset, offset += 2);
+        if (checkOffset(date, offset, ':')) {
+          offset += 1;
+        }
+        // second and milliseconds can be optional
+        if (date.length() > offset) {
+          char c = date.charAt(offset);
+          if (c != 'Z' && c != '+' && c != '-') {
+            seconds = parseInt(date, offset, offset += 2);
+            if (seconds > 59 && seconds < 63) seconds = 59; // truncate up to 3 leap seconds
+            // milliseconds can be optional in the format
+            if (checkOffset(date, offset, '.')) {
+              offset += 1;
+              int endOffset = indexOfNonDigit(date, offset + 1); // assume at least one digit
+              int parseEndOffset = Math.min(endOffset, offset + 3); // parse up to 3 digits
+              int fraction = parseInt(date, offset, parseEndOffset);
+              // compensate for "missing" digits
+              switch (parseEndOffset - offset) { // number of digits parsed
+                case 2:
+                  milliseconds = fraction * 10;
+                  break;
+                case 1:
+                  milliseconds = fraction * 100;
+                  break;
+                default:
+                  milliseconds = fraction;
+              }
+              offset = endOffset;
+            }
+          }
+        }
+      }
+
+      // extract timezone
+      if (date.length() <= offset) {
+        throw new IllegalArgumentException("No time zone indicator");
+      }
+
+      TimeZone timezone = null;
+      char timezoneIndicator = date.charAt(offset);
+
+      if (timezoneIndicator == 'Z') {
+        timezone = TIMEZONE_UTC;
+        offset += 1;
+      } else if (timezoneIndicator == '+' || timezoneIndicator == '-') {
+        String timezoneOffset = date.substring(offset);
+
+        // When timezone has no minutes, we should append it, valid timezones are, for example:
+        // +00:00, +0000 and +00
+        timezoneOffset = timezoneOffset.length() >= 5 ? timezoneOffset : timezoneOffset + "00";
+
+        offset += timezoneOffset.length();
+        // 18-Jun-2015, tatu: Minor simplification, skip offset of "+0000"/"+00:00"
+        if ("+0000".equals(timezoneOffset) || "+00:00".equals(timezoneOffset)) {
+          timezone = TIMEZONE_UTC;
         } else {
-            formatted.append('Z');
-        }
+          // 18-Jun-2015, tatu: Looks like offsets only work from GMT, not UTC...
+          //    not sure why, but that's the way it looks. Further, Javadocs for
+          //    `java.util.TimeZone` specifically instruct use of GMT as base for
+          //    custom timezones... odd.
+          String timezoneId = "GMT" + timezoneOffset;
+          // String timezoneId = "UTC" + timezoneOffset;
 
-        return formatted.toString();
+          timezone = TimeZone.getTimeZone(timezoneId);
+
+          String act = timezone.getID();
+          if (!act.equals(timezoneId)) {
+            /* 22-Jan-2015, tatu: Looks like canonical version has colons, but we may be given
+             *    one without. If so, don't sweat.
+             *   Yes, very inefficient. Hopefully not hit often.
+             *   If it becomes a perf problem, add 'loose' comparison instead.
+             */
+            String cleaned = act.replace(":", "");
+            if (!cleaned.equals(timezoneId)) {
+              throw new IndexOutOfBoundsException(
+                  "Mismatching time zone indicator: "
+                      + timezoneId
+                      + " given, resolves to "
+                      + timezone.getID());
+            }
+          }
+        }
+      } else {
+        throw new IndexOutOfBoundsException(
+            "Invalid time zone indicator '" + timezoneIndicator + "'");
+      }
+
+      Calendar calendar = new GregorianCalendar(timezone);
+      calendar.setLenient(false);
+      calendar.set(Calendar.YEAR, year);
+      calendar.set(Calendar.MONTH, month - 1);
+      calendar.set(Calendar.DAY_OF_MONTH, day);
+      calendar.set(Calendar.HOUR_OF_DAY, hour);
+      calendar.set(Calendar.MINUTE, minutes);
+      calendar.set(Calendar.SECOND, seconds);
+      calendar.set(Calendar.MILLISECOND, milliseconds);
+
+      pos.setIndex(offset);
+      return calendar.getTime();
+      // If we get a ParseException it'll already have the right message/offset.
+      // Other exception types can convert here.
+    } catch (IndexOutOfBoundsException e) {
+      fail = e;
+    } catch (NumberFormatException e) {
+      fail = e;
+    } catch (IllegalArgumentException e) {
+      fail = e;
     }
-
-    /*
-    /**********************************************************
-    /* Parsing
-    /**********************************************************
-     */
-
-    /**
-     * Parse a date from ISO-8601 formatted string. It expects a format
-     * [yyyy-MM-dd|yyyyMMdd][T(hh:mm[:ss[.sss]]|hhmm[ss[.sss]])]?[Z|[+-]hh[:mm]]]
-     * 
-     * @param date ISO string to parse in the appropriate format.
-     * @param pos The position to start parsing from, updated to where parsing stopped.
-     * @return the parsed date
-     * @throws ParseException if the date is not in the appropriate format
-     */
-    public static Date parse(String date, ParsePosition pos) throws ParseException {
-        Exception fail = null;
-        try {
-            int offset = pos.getIndex();
-
-            // extract year
-            int year = parseInt(date, offset, offset += 4);
-            if (checkOffset(date, offset, '-')) {
-                offset += 1;
-            }
-
-            // extract month
-            int month = parseInt(date, offset, offset += 2);
-            if (checkOffset(date, offset, '-')) {
-                offset += 1;
-            }
-
-            // extract day
-            int day = parseInt(date, offset, offset += 2);
-            // default time value
-            int hour = 0;
-            int minutes = 0;
-            int seconds = 0;
-            int milliseconds = 0; // always use 0 otherwise returned date will include millis of current time
-
-            // if the value has no time component (and no time zone), we are done
-            boolean hasT = checkOffset(date, offset, 'T');
-
-            if (!hasT && (date.length() <= offset)) {
-                Calendar calendar = new GregorianCalendar(year, month - 1, day);
-                calendar.setLenient(false);
-
-                pos.setIndex(offset);
-                return calendar.getTime();
-            }
-
-            if (hasT) {
-
-                // extract hours, minutes, seconds and milliseconds
-                hour = parseInt(date, offset += 1, offset += 2);
-                if (checkOffset(date, offset, ':')) {
-                    offset += 1;
-                }
-
-                minutes = parseInt(date, offset, offset += 2);
-                if (checkOffset(date, offset, ':')) {
-                    offset += 1;
-                }
-                // second and milliseconds can be optional
-                if (date.length() > offset) {
-                    char c = date.charAt(offset);
-                    if (c != 'Z' && c != '+' && c != '-') {
-                        seconds = parseInt(date, offset, offset += 2);
-                        if (seconds > 59 && seconds < 63) seconds = 59; // truncate up to 3 leap seconds
-                        // milliseconds can be optional in the format
-                        if (checkOffset(date, offset, '.')) {
-                            offset += 1;
-                            int endOffset = indexOfNonDigit(date, offset + 1); // assume at least one digit
-                            int parseEndOffset = Math.min(endOffset, offset + 3); // parse up to 3 digits
-                            int fraction = parseInt(date, offset, parseEndOffset);
-                            // compensate for "missing" digits
-                            switch (parseEndOffset - offset) { // number of digits parsed
-                            case 2:
-                                milliseconds = fraction * 10;
-                                break;
-                            case 1:
-                                milliseconds = fraction * 100;
-                                break;
-                            default:
-                                milliseconds = fraction;
-                            }
-                            offset = endOffset;
-                        }
-                    }
-                }
-            }
-
-            // extract timezone
-            if (date.length() <= offset) {
-                throw new IllegalArgumentException("No time zone indicator");
-            }
-
-            TimeZone timezone = null;
-            char timezoneIndicator = date.charAt(offset);
-
-            if (timezoneIndicator == 'Z') {
-                timezone = TIMEZONE_UTC;
-                offset += 1;
-            } else if (timezoneIndicator == '+' || timezoneIndicator == '-') {
-                String timezoneOffset = date.substring(offset);
-
-                // When timezone has no minutes, we should append it, valid timezones are, for example: +00:00, +0000 and +00
-                timezoneOffset = timezoneOffset.length() >= 5 ? timezoneOffset : timezoneOffset + "00";
-
-                offset += timezoneOffset.length();
-                // 18-Jun-2015, tatu: Minor simplification, skip offset of "+0000"/"+00:00"
-                if ("+0000".equals(timezoneOffset) || "+00:00".equals(timezoneOffset)) {
-                    timezone = TIMEZONE_UTC;
-                } else {
-                    // 18-Jun-2015, tatu: Looks like offsets only work from GMT, not UTC...
-                    //    not sure why, but that's the way it looks. Further, Javadocs for
-                    //    `java.util.TimeZone` specifically instruct use of GMT as base for
-                    //    custom timezones... odd.
-                    String timezoneId = "GMT" + timezoneOffset;
-//                    String timezoneId = "UTC" + timezoneOffset;
-
-                    timezone = TimeZone.getTimeZone(timezoneId);
-
-                    String act = timezone.getID();
-                    if (!act.equals(timezoneId)) {
-                        /* 22-Jan-2015, tatu: Looks like canonical version has colons, but we may be given
-                         *    one without. If so, don't sweat.
-                         *   Yes, very inefficient. Hopefully not hit often.
-                         *   If it becomes a perf problem, add 'loose' comparison instead.
-                         */
-                        String cleaned = act.replace(":", "");
-                        if (!cleaned.equals(timezoneId)) {
-                            throw new IndexOutOfBoundsException("Mismatching time zone indicator: "+timezoneId+" given, resolves to "
-                                    +timezone.getID());
-                        }
-                    }
-                }
-            } else {
-                throw new IndexOutOfBoundsException("Invalid time zone indicator '" + timezoneIndicator+"'");
-            }
-
-            Calendar calendar = new GregorianCalendar(timezone);
-            calendar.setLenient(false);
-            calendar.set(Calendar.YEAR, year);
-            calendar.set(Calendar.MONTH, month - 1);
-            calendar.set(Calendar.DAY_OF_MONTH, day);
-            calendar.set(Calendar.HOUR_OF_DAY, hour);
-            calendar.set(Calendar.MINUTE, minutes);
-            calendar.set(Calendar.SECOND, seconds);
-            calendar.set(Calendar.MILLISECOND, milliseconds);
-
-            pos.setIndex(offset);
-            return calendar.getTime();
-            // If we get a ParseException it'll already have the right message/offset.
-            // Other exception types can convert here.
-        } catch (IndexOutOfBoundsException e) {
-            fail = e;
-        } catch (NumberFormatException e) {
-            fail = e;
-        } catch (IllegalArgumentException e) {
-            fail = e;
-        }
-        String input = (date == null) ? null : ('"' + date + '"');
-        String msg = fail.getMessage();
-        if (msg == null || msg.isEmpty()) {
-            msg = "("+fail.getClass().getName()+")";
-        }
-        ParseException ex = new ParseException("Failed to parse date [" + input + "]: " + msg, pos.getIndex());
-        ex.initCause(fail);
-        throw ex;
+    String input = (date == null) ? null : ('"' + date + '"');
+    String msg = fail.getMessage();
+    if (msg == null || msg.isEmpty()) {
+      msg = "(" + fail.getClass().getName() + ")";
     }
+    ParseException ex =
+        new ParseException("Failed to parse date [" + input + "]: " + msg, pos.getIndex());
+    ex.initCause(fail);
+    throw ex;
+  }
 
-    /**
-     * Check if the expected character exist at the given offset in the value.
-     * 
-     * @param value the string to check at the specified offset
-     * @param offset the offset to look for the expected character
-     * @param expected the expected character
-     * @return true if the expected character exist at the given offset
-     */
-    private static boolean checkOffset(String value, int offset, char expected) {
-        return (offset < value.length()) && (value.charAt(offset) == expected);
+  /**
+   * Check if the expected character exist at the given offset in the value.
+   *
+   * @param value the string to check at the specified offset
+   * @param offset the offset to look for the expected character
+   * @param expected the expected character
+   * @return true if the expected character exist at the given offset
+   */
+  private static boolean checkOffset(String value, int offset, char expected) {
+    return (offset < value.length()) && (value.charAt(offset) == expected);
+  }
+
+  /**
+   * Parse an integer located between 2 given offsets in a string
+   *
+   * @param value the string to parse
+   * @param beginIndex the start index for the integer in the string
+   * @param endIndex the end index for the integer in the string
+   * @return the int
+   * @throws NumberFormatException if the value is not a number
+   */
+  private static int parseInt(String value, int beginIndex, int endIndex)
+      throws NumberFormatException {
+    if (beginIndex < 0 || endIndex > value.length() || beginIndex > endIndex) {
+      throw new NumberFormatException(value);
     }
-
-    /**
-     * Parse an integer located between 2 given offsets in a string
-     * 
-     * @param value the string to parse
-     * @param beginIndex the start index for the integer in the string
-     * @param endIndex the end index for the integer in the string
-     * @return the int
-     * @throws NumberFormatException if the value is not a number
-     */
-    private static int parseInt(String value, int beginIndex, int endIndex) throws NumberFormatException {
-        if (beginIndex < 0 || endIndex > value.length() || beginIndex > endIndex) {
-            throw new NumberFormatException(value);
-        }
-        // use same logic as in Integer.parseInt() but less generic we're not supporting negative values
-        int i = beginIndex;
-        int result = 0;
-        int digit;
-        if (i < endIndex) {
-            digit = Character.digit(value.charAt(i++), 10);
-            if (digit < 0) {
-                throw new NumberFormatException("Invalid number: " + value.substring(beginIndex, endIndex));
-            }
-            result = -digit;
-        }
-        while (i < endIndex) {
-            digit = Character.digit(value.charAt(i++), 10);
-            if (digit < 0) {
-                throw new NumberFormatException("Invalid number: " + value.substring(beginIndex, endIndex));
-            }
-            result *= 10;
-            result -= digit;
-        }
-        return -result;
+    // use same logic as in Integer.parseInt() but less generic we're not supporting negative values
+    int i = beginIndex;
+    int result = 0;
+    int digit;
+    if (i < endIndex) {
+      digit = Character.digit(value.charAt(i++), 10);
+      if (digit < 0) {
+        throw new NumberFormatException("Invalid number: " + value.substring(beginIndex, endIndex));
+      }
+      result = -digit;
     }
-
-    /**
-     * Zero pad a number to a specified length
-     * 
-     * @param buffer buffer to use for padding
-     * @param value the integer value to pad if necessary.
-     * @param length the length of the string we should zero pad
-     */
-    private static void padInt(StringBuilder buffer, int value, int length) {
-        String strValue = Integer.toString(value);
-        for (int i = length - strValue.length(); i > 0; i--) {
-            buffer.append('0');
-        }
-        buffer.append(strValue);
+    while (i < endIndex) {
+      digit = Character.digit(value.charAt(i++), 10);
+      if (digit < 0) {
+        throw new NumberFormatException("Invalid number: " + value.substring(beginIndex, endIndex));
+      }
+      result *= 10;
+      result -= digit;
     }
+    return -result;
+  }
 
-    /**
-     * Returns the index of the first character in the string that is not a digit, starting at offset.
-     */
-    private static int indexOfNonDigit(String string, int offset) {
-        for (int i = offset; i < string.length(); i++) {
-            char c = string.charAt(i);
-            if (c < '0' || c > '9') return i;
-        }
-        return string.length();
+  /**
+   * Zero pad a number to a specified length
+   *
+   * @param buffer buffer to use for padding
+   * @param value the integer value to pad if necessary.
+   * @param length the length of the string we should zero pad
+   */
+  private static void padInt(StringBuilder buffer, int value, int length) {
+    String strValue = Integer.toString(value);
+    for (int i = length - strValue.length(); i > 0; i--) {
+      buffer.append('0');
     }
+    buffer.append(strValue);
+  }
 
+  /**
+   * Returns the index of the first character in the string that is not a digit, starting at offset.
+   */
+  private static int indexOfNonDigit(String string, int offset) {
+    for (int i = offset; i < string.length(); i++) {
+      char c = string.charAt(i);
+      if (c < '0' || c > '9') return i;
+    }
+    return string.length();
+  }
 }

--- a/gson/src/main/java/com/google/gson/internal/package-info.java
+++ b/gson/src/main/java/com/google/gson/internal/package-info.java
@@ -15,8 +15,8 @@
  */
 
 /**
- * Do NOT use any class in this package as they are meant for internal use in Gson.
- * These classes will very likely change incompatibly in future versions. You have been warned.
+ * Do NOT use any class in this package as they are meant for internal use in Gson. These classes
+ * will very likely change incompatibly in future versions. You have been warned.
  *
  * @author Inderjeet Singh, Joel Leitch, Jesse Wilson
  */

--- a/gson/src/main/java/com/google/gson/internal/reflect/ReflectionHelper.java
+++ b/gson/src/main/java/com/google/gson/internal/reflect/ReflectionHelper.java
@@ -31,7 +31,8 @@ public class ReflectionHelper {
   static {
     RecordHelper instance;
     try {
-      // Try to construct the RecordSupportedHelper, if this fails, records are not supported on this JVM.
+      // Try to construct the RecordSupportedHelper, if this fails, records are not supported on
+      // this JVM.
       instance = new RecordSupportedHelper();
     } catch (ReflectiveOperationException e) {
       instance = new RecordNotSupportedHelper();
@@ -45,8 +46,10 @@ public class ReflectionHelper {
     // Class was added in Java 9, therefore cannot use instanceof
     if (e.getClass().getName().equals("java.lang.reflect.InaccessibleObjectException")) {
       String message = e.getMessage();
-      String troubleshootingId = message != null && message.contains("to module com.google.gson")
-          ? "reflection-inaccessible-to-module-gson" : "reflection-inaccessible";
+      String troubleshootingId =
+          message != null && message.contains("to module com.google.gson")
+              ? "reflection-inaccessible-to-module-gson"
+              : "reflection-inaccessible";
       return "\nSee " + TroubleshootingGuide.createUrl(troubleshootingId);
     }
     return "";
@@ -55,7 +58,8 @@ public class ReflectionHelper {
   /**
    * Internal implementation of making an {@link AccessibleObject} accessible.
    *
-   * @param object the object that {@link AccessibleObject#setAccessible(boolean)} should be called on.
+   * @param object the object that {@link AccessibleObject#setAccessible(boolean)} should be called
+   *     on.
    * @throws JsonIOException if making the object accessible fails
    */
   public static void makeAccessible(AccessibleObject object) throws JsonIOException {
@@ -63,22 +67,26 @@ public class ReflectionHelper {
       object.setAccessible(true);
     } catch (Exception exception) {
       String description = getAccessibleObjectDescription(object, false);
-      throw new JsonIOException("Failed making " + description + " accessible; either increase its visibility"
-          + " or write a custom TypeAdapter for its declaring type." + getInaccessibleTroubleshootingSuffix(exception),
+      throw new JsonIOException(
+          "Failed making "
+              + description
+              + " accessible; either increase its visibility"
+              + " or write a custom TypeAdapter for its declaring type."
+              + getInaccessibleTroubleshootingSuffix(exception),
           exception);
     }
   }
 
   /**
-   * Returns a short string describing the {@link AccessibleObject} in a human-readable way.
-   * The result is normally shorter than {@link AccessibleObject#toString()} because it omits
-   * modifiers (e.g. {@code final}) and uses simple names for constructor and method parameter
-   * types.
+   * Returns a short string describing the {@link AccessibleObject} in a human-readable way. The
+   * result is normally shorter than {@link AccessibleObject#toString()} because it omits modifiers
+   * (e.g. {@code final}) and uses simple names for constructor and method parameter types.
    *
    * @param object object to describe
    * @param uppercaseFirstLetter whether the first letter of the description should be uppercased
    */
-  public static String getAccessibleObjectDescription(AccessibleObject object, boolean uppercaseFirstLetter) {
+  public static String getAccessibleObjectDescription(
+      AccessibleObject object, boolean uppercaseFirstLetter) {
     String description;
 
     if (object instanceof Field) {
@@ -103,17 +111,14 @@ public class ReflectionHelper {
     return description;
   }
 
-  /**
-   * Creates a string representation for a field, omitting modifiers and
-   * the field type.
-   */
+  /** Creates a string representation for a field, omitting modifiers and the field type. */
   public static String fieldToString(Field field) {
     return field.getDeclaringClass().getName() + "#" + field.getName();
   }
 
   /**
-   * Creates a string representation for a constructor.
-   * E.g.: {@code java.lang.String(char[], int, int)}
+   * Creates a string representation for a constructor. E.g.: {@code java.lang.String(char[], int,
+   * int)}
    */
   public static String constructorToString(Constructor<?> constructor) {
     StringBuilder stringBuilder = new StringBuilder(constructor.getDeclaringClass().getName());
@@ -122,13 +127,15 @@ public class ReflectionHelper {
     return stringBuilder.toString();
   }
 
-  // Note: Ideally parameter type would be java.lang.reflect.Executable, but that was added in Java 8
-  private static void appendExecutableParameters(AccessibleObject executable, StringBuilder stringBuilder) {
+  // Ideally parameter type would be java.lang.reflect.Executable, but that was added in Java 8
+  private static void appendExecutableParameters(
+      AccessibleObject executable, StringBuilder stringBuilder) {
     stringBuilder.append('(');
 
-    Class<?>[] parameters = (executable instanceof Method)
-        ? ((Method) executable).getParameterTypes()
-        : ((Constructor<?>) executable).getParameterTypes();
+    Class<?>[] parameters =
+        (executable instanceof Method)
+            ? ((Method) executable).getParameterTypes()
+            : ((Constructor<?>) executable).getParameterTypes();
     for (int i = 0; i < parameters.length; i++) {
       if (i > 0) {
         stringBuilder.append(", ");
@@ -140,22 +147,24 @@ public class ReflectionHelper {
   }
 
   /**
-   * Tries making the constructor accessible, returning an exception message
-   * if this fails.
+   * Tries making the constructor accessible, returning an exception message if this fails.
    *
    * @param constructor constructor to make accessible
-   * @return exception message; {@code null} if successful, non-{@code null} if
-   *    unsuccessful
+   * @return exception message; {@code null} if successful, non-{@code null} if unsuccessful
    */
   public static String tryMakeAccessible(Constructor<?> constructor) {
     try {
       constructor.setAccessible(true);
       return null;
     } catch (Exception exception) {
-      return "Failed making constructor '" + constructorToString(constructor) + "' accessible;"
+      return "Failed making constructor '"
+          + constructorToString(constructor)
+          + "' accessible;"
           + " either increase its visibility or write a custom InstanceCreator or TypeAdapter for"
           // Include the message since it might contain more detailed information
-          + " its declaring type: " + exception.getMessage() + getInaccessibleTroubleshootingSuffix(exception);
+          + " its declaring type: "
+          + exception.getMessage()
+          + getInaccessibleTroubleshootingSuffix(exception);
     }
   }
 
@@ -179,26 +188,28 @@ public class ReflectionHelper {
 
   public static RuntimeException createExceptionForUnexpectedIllegalAccess(
       IllegalAccessException exception) {
-    throw new RuntimeException("Unexpected IllegalAccessException occurred (Gson " + GsonBuildConfig.VERSION + ")."
-        + " Certain ReflectionAccessFilter features require Java >= 9 to work correctly. If you are not using"
-        + " ReflectionAccessFilter, report this to the Gson maintainers.",
+    throw new RuntimeException(
+        "Unexpected IllegalAccessException occurred (Gson "
+            + GsonBuildConfig.VERSION
+            + "). Certain ReflectionAccessFilter features require Java >= 9 to work correctly. If"
+            + " you are not using ReflectionAccessFilter, report this to the Gson maintainers.",
         exception);
   }
 
-
   private static RuntimeException createExceptionForRecordReflectionException(
-          ReflectiveOperationException exception) {
-    throw new RuntimeException("Unexpected ReflectiveOperationException occurred"
-            + " (Gson " + GsonBuildConfig.VERSION + ")."
+      ReflectiveOperationException exception) {
+    throw new RuntimeException(
+        "Unexpected ReflectiveOperationException occurred"
+            + " (Gson "
+            + GsonBuildConfig.VERSION
+            + ")."
             + " To support Java records, reflection is utilized to read out information"
             + " about records. All these invocations happens after it is established"
             + " that records exist in the JVM. This exception is unexpected behavior.",
-            exception);
+        exception);
   }
 
-  /**
-   * Internal abstraction over reflection when Records are supported.
-   */
+  /** Internal abstraction over reflection when Records are supported. */
   private abstract static class RecordHelper {
     abstract boolean isRecord(Class<?> clazz);
 
@@ -254,8 +265,8 @@ public class ReflectionHelper {
         for (int i = 0; i < recordComponents.length; i++) {
           recordComponentTypes[i] = (Class<?>) getType.invoke(recordComponents[i]);
         }
-        // Uses getDeclaredConstructor because implicit constructor has same visibility as record and might
-        // therefore not be public
+        // Uses getDeclaredConstructor because implicit constructor has same visibility as record
+        // and might therefore not be public
         return raw.getDeclaredConstructor(recordComponentTypes);
       } catch (ReflectiveOperationException e) {
         throw createExceptionForRecordReflectionException(e);
@@ -265,8 +276,9 @@ public class ReflectionHelper {
     @Override
     public Method getAccessor(Class<?> raw, Field field) {
       try {
-        // Records consists of record components, each with a unique name, a corresponding field and accessor method
-        // with the same name. Ref.: https://docs.oracle.com/javase/specs/jls/se17/html/jls-8.html#jls-8.10.3
+        // Records consists of record components, each with a unique name, a corresponding field and
+        // accessor method with the same name. Ref.:
+        // https://docs.oracle.com/javase/specs/jls/se17/html/jls-8.html#jls-8.10.3
         return raw.getMethod(field.getName());
       } catch (ReflectiveOperationException e) {
         throw createExceptionForRecordReflectionException(e);
@@ -274,9 +286,7 @@ public class ReflectionHelper {
     }
   }
 
-  /**
-   * Instance used when records are not supported
-   */
+  /** Instance used when records are not supported */
   private static class RecordNotSupportedHelper extends RecordHelper {
 
     @Override
@@ -287,19 +297,19 @@ public class ReflectionHelper {
     @Override
     String[] getRecordComponentNames(Class<?> clazz) {
       throw new UnsupportedOperationException(
-              "Records are not supported on this JVM, this method should not be called");
+          "Records are not supported on this JVM, this method should not be called");
     }
 
     @Override
     <T> Constructor<T> getCanonicalRecordConstructor(Class<T> raw) {
       throw new UnsupportedOperationException(
-              "Records are not supported on this JVM, this method should not be called");
+          "Records are not supported on this JVM, this method should not be called");
     }
 
     @Override
     public Method getAccessor(Class<?> raw, Field field) {
       throw new UnsupportedOperationException(
-              "Records are not supported on this JVM, this method should not be called");
+          "Records are not supported on this JVM, this method should not be called");
     }
   }
 }

--- a/gson/src/main/java/com/google/gson/internal/sql/SqlDateTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/sql/SqlDateTypeAdapter.java
@@ -31,25 +31,26 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 /**
- * Adapter for java.sql.Date. Although this class appears stateless, it is not.
- * DateFormat captures its time zone and locale when it is created, which gives
- * this class state. DateFormat isn't thread safe either, so this class has
- * to synchronize its read and write methods.
+ * Adapter for java.sql.Date. Although this class appears stateless, it is not. DateFormat captures
+ * its time zone and locale when it is created, which gives this class state. DateFormat isn't
+ * thread safe either, so this class has to synchronize its read and write methods.
  */
 @SuppressWarnings("JavaUtilDate")
 final class SqlDateTypeAdapter extends TypeAdapter<java.sql.Date> {
-  static final TypeAdapterFactory FACTORY = new TypeAdapterFactory() {
-    @SuppressWarnings("unchecked") // we use a runtime check to make sure the 'T's equal
-    @Override public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
-      return typeToken.getRawType() == java.sql.Date.class
-          ? (TypeAdapter<T>) new SqlDateTypeAdapter() : null;
-    }
-  };
+  static final TypeAdapterFactory FACTORY =
+      new TypeAdapterFactory() {
+        @SuppressWarnings("unchecked") // we use a runtime check to make sure the 'T's equal
+        @Override
+        public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
+          return typeToken.getRawType() == java.sql.Date.class
+              ? (TypeAdapter<T>) new SqlDateTypeAdapter()
+              : null;
+        }
+      };
 
   private final DateFormat format = new SimpleDateFormat("MMM d, yyyy");
 
-  private SqlDateTypeAdapter() {
-  }
+  private SqlDateTypeAdapter() {}
 
   @Override
   public java.sql.Date read(JsonReader in) throws IOException {
@@ -65,7 +66,8 @@ final class SqlDateTypeAdapter extends TypeAdapter<java.sql.Date> {
       }
       return new java.sql.Date(utilDate.getTime());
     } catch (ParseException e) {
-      throw new JsonSyntaxException("Failed parsing '" + s + "' as SQL Date; at path " + in.getPreviousPath(), e);
+      throw new JsonSyntaxException(
+          "Failed parsing '" + s + "' as SQL Date; at path " + in.getPreviousPath(), e);
     }
   }
 

--- a/gson/src/main/java/com/google/gson/internal/sql/SqlTimeTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/sql/SqlTimeTypeAdapter.java
@@ -32,26 +32,29 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 /**
- * Adapter for java.sql.Time. Although this class appears stateless, it is not.
- * DateFormat captures its time zone and locale when it is created, which gives
- * this class state. DateFormat isn't thread safe either, so this class has
- * to synchronize its read and write methods.
+ * Adapter for java.sql.Time. Although this class appears stateless, it is not. DateFormat captures
+ * its time zone and locale when it is created, which gives this class state. DateFormat isn't
+ * thread safe either, so this class has to synchronize its read and write methods.
  */
 @SuppressWarnings("JavaUtilDate")
 final class SqlTimeTypeAdapter extends TypeAdapter<Time> {
-  static final TypeAdapterFactory FACTORY = new TypeAdapterFactory() {
-    @SuppressWarnings("unchecked") // we use a runtime check to make sure the 'T's equal
-    @Override public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
-      return typeToken.getRawType() == Time.class ? (TypeAdapter<T>) new SqlTimeTypeAdapter() : null;
-    }
-  };
+  static final TypeAdapterFactory FACTORY =
+      new TypeAdapterFactory() {
+        @SuppressWarnings("unchecked") // we use a runtime check to make sure the 'T's equal
+        @Override
+        public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
+          return typeToken.getRawType() == Time.class
+              ? (TypeAdapter<T>) new SqlTimeTypeAdapter()
+              : null;
+        }
+      };
 
   private final DateFormat format = new SimpleDateFormat("hh:mm:ss a");
 
-  private SqlTimeTypeAdapter() {
-  }
+  private SqlTimeTypeAdapter() {}
 
-  @Override public Time read(JsonReader in) throws IOException {
+  @Override
+  public Time read(JsonReader in) throws IOException {
     if (in.peek() == JsonToken.NULL) {
       in.nextNull();
       return null;
@@ -63,11 +66,13 @@ final class SqlTimeTypeAdapter extends TypeAdapter<Time> {
         return new Time(date.getTime());
       }
     } catch (ParseException e) {
-      throw new JsonSyntaxException("Failed parsing '" + s + "' as SQL Time; at path " + in.getPreviousPath(), e);
+      throw new JsonSyntaxException(
+          "Failed parsing '" + s + "' as SQL Time; at path " + in.getPreviousPath(), e);
     }
   }
 
-  @Override public void write(JsonWriter out, Time value) throws IOException {
+  @Override
+  public void write(JsonWriter out, Time value) throws IOException {
     if (value == null) {
       out.nullValue();
       return;

--- a/gson/src/main/java/com/google/gson/internal/sql/SqlTimestampTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/sql/SqlTimestampTypeAdapter.java
@@ -22,24 +22,25 @@ import com.google.gson.TypeAdapterFactory;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
-
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.Date;
 
 @SuppressWarnings("JavaUtilDate")
 class SqlTimestampTypeAdapter extends TypeAdapter<Timestamp> {
-  static final TypeAdapterFactory FACTORY = new TypeAdapterFactory() {
-    @SuppressWarnings("unchecked") // we use a runtime check to make sure the 'T's equal
-    @Override public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
-      if (typeToken.getRawType() == Timestamp.class) {
-        final TypeAdapter<Date> dateTypeAdapter = gson.getAdapter(Date.class);
-        return (TypeAdapter<T>) new SqlTimestampTypeAdapter(dateTypeAdapter);
-      } else {
-        return null;
-      }
-    }
-  };
+  static final TypeAdapterFactory FACTORY =
+      new TypeAdapterFactory() {
+        @SuppressWarnings("unchecked") // we use a runtime check to make sure the 'T's equal
+        @Override
+        public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
+          if (typeToken.getRawType() == Timestamp.class) {
+            final TypeAdapter<Date> dateTypeAdapter = gson.getAdapter(Date.class);
+            return (TypeAdapter<T>) new SqlTimestampTypeAdapter(dateTypeAdapter);
+          } else {
+            return null;
+          }
+        }
+      };
 
   private final TypeAdapter<Date> dateTypeAdapter;
 

--- a/gson/src/main/java/com/google/gson/internal/sql/SqlTypesSupport.java
+++ b/gson/src/main/java/com/google/gson/internal/sql/SqlTypesSupport.java
@@ -16,29 +16,23 @@
 
 package com.google.gson.internal.sql;
 
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.internal.bind.DefaultDateTypeAdapter.DateType;
 import java.sql.Timestamp;
 import java.util.Date;
 
-import com.google.gson.TypeAdapterFactory;
-import com.google.gson.internal.bind.DefaultDateTypeAdapter.DateType;
-
 /**
- * Encapsulates access to {@code java.sql} types, to allow Gson to
- * work without the {@code java.sql} module being present.
- * No {@link ClassNotFoundException}s will be thrown in case
- * the {@code java.sql} module is not present.
+ * Encapsulates access to {@code java.sql} types, to allow Gson to work without the {@code java.sql}
+ * module being present. No {@link ClassNotFoundException}s will be thrown in case the {@code
+ * java.sql} module is not present.
  *
- * <p>If {@link #SUPPORTS_SQL_TYPES} is {@code true}, all other
- * constants of this class will be non-{@code null}. However, if
- * it is {@code false} all other constants will be {@code null} and
+ * <p>If {@link #SUPPORTS_SQL_TYPES} is {@code true}, all other constants of this class will be
+ * non-{@code null}. However, if it is {@code false} all other constants will be {@code null} and
  * there will be no support for {@code java.sql} types.
  */
 @SuppressWarnings("JavaUtilDate")
 public final class SqlTypesSupport {
-  /**
-   * {@code true} if {@code java.sql} types are supported,
-   * {@code false} otherwise
-   */
+  /** {@code true} if {@code java.sql} types are supported, {@code false} otherwise */
   public static final boolean SUPPORTS_SQL_TYPES;
 
   public static final DateType<? extends Date> DATE_DATE_TYPE;
@@ -59,16 +53,20 @@ public final class SqlTypesSupport {
     SUPPORTS_SQL_TYPES = sqlTypesSupport;
 
     if (SUPPORTS_SQL_TYPES) {
-      DATE_DATE_TYPE = new DateType<java.sql.Date>(java.sql.Date.class) {
-        @Override protected java.sql.Date deserialize(Date date) {
-          return new java.sql.Date(date.getTime());
-        }
-      };
-      TIMESTAMP_DATE_TYPE = new DateType<Timestamp>(Timestamp.class) {
-        @Override protected Timestamp deserialize(Date date) {
-          return new Timestamp(date.getTime());
-        }
-      };
+      DATE_DATE_TYPE =
+          new DateType<java.sql.Date>(java.sql.Date.class) {
+            @Override
+            protected java.sql.Date deserialize(Date date) {
+              return new java.sql.Date(date.getTime());
+            }
+          };
+      TIMESTAMP_DATE_TYPE =
+          new DateType<Timestamp>(Timestamp.class) {
+            @Override
+            protected Timestamp deserialize(Date date) {
+              return new Timestamp(date.getTime());
+            }
+          };
 
       DATE_FACTORY = SqlDateTypeAdapter.FACTORY;
       TIME_FACTORY = SqlTimeTypeAdapter.FACTORY;
@@ -83,6 +81,5 @@ public final class SqlTypesSupport {
     }
   }
 
-  private SqlTypesSupport() {
-  }
+  private SqlTypesSupport() {}
 }

--- a/gson/src/main/java/com/google/gson/package-info.java
+++ b/gson/src/main/java/com/google/gson/package-info.java
@@ -18,9 +18,9 @@
  * This package provides the {@link com.google.gson.Gson} class to convert Json to Java and
  * vice-versa.
  *
- * <p>The primary class to use is {@link com.google.gson.Gson} which can be constructed with
- * {@code new Gson()} (using default settings) or by using {@link com.google.gson.GsonBuilder}
- * (to configure various options such as using versioning and so on).</p>
+ * <p>The primary class to use is {@link com.google.gson.Gson} which can be constructed with {@code
+ * new Gson()} (using default settings) or by using {@link com.google.gson.GsonBuilder} (to
+ * configure various options such as using versioning and so on).
  *
  * @author Inderjeet Singh, Joel Leitch
  */

--- a/gson/src/main/java/com/google/gson/reflect/TypeToken.java
+++ b/gson/src/main/java/com/google/gson/reflect/TypeToken.java
@@ -28,28 +28,24 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Represents a generic type {@code T}. Java doesn't yet provide a way to
- * represent generic types, so this class does. Forces clients to create a
- * subclass of this class which enables retrieval the type information even at
- * runtime.
+ * Represents a generic type {@code T}. Java doesn't yet provide a way to represent generic types,
+ * so this class does. Forces clients to create a subclass of this class which enables retrieval the
+ * type information even at runtime.
  *
- * <p>For example, to create a type literal for {@code List<String>}, you can
- * create an empty anonymous class:
+ * <p>For example, to create a type literal for {@code List<String>}, you can create an empty
+ * anonymous class:
  *
- * <p>
- * {@code TypeToken<List<String>> list = new TypeToken<List<String>>() {};}
+ * <p>{@code TypeToken<List<String>> list = new TypeToken<List<String>>() {};}
  *
- * <p>Capturing a type variable as type argument of an anonymous {@code TypeToken}
- * subclass is not allowed, for example {@code TypeToken<List<T>>}.
- * Due to type erasure the runtime type of a type variable is not available
- * to Gson and therefore it cannot provide the functionality one might expect.
- * This would give a false sense of type-safety at compile time and could
- * lead to an unexpected {@code ClassCastException} at runtime.
+ * <p>Capturing a type variable as type argument of an anonymous {@code TypeToken} subclass is not
+ * allowed, for example {@code TypeToken<List<T>>}. Due to type erasure the runtime type of a type
+ * variable is not available to Gson and therefore it cannot provide the functionality one might
+ * expect. This would give a false sense of type-safety at compile time and could lead to an
+ * unexpected {@code ClassCastException} at runtime.
  *
- * <p>If the type arguments of the parameterized type are only available at
- * runtime, for example when you want to create a {@code List<E>} based on
- * a {@code Class<E>} representing the element type, the method
- * {@link #getParameterized(Type, Type...)} can be used.
+ * <p>If the type arguments of the parameterized type are only available at runtime, for example
+ * when you want to create a {@code List<E>} based on a {@code Class<E>} representing the element
+ * type, the method {@link #getParameterized(Type, Type...)} can be used.
  *
  * @author Bob Lee
  * @author Sven Mawson
@@ -61,19 +57,17 @@ public class TypeToken<T> {
   private final int hashCode;
 
   /**
-   * Constructs a new type literal. Derives represented class from type
-   * parameter.
+   * Constructs a new type literal. Derives represented class from type parameter.
    *
-   * <p>Clients create an empty anonymous subclass. Doing so embeds the type
-   * parameter in the anonymous class's type hierarchy so we can reconstitute it
-   * at runtime despite erasure, for example:
-   * <p>
-   * {@code new TypeToken<List<String>>() {}}
+   * <p>Clients create an empty anonymous subclass. Doing so embeds the type parameter in the
+   * anonymous class's type hierarchy so we can reconstitute it at runtime despite erasure, for
+   * example:
    *
-   * @throws IllegalArgumentException
-   *   If the anonymous {@code TypeToken} subclass captures a type variable,
-   *   for example {@code TypeToken<List<T>>}. See the {@code TypeToken}
-   *   class documentation for more details.
+   * <p>{@code new TypeToken<List<String>>() {}}
+   *
+   * @throws IllegalArgumentException If the anonymous {@code TypeToken} subclass captures a type
+   *     variable, for example {@code TypeToken<List<T>>}. See the {@code TypeToken} class
+   *     documentation for more details.
    */
   @SuppressWarnings("unchecked")
   protected TypeToken() {
@@ -82,9 +76,7 @@ public class TypeToken<T> {
     this.hashCode = type.hashCode();
   }
 
-  /**
-   * Unsafe. Constructs a type literal manually.
-   */
+  /** Unsafe. Constructs a type literal manually. */
   @SuppressWarnings("unchecked")
   private TypeToken(Type type) {
     this.type = $Gson$Types.canonicalize(Objects.requireNonNull(type));
@@ -97,9 +89,8 @@ public class TypeToken<T> {
   }
 
   /**
-   * Verifies that {@code this} is an instance of a direct subclass of TypeToken and
-   * returns the type argument for {@code T} in {@link $Gson$Types#canonicalize
-   * canonical form}.
+   * Verifies that {@code this} is an instance of a direct subclass of TypeToken and returns the
+   * type argument for {@code T} in {@link $Gson$Types#canonicalize canonical form}.
    */
   private Type getTypeTokenTypeArgument() {
     Type superclass = getClass().getGenericSuperclass();
@@ -116,10 +107,11 @@ public class TypeToken<T> {
     }
     // Check for raw TypeToken as superclass
     else if (superclass == TypeToken.class) {
-      throw new IllegalStateException("TypeToken must be created with a type argument: new TypeToken<...>() {};"
-          + " When using code shrinkers (ProGuard, R8, ...) make sure that generic signatures are preserved."
-          + "\nSee " + TroubleshootingGuide.createUrl("type-token-raw")
-      );
+      throw new IllegalStateException(
+          "TypeToken must be created with a type argument: new TypeToken<...>() {}; When using code"
+              + " shrinkers (ProGuard, R8, ...) make sure that generic signatures are preserved.\n"
+              + "See "
+              + TroubleshootingGuide.createUrl("type-token-raw"));
     }
 
     // User created subclass of subclass of TypeToken
@@ -129,9 +121,13 @@ public class TypeToken<T> {
   private static void verifyNoTypeVariable(Type type) {
     if (type instanceof TypeVariable) {
       TypeVariable<?> typeVariable = (TypeVariable<?>) type;
-      throw new IllegalArgumentException("TypeToken type argument must not contain a type variable; captured type variable "
-          + typeVariable.getName() + " declared by " + typeVariable.getGenericDeclaration()
-          + "\nSee " + TroubleshootingGuide.createUrl("typetoken-type-variable"));
+      throw new IllegalArgumentException(
+          "TypeToken type argument must not contain a type variable; captured type variable "
+              + typeVariable.getName()
+              + " declared by "
+              + typeVariable.getGenericDeclaration()
+              + "\nSee "
+              + TroubleshootingGuide.createUrl("typetoken-type-variable"));
     } else if (type instanceof GenericArrayType) {
       verifyNoTypeVariable(((GenericArrayType) type).getGenericComponentType());
     } else if (type instanceof ParameterizedType) {
@@ -153,22 +149,20 @@ public class TypeToken<T> {
         verifyNoTypeVariable(bound);
       }
     } else if (type == null) {
-      // Occurs in Eclipse IDE and certain Java versions (e.g. Java 11.0.18) when capturing type variable
-      // declared by method of local class, see https://github.com/eclipse-jdt/eclipse.jdt.core/issues/975
-      throw new IllegalArgumentException("TypeToken captured `null` as type argument; probably a compiler / runtime bug");
+      // Occurs in Eclipse IDE and certain Java versions (e.g. Java 11.0.18) when capturing type
+      // variable declared by method of local class, see
+      // https://github.com/eclipse-jdt/eclipse.jdt.core/issues/975
+      throw new IllegalArgumentException(
+          "TypeToken captured `null` as type argument; probably a compiler / runtime bug");
     }
   }
 
-  /**
-   * Returns the raw (non-generic) type for this type.
-   */
+  /** Returns the raw (non-generic) type for this type. */
   public final Class<? super T> getRawType() {
     return rawType;
   }
 
-  /**
-   * Gets underlying {@code Type} instance.
-   */
+  /** Gets underlying {@code Type} instance. */
   public final Type getType() {
     return type;
   }
@@ -176,8 +170,7 @@ public class TypeToken<T> {
   /**
    * Check if this type is assignable from the given class object.
    *
-   * @deprecated this implementation may be inconsistent with javac for types
-   *     with wildcards.
+   * @deprecated this implementation may be inconsistent with javac for types with wildcards.
    */
   @Deprecated
   public boolean isAssignableFrom(Class<?> cls) {
@@ -187,8 +180,7 @@ public class TypeToken<T> {
   /**
    * Check if this type is assignable from the given Type.
    *
-   * @deprecated this implementation may be inconsistent with javac for types
-   *     with wildcards.
+   * @deprecated this implementation may be inconsistent with javac for types with wildcards.
    */
   @Deprecated
   public boolean isAssignableFrom(Type from) {
@@ -203,8 +195,7 @@ public class TypeToken<T> {
     if (type instanceof Class<?>) {
       return rawType.isAssignableFrom($Gson$Types.getRawType(from));
     } else if (type instanceof ParameterizedType) {
-      return isAssignableFrom(from, (ParameterizedType) type,
-          new HashMap<String, Type>());
+      return isAssignableFrom(from, (ParameterizedType) type, new HashMap<String, Type>());
     } else if (type instanceof GenericArrayType) {
       return rawType.isAssignableFrom($Gson$Types.getRawType(from))
           && isAssignableFrom(from, (GenericArrayType) type);
@@ -217,8 +208,7 @@ public class TypeToken<T> {
   /**
    * Check if this type is assignable from the given type token.
    *
-   * @deprecated this implementation may be inconsistent with javac for types
-   *     with wildcards.
+   * @deprecated this implementation may be inconsistent with javac for types with wildcards.
    */
   @Deprecated
   public boolean isAssignableFrom(TypeToken<?> token) {
@@ -226,8 +216,8 @@ public class TypeToken<T> {
   }
 
   /**
-   * Private helper function that performs some assignability checks for
-   * the provided GenericArrayType.
+   * Private helper function that performs some assignability checks for the provided
+   * GenericArrayType.
    */
   private static boolean isAssignableFrom(Type from, GenericArrayType to) {
     Type toGenericComponentType = to.getGenericComponentType();
@@ -242,20 +232,17 @@ public class TypeToken<T> {
         }
         t = classType;
       }
-      return isAssignableFrom(t, (ParameterizedType) toGenericComponentType,
-          new HashMap<String, Type>());
+      return isAssignableFrom(
+          t, (ParameterizedType) toGenericComponentType, new HashMap<String, Type>());
     }
     // No generic defined on "to"; therefore, return true and let other
     // checks determine assignability
     return true;
   }
 
-  /**
-   * Private recursive helper function to actually do the type-safe checking
-   * of assignability.
-   */
-  private static boolean isAssignableFrom(Type from, ParameterizedType to,
-      Map<String, Type> typeVarMap) {
+  /** Private recursive helper function to actually do the type-safe checking of assignability. */
+  private static boolean isAssignableFrom(
+      Type from, ParameterizedType to, Map<String, Type> typeVarMap) {
 
     if (from == null) {
       return false;
@@ -304,11 +291,11 @@ public class TypeToken<T> {
   }
 
   /**
-   * Checks if two parameterized types are exactly equal, under the variable
-   * replacement described in the typeVarMap.
+   * Checks if two parameterized types are exactly equal, under the variable replacement described
+   * in the typeVarMap.
    */
-  private static boolean typeEquals(ParameterizedType from,
-      ParameterizedType to, Map<String, Type> typeVarMap) {
+  private static boolean typeEquals(
+      ParameterizedType from, ParameterizedType to, Map<String, Type> typeVarMap) {
     if (from.getRawType().equals(to.getRawType())) {
       Type[] fromArgs = from.getActualTypeArguments();
       Type[] toArgs = to.getActualTypeArguments();
@@ -322,55 +309,54 @@ public class TypeToken<T> {
     return false;
   }
 
-  private static AssertionError buildUnexpectedTypeError(
-      Type token, Class<?>... expected) {
+  private static AssertionError buildUnexpectedTypeError(Type token, Class<?>... expected) {
 
     // Build exception message
-    StringBuilder exceptionMessage =
-        new StringBuilder("Unexpected type. Expected one of: ");
+    StringBuilder exceptionMessage = new StringBuilder("Unexpected type. Expected one of: ");
     for (Class<?> clazz : expected) {
       exceptionMessage.append(clazz.getName()).append(", ");
     }
-    exceptionMessage.append("but got: ").append(token.getClass().getName())
-        .append(", for type token: ").append(token.toString()).append('.');
+    exceptionMessage
+        .append("but got: ")
+        .append(token.getClass().getName())
+        .append(", for type token: ")
+        .append(token.toString())
+        .append('.');
 
     return new AssertionError(exceptionMessage.toString());
   }
 
   /**
-   * Checks if two types are the same or are equivalent under a variable mapping
-   * given in the type map that was provided.
+   * Checks if two types are the same or are equivalent under a variable mapping given in the type
+   * map that was provided.
    */
   private static boolean matches(Type from, Type to, Map<String, Type> typeMap) {
     return to.equals(from)
         || (from instanceof TypeVariable
-        && to.equals(typeMap.get(((TypeVariable<?>) from).getName())));
-
+            && to.equals(typeMap.get(((TypeVariable<?>) from).getName())));
   }
 
-  @Override public final int hashCode() {
+  @Override
+  public final int hashCode() {
     return this.hashCode;
   }
 
-  @Override public final boolean equals(Object o) {
-    return o instanceof TypeToken<?>
-        && $Gson$Types.equals(type, ((TypeToken<?>) o).type);
+  @Override
+  public final boolean equals(Object o) {
+    return o instanceof TypeToken<?> && $Gson$Types.equals(type, ((TypeToken<?>) o).type);
   }
 
-  @Override public final String toString() {
+  @Override
+  public final String toString() {
     return $Gson$Types.typeToString(type);
   }
 
-  /**
-   * Gets type literal for the given {@code Type} instance.
-   */
+  /** Gets type literal for the given {@code Type} instance. */
   public static TypeToken<?> get(Type type) {
     return new TypeToken<>(type);
   }
 
-  /**
-   * Gets type literal for the given {@code Class} instance.
-   */
+  /** Gets type literal for the given {@code Class} instance. */
   public static <T> TypeToken<T> get(Class<T> type) {
     return new TypeToken<>(type);
   }
@@ -380,20 +366,21 @@ public class TypeToken<T> {
    * {@code rawType}. This is mainly intended for situations where the type arguments are not
    * available at compile time. The following example shows how a type token for {@code Map<K, V>}
    * can be created:
+   *
    * <pre>{@code
    * Class<K> keyClass = ...;
    * Class<V> valueClass = ...;
    * TypeToken<?> mapTypeToken = TypeToken.getParameterized(Map.class, keyClass, valueClass);
    * }</pre>
+   *
    * As seen here the result is a {@code TypeToken<?>}; this method cannot provide any type-safety,
    * and care must be taken to pass in the correct number of type arguments.
    *
    * <p>If {@code rawType} is a non-generic class and no type arguments are provided, this method
    * simply delegates to {@link #get(Class)} and creates a {@code TypeToken(Class)}.
    *
-   * @throws IllegalArgumentException
-   *   If {@code rawType} is not of type {@code Class}, or if the type arguments are invalid for
-   *   the raw type
+   * @throws IllegalArgumentException If {@code rawType} is not of type {@code Class}, or if the
+   *     type arguments are invalid for the raw type
    */
   public static TypeToken<?> getParameterized(Type rawType, Type... typeArguments) {
     Objects.requireNonNull(rawType);
@@ -411,8 +398,12 @@ public class TypeToken<T> {
     int expectedArgsCount = typeVariables.length;
     int actualArgsCount = typeArguments.length;
     if (actualArgsCount != expectedArgsCount) {
-      throw new IllegalArgumentException(rawClass.getName() + " requires " + expectedArgsCount +
-          " type arguments, but got " + actualArgsCount);
+      throw new IllegalArgumentException(
+          rawClass.getName()
+              + " requires "
+              + expectedArgsCount
+              + " type arguments, but got "
+              + actualArgsCount);
     }
 
     // For legacy reasons create a TypeToken(Class) if the type is not generic
@@ -422,12 +413,16 @@ public class TypeToken<T> {
 
     // Check for this here to avoid misleading exception thrown by ParameterizedTypeImpl
     if ($Gson$Types.requiresOwnerType(rawType)) {
-      throw new IllegalArgumentException("Raw type " + rawClass.getName() + " is not supported because"
-          + " it requires specifying an owner type");
+      throw new IllegalArgumentException(
+          "Raw type "
+              + rawClass.getName()
+              + " is not supported because"
+              + " it requires specifying an owner type");
     }
 
     for (int i = 0; i < expectedArgsCount; i++) {
-      Type typeArgument = Objects.requireNonNull(typeArguments[i], "Type argument must not be null");
+      Type typeArgument =
+          Objects.requireNonNull(typeArguments[i], "Type argument must not be null");
       Class<?> rawTypeArgument = $Gson$Types.getRawType(typeArgument);
       TypeVariable<?> typeVariable = typeVariables[i];
 
@@ -435,8 +430,14 @@ public class TypeToken<T> {
         Class<?> rawBound = $Gson$Types.getRawType(bound);
 
         if (!rawBound.isAssignableFrom(rawTypeArgument)) {
-          throw new IllegalArgumentException("Type argument " + typeArgument + " does not satisfy bounds"
-              + " for type variable " + typeVariable + " declared by " + rawType);
+          throw new IllegalArgumentException(
+              "Type argument "
+                  + typeArgument
+                  + " does not satisfy bounds"
+                  + " for type variable "
+                  + typeVariable
+                  + " declared by "
+                  + rawType);
         }
       }
     }

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -30,54 +30,56 @@ import java.util.Arrays;
 import java.util.Objects;
 
 /**
- * Reads a JSON (<a href="https://www.ietf.org/rfc/rfc8259.txt">RFC 8259</a>)
- * encoded value as a stream of tokens. This stream includes both literal
- * values (strings, numbers, booleans, and nulls) as well as the begin and
- * end delimiters of objects and arrays. The tokens are traversed in
- * depth-first order, the same order that they appear in the JSON document.
- * Within JSON objects, name/value pairs are represented by a single token.
+ * Reads a JSON (<a href="https://www.ietf.org/rfc/rfc8259.txt">RFC 8259</a>) encoded value as a
+ * stream of tokens. This stream includes both literal values (strings, numbers, booleans, and
+ * nulls) as well as the begin and end delimiters of objects and arrays. The tokens are traversed in
+ * depth-first order, the same order that they appear in the JSON document. Within JSON objects,
+ * name/value pairs are represented by a single token.
  *
  * <h2>Parsing JSON</h2>
- * To create a recursive descent parser for your own JSON streams, first create
- * an entry point method that creates a {@code JsonReader}.
  *
- * <p>Next, create handler methods for each structure in your JSON text. You'll
- * need a method for each object type and for each array type.
+ * To create a recursive descent parser for your own JSON streams, first create an entry point
+ * method that creates a {@code JsonReader}.
+ *
+ * <p>Next, create handler methods for each structure in your JSON text. You'll need a method for
+ * each object type and for each array type.
+ *
  * <ul>
- *   <li>Within <strong>array handling</strong> methods, first call {@link
- *       #beginArray} to consume the array's opening bracket. Then create a
- *       while loop that accumulates values, terminating when {@link #hasNext}
- *       is false. Finally, read the array's closing bracket by calling {@link
+ *   <li>Within <strong>array handling</strong> methods, first call {@link #beginArray} to consume
+ *       the array's opening bracket. Then create a while loop that accumulates values, terminating
+ *       when {@link #hasNext} is false. Finally, read the array's closing bracket by calling {@link
  *       #endArray}.
- *   <li>Within <strong>object handling</strong> methods, first call {@link
- *       #beginObject} to consume the object's opening brace. Then create a
- *       while loop that assigns values to local variables based on their name.
- *       This loop should terminate when {@link #hasNext} is false. Finally,
+ *   <li>Within <strong>object handling</strong> methods, first call {@link #beginObject} to consume
+ *       the object's opening brace. Then create a while loop that assigns values to local variables
+ *       based on their name. This loop should terminate when {@link #hasNext} is false. Finally,
  *       read the object's closing brace by calling {@link #endObject}.
  * </ul>
- * <p>When a nested object or array is encountered, delegate to the
- * corresponding handler method.
  *
- * <p>When an unknown name is encountered, strict parsers should fail with an
- * exception. Lenient parsers should call {@link #skipValue()} to recursively
- * skip the value's nested tokens, which may otherwise conflict.
+ * <p>When a nested object or array is encountered, delegate to the corresponding handler method.
  *
- * <p>If a value may be null, you should first check using {@link #peek()}.
- * Null literals can be consumed using either {@link #nextNull()} or {@link
- * #skipValue()}.
+ * <p>When an unknown name is encountered, strict parsers should fail with an exception. Lenient
+ * parsers should call {@link #skipValue()} to recursively skip the value's nested tokens, which may
+ * otherwise conflict.
+ *
+ * <p>If a value may be null, you should first check using {@link #peek()}. Null literals can be
+ * consumed using either {@link #nextNull()} or {@link #skipValue()}.
  *
  * <h2>Configuration</h2>
+ *
  * The behavior of this reader can be customized with the following methods:
+ *
  * <ul>
  *   <li>{@link #setStrictness(Strictness)}, the default is {@link Strictness#LEGACY_STRICT}
  * </ul>
  *
- * The default configuration of {@code JsonReader} instances used internally by
- * the {@link Gson} class differs, and can be adjusted with the various
- * {@link GsonBuilder} methods.
+ * The default configuration of {@code JsonReader} instances used internally by the {@link Gson}
+ * class differs, and can be adjusted with the various {@link GsonBuilder} methods.
  *
  * <h2>Example</h2>
- * Suppose we'd like to parse a stream of messages such as the following: <pre> {@code
+ *
+ * Suppose we'd like to parse a stream of messages such as the following:
+ *
+ * <pre>{@code
  * [
  *   {
  *     "id": 912345678901,
@@ -97,108 +99,111 @@ import java.util.Objects;
  *       "followers_count": 2
  *     }
  *   }
- * ]}</pre>
- * This code implements the parser for the above structure: <pre>   {@code
+ * ]
+ * }</pre>
  *
- *   public List<Message> readJsonStream(InputStream in) throws IOException {
- *     JsonReader reader = new JsonReader(new InputStreamReader(in, "UTF-8"));
- *     try {
- *       return readMessagesArray(reader);
- *     } finally {
- *       reader.close();
+ * This code implements the parser for the above structure:
+ *
+ * <pre>{@code
+ * public List<Message> readJsonStream(InputStream in) throws IOException {
+ *   JsonReader reader = new JsonReader(new InputStreamReader(in, "UTF-8"));
+ *   try {
+ *     return readMessagesArray(reader);
+ *   } finally {
+ *     reader.close();
+ *   }
+ * }
+ *
+ * public List<Message> readMessagesArray(JsonReader reader) throws IOException {
+ *   List<Message> messages = new ArrayList<>();
+ *
+ *   reader.beginArray();
+ *   while (reader.hasNext()) {
+ *     messages.add(readMessage(reader));
+ *   }
+ *   reader.endArray();
+ *   return messages;
+ * }
+ *
+ * public Message readMessage(JsonReader reader) throws IOException {
+ *   long id = -1;
+ *   String text = null;
+ *   User user = null;
+ *   List<Double> geo = null;
+ *
+ *   reader.beginObject();
+ *   while (reader.hasNext()) {
+ *     String name = reader.nextName();
+ *     if (name.equals("id")) {
+ *       id = reader.nextLong();
+ *     } else if (name.equals("text")) {
+ *       text = reader.nextString();
+ *     } else if (name.equals("geo") && reader.peek() != JsonToken.NULL) {
+ *       geo = readDoublesArray(reader);
+ *     } else if (name.equals("user")) {
+ *       user = readUser(reader);
+ *     } else {
+ *       reader.skipValue();
  *     }
  *   }
+ *   reader.endObject();
+ *   return new Message(id, text, user, geo);
+ * }
  *
- *   public List<Message> readMessagesArray(JsonReader reader) throws IOException {
- *     List<Message> messages = new ArrayList<>();
+ * public List<Double> readDoublesArray(JsonReader reader) throws IOException {
+ *   List<Double> doubles = new ArrayList<>();
  *
- *     reader.beginArray();
- *     while (reader.hasNext()) {
- *       messages.add(readMessage(reader));
- *     }
- *     reader.endArray();
- *     return messages;
+ *   reader.beginArray();
+ *   while (reader.hasNext()) {
+ *     doubles.add(reader.nextDouble());
  *   }
+ *   reader.endArray();
+ *   return doubles;
+ * }
  *
- *   public Message readMessage(JsonReader reader) throws IOException {
- *     long id = -1;
- *     String text = null;
- *     User user = null;
- *     List<Double> geo = null;
+ * public User readUser(JsonReader reader) throws IOException {
+ *   String username = null;
+ *   int followersCount = -1;
  *
- *     reader.beginObject();
- *     while (reader.hasNext()) {
- *       String name = reader.nextName();
- *       if (name.equals("id")) {
- *         id = reader.nextLong();
- *       } else if (name.equals("text")) {
- *         text = reader.nextString();
- *       } else if (name.equals("geo") && reader.peek() != JsonToken.NULL) {
- *         geo = readDoublesArray(reader);
- *       } else if (name.equals("user")) {
- *         user = readUser(reader);
- *       } else {
- *         reader.skipValue();
- *       }
+ *   reader.beginObject();
+ *   while (reader.hasNext()) {
+ *     String name = reader.nextName();
+ *     if (name.equals("name")) {
+ *       username = reader.nextString();
+ *     } else if (name.equals("followers_count")) {
+ *       followersCount = reader.nextInt();
+ *     } else {
+ *       reader.skipValue();
  *     }
- *     reader.endObject();
- *     return new Message(id, text, user, geo);
  *   }
- *
- *   public List<Double> readDoublesArray(JsonReader reader) throws IOException {
- *     List<Double> doubles = new ArrayList<>();
- *
- *     reader.beginArray();
- *     while (reader.hasNext()) {
- *       doubles.add(reader.nextDouble());
- *     }
- *     reader.endArray();
- *     return doubles;
- *   }
- *
- *   public User readUser(JsonReader reader) throws IOException {
- *     String username = null;
- *     int followersCount = -1;
- *
- *     reader.beginObject();
- *     while (reader.hasNext()) {
- *       String name = reader.nextName();
- *       if (name.equals("name")) {
- *         username = reader.nextString();
- *       } else if (name.equals("followers_count")) {
- *         followersCount = reader.nextInt();
- *       } else {
- *         reader.skipValue();
- *       }
- *     }
- *     reader.endObject();
- *     return new User(username, followersCount);
- *   }}</pre>
+ *   reader.endObject();
+ *   return new User(username, followersCount);
+ * }
+ * }</pre>
  *
  * <h2>Number Handling</h2>
- * This reader permits numeric values to be read as strings and string values to
- * be read as numbers. For example, both elements of the JSON array {@code
- * [1, "1"]} may be read using either {@link #nextInt} or {@link #nextString}.
- * This behavior is intended to prevent lossy numeric conversions: double is
- * JavaScript's only numeric type and very large values like {@code
- * 9007199254740993} cannot be represented exactly on that platform. To minimize
- * precision loss, extremely large values should be written and read as strings
- * in JSON.
+ *
+ * This reader permits numeric values to be read as strings and string values to be read as numbers.
+ * For example, both elements of the JSON array {@code [1, "1"]} may be read using either {@link
+ * #nextInt} or {@link #nextString}. This behavior is intended to prevent lossy numeric conversions:
+ * double is JavaScript's only numeric type and very large values like {@code 9007199254740993}
+ * cannot be represented exactly on that platform. To minimize precision loss, extremely large
+ * values should be written and read as strings in JSON.
  *
  * <h2 id="nonexecuteprefix">Non-Execute Prefix</h2>
+ *
  * Web servers that serve private data using JSON may be vulnerable to <a
- * href="http://en.wikipedia.org/wiki/JSON#Cross-site_request_forgery">Cross-site
- * request forgery</a> attacks. In such an attack, a malicious site gains access
- * to a private JSON file by executing it with an HTML {@code <script>} tag.
+ * href="http://en.wikipedia.org/wiki/JSON#Cross-site_request_forgery">Cross-site request
+ * forgery</a> attacks. In such an attack, a malicious site gains access to a private JSON file by
+ * executing it with an HTML {@code <script>} tag.
  *
- * <p>Prefixing JSON files with <code>")]}'\n"</code> makes them non-executable
- * by {@code <script>} tags, disarming the attack. Since the prefix is malformed
- * JSON, strict parsing fails when it is encountered. This class permits the
- * non-execute prefix when {@linkplain #setStrictness(Strictness) lenient parsing} is
- * enabled.
+ * <p>Prefixing JSON files with <code>")]}'\n"</code> makes them non-executable by {@code <script>}
+ * tags, disarming the attack. Since the prefix is malformed JSON, strict parsing fails when it is
+ * encountered. This class permits the non-execute prefix when {@linkplain
+ * #setStrictness(Strictness) lenient parsing} is enabled.
  *
- * <p>Each {@code JsonReader} may be used to read a single JSON stream. Instances
- * of this class are not thread safe.
+ * <p>Each {@code JsonReader} may be used to read a single JSON stream. Instances of this class are
+ * not thread safe.
  *
  * @author Jesse Wilson
  * @since 1.6
@@ -217,13 +222,17 @@ public class JsonReader implements Closeable {
   private static final int PEEKED_SINGLE_QUOTED = 8;
   private static final int PEEKED_DOUBLE_QUOTED = 9;
   private static final int PEEKED_UNQUOTED = 10;
+
   /** When this is returned, the string value is stored in peekedString. */
   private static final int PEEKED_BUFFERED = 11;
+
   private static final int PEEKED_SINGLE_QUOTED_NAME = 12;
   private static final int PEEKED_DOUBLE_QUOTED_NAME = 13;
   private static final int PEEKED_UNQUOTED_NAME = 14;
+
   /** When this is returned, the integer value is stored in peekedLong. */
   private static final int PEEKED_LONG = 15;
+
   private static final int PEEKED_NUMBER = 16;
   private static final int PEEKED_EOF = 17;
 
@@ -243,13 +252,14 @@ public class JsonReader implements Closeable {
   private Strictness strictness = Strictness.LEGACY_STRICT;
 
   static final int BUFFER_SIZE = 1024;
+
   /**
-   * Use a manual buffer to easily read and unread upcoming characters, and
-   * also so we can create strings without an intermediate StringBuilder.
-   * We decode literals directly out of this buffer, so it must be at least as
-   * long as the longest token that can be reported as a number.
+   * Use a manual buffer to easily read and unread upcoming characters, and also so we can create
+   * strings without an intermediate StringBuilder. We decode literals directly out of this buffer,
+   * so it must be at least as long as the longest token that can be reported as a number.
    */
   private final char[] buffer = new char[BUFFER_SIZE];
+
   private int pos = 0;
   private int limit = 0;
 
@@ -259,21 +269,20 @@ public class JsonReader implements Closeable {
   int peeked = PEEKED_NONE;
 
   /**
-   * A peeked value that was composed entirely of digits with an optional
-   * leading dash. Positive values may not have a leading 0.
+   * A peeked value that was composed entirely of digits with an optional leading dash. Positive
+   * values may not have a leading 0.
    */
   private long peekedLong;
 
   /**
-   * The number of characters in a peeked number literal. Increment 'pos' by
-   * this after reading a number.
+   * The number of characters in a peeked number literal. Increment 'pos' by this after reading a
+   * number.
    */
   private int peekedNumberLength;
 
   /**
-   * A peeked string that should be parsed on the next double, long or string.
-   * This is populated before a numeric value is parsed and used if that parsing
-   * fails.
+   * A peeked string that should be parsed on the next double, long or string. This is populated
+   * before a numeric value is parsed and used if that parsing fails.
    */
   private String peekedString;
 
@@ -282,6 +291,7 @@ public class JsonReader implements Closeable {
    */
   private int[] stack = new int[32];
   private int stackSize = 0;
+
   {
     stack[stackSize++] = JsonScope.EMPTY_DOCUMENT;
   }
@@ -297,9 +307,7 @@ public class JsonReader implements Closeable {
   private String[] pathNames = new String[32];
   private int[] pathIndices = new int[32];
 
-  /**
-   * Creates a new instance that reads a JSON-encoded stream from {@code in}.
-   */
+  /** Creates a new instance that reads a JSON-encoded stream from {@code in}. */
   public JsonReader(Reader in) {
     this.in = Objects.requireNonNull(in, "in == null");
   }
@@ -307,17 +315,20 @@ public class JsonReader implements Closeable {
   /**
    * Sets the strictness of this reader.
    *
-   * @deprecated Please use {@link #setStrictness(Strictness)} instead.
-   * {@code JsonReader.setLenient(true)} should be replaced by {@code JsonReader.setStrictness(Strictness.LENIENT)}
-   * and {@code JsonReader.setLenient(false)} should be replaced by {@code JsonReader.setStrictness(Strictness.LEGACY_STRICT)}.<br>
-   * However, if you used {@code setLenient(false)} before, you might prefer {@link Strictness#STRICT} now instead.
-   *
-   * @param lenient whether this reader should be lenient. If true, the strictness is set to {@link Strictness#LENIENT}.
-   *                If false, the strictness is set to {@link Strictness#LEGACY_STRICT}.
+   * @deprecated Please use {@link #setStrictness(Strictness)} instead. {@code
+   *     JsonReader.setLenient(true)} should be replaced by {@code
+   *     JsonReader.setStrictness(Strictness.LENIENT)} and {@code JsonReader.setLenient(false)}
+   *     should be replaced by {@code JsonReader.setStrictness(Strictness.LEGACY_STRICT)}.<br>
+   *     However, if you used {@code setLenient(false)} before, you might prefer {@link
+   *     Strictness#STRICT} now instead.
+   * @param lenient whether this reader should be lenient. If true, the strictness is set to {@link
+   *     Strictness#LENIENT}. If false, the strictness is set to {@link Strictness#LEGACY_STRICT}.
    * @see #setStrictness(Strictness)
    */
   @Deprecated
-  @SuppressWarnings("InlineMeSuggester") // Don't specify @InlineMe, so caller with `setLenient(false)` becomes aware of new Strictness.STRICT
+  // Don't specify @InlineMe, so caller with `setLenient(false)` becomes aware of new
+  // Strictness.STRICT
+  @SuppressWarnings("InlineMeSuggester")
   public final void setLenient(boolean lenient) {
     setStrictness(lenient ? Strictness.LENIENT : Strictness.LEGACY_STRICT);
   }
@@ -334,53 +345,51 @@ public class JsonReader implements Closeable {
   /**
    * Configures how liberal this parser is in what it accepts.
    *
-   * <p>In {@linkplain Strictness#STRICT strict} mode, the
-   * parser only accepts JSON in accordance with <a href="https://www.ietf.org/rfc/rfc8259.txt">RFC 8259</a>.
-   * In {@linkplain Strictness#LEGACY_STRICT legacy strict} mode (the default), only JSON in accordance with the
+   * <p>In {@linkplain Strictness#STRICT strict} mode, the parser only accepts JSON in accordance
+   * with <a href="https://www.ietf.org/rfc/rfc8259.txt">RFC 8259</a>. In {@linkplain
+   * Strictness#LEGACY_STRICT legacy strict} mode (the default), only JSON in accordance with the
    * RFC 8259 is accepted, with a few exceptions denoted below for backwards compatibility reasons.
-   * In {@linkplain Strictness#LENIENT lenient} mode, all sort of non-spec compliant JSON is accepted (see below).</p>
+   * In {@linkplain Strictness#LENIENT lenient} mode, all sort of non-spec compliant JSON is
+   * accepted (see below).
    *
    * <dl>
-   *     <dt>{@link Strictness#STRICT}</dt>
-   *     <dd>
-   *         In strict mode, only input compliant with RFC 8259 is accepted.
-   *     </dd>
-   *     <dt>{@link Strictness#LEGACY_STRICT}</dt>
-   *     <dd>
-   *         In legacy strict mode, the following departures from RFC 8259 are accepted:
-   *         <ul>
-   *             <li>JsonReader allows the literals {@code true}, {@code false} and {@code null}
-   *                 to have any capitalization, for example {@code fAlSe} or {@code NULL}
-   *             <li>JsonReader supports the escape sequence {@code \'}, representing a {@code '} (single-quote)
-   *             <li>JsonReader supports the escape sequence <code>\<i>LF</i></code> (with {@code LF}
-   *                 being the Unicode character {@code U+000A}), resulting in a {@code LF} within the
-   *                 read JSON string
-   *             <li>JsonReader allows unescaped control characters ({@code U+0000} through {@code U+001F})
-   *         </ul>
-   *     </dd>
-   *     <dt>{@link Strictness#LENIENT}</dt>
-   *     <dd>
-   *         In lenient mode, all input that is accepted in legacy strict mode is accepted in addition to the following
-   *         departures from RFC 8259:
-   *         <ul>
-   *             <li>Streams that start with the <a href="#nonexecuteprefix">non-execute prefix</a>, {@code ")]}'\n"}
-   *             <li>Streams that include multiple top-level values. With legacy strict or strict parsing,
-   *                 each stream must contain exactly one top-level value.
-   *             <li>Numbers may be {@link Double#isNaN() NaNs} or {@link Double#isInfinite() infinities} represented by
-   *                 {@code NaN} and {@code (-)Infinity} respectively.
-   *             <li>End of line comments starting with {@code //} or {@code #} and ending with a newline character.
-   *             <li>C-style comments starting with {@code /*} and ending with
-   *                 {@code *}{@code /}. Such comments may not be nested.
-   *             <li>Names that are unquoted or {@code 'single quoted'}.
-   *             <li>Strings that are unquoted or {@code 'single quoted'}.
-   *             <li>Array elements separated by {@code ;} instead of {@code ,}.
-   *             <li>Unnecessary array separators. These are interpreted as if null
-   *                 was the omitted value.
-   *             <li>Names and values separated by {@code =} or {@code =>} instead of
-   *                 {@code :}.
-   *             <li>Name/value pairs separated by {@code ;} instead of {@code ,}.
-   *         </ul>
-   *     </dd>
+   *   <dt>{@link Strictness#STRICT}
+   *   <dd>In strict mode, only input compliant with RFC 8259 is accepted.
+   *   <dt>{@link Strictness#LEGACY_STRICT}
+   *   <dd>In legacy strict mode, the following departures from RFC 8259 are accepted:
+   *       <ul>
+   *         <li>JsonReader allows the literals {@code true}, {@code false} and {@code null} to have
+   *             any capitalization, for example {@code fAlSe} or {@code NULL}
+   *         <li>JsonReader supports the escape sequence {@code \'}, representing a {@code '}
+   *             (single-quote)
+   *         <li>JsonReader supports the escape sequence <code>\<i>LF</i></code> (with {@code LF}
+   *             being the Unicode character {@code U+000A}), resulting in a {@code LF} within the
+   *             read JSON string
+   *         <li>JsonReader allows unescaped control characters ({@code U+0000} through {@code
+   *             U+001F})
+   *       </ul>
+   *   <dt>{@link Strictness#LENIENT}
+   *   <dd>In lenient mode, all input that is accepted in legacy strict mode is accepted in addition
+   *       to the following departures from RFC 8259:
+   *       <ul>
+   *         <li>Streams that start with the <a href="#nonexecuteprefix">non-execute prefix</a>,
+   *             {@code ")]}'\n"}
+   *         <li>Streams that include multiple top-level values. With legacy strict or strict
+   *             parsing, each stream must contain exactly one top-level value.
+   *         <li>Numbers may be {@link Double#isNaN() NaNs} or {@link Double#isInfinite()
+   *             infinities} represented by {@code NaN} and {@code (-)Infinity} respectively.
+   *         <li>End of line comments starting with {@code //} or {@code #} and ending with a
+   *             newline character.
+   *         <li>C-style comments starting with {@code /*} and ending with {@code *}{@code /}. Such
+   *             comments may not be nested.
+   *         <li>Names that are unquoted or {@code 'single quoted'}.
+   *         <li>Strings that are unquoted or {@code 'single quoted'}.
+   *         <li>Array elements separated by {@code ;} instead of {@code ,}.
+   *         <li>Unnecessary array separators. These are interpreted as if null was the omitted
+   *             value.
+   *         <li>Names and values separated by {@code =} or {@code =>} instead of {@code :}.
+   *         <li>Name/value pairs separated by {@code ;} instead of {@code ,}.
+   *       </ul>
    * </dl>
    *
    * @param strictness the new strictness value of this reader. May not be {@code null}.
@@ -400,9 +409,10 @@ public class JsonReader implements Closeable {
   public final Strictness getStrictness() {
     return strictness;
   }
+
   /**
-   * Consumes the next token from the JSON stream and asserts that it is the
-   * beginning of a new array.
+   * Consumes the next token from the JSON stream and asserts that it is the beginning of a new
+   * array.
    */
   public void beginArray() throws IOException {
     int p = peeked;
@@ -419,8 +429,8 @@ public class JsonReader implements Closeable {
   }
 
   /**
-   * Consumes the next token from the JSON stream and asserts that it is the
-   * end of the current array.
+   * Consumes the next token from the JSON stream and asserts that it is the end of the current
+   * array.
    */
   public void endArray() throws IOException {
     int p = peeked;
@@ -437,8 +447,8 @@ public class JsonReader implements Closeable {
   }
 
   /**
-   * Consumes the next token from the JSON stream and asserts that it is the
-   * beginning of a new object.
+   * Consumes the next token from the JSON stream and asserts that it is the beginning of a new
+   * object.
    */
   public void beginObject() throws IOException {
     int p = peeked;
@@ -454,8 +464,8 @@ public class JsonReader implements Closeable {
   }
 
   /**
-   * Consumes the next token from the JSON stream and asserts that it is the
-   * end of the current object.
+   * Consumes the next token from the JSON stream and asserts that it is the end of the current
+   * object.
    */
   public void endObject() throws IOException {
     int p = peeked;
@@ -472,9 +482,7 @@ public class JsonReader implements Closeable {
     }
   }
 
-  /**
-   * Returns true if the current array or object has another element.
-   */
+  /** Returns true if the current array or object has another element. */
   public boolean hasNext() throws IOException {
     int p = peeked;
     if (p == PEEKED_NONE) {
@@ -483,9 +491,7 @@ public class JsonReader implements Closeable {
     return p != PEEKED_END_OBJECT && p != PEEKED_END_ARRAY && p != PEEKED_EOF;
   }
 
-  /**
-   * Returns the type of the next token without consuming it.
-   */
+  /** Returns the type of the next token without consuming it. */
   public JsonToken peek() throws IOException {
     int p = peeked;
     if (p == PEEKED_NONE) {
@@ -493,35 +499,35 @@ public class JsonReader implements Closeable {
     }
 
     switch (p) {
-    case PEEKED_BEGIN_OBJECT:
-      return JsonToken.BEGIN_OBJECT;
-    case PEEKED_END_OBJECT:
-      return JsonToken.END_OBJECT;
-    case PEEKED_BEGIN_ARRAY:
-      return JsonToken.BEGIN_ARRAY;
-    case PEEKED_END_ARRAY:
-      return JsonToken.END_ARRAY;
-    case PEEKED_SINGLE_QUOTED_NAME:
-    case PEEKED_DOUBLE_QUOTED_NAME:
-    case PEEKED_UNQUOTED_NAME:
-      return JsonToken.NAME;
-    case PEEKED_TRUE:
-    case PEEKED_FALSE:
-      return JsonToken.BOOLEAN;
-    case PEEKED_NULL:
-      return JsonToken.NULL;
-    case PEEKED_SINGLE_QUOTED:
-    case PEEKED_DOUBLE_QUOTED:
-    case PEEKED_UNQUOTED:
-    case PEEKED_BUFFERED:
-      return JsonToken.STRING;
-    case PEEKED_LONG:
-    case PEEKED_NUMBER:
-      return JsonToken.NUMBER;
-    case PEEKED_EOF:
-      return JsonToken.END_DOCUMENT;
-    default:
-      throw new AssertionError();
+      case PEEKED_BEGIN_OBJECT:
+        return JsonToken.BEGIN_OBJECT;
+      case PEEKED_END_OBJECT:
+        return JsonToken.END_OBJECT;
+      case PEEKED_BEGIN_ARRAY:
+        return JsonToken.BEGIN_ARRAY;
+      case PEEKED_END_ARRAY:
+        return JsonToken.END_ARRAY;
+      case PEEKED_SINGLE_QUOTED_NAME:
+      case PEEKED_DOUBLE_QUOTED_NAME:
+      case PEEKED_UNQUOTED_NAME:
+        return JsonToken.NAME;
+      case PEEKED_TRUE:
+      case PEEKED_FALSE:
+        return JsonToken.BOOLEAN;
+      case PEEKED_NULL:
+        return JsonToken.NULL;
+      case PEEKED_SINGLE_QUOTED:
+      case PEEKED_DOUBLE_QUOTED:
+      case PEEKED_UNQUOTED:
+      case PEEKED_BUFFERED:
+        return JsonToken.STRING;
+      case PEEKED_LONG:
+      case PEEKED_NUMBER:
+        return JsonToken.NUMBER;
+      case PEEKED_EOF:
+        return JsonToken.END_DOCUMENT;
+      default:
+        throw new AssertionError();
     }
   }
 
@@ -534,14 +540,14 @@ public class JsonReader implements Closeable {
       // Look for a comma before the next element.
       int c = nextNonWhitespace(true);
       switch (c) {
-      case ']':
-        return peeked = PEEKED_END_ARRAY;
-      case ';':
-        checkLenient(); // fall-through
-      case ',':
-        break;
-      default:
-        throw syntaxError("Unterminated array");
+        case ']':
+          return peeked = PEEKED_END_ARRAY;
+        case ';':
+          checkLenient(); // fall-through
+        case ',':
+          break;
+        default:
+          throw syntaxError("Unterminated array");
       }
     } else if (peekStack == JsonScope.EMPTY_OBJECT || peekStack == JsonScope.NONEMPTY_OBJECT) {
       stack[stackSize - 1] = JsonScope.DANGLING_NAME;
@@ -549,53 +555,53 @@ public class JsonReader implements Closeable {
       if (peekStack == JsonScope.NONEMPTY_OBJECT) {
         int c = nextNonWhitespace(true);
         switch (c) {
-        case '}':
-          return peeked = PEEKED_END_OBJECT;
-        case ';':
-          checkLenient(); // fall-through
-        case ',':
-          break;
-        default:
-          throw syntaxError("Unterminated object");
+          case '}':
+            return peeked = PEEKED_END_OBJECT;
+          case ';':
+            checkLenient(); // fall-through
+          case ',':
+            break;
+          default:
+            throw syntaxError("Unterminated object");
         }
       }
       int c = nextNonWhitespace(true);
       switch (c) {
-      case '"':
-        return peeked = PEEKED_DOUBLE_QUOTED_NAME;
-      case '\'':
-        checkLenient();
-        return peeked = PEEKED_SINGLE_QUOTED_NAME;
-      case '}':
-        if (peekStack != JsonScope.NONEMPTY_OBJECT) {
-          return peeked = PEEKED_END_OBJECT;
-        } else {
-          throw syntaxError("Expected name");
-        }
-      default:
-        checkLenient();
-        pos--; // Don't consume the first character in an unquoted string.
-        if (isLiteral((char) c)) {
-          return peeked = PEEKED_UNQUOTED_NAME;
-        } else {
-          throw syntaxError("Expected name");
-        }
+        case '"':
+          return peeked = PEEKED_DOUBLE_QUOTED_NAME;
+        case '\'':
+          checkLenient();
+          return peeked = PEEKED_SINGLE_QUOTED_NAME;
+        case '}':
+          if (peekStack != JsonScope.NONEMPTY_OBJECT) {
+            return peeked = PEEKED_END_OBJECT;
+          } else {
+            throw syntaxError("Expected name");
+          }
+        default:
+          checkLenient();
+          pos--; // Don't consume the first character in an unquoted string.
+          if (isLiteral((char) c)) {
+            return peeked = PEEKED_UNQUOTED_NAME;
+          } else {
+            throw syntaxError("Expected name");
+          }
       }
     } else if (peekStack == JsonScope.DANGLING_NAME) {
       stack[stackSize - 1] = JsonScope.NONEMPTY_OBJECT;
       // Look for a colon before the value.
       int c = nextNonWhitespace(true);
       switch (c) {
-      case ':':
-        break;
-      case '=':
-        checkLenient();
-        if ((pos < limit || fillBuffer(1)) && buffer[pos] == '>') {
-          pos++;
-        }
-        break;
-      default:
-        throw syntaxError("Expected ':'");
+        case ':':
+          break;
+        case '=':
+          checkLenient();
+          if ((pos < limit || fillBuffer(1)) && buffer[pos] == '>') {
+            pos++;
+          }
+          break;
+        default:
+          throw syntaxError("Expected ':'");
       }
     } else if (peekStack == JsonScope.EMPTY_DOCUMENT) {
       if (strictness == Strictness.LENIENT) {
@@ -616,32 +622,32 @@ public class JsonReader implements Closeable {
 
     int c = nextNonWhitespace(true);
     switch (c) {
-    case ']':
-      if (peekStack == JsonScope.EMPTY_ARRAY) {
-        return peeked = PEEKED_END_ARRAY;
-      }
-      // fall-through to handle ",]"
-    case ';':
-    case ',':
-      // In lenient mode, a 0-length literal in an array means 'null'.
-      if (peekStack == JsonScope.EMPTY_ARRAY || peekStack == JsonScope.NONEMPTY_ARRAY) {
+      case ']':
+        if (peekStack == JsonScope.EMPTY_ARRAY) {
+          return peeked = PEEKED_END_ARRAY;
+        }
+        // fall-through to handle ",]"
+      case ';':
+      case ',':
+        // In lenient mode, a 0-length literal in an array means 'null'.
+        if (peekStack == JsonScope.EMPTY_ARRAY || peekStack == JsonScope.NONEMPTY_ARRAY) {
+          checkLenient();
+          pos--;
+          return peeked = PEEKED_NULL;
+        } else {
+          throw syntaxError("Unexpected value");
+        }
+      case '\'':
         checkLenient();
-        pos--;
-        return peeked = PEEKED_NULL;
-      } else {
-        throw syntaxError("Unexpected value");
-      }
-    case '\'':
-      checkLenient();
-      return peeked = PEEKED_SINGLE_QUOTED;
-    case '"':
-      return peeked = PEEKED_DOUBLE_QUOTED;
-    case '[':
-      return peeked = PEEKED_BEGIN_ARRAY;
-    case '{':
-      return peeked = PEEKED_BEGIN_OBJECT;
-    default:
-      pos--; // Don't consume the first character in a literal value.
+        return peeked = PEEKED_SINGLE_QUOTED;
+      case '"':
+        return peeked = PEEKED_DOUBLE_QUOTED;
+      case '[':
+        return peeked = PEEKED_BEGIN_ARRAY;
+      case '{':
+        return peeked = PEEKED_BEGIN_OBJECT;
+      default:
+        pos--; // Don't consume the first character in a literal value.
     }
 
     int result = peekKeyword();
@@ -702,8 +708,7 @@ public class JsonReader implements Closeable {
       }
     }
 
-    if ((pos + length < limit || fillBuffer(length + 1))
-        && isLiteral(buffer[pos + length])) {
+    if ((pos + length < limit || fillBuffer(length + 1)) && isLiteral(buffer[pos + length])) {
       return PEEKED_NONE; // Don't match trues, falsey or nullsoft!
     }
 
@@ -742,73 +747,78 @@ public class JsonReader implements Closeable {
 
       char c = buffer[p + i];
       switch (c) {
-      case '-':
-        if (last == NUMBER_CHAR_NONE) {
-          negative = true;
-          last = NUMBER_CHAR_SIGN;
-          continue;
-        } else if (last == NUMBER_CHAR_EXP_E) {
-          last = NUMBER_CHAR_EXP_SIGN;
-          continue;
-        }
-        return PEEKED_NONE;
-
-      case '+':
-        if (last == NUMBER_CHAR_EXP_E) {
-          last = NUMBER_CHAR_EXP_SIGN;
-          continue;
-        }
-        return PEEKED_NONE;
-
-      case 'e':
-      case 'E':
-        if (last == NUMBER_CHAR_DIGIT || last == NUMBER_CHAR_FRACTION_DIGIT) {
-          last = NUMBER_CHAR_EXP_E;
-          continue;
-        }
-        return PEEKED_NONE;
-
-      case '.':
-        if (last == NUMBER_CHAR_DIGIT) {
-          last = NUMBER_CHAR_DECIMAL;
-          continue;
-        }
-        return PEEKED_NONE;
-
-      default:
-        if (c < '0' || c > '9') {
-          if (!isLiteral(c)) {
-            break charactersOfNumber;
+        case '-':
+          if (last == NUMBER_CHAR_NONE) {
+            negative = true;
+            last = NUMBER_CHAR_SIGN;
+            continue;
+          } else if (last == NUMBER_CHAR_EXP_E) {
+            last = NUMBER_CHAR_EXP_SIGN;
+            continue;
           }
           return PEEKED_NONE;
-        }
-        if (last == NUMBER_CHAR_SIGN || last == NUMBER_CHAR_NONE) {
-          value = -(c - '0');
-          last = NUMBER_CHAR_DIGIT;
-        } else if (last == NUMBER_CHAR_DIGIT) {
-          if (value == 0) {
-            return PEEKED_NONE; // Leading '0' prefix is not allowed (since it could be octal).
+
+        case '+':
+          if (last == NUMBER_CHAR_EXP_E) {
+            last = NUMBER_CHAR_EXP_SIGN;
+            continue;
           }
-          long newValue = value * 10 - (c - '0');
-          fitsInLong &= value > MIN_INCOMPLETE_INTEGER
-              || (value == MIN_INCOMPLETE_INTEGER && newValue < value);
-          value = newValue;
-        } else if (last == NUMBER_CHAR_DECIMAL) {
-          last = NUMBER_CHAR_FRACTION_DIGIT;
-        } else if (last == NUMBER_CHAR_EXP_E || last == NUMBER_CHAR_EXP_SIGN) {
-          last = NUMBER_CHAR_EXP_DIGIT;
-        }
+          return PEEKED_NONE;
+
+        case 'e':
+        case 'E':
+          if (last == NUMBER_CHAR_DIGIT || last == NUMBER_CHAR_FRACTION_DIGIT) {
+            last = NUMBER_CHAR_EXP_E;
+            continue;
+          }
+          return PEEKED_NONE;
+
+        case '.':
+          if (last == NUMBER_CHAR_DIGIT) {
+            last = NUMBER_CHAR_DECIMAL;
+            continue;
+          }
+          return PEEKED_NONE;
+
+        default:
+          if (c < '0' || c > '9') {
+            if (!isLiteral(c)) {
+              break charactersOfNumber;
+            }
+            return PEEKED_NONE;
+          }
+          if (last == NUMBER_CHAR_SIGN || last == NUMBER_CHAR_NONE) {
+            value = -(c - '0');
+            last = NUMBER_CHAR_DIGIT;
+          } else if (last == NUMBER_CHAR_DIGIT) {
+            if (value == 0) {
+              return PEEKED_NONE; // Leading '0' prefix is not allowed (since it could be octal).
+            }
+            long newValue = value * 10 - (c - '0');
+            fitsInLong &=
+                value > MIN_INCOMPLETE_INTEGER
+                    || (value == MIN_INCOMPLETE_INTEGER && newValue < value);
+            value = newValue;
+          } else if (last == NUMBER_CHAR_DECIMAL) {
+            last = NUMBER_CHAR_FRACTION_DIGIT;
+          } else if (last == NUMBER_CHAR_EXP_E || last == NUMBER_CHAR_EXP_SIGN) {
+            last = NUMBER_CHAR_EXP_DIGIT;
+          }
       }
     }
 
     // We've read a complete number. Decide if it's a PEEKED_LONG or a PEEKED_NUMBER.
     // Don't store -0 as long; user might want to read it as double -0.0
     // Don't try to convert Long.MIN_VALUE to positive long; it would overflow MAX_VALUE
-    if (last == NUMBER_CHAR_DIGIT && fitsInLong && (value != Long.MIN_VALUE || negative) && (value != 0 || !negative)) {
+    if (last == NUMBER_CHAR_DIGIT
+        && fitsInLong
+        && (value != Long.MIN_VALUE || negative)
+        && (value != 0 || !negative)) {
       peekedLong = negative ? value : -value;
       pos += i;
       return peeked = PEEKED_LONG;
-    } else if (last == NUMBER_CHAR_DIGIT || last == NUMBER_CHAR_FRACTION_DIGIT
+    } else if (last == NUMBER_CHAR_DIGIT
+        || last == NUMBER_CHAR_FRACTION_DIGIT
         || last == NUMBER_CHAR_EXP_DIGIT) {
       peekedNumberLength = i;
       return peeked = PEEKED_NUMBER;
@@ -820,34 +830,33 @@ public class JsonReader implements Closeable {
   @SuppressWarnings("fallthrough")
   private boolean isLiteral(char c) throws IOException {
     switch (c) {
-    case '/':
-    case '\\':
-    case ';':
-    case '#':
-    case '=':
-      checkLenient(); // fall-through
-    case '{':
-    case '}':
-    case '[':
-    case ']':
-    case ':':
-    case ',':
-    case ' ':
-    case '\t':
-    case '\f':
-    case '\r':
-    case '\n':
-      return false;
-    default:
-      return true;
+      case '/':
+      case '\\':
+      case ';':
+      case '#':
+      case '=':
+        checkLenient(); // fall-through
+      case '{':
+      case '}':
+      case '[':
+      case ']':
+      case ':':
+      case ',':
+      case ' ':
+      case '\t':
+      case '\f':
+      case '\r':
+      case '\n':
+        return false;
+      default:
+        return true;
     }
   }
 
   /**
    * Returns the next token, a {@link JsonToken#NAME property name}, and consumes it.
    *
-   * @throws IOException if the next token in the stream is not a property
-   *     name.
+   * @throws IOException if the next token in the stream is not a property name.
    */
   public String nextName() throws IOException {
     int p = peeked;
@@ -870,12 +879,10 @@ public class JsonReader implements Closeable {
   }
 
   /**
-   * Returns the {@link JsonToken#STRING string} value of the next token,
-   * consuming it. If the next token is a number, this method will return its
-   * string form.
+   * Returns the {@link JsonToken#STRING string} value of the next token, consuming it. If the next
+   * token is a number, this method will return its string form.
    *
-   * @throws IllegalStateException if the next token is not a string or if
-   *     this reader is closed.
+   * @throws IllegalStateException if the next token is not a string or if this reader is closed.
    */
   public String nextString() throws IOException {
     int p = peeked;
@@ -906,11 +913,9 @@ public class JsonReader implements Closeable {
   }
 
   /**
-   * Returns the {@link JsonToken#BOOLEAN boolean} value of the next token,
-   * consuming it.
+   * Returns the {@link JsonToken#BOOLEAN boolean} value of the next token, consuming it.
    *
-   * @throws IllegalStateException if the next token is not a boolean or if
-   *     this reader is closed.
+   * @throws IllegalStateException if the next token is not a boolean or if this reader is closed.
    */
   public boolean nextBoolean() throws IOException {
     int p = peeked;
@@ -930,11 +935,9 @@ public class JsonReader implements Closeable {
   }
 
   /**
-   * Consumes the next token from the JSON stream and asserts that it is a
-   * literal null.
+   * Consumes the next token from the JSON stream and asserts that it is a literal null.
    *
-   * @throws IllegalStateException if the next token is not null or if this
-   *     reader is closed.
+   * @throws IllegalStateException if the next token is not null or if this reader is closed.
    */
   public void nextNull() throws IOException {
     int p = peeked;
@@ -950,15 +953,14 @@ public class JsonReader implements Closeable {
   }
 
   /**
-   * Returns the {@link JsonToken#NUMBER double} value of the next token,
-   * consuming it. If the next token is a string, this method will attempt to
-   * parse it as a double using {@link Double#parseDouble(String)}.
+   * Returns the {@link JsonToken#NUMBER double} value of the next token, consuming it. If the next
+   * token is a string, this method will attempt to parse it as a double using {@link
+   * Double#parseDouble(String)}.
    *
    * @throws IllegalStateException if the next token is not a literal value.
-   * @throws NumberFormatException if the next literal value cannot be parsed
-   *     as a double.
-   * @throws MalformedJsonException if the next literal value is NaN or Infinity
-   *     and this reader is not {@link #setStrictness(Strictness) lenient}.
+   * @throws NumberFormatException if the next literal value cannot be parsed as a double.
+   * @throws MalformedJsonException if the next literal value is NaN or Infinity and this reader is
+   *     not {@link #setStrictness(Strictness) lenient}.
    */
   public double nextDouble() throws IOException {
     int p = peeked;
@@ -995,14 +997,13 @@ public class JsonReader implements Closeable {
   }
 
   /**
-   * Returns the {@link JsonToken#NUMBER long} value of the next token,
-   * consuming it. If the next token is a string, this method will attempt to
-   * parse it as a long. If the next token's numeric value cannot be exactly
-   * represented by a Java {@code long}, this method throws.
+   * Returns the {@link JsonToken#NUMBER long} value of the next token, consuming it. If the next
+   * token is a string, this method will attempt to parse it as a long. If the next token's numeric
+   * value cannot be exactly represented by a Java {@code long}, this method throws.
    *
    * @throws IllegalStateException if the next token is not a literal value.
-   * @throws NumberFormatException if the next literal value cannot be parsed
-   *     as a number, or exactly represented as a long.
+   * @throws NumberFormatException if the next literal value cannot be parsed as a number, or
+   *     exactly represented as a long.
    */
   public long nextLong() throws IOException {
     int p = peeked;
@@ -1050,14 +1051,12 @@ public class JsonReader implements Closeable {
   }
 
   /**
-   * Returns the string up to but not including {@code quote}, unescaping any
-   * character escape sequences encountered along the way. The opening quote
-   * should have already been read. This consumes the closing quote, but does
-   * not include it in the returned string.
+   * Returns the string up to but not including {@code quote}, unescaping any character escape
+   * sequences encountered along the way. The opening quote should have already been read. This
+   * consumes the closing quote, but does not include it in the returned string.
    *
    * @param quote either ' or ".
-   * @throws NumberFormatException if any unicode escape sequences are
-   *     malformed.
+   * @throws NumberFormatException if any unicode escape sequences are malformed.
    */
   private String nextQuotedValue(char quote) throws IOException {
     // Like nextNonWhitespace, this uses locals 'p' and 'l' to save inner-loop field access.
@@ -1071,9 +1070,11 @@ public class JsonReader implements Closeable {
       while (p < l) {
         int c = buffer[p++];
 
-        // In strict mode, throw an exception when meeting unescaped control characters (U+0000 through U+001F)
+        // In strict mode, throw an exception when meeting unescaped control characters (U+0000
+        // through U+001F)
         if (strictness == Strictness.STRICT && c < 0x20) {
-          throw syntaxError("Unescaped control characters (\\u0000-\\u001F) are not allowed in strict mode");
+          throw syntaxError(
+              "Unescaped control characters (\\u0000-\\u001F) are not allowed in strict mode");
         } else if (c == quote) {
           pos = p;
           int len = p - start - 1;
@@ -1113,9 +1114,7 @@ public class JsonReader implements Closeable {
     }
   }
 
-  /**
-   * Returns an unquoted value as a string.
-   */
+  /** Returns an unquoted value as a string. */
   @SuppressWarnings("fallthrough")
   private String nextUnquotedValue() throws IOException {
     StringBuilder builder = null;
@@ -1125,24 +1124,24 @@ public class JsonReader implements Closeable {
     while (true) {
       for (; pos + i < limit; i++) {
         switch (buffer[pos + i]) {
-        case '/':
-        case '\\':
-        case ';':
-        case '#':
-        case '=':
-          checkLenient(); // fall-through
-        case '{':
-        case '}':
-        case '[':
-        case ']':
-        case ':':
-        case ',':
-        case ' ':
-        case '\t':
-        case '\f':
-        case '\r':
-        case '\n':
-          break findNonLiteralCharacter;
+          case '/':
+          case '\\':
+          case ';':
+          case '#':
+          case '=':
+            checkLenient(); // fall-through
+          case '{':
+          case '}':
+          case '[':
+          case ']':
+          case ':':
+          case ',':
+          case ' ':
+          case '\t':
+          case '\f':
+          case '\r':
+          case '\n':
+            break findNonLiteralCharacter;
         }
       }
 
@@ -1157,7 +1156,7 @@ public class JsonReader implements Closeable {
 
       // use a StringBuilder when the value is too long. This is too long to be a number!
       if (builder == null) {
-        builder = new StringBuilder(Math.max(i,16));
+        builder = new StringBuilder(Math.max(i, 16));
       }
       builder.append(buffer, pos, i);
       pos += i;
@@ -1167,7 +1166,8 @@ public class JsonReader implements Closeable {
       }
     }
 
-    String result = (null == builder) ? new String(buffer, pos, i) : builder.append(buffer, pos, i).toString();
+    String result =
+        (null == builder) ? new String(buffer, pos, i) : builder.append(buffer, pos, i).toString();
     pos += i;
     return result;
   }
@@ -1205,25 +1205,25 @@ public class JsonReader implements Closeable {
       int i = 0;
       for (; pos + i < limit; i++) {
         switch (buffer[pos + i]) {
-        case '/':
-        case '\\':
-        case ';':
-        case '#':
-        case '=':
-          checkLenient(); // fall-through
-        case '{':
-        case '}':
-        case '[':
-        case ']':
-        case ':':
-        case ',':
-        case ' ':
-        case '\t':
-        case '\f':
-        case '\r':
-        case '\n':
-          pos += i;
-          return;
+          case '/':
+          case '\\':
+          case ';':
+          case '#':
+          case '=':
+            checkLenient(); // fall-through
+          case '{':
+          case '}':
+          case '[':
+          case ']':
+          case ':':
+          case ',':
+          case ' ':
+          case '\t':
+          case '\f':
+          case '\r':
+          case '\n':
+            pos += i;
+            return;
         }
       }
       pos += i;
@@ -1231,14 +1231,13 @@ public class JsonReader implements Closeable {
   }
 
   /**
-   * Returns the {@link JsonToken#NUMBER int} value of the next token,
-   * consuming it. If the next token is a string, this method will attempt to
-   * parse it as an int. If the next token's numeric value cannot be exactly
-   * represented by a Java {@code int}, this method throws.
+   * Returns the {@link JsonToken#NUMBER int} value of the next token, consuming it. If the next
+   * token is a string, this method will attempt to parse it as an int. If the next token's numeric
+   * value cannot be exactly represented by a Java {@code int}, this method throws.
    *
    * @throws IllegalStateException if the next token is not a literal value.
-   * @throws NumberFormatException if the next literal value cannot be parsed
-   *     as a number, or exactly represented as an int.
+   * @throws NumberFormatException if the next literal value cannot be parsed as a number, or
+   *     exactly represented as an int.
    */
   public int nextInt() throws IOException {
     int p = peeked;
@@ -1290,10 +1289,9 @@ public class JsonReader implements Closeable {
     return result;
   }
 
-  /**
-   * Closes this JSON reader and the underlying {@link Reader}.
-   */
-  @Override public void close() throws IOException {
+  /** Closes this JSON reader and the underlying {@link Reader}. */
+  @Override
+  public void close() throws IOException {
     peeked = PEEKED_NONE;
     stack[0] = JsonScope.CLOSED;
     stackSize = 1;
@@ -1301,18 +1299,19 @@ public class JsonReader implements Closeable {
   }
 
   /**
-   * Skips the next value recursively. This method is intended for use when
-   * the JSON token stream contains unrecognized or unhandled values.
+   * Skips the next value recursively. This method is intended for use when the JSON token stream
+   * contains unrecognized or unhandled values.
    *
    * <p>The behavior depends on the type of the next JSON token:
+   *
    * <ul>
-   *   <li>Start of a JSON array or object: It and all of its nested values are skipped.</li>
-   *   <li>Primitive value (for example a JSON number): The primitive value is skipped.</li>
-   *   <li>Property name: Only the name but not the value of the property is skipped.
-   *   {@code skipValue()} has to be called again to skip the property value as well.</li>
-   *   <li>End of a JSON array or object: Only this end token is skipped.</li>
-   *   <li>End of JSON document: Skipping has no effect, the next token continues to be the
-   *   end of the document.</li>
+   *   <li>Start of a JSON array or object: It and all of its nested values are skipped.
+   *   <li>Primitive value (for example a JSON number): The primitive value is skipped.
+   *   <li>Property name: Only the name but not the value of the property is skipped. {@code
+   *       skipValue()} has to be called again to skip the property value as well.
+   *   <li>End of a JSON array or object: Only this end token is skipped.
+   *   <li>End of JSON document: Skipping has no effect, the next token continues to be the end of
+   *       the document.
    * </ul>
    */
   public void skipValue() throws IOException {
@@ -1337,9 +1336,11 @@ public class JsonReader implements Closeable {
           count--;
           break;
         case PEEKED_END_OBJECT:
-          // Only update when object end is explicitly skipped, otherwise stack is not updated anyways
+          // Only update when object end is explicitly skipped, otherwise stack is not updated
+          // anyways
           if (count == 0) {
-            pathNames[stackSize - 1] = null; // Free the last path name so that it can be garbage collected
+            pathNames[stackSize - 1] =
+                null; // Free the last path name so that it can be garbage collected
           }
           stackSize--;
           count--;
@@ -1380,7 +1381,8 @@ public class JsonReader implements Closeable {
         case PEEKED_EOF:
           // Do nothing
           return;
-        // For all other tokens there is nothing to do; token has already been consumed from underlying reader
+          // For all other tokens there is nothing to do; token has already been consumed from
+          // underlying reader
       }
       peeked = PEEKED_NONE;
     } while (count > 0);
@@ -1399,9 +1401,8 @@ public class JsonReader implements Closeable {
   }
 
   /**
-   * Returns true once {@code limit - pos >= minimum}. If the data is
-   * exhausted before that many characters are available, this returns
-   * false.
+   * Returns true once {@code limit - pos >= minimum}. If the data is exhausted before that many
+   * characters are available, this returns false.
    */
   private boolean fillBuffer(int minimum) throws IOException {
     char[] buffer = this.buffer;
@@ -1433,10 +1434,9 @@ public class JsonReader implements Closeable {
   }
 
   /**
-   * Returns the next character in the stream that is neither whitespace nor a
-   * part of a comment. When this returns, the returned character is always at
-   * {@code buffer[pos-1]}; this means the caller can always push back the
-   * returned character by decrementing {@code pos}.
+   * Returns the next character in the stream that is neither whitespace nor a part of a comment.
+   * When this returns, the returned character is always at {@code buffer[pos-1]}; this means the
+   * caller can always push back the returned character by decrementing {@code pos}.
    */
   private int nextNonWhitespace(boolean throwOnEof) throws IOException {
     /*
@@ -1483,26 +1483,26 @@ public class JsonReader implements Closeable {
         checkLenient();
         char peek = buffer[pos];
         switch (peek) {
-        case '*':
-          // skip a /* c-style comment */
-          pos++;
-          if (!skipTo("*/")) {
-            throw syntaxError("Unterminated comment");
-          }
-          p = pos + 2;
-          l = limit;
-          continue;
+          case '*':
+            // skip a /* c-style comment */
+            pos++;
+            if (!skipTo("*/")) {
+              throw syntaxError("Unterminated comment");
+            }
+            p = pos + 2;
+            l = limit;
+            continue;
 
-        case '/':
-          // skip a // end-of-line comment
-          pos++;
-          skipToEndOfLine();
-          p = pos;
-          l = limit;
-          continue;
+          case '/':
+            // skip a // end-of-line comment
+            pos++;
+            skipToEndOfLine();
+            p = pos;
+            l = limit;
+            continue;
 
-        default:
-          return c;
+          default:
+            return c;
         }
       } else if (c == '#') {
         pos = p;
@@ -1529,14 +1529,14 @@ public class JsonReader implements Closeable {
 
   private void checkLenient() throws IOException {
     if (strictness != Strictness.LENIENT) {
-      throw syntaxError("Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON");
+      throw syntaxError(
+          "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON");
     }
   }
 
   /**
-   * Advances the position until after the next newline character. If the line
-   * is terminated by "\r\n", the '\n' must be consumed as whitespace by the
-   * caller.
+   * Advances the position until after the next newline character. If the line is terminated by
+   * "\r\n", the '\n' must be consumed as whitespace by the caller.
    */
   private void skipToEndOfLine() throws IOException {
     while (pos < limit || fillBuffer(1)) {
@@ -1573,7 +1573,8 @@ public class JsonReader implements Closeable {
     return false;
   }
 
-  @Override public String toString() {
+  @Override
+  public String toString() {
     return getClass().getSimpleName() + locationString();
   }
 
@@ -1614,48 +1615,47 @@ public class JsonReader implements Closeable {
   }
 
   /**
-   * Returns a <a href="https://goessner.net/articles/JsonPath/">JSONPath</a>
-   * in <i>dot-notation</i> to the previous (or current) location in the JSON document:
+   * Returns a <a href="https://goessner.net/articles/JsonPath/">JSONPath</a> in <i>dot-notation</i>
+   * to the previous (or current) location in the JSON document:
+   *
    * <ul>
    *   <li>For JSON arrays the path points to the index of the previous element.<br>
-   *   If no element has been consumed yet it uses the index 0 (even if there are no elements).</li>
-   *   <li>For JSON objects the path points to the last property, or to the current
-   *   property if its name has already been consumed.</li>
+   *       If no element has been consumed yet it uses the index 0 (even if there are no elements).
+   *   <li>For JSON objects the path points to the last property, or to the current property if its
+   *       name has already been consumed.
    * </ul>
    *
-   * <p>This method can be useful to add additional context to exception messages
-   * <i>after</i> a value has been consumed.
+   * <p>This method can be useful to add additional context to exception messages <i>after</i> a
+   * value has been consumed.
    */
   public String getPreviousPath() {
     return getPath(true);
   }
 
   /**
-   * Returns a <a href="https://goessner.net/articles/JsonPath/">JSONPath</a>
-   * in <i>dot-notation</i> to the next (or current) location in the JSON document:
+   * Returns a <a href="https://goessner.net/articles/JsonPath/">JSONPath</a> in <i>dot-notation</i>
+   * to the next (or current) location in the JSON document:
+   *
    * <ul>
-   *   <li>For JSON arrays the path points to the index of the next element (even
-   *   if there are no further elements).</li>
-   *   <li>For JSON objects the path points to the last property, or to the current
-   *   property if its name has already been consumed.</li>
+   *   <li>For JSON arrays the path points to the index of the next element (even if there are no
+   *       further elements).
+   *   <li>For JSON objects the path points to the last property, or to the current property if its
+   *       name has already been consumed.
    * </ul>
    *
-   * <p>This method can be useful to add additional context to exception messages
-   * <i>before</i> a value is consumed, for example when the {@linkplain #peek() peeked}
-   * token is unexpected.
+   * <p>This method can be useful to add additional context to exception messages <i>before</i> a
+   * value is consumed, for example when the {@linkplain #peek() peeked} token is unexpected.
    */
   public String getPath() {
     return getPath(false);
   }
 
   /**
-   * Unescapes the character identified by the character or characters that
-   * immediately follow a backslash. The backslash '\' should have already
-   * been read. This supports both Unicode escapes "u000A" and two-character
-   * escapes "\n".
+   * Unescapes the character identified by the character or characters that immediately follow a
+   * backslash. The backslash '\' should have already been read. This supports both Unicode escapes
+   * "u000A" and two-character escapes "\n".
    *
-   * @throws MalformedJsonException if any Unicode escape sequences are
-   *     malformed.
+   * @throws MalformedJsonException if any Unicode escape sequences are malformed.
    */
   @SuppressWarnings("fallthrough")
   private char readEscapeCharacter() throws IOException {
@@ -1665,85 +1665,89 @@ public class JsonReader implements Closeable {
 
     char escaped = buffer[pos++];
     switch (escaped) {
-    case 'u':
-      if (pos + 4 > limit && !fillBuffer(4)) {
-        throw syntaxError("Unterminated escape sequence");
-      }
-      // Equivalent to Integer.parseInt(stringPool.get(buffer, pos, 4), 16);
-      int result = 0;
-      for (int i = pos, end = i + 4; i < end; i++) {
-        char c = buffer[i];
-        result <<= 4;
-        if (c >= '0' && c <= '9') {
-          result += (c - '0');
-        } else if (c >= 'a' && c <= 'f') {
-          result += (c - 'a' + 10);
-        } else if (c >= 'A' && c <= 'F') {
-          result += (c - 'A' + 10);
-        } else {
-          throw syntaxError("Malformed Unicode escape \\u" + new String(buffer, pos, 4));
+      case 'u':
+        if (pos + 4 > limit && !fillBuffer(4)) {
+          throw syntaxError("Unterminated escape sequence");
         }
-      }
-      pos += 4;
-      return (char) result;
+        // Equivalent to Integer.parseInt(stringPool.get(buffer, pos, 4), 16);
+        int result = 0;
+        for (int i = pos, end = i + 4; i < end; i++) {
+          char c = buffer[i];
+          result <<= 4;
+          if (c >= '0' && c <= '9') {
+            result += (c - '0');
+          } else if (c >= 'a' && c <= 'f') {
+            result += (c - 'a' + 10);
+          } else if (c >= 'A' && c <= 'F') {
+            result += (c - 'A' + 10);
+          } else {
+            throw syntaxError("Malformed Unicode escape \\u" + new String(buffer, pos, 4));
+          }
+        }
+        pos += 4;
+        return (char) result;
 
-    case 't':
-      return '\t';
+      case 't':
+        return '\t';
 
-    case 'b':
-      return '\b';
+      case 'b':
+        return '\b';
 
-    case 'n':
-      return '\n';
+      case 'n':
+        return '\n';
 
-    case 'r':
-      return '\r';
+      case 'r':
+        return '\r';
 
-    case 'f':
-      return '\f';
+      case 'f':
+        return '\f';
 
-    case '\n':
-      if (strictness == Strictness.STRICT) {
-        throw syntaxError("Cannot escape a newline character in strict mode");
-      }
-      lineNumber++;
-      lineStart = pos;
-      // fall-through
+      case '\n':
+        if (strictness == Strictness.STRICT) {
+          throw syntaxError("Cannot escape a newline character in strict mode");
+        }
+        lineNumber++;
+        lineStart = pos;
+        // fall-through
 
-    case '\'':
-      if (strictness == Strictness.STRICT) {
-        throw syntaxError("Invalid escaped character \"'\" in strict mode");
-      }
-    case '"':
-    case '\\':
-    case '/':
-      return escaped;
-    default:
-      // throw error when none of the above cases are matched
-      throw syntaxError("Invalid escape sequence");
+      case '\'':
+        if (strictness == Strictness.STRICT) {
+          throw syntaxError("Invalid escaped character \"'\" in strict mode");
+        }
+      case '"':
+      case '\\':
+      case '/':
+        return escaped;
+      default:
+        // throw error when none of the above cases are matched
+        throw syntaxError("Invalid escape sequence");
     }
   }
 
   /**
-   * Throws a new IO exception with the given message and a context snippet
-   * with this reader's content.
+   * Throws a new IO exception with the given message and a context snippet with this reader's
+   * content.
    */
   private IOException syntaxError(String message) throws IOException {
-    throw new MalformedJsonException(message + locationString()
-      + "\nSee " + TroubleshootingGuide.createUrl("malformed-json"));
+    throw new MalformedJsonException(
+        message + locationString() + "\nSee " + TroubleshootingGuide.createUrl("malformed-json"));
   }
 
   private IllegalStateException unexpectedTokenError(String expected) throws IOException {
     JsonToken peeked = peek();
-    String troubleshootingId = peeked == JsonToken.NULL
-        ? "adapter-not-null-safe" : "unexpected-json-structure";
-    return new IllegalStateException("Expected " + expected + " but was " + peek() + locationString()
-        + "\nSee " + TroubleshootingGuide.createUrl(troubleshootingId));
+    String troubleshootingId =
+        peeked == JsonToken.NULL ? "adapter-not-null-safe" : "unexpected-json-structure";
+    return new IllegalStateException(
+        "Expected "
+            + expected
+            + " but was "
+            + peek()
+            + locationString()
+            + "\nSee "
+            + TroubleshootingGuide.createUrl(troubleshootingId));
   }
 
-  /**
-   * Consumes the non-execute prefix if it exists.
-   */
+  /** Consumes the non-execute prefix if it exists. */
   private void consumeNonExecutePrefix() throws IOException {
     // fast-forward through the leading whitespace
     int unused = nextNonWhitespace(true);
@@ -1755,7 +1759,11 @@ public class JsonReader implements Closeable {
 
     int p = pos;
     char[] buf = buffer;
-    if (buf[p] != ')' || buf[p + 1] != ']' || buf[p + 2] != '}' || buf[p + 3] != '\'' || buf[p + 4] != '\n') {
+    if (buf[p] != ')'
+        || buf[p + 1] != ']'
+        || buf[p + 2] != '}'
+        || buf[p + 3] != '\''
+        || buf[p + 4] != '\n') {
       return; // not a security token!
     }
 
@@ -1764,26 +1772,28 @@ public class JsonReader implements Closeable {
   }
 
   static {
-    JsonReaderInternalAccess.INSTANCE = new JsonReaderInternalAccess() {
-      @Override public void promoteNameToValue(JsonReader reader) throws IOException {
-        if (reader instanceof JsonTreeReader) {
-          ((JsonTreeReader)reader).promoteNameToValue();
-          return;
-        }
-        int p = reader.peeked;
-        if (p == PEEKED_NONE) {
-          p = reader.doPeek();
-        }
-        if (p == PEEKED_DOUBLE_QUOTED_NAME) {
-          reader.peeked = PEEKED_DOUBLE_QUOTED;
-        } else if (p == PEEKED_SINGLE_QUOTED_NAME) {
-          reader.peeked = PEEKED_SINGLE_QUOTED;
-        } else if (p == PEEKED_UNQUOTED_NAME) {
-          reader.peeked = PEEKED_UNQUOTED;
-        } else {
-          throw reader.unexpectedTokenError("a name");
-        }
-      }
-    };
+    JsonReaderInternalAccess.INSTANCE =
+        new JsonReaderInternalAccess() {
+          @Override
+          public void promoteNameToValue(JsonReader reader) throws IOException {
+            if (reader instanceof JsonTreeReader) {
+              ((JsonTreeReader) reader).promoteNameToValue();
+              return;
+            }
+            int p = reader.peeked;
+            if (p == PEEKED_NONE) {
+              p = reader.doPeek();
+            }
+            if (p == PEEKED_DOUBLE_QUOTED_NAME) {
+              reader.peeked = PEEKED_DOUBLE_QUOTED;
+            } else if (p == PEEKED_SINGLE_QUOTED_NAME) {
+              reader.peeked = PEEKED_SINGLE_QUOTED;
+            } else if (p == PEEKED_UNQUOTED_NAME) {
+              reader.peeked = PEEKED_UNQUOTED;
+            } else {
+              throw reader.unexpectedTokenError("a name");
+            }
+          }
+        };
   }
 }

--- a/gson/src/main/java/com/google/gson/stream/JsonScope.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonScope.java
@@ -24,48 +24,30 @@ package com.google.gson.stream;
  */
 final class JsonScope {
 
-    /**
-     * An array with no elements requires no separators or newlines before
-     * it is closed.
-     */
-    static final int EMPTY_ARRAY = 1;
+  /** An array with no elements requires no separators or newlines before it is closed. */
+  static final int EMPTY_ARRAY = 1;
 
-    /**
-     * An array with at least one value requires a comma and newline before
-     * the next element.
-     */
-    static final int NONEMPTY_ARRAY = 2;
+  /** An array with at least one value requires a comma and newline before the next element. */
+  static final int NONEMPTY_ARRAY = 2;
 
-    /**
-     * An object with no name/value pairs requires no separators or newlines
-     * before it is closed.
-     */
-    static final int EMPTY_OBJECT = 3;
+  /** An object with no name/value pairs requires no separators or newlines before it is closed. */
+  static final int EMPTY_OBJECT = 3;
 
-    /**
-     * An object whose most recent element is a key. The next element must
-     * be a value.
-     */
-    static final int DANGLING_NAME = 4;
+  /** An object whose most recent element is a key. The next element must be a value. */
+  static final int DANGLING_NAME = 4;
 
-    /**
-     * An object with at least one name/value pair requires a comma and
-     * newline before the next element.
-     */
-    static final int NONEMPTY_OBJECT = 5;
+  /**
+   * An object with at least one name/value pair requires a comma and newline before the next
+   * element.
+   */
+  static final int NONEMPTY_OBJECT = 5;
 
-    /**
-     * No object or array has been started.
-     */
-    static final int EMPTY_DOCUMENT = 6;
+  /** No object or array has been started. */
+  static final int EMPTY_DOCUMENT = 6;
 
-    /**
-     * A document with at an array or object.
-     */
-    static final int NONEMPTY_DOCUMENT = 7;
+  /** A document with at an array or object. */
+  static final int NONEMPTY_DOCUMENT = 7;
 
-    /**
-     * A document that's been closed and cannot be accessed.
-     */
-    static final int CLOSED = 8;
+  /** A document that's been closed and cannot be accessed. */
+  static final int CLOSED = 8;
 }

--- a/gson/src/main/java/com/google/gson/stream/JsonToken.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonToken.java
@@ -25,61 +25,52 @@ package com.google.gson.stream;
 public enum JsonToken {
 
   /**
-   * The opening of a JSON array. Written using {@link JsonWriter#beginArray}
-   * and read using {@link JsonReader#beginArray}.
+   * The opening of a JSON array. Written using {@link JsonWriter#beginArray} and read using {@link
+   * JsonReader#beginArray}.
    */
   BEGIN_ARRAY,
 
   /**
-   * The closing of a JSON array. Written using {@link JsonWriter#endArray}
-   * and read using {@link JsonReader#endArray}.
+   * The closing of a JSON array. Written using {@link JsonWriter#endArray} and read using {@link
+   * JsonReader#endArray}.
    */
   END_ARRAY,
 
   /**
-   * The opening of a JSON object. Written using {@link JsonWriter#beginObject}
-   * and read using {@link JsonReader#beginObject}.
+   * The opening of a JSON object. Written using {@link JsonWriter#beginObject} and read using
+   * {@link JsonReader#beginObject}.
    */
   BEGIN_OBJECT,
 
   /**
-   * The closing of a JSON object. Written using {@link JsonWriter#endObject}
-   * and read using {@link JsonReader#endObject}.
+   * The closing of a JSON object. Written using {@link JsonWriter#endObject} and read using {@link
+   * JsonReader#endObject}.
    */
   END_OBJECT,
 
   /**
-   * A JSON property name. Within objects, tokens alternate between names and
-   * their values. Written using {@link JsonWriter#name} and read using {@link
-   * JsonReader#nextName}
+   * A JSON property name. Within objects, tokens alternate between names and their values. Written
+   * using {@link JsonWriter#name} and read using {@link JsonReader#nextName}
    */
   NAME,
 
-  /**
-   * A JSON string.
-   */
+  /** A JSON string. */
   STRING,
 
   /**
-   * A JSON number represented in this API by a Java {@code double}, {@code
-   * long}, or {@code int}.
+   * A JSON number represented in this API by a Java {@code double}, {@code long}, or {@code int}.
    */
   NUMBER,
 
-  /**
-   * A JSON {@code true} or {@code false}.
-   */
+  /** A JSON {@code true} or {@code false}. */
   BOOLEAN,
 
-  /**
-   * A JSON {@code null}.
-   */
+  /** A JSON {@code null}. */
   NULL,
 
   /**
-   * The end of the JSON stream. This sentinel value is returned by {@link
-   * JsonReader#peek()} to signal that the JSON-encoded value has no more
-   * tokens.
+   * The end of the JSON stream. This sentinel value is returned by {@link JsonReader#peek()} to
+   * signal that the JSON-encoded value has no more tokens.
    */
   END_DOCUMENT
 }

--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -42,43 +42,46 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 
 /**
- * Writes a JSON (<a href="https://www.ietf.org/rfc/rfc8259.txt">RFC 8259</a>)
- * encoded value to a stream, one token at a time. The stream includes both
- * literal values (strings, numbers, booleans and nulls) as well as the begin
- * and end delimiters of objects and arrays.
+ * Writes a JSON (<a href="https://www.ietf.org/rfc/rfc8259.txt">RFC 8259</a>) encoded value to a
+ * stream, one token at a time. The stream includes both literal values (strings, numbers, booleans
+ * and nulls) as well as the begin and end delimiters of objects and arrays.
  *
  * <h2>Encoding JSON</h2>
- * To encode your data as JSON, create a new {@code JsonWriter}. Call methods
- * on the writer as you walk the structure's contents, nesting arrays and objects
- * as necessary:
+ *
+ * To encode your data as JSON, create a new {@code JsonWriter}. Call methods on the writer as you
+ * walk the structure's contents, nesting arrays and objects as necessary:
+ *
  * <ul>
- *   <li>To write <strong>arrays</strong>, first call {@link #beginArray()}.
- *       Write each of the array's elements with the appropriate {@link #value}
- *       methods or by nesting other arrays and objects. Finally close the array
- *       using {@link #endArray()}.
- *   <li>To write <strong>objects</strong>, first call {@link #beginObject()}.
- *       Write each of the object's properties by alternating calls to
- *       {@link #name} with the property's value. Write property values with the
- *       appropriate {@link #value} method or by nesting other objects or arrays.
- *       Finally close the object using {@link #endObject()}.
+ *   <li>To write <strong>arrays</strong>, first call {@link #beginArray()}. Write each of the
+ *       array's elements with the appropriate {@link #value} methods or by nesting other arrays and
+ *       objects. Finally close the array using {@link #endArray()}.
+ *   <li>To write <strong>objects</strong>, first call {@link #beginObject()}. Write each of the
+ *       object's properties by alternating calls to {@link #name} with the property's value. Write
+ *       property values with the appropriate {@link #value} method or by nesting other objects or
+ *       arrays. Finally close the object using {@link #endObject()}.
  * </ul>
  *
  * <h2>Configuration</h2>
+ *
  * The behavior of this writer can be customized with the following methods:
+ *
  * <ul>
- *   <li>{@link #setFormattingStyle(FormattingStyle)}, the default is {@link FormattingStyle#COMPACT}
- *   <li>{@link #setHtmlSafe(boolean)}, by default HTML characters are not escaped
- *       in the JSON output
+ *   <li>{@link #setFormattingStyle(FormattingStyle)}, the default is {@link
+ *       FormattingStyle#COMPACT}
+ *   <li>{@link #setHtmlSafe(boolean)}, by default HTML characters are not escaped in the JSON
+ *       output
  *   <li>{@link #setStrictness(Strictness)}, the default is {@link Strictness#LEGACY_STRICT}
  *   <li>{@link #setSerializeNulls(boolean)}, by default {@code null} is serialized
  * </ul>
  *
- * The default configuration of {@code JsonWriter} instances used internally by
- * the {@link Gson} class differs, and can be adjusted with the various
- * {@link GsonBuilder} methods.
+ * The default configuration of {@code JsonWriter} instances used internally by the {@link Gson}
+ * class differs, and can be adjusted with the various {@link GsonBuilder} methods.
  *
  * <h2>Example</h2>
- * Suppose we'd like to encode a stream of messages such as the following: <pre> {@code
+ *
+ * Suppose we'd like to encode a stream of messages such as the following:
+ *
+ * <pre>{@code
  * [
  *   {
  *     "id": 912345678901,
@@ -98,56 +101,61 @@ import java.util.regex.Pattern;
  *       "followers_count": 2
  *     }
  *   }
- * ]}</pre>
- * This code encodes the above structure: <pre>   {@code
- *   public void writeJsonStream(OutputStream out, List<Message> messages) throws IOException {
- *     JsonWriter writer = new JsonWriter(new OutputStreamWriter(out, "UTF-8"));
- *     writer.setIndent("    ");
- *     writeMessagesArray(writer, messages);
- *     writer.close();
+ * ]
+ * }</pre>
+ *
+ * This code encodes the above structure:
+ *
+ * <pre>{@code
+ * public void writeJsonStream(OutputStream out, List<Message> messages) throws IOException {
+ *   JsonWriter writer = new JsonWriter(new OutputStreamWriter(out, "UTF-8"));
+ *   writer.setIndent("    ");
+ *   writeMessagesArray(writer, messages);
+ *   writer.close();
+ * }
+ *
+ * public void writeMessagesArray(JsonWriter writer, List<Message> messages) throws IOException {
+ *   writer.beginArray();
+ *   for (Message message : messages) {
+ *     writeMessage(writer, message);
  *   }
+ *   writer.endArray();
+ * }
  *
- *   public void writeMessagesArray(JsonWriter writer, List<Message> messages) throws IOException {
- *     writer.beginArray();
- *     for (Message message : messages) {
- *       writeMessage(writer, message);
- *     }
- *     writer.endArray();
+ * public void writeMessage(JsonWriter writer, Message message) throws IOException {
+ *   writer.beginObject();
+ *   writer.name("id").value(message.getId());
+ *   writer.name("text").value(message.getText());
+ *   if (message.getGeo() != null) {
+ *     writer.name("geo");
+ *     writeDoublesArray(writer, message.getGeo());
+ *   } else {
+ *     writer.name("geo").nullValue();
  *   }
+ *   writer.name("user");
+ *   writeUser(writer, message.getUser());
+ *   writer.endObject();
+ * }
  *
- *   public void writeMessage(JsonWriter writer, Message message) throws IOException {
- *     writer.beginObject();
- *     writer.name("id").value(message.getId());
- *     writer.name("text").value(message.getText());
- *     if (message.getGeo() != null) {
- *       writer.name("geo");
- *       writeDoublesArray(writer, message.getGeo());
- *     } else {
- *       writer.name("geo").nullValue();
- *     }
- *     writer.name("user");
- *     writeUser(writer, message.getUser());
- *     writer.endObject();
+ * public void writeUser(JsonWriter writer, User user) throws IOException {
+ *   writer.beginObject();
+ *   writer.name("name").value(user.getName());
+ *   writer.name("followers_count").value(user.getFollowersCount());
+ *   writer.endObject();
+ * }
+ *
+ * public void writeDoublesArray(JsonWriter writer, List<Double> doubles) throws IOException {
+ *   writer.beginArray();
+ *   for (Double value : doubles) {
+ *     writer.value(value);
  *   }
+ *   writer.endArray();
+ * }
+ * }</pre>
  *
- *   public void writeUser(JsonWriter writer, User user) throws IOException {
- *     writer.beginObject();
- *     writer.name("name").value(user.getName());
- *     writer.name("followers_count").value(user.getFollowersCount());
- *     writer.endObject();
- *   }
- *
- *   public void writeDoublesArray(JsonWriter writer, List<Double> doubles) throws IOException {
- *     writer.beginArray();
- *     for (Double value : doubles) {
- *       writer.value(value);
- *     }
- *     writer.endArray();
- *   }}</pre>
- *
- * <p>Each {@code JsonWriter} may be used to write a single JSON stream.
- * Instances of this class are not thread safe. Calls that would result in a
- * malformed JSON string will fail with an {@link IllegalStateException}.
+ * <p>Each {@code JsonWriter} may be used to write a single JSON stream. Instances of this class are
+ * not thread safe. Calls that would result in a malformed JSON string will fail with an {@link
+ * IllegalStateException}.
  *
  * @author Jesse Wilson
  * @since 1.6
@@ -155,7 +163,8 @@ import java.util.regex.Pattern;
 public class JsonWriter implements Closeable, Flushable {
 
   // Syntax as defined by https://datatracker.ietf.org/doc/html/rfc8259#section-6
-  private static final Pattern VALID_JSON_NUMBER_PATTERN = Pattern.compile("-?(?:0|[1-9][0-9]*)(?:\\.[0-9]+)?(?:[eE][-+]?[0-9]+)?");
+  private static final Pattern VALID_JSON_NUMBER_PATTERN =
+      Pattern.compile("-?(?:0|[1-9][0-9]*)(?:\\.[0-9]+)?(?:[eE][-+]?[0-9]+)?");
 
   /*
    * From RFC 8259, "All Unicode characters may be placed within the
@@ -169,6 +178,7 @@ public class JsonWriter implements Closeable, Flushable {
    */
   private static final String[] REPLACEMENT_CHARS;
   private static final String[] HTML_SAFE_REPLACEMENT_CHARS;
+
   static {
     REPLACEMENT_CHARS = new String[128];
     for (int i = 0; i <= 0x1f; i++) {
@@ -194,6 +204,7 @@ public class JsonWriter implements Closeable, Flushable {
 
   private int[] stack = new int[32];
   private int stackSize = 0;
+
   {
     push(EMPTY_DOCUMENT);
   }
@@ -214,9 +225,9 @@ public class JsonWriter implements Closeable, Flushable {
   private boolean serializeNulls = true;
 
   /**
-   * Creates a new instance that writes a JSON-encoded stream to {@code out}.
-   * For best performance, ensure {@link Writer} is buffered; wrapping in
-   * {@link java.io.BufferedWriter BufferedWriter} if necessary.
+   * Creates a new instance that writes a JSON-encoded stream to {@code out}. For best performance,
+   * ensure {@link Writer} is buffered; wrapping in {@link java.io.BufferedWriter BufferedWriter} if
+   * necessary.
    */
   public JsonWriter(Writer out) {
     this.out = Objects.requireNonNull(out, "out == null");
@@ -224,16 +235,14 @@ public class JsonWriter implements Closeable, Flushable {
   }
 
   /**
-   * Sets the indentation string to be repeated for each level of indentation
-   * in the encoded document. If {@code indent.isEmpty()} the encoded document
-   * will be compact. Otherwise the encoded document will be more
-   * human-readable.
+   * Sets the indentation string to be repeated for each level of indentation in the encoded
+   * document. If {@code indent.isEmpty()} the encoded document will be compact. Otherwise the
+   * encoded document will be more human-readable.
    *
-   * <p>This is a convenience method which overwrites any previously
-   * {@linkplain #setFormattingStyle(FormattingStyle) set formatting style} with
-   * either {@link FormattingStyle#COMPACT} if the given indent string is
-   * empty, or {@link FormattingStyle#PRETTY} with the given indent if
-   * not empty.
+   * <p>This is a convenience method which overwrites any previously {@linkplain
+   * #setFormattingStyle(FormattingStyle) set formatting style} with either {@link
+   * FormattingStyle#COMPACT} if the given indent string is empty, or {@link FormattingStyle#PRETTY}
+   * with the given indent if not empty.
    *
    * @param indent a string containing only whitespace.
    */
@@ -248,9 +257,8 @@ public class JsonWriter implements Closeable, Flushable {
   /**
    * Sets the formatting style to be used in the encoded document.
    *
-   * <p>The formatting style specifies for example the indentation string to be
-   * repeated for each level of indentation, or the newline style, to accommodate
-   * various OS styles.</p>
+   * <p>The formatting style specifies for example the indentation string to be repeated for each
+   * level of indentation, or the newline style, to accommodate various OS styles.
    *
    * @param formattingStyle the formatting style to use, must not be {@code null}.
    * @since $next-version$
@@ -270,8 +278,8 @@ public class JsonWriter implements Closeable, Flushable {
       this.formattedColon = ":";
     }
 
-    this.usesEmptyNewlineAndIndent = this.formattingStyle.getNewline().isEmpty()
-        && this.formattingStyle.getIndent().isEmpty();
+    this.usesEmptyNewlineAndIndent =
+        this.formattingStyle.getNewline().isEmpty() && this.formattingStyle.getIndent().isEmpty();
   }
 
   /**
@@ -287,17 +295,20 @@ public class JsonWriter implements Closeable, Flushable {
   /**
    * Sets the strictness of this writer.
    *
-   * @deprecated Please use {@link #setStrictness(Strictness)} instead.
-   * {@code JsonWriter.setLenient(true)} should be replaced by {@code JsonWriter.setStrictness(Strictness.LENIENT)}
-   * and {@code JsonWriter.setLenient(false)} should be replaced by {@code JsonWriter.setStrictness(Strictness.LEGACY_STRICT)}.<br>
-   * However, if you used {@code setLenient(false)} before, you might prefer {@link Strictness#STRICT} now instead.
-   *
-   * @param lenient whether this writer should be lenient. If true, the strictness is set to {@link Strictness#LENIENT}.
-   *                If false, the strictness is set to {@link Strictness#LEGACY_STRICT}.
+   * @deprecated Please use {@link #setStrictness(Strictness)} instead. {@code
+   *     JsonWriter.setLenient(true)} should be replaced by {@code
+   *     JsonWriter.setStrictness(Strictness.LENIENT)} and {@code JsonWriter.setLenient(false)}
+   *     should be replaced by {@code JsonWriter.setStrictness(Strictness.LEGACY_STRICT)}.<br>
+   *     However, if you used {@code setLenient(false)} before, you might prefer {@link
+   *     Strictness#STRICT} now instead.
+   * @param lenient whether this writer should be lenient. If true, the strictness is set to {@link
+   *     Strictness#LENIENT}. If false, the strictness is set to {@link Strictness#LEGACY_STRICT}.
    * @see #setStrictness(Strictness)
    */
   @Deprecated
-  @SuppressWarnings("InlineMeSuggester") // Don't specify @InlineMe, so caller with `setLenient(false)` becomes aware of new Strictness.STRICT
+  @SuppressWarnings(
+      "InlineMeSuggester") // Don't specify @InlineMe, so caller with `setLenient(false)` becomes
+  // aware of new Strictness.STRICT
   public final void setLenient(boolean lenient) {
     setStrictness(lenient ? Strictness.LENIENT : Strictness.LEGACY_STRICT);
   }
@@ -313,19 +324,17 @@ public class JsonWriter implements Closeable, Flushable {
 
   /**
    * Configures how strict this writer is with regard to the syntax rules specified in <a
-   * href="https://www.ietf.org/rfc/rfc8259.txt">RFC 8259</a>. By default, {@link Strictness#LEGACY_STRICT} is used.
+   * href="https://www.ietf.org/rfc/rfc8259.txt">RFC 8259</a>. By default, {@link
+   * Strictness#LEGACY_STRICT} is used.
    *
    * <dl>
-   *     <dt>{@link Strictness#STRICT} &amp; {@link Strictness#LEGACY_STRICT}</dt>
-   *     <dd>
-   *         The behavior of these is currently identical. In these strictness modes, the writer only writes JSON
-   *         in accordance with RFC 8259.
-   *     </dd>
-   *     <dt>{@link Strictness#LENIENT}</dt>
-   *     <dd>
-   *         This mode relaxes the behavior of the writer to allow the writing of {@link Double#isNaN() NaNs}
-   *         and {@link Double#isInfinite() infinities}. It also allows writing multiple top level values.
-   *     </dd>
+   *   <dt>{@link Strictness#STRICT} &amp; {@link Strictness#LEGACY_STRICT}
+   *   <dd>The behavior of these is currently identical. In these strictness modes, the writer only
+   *       writes JSON in accordance with RFC 8259.
+   *   <dt>{@link Strictness#LENIENT}
+   *   <dd>This mode relaxes the behavior of the writer to allow the writing of {@link
+   *       Double#isNaN() NaNs} and {@link Double#isInfinite() infinities}. It also allows writing
+   *       multiple top level values.
    * </dl>
    *
    * @param strictness the new strictness of this writer. May not be {@code null}.
@@ -346,43 +355,41 @@ public class JsonWriter implements Closeable, Flushable {
   }
 
   /**
-   * Configures this writer to emit JSON that's safe for direct inclusion in HTML
-   * and XML documents. This escapes the HTML characters {@code <}, {@code >},
-   * {@code &} and {@code =} before writing them to the stream. Without this
-   * setting, your XML/HTML encoder should replace these characters with the
-   * corresponding escape sequences.
+   * Configures this writer to emit JSON that's safe for direct inclusion in HTML and XML documents.
+   * This escapes the HTML characters {@code <}, {@code >}, {@code &} and {@code =} before writing
+   * them to the stream. Without this setting, your XML/HTML encoder should replace these characters
+   * with the corresponding escape sequences.
    */
   public final void setHtmlSafe(boolean htmlSafe) {
     this.htmlSafe = htmlSafe;
   }
 
   /**
-   * Returns true if this writer writes JSON that's safe for inclusion in HTML
-   * and XML documents.
+   * Returns true if this writer writes JSON that's safe for inclusion in HTML and XML documents.
    */
   public final boolean isHtmlSafe() {
     return htmlSafe;
   }
 
   /**
-   * Sets whether object members are serialized when their value is null.
-   * This has no impact on array elements. The default is true.
+   * Sets whether object members are serialized when their value is null. This has no impact on
+   * array elements. The default is true.
    */
   public final void setSerializeNulls(boolean serializeNulls) {
     this.serializeNulls = serializeNulls;
   }
 
   /**
-   * Returns true if object members are serialized when their value is null.
-   * This has no impact on array elements. The default is true.
+   * Returns true if object members are serialized when their value is null. This has no impact on
+   * array elements. The default is true.
    */
   public final boolean getSerializeNulls() {
     return serializeNulls;
   }
 
   /**
-   * Begins encoding a new array. Each call to this method must be paired with
-   * a call to {@link #endArray}.
+   * Begins encoding a new array. Each call to this method must be paired with a call to {@link
+   * #endArray}.
    *
    * @return this writer.
    */
@@ -403,8 +410,8 @@ public class JsonWriter implements Closeable, Flushable {
   }
 
   /**
-   * Begins encoding a new object. Each call to this method must be paired
-   * with a call to {@link #endObject}.
+   * Begins encoding a new object. Each call to this method must be paired with a call to {@link
+   * #endObject}.
    *
    * @return this writer.
    */
@@ -424,10 +431,7 @@ public class JsonWriter implements Closeable, Flushable {
     return close(EMPTY_OBJECT, NONEMPTY_OBJECT, '}');
   }
 
-  /**
-   * Enters a new scope by appending any necessary whitespace and the given
-   * bracket.
-   */
+  /** Enters a new scope by appending any necessary whitespace and the given bracket. */
   @CanIgnoreReturnValue
   private JsonWriter open(int empty, char openBracket) throws IOException {
     beforeValue();
@@ -436,13 +440,9 @@ public class JsonWriter implements Closeable, Flushable {
     return this;
   }
 
-  /**
-   * Closes the current scope by appending any necessary whitespace and the
-   * given bracket.
-   */
+  /** Closes the current scope by appending any necessary whitespace and the given bracket. */
   @CanIgnoreReturnValue
-  private JsonWriter close(int empty, int nonempty, char closeBracket)
-      throws IOException {
+  private JsonWriter close(int empty, int nonempty, char closeBracket) throws IOException {
     int context = peek();
     if (context != nonempty && context != empty) {
       throw new IllegalStateException("Nesting problem.");
@@ -466,9 +466,7 @@ public class JsonWriter implements Closeable, Flushable {
     stack[stackSize++] = newTop;
   }
 
-  /**
-   * Returns the value on the top of the stack.
-   */
+  /** Returns the value on the top of the stack. */
   private int peek() {
     if (stackSize == 0) {
       throw new IllegalStateException("JsonWriter is closed.");
@@ -476,9 +474,7 @@ public class JsonWriter implements Closeable, Flushable {
     return stack[stackSize - 1];
   }
 
-  /**
-   * Replace the value on the top of the stack with the given value.
-   */
+  /** Replace the value on the top of the stack with the given value. */
   private void replaceTop(int topOfStack) {
     stack[stackSize - 1] = topOfStack;
   }
@@ -529,14 +525,13 @@ public class JsonWriter implements Closeable, Flushable {
   }
 
   /**
-   * Writes {@code value} directly to the writer without quoting or
-   * escaping. This might not be supported by all implementations, if
-   * not supported an {@code UnsupportedOperationException} is thrown.
+   * Writes {@code value} directly to the writer without quoting or escaping. This might not be
+   * supported by all implementations, if not supported an {@code UnsupportedOperationException} is
+   * thrown.
    *
    * @param value the literal string value, or null to encode a null literal.
    * @return this writer.
-   * @throws UnsupportedOperationException if this writer does not support
-   *    writing raw JSON values.
+   * @throws UnsupportedOperationException if this writer does not support writing raw JSON values.
    * @since 2.4
    */
   @CanIgnoreReturnValue
@@ -603,9 +598,8 @@ public class JsonWriter implements Closeable, Flushable {
   /**
    * Encodes {@code value}.
    *
-   * @param value a finite value, or if {@link #setStrictness(Strictness) lenient},
-   *     also {@link Float#isNaN() NaN} or {@link Float#isInfinite()
-   *     infinity}.
+   * @param value a finite value, or if {@link #setStrictness(Strictness) lenient}, also {@link
+   *     Float#isNaN() NaN} or {@link Float#isInfinite() infinity}.
    * @return this writer.
    * @throws IllegalArgumentException if the value is NaN or Infinity and this writer is not {@link
    *     #setStrictness(Strictness) lenient}.
@@ -625,11 +619,11 @@ public class JsonWriter implements Closeable, Flushable {
   /**
    * Encodes {@code value}.
    *
-   * @param value a finite value, or if {@link #setStrictness(Strictness) lenient},
-   *     also {@link Double#isNaN() NaN} or {@link Double#isInfinite() infinity}.
+   * @param value a finite value, or if {@link #setStrictness(Strictness) lenient}, also {@link
+   *     Double#isNaN() NaN} or {@link Double#isInfinite() infinity}.
    * @return this writer.
-   * @throws IllegalArgumentException if the value is NaN or Infinity and this writer is
-   *     not {@link #setStrictness(Strictness) lenient}.
+   * @throws IllegalArgumentException if the value is NaN or Infinity and this writer is not {@link
+   *     #setStrictness(Strictness) lenient}.
    */
   @CanIgnoreReturnValue
   public JsonWriter value(double value) throws IOException {
@@ -656,26 +650,34 @@ public class JsonWriter implements Closeable, Flushable {
   }
 
   /**
-   * Returns whether the {@code toString()} of {@code c} can be trusted to return
-   * a valid JSON number.
+   * Returns whether the {@code toString()} of {@code c} can be trusted to return a valid JSON
+   * number.
    */
   private static boolean isTrustedNumberType(Class<? extends Number> c) {
     // Note: Don't consider LazilyParsedNumber trusted because it could contain
     // an arbitrary malformed string
-    return c == Integer.class || c == Long.class || c == Double.class || c == Float.class || c == Byte.class || c == Short.class
-        || c == BigDecimal.class || c == BigInteger.class || c == AtomicInteger.class || c == AtomicLong.class;
+    return c == Integer.class
+        || c == Long.class
+        || c == Double.class
+        || c == Float.class
+        || c == Byte.class
+        || c == Short.class
+        || c == BigDecimal.class
+        || c == BigInteger.class
+        || c == AtomicInteger.class
+        || c == AtomicLong.class;
   }
 
   /**
    * Encodes {@code value}. The value is written by directly writing the {@link Number#toString()}
    * result to JSON. Implementations must make sure that the result represents a valid JSON number.
    *
-   * @param value a finite value, or if {@link #setStrictness(Strictness) lenient},
-   *     also {@link Double#isNaN() NaN} or {@link Double#isInfinite() infinity}.
+   * @param value a finite value, or if {@link #setStrictness(Strictness) lenient}, also {@link
+   *     Double#isNaN() NaN} or {@link Double#isInfinite() infinity}.
    * @return this writer.
-   * @throws IllegalArgumentException if the value is NaN or Infinity and this writer is
-   *     not {@link #setStrictness(Strictness) lenient}; or if the {@code toString()} result is not a
-   *     valid JSON number.
+   * @throws IllegalArgumentException if the value is NaN or Infinity and this writer is not {@link
+   *     #setStrictness(Strictness) lenient}; or if the {@code toString()} result is not a valid
+   *     JSON number.
    */
   @CanIgnoreReturnValue
   public JsonWriter value(Number value) throws IOException {
@@ -692,8 +694,10 @@ public class JsonWriter implements Closeable, Flushable {
     } else {
       Class<? extends Number> numberClass = value.getClass();
       // Validate that string is valid before writing it directly to JSON output
-      if (!isTrustedNumberType(numberClass) && !VALID_JSON_NUMBER_PATTERN.matcher(string).matches()) {
-        throw new IllegalArgumentException("String created by " + numberClass + " is not a valid JSON number: " + string);
+      if (!isTrustedNumberType(numberClass)
+          && !VALID_JSON_NUMBER_PATTERN.matcher(string).matches()) {
+        throw new IllegalArgumentException(
+            "String created by " + numberClass + " is not a valid JSON number: " + string);
       }
     }
 
@@ -703,10 +707,10 @@ public class JsonWriter implements Closeable, Flushable {
   }
 
   /**
-   * Ensures all buffered data is written to the underlying {@link Writer}
-   * and flushes that writer.
+   * Ensures all buffered data is written to the underlying {@link Writer} and flushes that writer.
    */
-  @Override public void flush() throws IOException {
+  @Override
+  public void flush() throws IOException {
     if (stackSize == 0) {
       throw new IllegalStateException("JsonWriter is closed.");
     }
@@ -718,7 +722,8 @@ public class JsonWriter implements Closeable, Flushable {
    *
    * @throws IOException if the JSON document is incomplete.
    */
-  @Override public void close() throws IOException {
+  @Override
+  public void close() throws IOException {
     out.close();
 
     int size = stackSize;
@@ -772,8 +777,8 @@ public class JsonWriter implements Closeable, Flushable {
   }
 
   /**
-   * Inserts any necessary separators and whitespace before a name. Also
-   * adjusts the stack to expect the name's value.
+   * Inserts any necessary separators and whitespace before a name. Also adjusts the stack to expect
+   * the name's value.
    */
   private void beforeName() throws IOException {
     int context = peek();
@@ -787,40 +792,38 @@ public class JsonWriter implements Closeable, Flushable {
   }
 
   /**
-   * Inserts any necessary separators and whitespace before a literal value,
-   * inline array, or inline object. Also adjusts the stack to expect either a
-   * closing bracket or another element.
+   * Inserts any necessary separators and whitespace before a literal value, inline array, or inline
+   * object. Also adjusts the stack to expect either a closing bracket or another element.
    */
   @SuppressWarnings("fallthrough")
   private void beforeValue() throws IOException {
     switch (peek()) {
-    case NONEMPTY_DOCUMENT:
-      if (strictness != Strictness.LENIENT) {
-        throw new IllegalStateException(
-            "JSON must have only one top-level value.");
-      }
-      // fall-through
-    case EMPTY_DOCUMENT: // first in document
-      replaceTop(NONEMPTY_DOCUMENT);
-      break;
+      case NONEMPTY_DOCUMENT:
+        if (strictness != Strictness.LENIENT) {
+          throw new IllegalStateException("JSON must have only one top-level value.");
+        }
+        // fall-through
+      case EMPTY_DOCUMENT: // first in document
+        replaceTop(NONEMPTY_DOCUMENT);
+        break;
 
-    case EMPTY_ARRAY: // first in array
-      replaceTop(NONEMPTY_ARRAY);
-      newline();
-      break;
+      case EMPTY_ARRAY: // first in array
+        replaceTop(NONEMPTY_ARRAY);
+        newline();
+        break;
 
-    case NONEMPTY_ARRAY: // another in array
-      out.append(formattedComma);
-      newline();
-      break;
+      case NONEMPTY_ARRAY: // another in array
+        out.append(formattedComma);
+        newline();
+        break;
 
-    case DANGLING_NAME: // value for name
-      out.append(formattedColon);
-      replaceTop(NONEMPTY_OBJECT);
-      break;
+      case DANGLING_NAME: // value for name
+        out.append(formattedColon);
+        replaceTop(NONEMPTY_OBJECT);
+        break;
 
-    default:
-      throw new IllegalStateException("Nesting problem.");
+      default:
+        throw new IllegalStateException("Nesting problem.");
     }
   }
 }

--- a/gson/src/main/java/com/google/gson/stream/MalformedJsonException.java
+++ b/gson/src/main/java/com/google/gson/stream/MalformedJsonException.java
@@ -20,8 +20,8 @@ import com.google.gson.Strictness;
 import java.io.IOException;
 
 /**
- * Thrown when a reader encounters malformed JSON. Some syntax errors can be
- * ignored by using {@link Strictness#LENIENT} for {@link JsonReader#setStrictness(Strictness)}.
+ * Thrown when a reader encounters malformed JSON. Some syntax errors can be ignored by using {@link
+ * Strictness#LENIENT} for {@link JsonReader#setStrictness(Strictness)}.
  */
 public final class MalformedJsonException extends IOException {
   private static final long serialVersionUID = 1L;

--- a/gson/src/main/java/com/google/gson/stream/package-info.java
+++ b/gson/src/main/java/com/google/gson/stream/package-info.java
@@ -14,7 +14,5 @@
  * limitations under the License.
  */
 
-/**
- * This package provides classes for processing JSON in an efficient streaming way.
- */
+/** This package provides classes for processing JSON in an efficient streaming way. */
 package com.google.gson.stream;

--- a/gson/src/main/java/module-info.java
+++ b/gson/src/main/java/module-info.java
@@ -16,6 +16,7 @@
 
 /**
  * Defines the Gson serialization/deserialization API.
+ *
  * @since 2.8.6
  */
 module com.google.gson {

--- a/gson/src/test/java/com/google/gson/CommentsTest.java
+++ b/gson/src/test/java/com/google/gson/CommentsTest.java
@@ -29,19 +29,18 @@ import org.junit.Test;
  */
 public final class CommentsTest {
 
-  /**
-   * Test for issue 212.
-   */
+  /** Test for issue 212. */
   @Test
   public void testParseComments() {
-    String json = "[\n"
-        + "  // this is a comment\n"
-        + "  \"a\",\n"
-        + "  /* this is another comment */\n"
-        + "  \"b\",\n"
-        + "  # this is yet another comment\n"
-        + "  \"c\"\n"
-        + "]";
+    String json =
+        "[\n"
+            + "  // this is a comment\n"
+            + "  \"a\",\n"
+            + "  /* this is another comment */\n"
+            + "  \"b\",\n"
+            + "  # this is yet another comment\n"
+            + "  \"c\"\n"
+            + "]";
 
     List<String> abc = new Gson().fromJson(json, new TypeToken<List<String>>() {}.getType());
     assertThat(abc).containsExactly("a", "b", "c").inOrder();

--- a/gson/src/test/java/com/google/gson/DefaultInetAddressTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/DefaultInetAddressTypeAdapterTest.java
@@ -24,17 +24,17 @@ import org.junit.Test;
 
 /**
  * Unit tests for the default serializer/deserializer for the {@code InetAddress} type.
- * 
+ *
  * @author Joel Leitch
  */
 public class DefaultInetAddressTypeAdapterTest {
   private Gson gson;
-  
+
   @Before
   public void setUp() throws Exception {
     gson = new Gson();
   }
-  
+
   @Test
   public void testInetAddressSerializationAndDeserialization() throws Exception {
     @SuppressWarnings("AddressSelection") // we really do want this method

--- a/gson/src/test/java/com/google/gson/DefaultMapJsonSerializerTest.java
+++ b/gson/src/test/java/com/google/gson/DefaultMapJsonSerializerTest.java
@@ -25,8 +25,8 @@ import java.util.Map;
 import org.junit.Test;
 
 /**
- * Unit test for the default JSON map serialization object located in the
- * {@link DefaultTypeAdapters} class.
+ * Unit test for the default JSON map serialization object located in the {@link
+ * DefaultTypeAdapters} class.
  *
  * @author Joel Leitch
  */
@@ -44,7 +44,7 @@ public class DefaultMapJsonSerializerTest {
 
   @Test
   public void testEmptyMapSerialization() {
-    Type mapType = new TypeToken<Map<String, String>>() { }.getType();
+    Type mapType = new TypeToken<Map<String, String>>() {}.getType();
     Map<String, String> emptyMap = new HashMap<>();
     JsonElement element = gson.toJsonTree(emptyMap, mapType);
 
@@ -55,7 +55,7 @@ public class DefaultMapJsonSerializerTest {
 
   @Test
   public void testNonEmptyMapSerialization() {
-    Type mapType = new TypeToken<Map<String, String>>() { }.getType();
+    Type mapType = new TypeToken<Map<String, String>>() {}.getType();
     Map<String, String> myMap = new HashMap<>();
     String key = "key1";
     myMap.put(key, "value1");

--- a/gson/src/test/java/com/google/gson/ExposeAnnotationExclusionStrategyTest.java
+++ b/gson/src/test/java/com/google/gson/ExposeAnnotationExclusionStrategyTest.java
@@ -78,16 +78,15 @@ public class ExposeAnnotationExclusionStrategyTest {
 
   @SuppressWarnings("unused")
   private static class MockObject {
-    @Expose
-    public final int exposedField = 0;
+    @Expose public final int exposedField = 0;
 
-    @Expose(serialize=true, deserialize=true)
+    @Expose(serialize = true, deserialize = true)
     public final int explicitlyExposedField = 0;
 
-    @Expose(serialize=false, deserialize=false)
+    @Expose(serialize = false, deserialize = false)
     public final int explicitlyHiddenField = 0;
 
-    @Expose(serialize=true, deserialize=false)
+    @Expose(serialize = true, deserialize = false)
     public final int explicitlyDifferentModeField = 0;
 
     public final int hiddenField = 0;

--- a/gson/src/test/java/com/google/gson/FieldAttributesTest.java
+++ b/gson/src/test/java/com/google/gson/FieldAttributesTest.java
@@ -46,7 +46,8 @@ public class FieldAttributesTest {
     try {
       new FieldAttributes(null);
       fail("Field parameter can not be null");
-    } catch (NullPointerException expected) { }
+    } catch (NullPointerException expected) {
+    }
   }
 
   @Test

--- a/gson/src/test/java/com/google/gson/FieldNamingPolicyTest.java
+++ b/gson/src/test/java/com/google/gson/FieldNamingPolicyTest.java
@@ -19,29 +19,29 @@ package com.google.gson;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 
+import com.google.gson.functional.FieldNamingTest;
 import java.lang.reflect.Field;
 import java.util.Locale;
 import org.junit.Test;
-import com.google.gson.functional.FieldNamingTest;
 
 /**
- * Performs tests directly against {@link FieldNamingPolicy}; for integration tests
- * see {@link FieldNamingTest}.
+ * Performs tests directly against {@link FieldNamingPolicy}; for integration tests see {@link
+ * FieldNamingTest}.
  */
 public class FieldNamingPolicyTest {
   @Test
   public void testSeparateCamelCase() {
     // Map from original -> expected
-    String[][] argumentPairs =  {
-      { "a", "a" },
-      { "ab", "ab" },
-      { "Ab", "Ab" },
-      { "aB", "a_B" },
-      { "AB", "A_B" },
-      { "A_B", "A__B" },
-      { "firstSecondThird", "first_Second_Third" },
-      { "__", "__" },
-      { "_123", "_123" }
+    String[][] argumentPairs = {
+      {"a", "a"},
+      {"ab", "ab"},
+      {"Ab", "Ab"},
+      {"aB", "a_B"},
+      {"AB", "A_B"},
+      {"A_B", "A__B"},
+      {"firstSecondThird", "first_Second_Third"},
+      {"__", "__"},
+      {"_123", "_123"}
     };
 
     for (String[] pair : argumentPairs) {
@@ -52,19 +52,19 @@ public class FieldNamingPolicyTest {
   @Test
   public void testUpperCaseFirstLetter() {
     // Map from original -> expected
-    String[][] argumentPairs =  {
-      { "a", "A" },
-      { "ab", "Ab" },
-      { "AB", "AB" },
-      { "_a", "_A" },
-      { "_ab", "_Ab" },
-      { "__", "__" },
-      { "_1", "_1" },
+    String[][] argumentPairs = {
+      {"a", "A"},
+      {"ab", "Ab"},
+      {"AB", "AB"},
+      {"_a", "_A"},
+      {"_ab", "_Ab"},
+      {"__", "__"},
+      {"_1", "_1"},
       // Not a letter, but has uppercase variant (should not be uppercased)
       // See https://github.com/google/gson/issues/1965
-      { "\u2170", "\u2170" },
-      { "_\u2170", "_\u2170" },
-      { "\u2170a", "\u2170A" },
+      {"\u2170", "\u2170"},
+      {"_\u2170", "_\u2170"},
+      {"\u2170a", "\u2170A"},
     };
 
     for (String[] pair : argumentPairs) {
@@ -72,9 +72,7 @@ public class FieldNamingPolicyTest {
     }
   }
 
-  /**
-   * Upper-casing policies should be unaffected by default Locale.
-   */
+  /** Upper-casing policies should be unaffected by default Locale. */
   @Test
   public void testUpperCasingLocaleIndependent() throws Exception {
     class Dummy {
@@ -99,21 +97,21 @@ public class FieldNamingPolicyTest {
     try {
       // Verify that default Locale has different case conversion rules
       assertWithMessage("Test setup is broken")
-          .that(name.toUpperCase(Locale.getDefault())).doesNotMatch(expected);
+          .that(name.toUpperCase(Locale.getDefault()))
+          .doesNotMatch(expected);
 
       for (FieldNamingPolicy policy : policies) {
         // Should ignore default Locale
         assertWithMessage("Unexpected conversion for %s", policy)
-            .that(policy.translateName(field)).matches(expected);
+            .that(policy.translateName(field))
+            .matches(expected);
       }
     } finally {
-        Locale.setDefault(oldLocale);
+      Locale.setDefault(oldLocale);
     }
   }
 
-  /**
-   * Lower casing policies should be unaffected by default Locale.
-   */
+  /** Lower casing policies should be unaffected by default Locale. */
   @Test
   public void testLowerCasingLocaleIndependent() throws Exception {
     class Dummy {
@@ -138,15 +136,17 @@ public class FieldNamingPolicyTest {
     try {
       // Verify that default Locale has different case conversion rules
       assertWithMessage("Test setup is broken")
-          .that(name.toLowerCase(Locale.getDefault())).doesNotMatch(expected);
+          .that(name.toLowerCase(Locale.getDefault()))
+          .doesNotMatch(expected);
 
       for (FieldNamingPolicy policy : policies) {
         // Should ignore default Locale
         assertWithMessage("Unexpected conversion for %s", policy)
-            .that(policy.translateName(field)).matches(expected);
+            .that(policy.translateName(field))
+            .matches(expected);
       }
     } finally {
-        Locale.setDefault(oldLocale);
+      Locale.setDefault(oldLocale);
     }
   }
 }

--- a/gson/src/test/java/com/google/gson/GenericArrayTypeTest.java
+++ b/gson/src/test/java/com/google/gson/GenericArrayTypeTest.java
@@ -37,7 +37,9 @@ public class GenericArrayTypeTest {
 
   @Before
   public void setUp() throws Exception {
-    ourType = $Gson$Types.arrayOf($Gson$Types.newParameterizedTypeWithOwner(null, List.class, String.class));
+    ourType =
+        $Gson$Types.arrayOf(
+            $Gson$Types.newParameterizedTypeWithOwner(null, List.class, String.class));
   }
 
   @Test

--- a/gson/src/test/java/com/google/gson/GsonBuilderTest.java
+++ b/gson/src/test/java/com/google/gson/GsonBuilderTest.java
@@ -36,14 +36,18 @@ import org.junit.Test;
  * @author Inderjeet Singh
  */
 public class GsonBuilderTest {
-  private static final TypeAdapter<Object> NULL_TYPE_ADAPTER = new TypeAdapter<Object>() {
-    @Override public void write(JsonWriter out, Object value) {
-      throw new AssertionError();
-    }
-    @Override public Object read(JsonReader in) {
-      throw new AssertionError();
-    }
-  };
+  private static final TypeAdapter<Object> NULL_TYPE_ADAPTER =
+      new TypeAdapter<Object>() {
+        @Override
+        public void write(JsonWriter out, Object value) {
+          throw new AssertionError();
+        }
+
+        @Override
+        public Object read(JsonReader in) {
+          throw new AssertionError();
+        }
+      };
 
   @Test
   public void testCreatingMoreThanOnce() {
@@ -52,11 +56,13 @@ public class GsonBuilderTest {
     assertThat(gson).isNotNull();
     assertThat(builder.create()).isNotNull();
 
-    builder.setFieldNamingStrategy(new FieldNamingStrategy() {
-      @Override public String translateName(Field f) {
-        return "test";
-      }
-    });
+    builder.setFieldNamingStrategy(
+        new FieldNamingStrategy() {
+          @Override
+          public String translateName(Field f) {
+            return "test";
+          }
+        });
 
     Gson otherGson = builder.create();
     assertThat(otherGson).isNotNull();
@@ -65,8 +71,8 @@ public class GsonBuilderTest {
   }
 
   /**
-   * Gson instances should not be affected by subsequent modification of GsonBuilder
-   * which created them.
+   * Gson instances should not be affected by subsequent modification of GsonBuilder which created
+   * them.
    */
   @Test
   public void testModificationAfterCreate() {
@@ -74,26 +80,36 @@ public class GsonBuilderTest {
     Gson gson = gsonBuilder.create();
 
     // Modifications of `gsonBuilder` should not affect `gson` object
-    gsonBuilder.registerTypeAdapter(CustomClass1.class, new TypeAdapter<CustomClass1>() {
-      @Override public CustomClass1 read(JsonReader in) {
-        throw new UnsupportedOperationException();
-      }
+    gsonBuilder.registerTypeAdapter(
+        CustomClass1.class,
+        new TypeAdapter<CustomClass1>() {
+          @Override
+          public CustomClass1 read(JsonReader in) {
+            throw new UnsupportedOperationException();
+          }
 
-      @Override public void write(JsonWriter out, CustomClass1 value) throws IOException {
-        out.value("custom-adapter");
-      }
-    });
-    gsonBuilder.registerTypeHierarchyAdapter(CustomClass2.class, new JsonSerializer<CustomClass2>() {
-      @Override public JsonElement serialize(CustomClass2 src, Type typeOfSrc, JsonSerializationContext context) {
-        return new JsonPrimitive("custom-hierarchy-adapter");
-      }
-    });
-    gsonBuilder.registerTypeAdapter(CustomClass3.class, new InstanceCreator<CustomClass3>() {
-      @Override public CustomClass3 createInstance(Type type) {
-        return new CustomClass3("custom-instance");
-      }
-    });
-
+          @Override
+          public void write(JsonWriter out, CustomClass1 value) throws IOException {
+            out.value("custom-adapter");
+          }
+        });
+    gsonBuilder.registerTypeHierarchyAdapter(
+        CustomClass2.class,
+        new JsonSerializer<CustomClass2>() {
+          @Override
+          public JsonElement serialize(
+              CustomClass2 src, Type typeOfSrc, JsonSerializationContext context) {
+            return new JsonPrimitive("custom-hierarchy-adapter");
+          }
+        });
+    gsonBuilder.registerTypeAdapter(
+        CustomClass3.class,
+        new InstanceCreator<CustomClass3>() {
+          @Override
+          public CustomClass3 createInstance(Type type) {
+            return new CustomClass3("custom-instance");
+          }
+        });
 
     assertDefaultGson(gson);
     // New GsonBuilder created from `gson` should not have been affected by changes
@@ -129,8 +145,10 @@ public class GsonBuilderTest {
     assertThat(customClass3.s).isEqualTo("custom-instance");
   }
 
-  static class CustomClass1 { }
-  static class CustomClass2 { }
+  static class CustomClass1 {}
+
+  static class CustomClass2 {}
+
   static class CustomClass3 {
     static final String NO_ARG_CONSTRUCTOR_VALUE = "default instance";
 
@@ -147,9 +165,8 @@ public class GsonBuilderTest {
 
   @Test
   public void testExcludeFieldsWithModifiers() {
-    Gson gson = new GsonBuilder()
-        .excludeFieldsWithModifiers(Modifier.VOLATILE, Modifier.PRIVATE)
-        .create();
+    Gson gson =
+        new GsonBuilder().excludeFieldsWithModifiers(Modifier.VOLATILE, Modifier.PRIVATE).create();
     assertThat(gson.toJson(new HasModifiers())).isEqualTo("{\"d\":\"d\"}");
   }
 
@@ -163,9 +180,7 @@ public class GsonBuilderTest {
 
   @Test
   public void testTransientFieldExclusion() {
-    Gson gson = new GsonBuilder()
-        .excludeFieldsWithModifiers()
-        .create();
+    Gson gson = new GsonBuilder().excludeFieldsWithModifiers().create();
     assertThat(gson.toJson(new HasTransients())).isEqualTo("{\"a\":\"a\"}");
   }
 
@@ -176,12 +191,7 @@ public class GsonBuilderTest {
   @Test
   public void testRegisterTypeAdapterForCoreType() {
     Type[] types = {
-        byte.class,
-        int.class,
-        double.class,
-        Short.class,
-        Long.class,
-        String.class,
+      byte.class, int.class, double.class, Short.class, Long.class, String.class,
     };
     for (Type type : types) {
       new GsonBuilder().registerTypeAdapter(type, NULL_TYPE_ADAPTER);
@@ -190,24 +200,25 @@ public class GsonBuilderTest {
 
   @Test
   public void testDisableJdkUnsafe() {
-    Gson gson = new GsonBuilder()
-        .disableJdkUnsafe()
-        .create();
+    Gson gson = new GsonBuilder().disableJdkUnsafe().create();
     try {
       gson.fromJson("{}", ClassWithoutNoArgsConstructor.class);
       fail("Expected exception");
     } catch (JsonIOException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo(
-          "Unable to create instance of class com.google.gson.GsonBuilderTest$ClassWithoutNoArgsConstructor; "
-          + "usage of JDK Unsafe is disabled. Registering an InstanceCreator or a TypeAdapter for this type, "
-          + "adding a no-args constructor, or enabling usage of JDK Unsafe may fix this problem.");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Unable to create instance of class"
+                  + " com.google.gson.GsonBuilderTest$ClassWithoutNoArgsConstructor; usage of JDK"
+                  + " Unsafe is disabled. Registering an InstanceCreator or a TypeAdapter for this"
+                  + " type, adding a no-args constructor, or enabling usage of JDK Unsafe may fix"
+                  + " this problem.");
     }
   }
 
   private static class ClassWithoutNoArgsConstructor {
     @SuppressWarnings("unused")
-    public ClassWithoutNoArgsConstructor(String s) {
-    }
+    public ClassWithoutNoArgsConstructor(String s) {}
   }
 
   @Test
@@ -232,8 +243,10 @@ public class GsonBuilderTest {
   public void testDefaultStrictness() throws IOException {
     GsonBuilder builder = new GsonBuilder();
     Gson gson = builder.create();
-    assertThat(gson.newJsonReader(new StringReader("{}")).getStrictness()).isEqualTo(Strictness.LEGACY_STRICT);
-    assertThat(gson.newJsonWriter(new StringWriter()).getStrictness()).isEqualTo(Strictness.LEGACY_STRICT);
+    assertThat(gson.newJsonReader(new StringReader("{}")).getStrictness())
+        .isEqualTo(Strictness.LEGACY_STRICT);
+    assertThat(gson.newJsonWriter(new StringWriter()).getStrictness())
+        .isEqualTo(Strictness.LEGACY_STRICT);
   }
 
   @SuppressWarnings({"deprecation", "InlineMeInliner"}) // for GsonBuilder.setLenient
@@ -242,8 +255,10 @@ public class GsonBuilderTest {
     GsonBuilder builder = new GsonBuilder();
     builder.setLenient();
     Gson gson = builder.create();
-    assertThat(gson.newJsonReader(new StringReader("{}")).getStrictness()).isEqualTo(Strictness.LENIENT);
-    assertThat(gson.newJsonWriter(new StringWriter()).getStrictness()).isEqualTo(Strictness.LENIENT);
+    assertThat(gson.newJsonReader(new StringReader("{}")).getStrictness())
+        .isEqualTo(Strictness.LENIENT);
+    assertThat(gson.newJsonWriter(new StringWriter()).getStrictness())
+        .isEqualTo(Strictness.LENIENT);
   }
 
   @Test
@@ -260,30 +275,30 @@ public class GsonBuilderTest {
   public void testRegisterTypeAdapterForObjectAndJsonElements() {
     final String ERROR_MESSAGE = "Cannot override built-in adapter for ";
     Type[] types = {
-        Object.class,
-        JsonElement.class,
-        JsonArray.class,
+      Object.class, JsonElement.class, JsonArray.class,
     };
     GsonBuilder gsonBuilder = new GsonBuilder();
     for (Type type : types) {
-      IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-          () -> gsonBuilder.registerTypeAdapter(type, NULL_TYPE_ADAPTER));
+      IllegalArgumentException e =
+          assertThrows(
+              IllegalArgumentException.class,
+              () -> gsonBuilder.registerTypeAdapter(type, NULL_TYPE_ADAPTER));
       assertThat(e).hasMessageThat().isEqualTo(ERROR_MESSAGE + type);
     }
   }
-
 
   @Test
   public void testRegisterTypeHierarchyAdapterJsonElements() {
     final String ERROR_MESSAGE = "Cannot override built-in adapter for ";
     Class<?>[] types = {
-        JsonElement.class,
-        JsonArray.class,
+      JsonElement.class, JsonArray.class,
     };
     GsonBuilder gsonBuilder = new GsonBuilder();
     for (Class<?> type : types) {
-      IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-          () -> gsonBuilder.registerTypeHierarchyAdapter(type, NULL_TYPE_ADAPTER));
+      IllegalArgumentException e =
+          assertThrows(
+              IllegalArgumentException.class,
+              () -> gsonBuilder.registerTypeHierarchyAdapter(type, NULL_TYPE_ADAPTER));
 
       assertThat(e).hasMessageThat().isEqualTo(ERROR_MESSAGE + type);
     }

--- a/gson/src/test/java/com/google/gson/GsonTest.java
+++ b/gson/src/test/java/com/google/gson/GsonTest.java
@@ -46,18 +46,20 @@ import org.junit.Test;
  */
 public final class GsonTest {
 
-  private static final Excluder CUSTOM_EXCLUDER = Excluder.DEFAULT
-      .excludeFieldsWithoutExposeAnnotation()
-      .disableInnerClassSerialization();
+  private static final Excluder CUSTOM_EXCLUDER =
+      Excluder.DEFAULT.excludeFieldsWithoutExposeAnnotation().disableInnerClassSerialization();
 
-  private static final FieldNamingStrategy CUSTOM_FIELD_NAMING_STRATEGY = new FieldNamingStrategy() {
-    @Override public String translateName(Field f) {
-      return "foo";
-    }
-  };
+  private static final FieldNamingStrategy CUSTOM_FIELD_NAMING_STRATEGY =
+      new FieldNamingStrategy() {
+        @Override
+        public String translateName(Field f) {
+          return "foo";
+        }
+      };
 
   private static final ToNumberStrategy CUSTOM_OBJECT_TO_NUMBER_STRATEGY = ToNumberPolicy.DOUBLE;
-  private static final ToNumberStrategy CUSTOM_NUMBER_TO_NUMBER_STRATEGY = ToNumberPolicy.LAZILY_PARSED_NUMBER;
+  private static final ToNumberStrategy CUSTOM_NUMBER_TO_NUMBER_STRATEGY =
+      ToNumberPolicy.LAZILY_PARSED_NUMBER;
 
   @Test
   public void testStrictnessDefault() {
@@ -66,14 +68,29 @@ public final class GsonTest {
 
   @Test
   public void testOverridesDefaultExcluder() {
-    Gson gson = new Gson(CUSTOM_EXCLUDER, CUSTOM_FIELD_NAMING_STRATEGY,
-        new HashMap<Type, InstanceCreator<?>>(), true, false, true, false,
-        FormattingStyle.PRETTY, Strictness.LENIENT, false, true,
-        LongSerializationPolicy.DEFAULT, null, DateFormat.DEFAULT,
-        DateFormat.DEFAULT, new ArrayList<TypeAdapterFactory>(),
-        new ArrayList<TypeAdapterFactory>(), new ArrayList<TypeAdapterFactory>(),
-        CUSTOM_OBJECT_TO_NUMBER_STRATEGY, CUSTOM_NUMBER_TO_NUMBER_STRATEGY,
-        Collections.<ReflectionAccessFilter>emptyList());
+    Gson gson =
+        new Gson(
+            CUSTOM_EXCLUDER,
+            CUSTOM_FIELD_NAMING_STRATEGY,
+            new HashMap<Type, InstanceCreator<?>>(),
+            true,
+            false,
+            true,
+            false,
+            FormattingStyle.PRETTY,
+            Strictness.LENIENT,
+            false,
+            true,
+            LongSerializationPolicy.DEFAULT,
+            null,
+            DateFormat.DEFAULT,
+            DateFormat.DEFAULT,
+            new ArrayList<TypeAdapterFactory>(),
+            new ArrayList<TypeAdapterFactory>(),
+            new ArrayList<TypeAdapterFactory>(),
+            CUSTOM_OBJECT_TO_NUMBER_STRATEGY,
+            CUSTOM_NUMBER_TO_NUMBER_STRATEGY,
+            Collections.<ReflectionAccessFilter>emptyList());
 
     assertThat(gson.excluder).isEqualTo(CUSTOM_EXCLUDER);
     assertThat(gson.fieldNamingStrategy()).isEqualTo(CUSTOM_FIELD_NAMING_STRATEGY);
@@ -83,44 +100,66 @@ public final class GsonTest {
 
   @Test
   public void testClonedTypeAdapterFactoryListsAreIndependent() {
-    Gson original = new Gson(CUSTOM_EXCLUDER, CUSTOM_FIELD_NAMING_STRATEGY,
-        new HashMap<Type, InstanceCreator<?>>(), true, false, true, false,
-        FormattingStyle.PRETTY, Strictness.LENIENT, false, true,
-        LongSerializationPolicy.DEFAULT, null, DateFormat.DEFAULT,
-        DateFormat.DEFAULT, new ArrayList<TypeAdapterFactory>(),
-        new ArrayList<TypeAdapterFactory>(), new ArrayList<TypeAdapterFactory>(),
-        CUSTOM_OBJECT_TO_NUMBER_STRATEGY, CUSTOM_NUMBER_TO_NUMBER_STRATEGY,
-        Collections.<ReflectionAccessFilter>emptyList());
+    Gson original =
+        new Gson(
+            CUSTOM_EXCLUDER,
+            CUSTOM_FIELD_NAMING_STRATEGY,
+            new HashMap<Type, InstanceCreator<?>>(),
+            true,
+            false,
+            true,
+            false,
+            FormattingStyle.PRETTY,
+            Strictness.LENIENT,
+            false,
+            true,
+            LongSerializationPolicy.DEFAULT,
+            null,
+            DateFormat.DEFAULT,
+            DateFormat.DEFAULT,
+            new ArrayList<TypeAdapterFactory>(),
+            new ArrayList<TypeAdapterFactory>(),
+            new ArrayList<TypeAdapterFactory>(),
+            CUSTOM_OBJECT_TO_NUMBER_STRATEGY,
+            CUSTOM_NUMBER_TO_NUMBER_STRATEGY,
+            Collections.<ReflectionAccessFilter>emptyList());
 
-    Gson clone = original.newBuilder()
-        .registerTypeAdapter(int.class, new TestTypeAdapter())
-        .create();
+    Gson clone =
+        original.newBuilder().registerTypeAdapter(int.class, new TestTypeAdapter()).create();
 
     assertThat(clone.factories).hasSize(original.factories.size() + 1);
   }
 
   private static final class TestTypeAdapter extends TypeAdapter<Object> {
-    @Override public void write(JsonWriter out, Object value) {
+    @Override
+    public void write(JsonWriter out, Object value) {
       // Test stub.
     }
-    @Override public Object read(JsonReader in) { return null; }
+
+    @Override
+    public Object read(JsonReader in) {
+      return null;
+    }
   }
 
   @Test
   public void testGetAdapter_Null() {
     Gson gson = new Gson();
-    NullPointerException e = assertThrows(NullPointerException.class, () -> gson.getAdapter((TypeToken<?>) null));
+    NullPointerException e =
+        assertThrows(NullPointerException.class, () -> gson.getAdapter((TypeToken<?>) null));
     assertThat(e).hasMessageThat().isEqualTo("type must not be null");
   }
 
   @Test
   public void testGetAdapter_Concurrency() {
     class DummyAdapter<T> extends TypeAdapter<T> {
-      @Override public void write(JsonWriter out, T value) throws IOException {
+      @Override
+      public void write(JsonWriter out, T value) throws IOException {
         throw new AssertionError("not needed for this test");
       }
 
-      @Override public T read(JsonReader in) throws IOException {
+      @Override
+      public T read(JsonReader in) throws IOException {
         throw new AssertionError("not needed for this test");
       }
     }
@@ -129,36 +168,41 @@ public final class GsonTest {
     final AtomicReference<TypeAdapter<?>> threadAdapter = new AtomicReference<>();
     final Class<?> requestedType = Number.class;
 
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapterFactory(new TypeAdapterFactory() {
-          private volatile boolean isFirstCall = true;
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapterFactory(
+                new TypeAdapterFactory() {
+                  private volatile boolean isFirstCall = true;
 
-          @Override public <T> TypeAdapter<T> create(final Gson gson, TypeToken<T> type) {
-            if (isFirstCall) {
-              isFirstCall = false;
+                  @Override
+                  public <T> TypeAdapter<T> create(final Gson gson, TypeToken<T> type) {
+                    if (isFirstCall) {
+                      isFirstCall = false;
 
-              // Create a separate thread which requests an adapter for the same type
-              // This will cause this factory to return a different adapter instance than
-              // the one it is currently creating
-              Thread thread = new Thread() {
-                @Override public void run() {
-                  threadAdapter.set(gson.getAdapter(requestedType));
-                }
-              };
-              thread.start();
-              try {
-                thread.join();
-              } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-              }
-            }
+                      // Create a separate thread which requests an adapter for the same type
+                      // This will cause this factory to return a different adapter instance than
+                      // the one it is currently creating
+                      Thread thread =
+                          new Thread() {
+                            @Override
+                            public void run() {
+                              threadAdapter.set(gson.getAdapter(requestedType));
+                            }
+                          };
+                      thread.start();
+                      try {
+                        thread.join();
+                      } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                      }
+                    }
 
-            // Create a new dummy adapter instance
-            adapterInstancesCreated.incrementAndGet();
-            return new DummyAdapter<>();
-          }
-        })
-        .create();
+                    // Create a new dummy adapter instance
+                    adapterInstancesCreated.incrementAndGet();
+                    return new DummyAdapter<>();
+                  }
+                })
+            .create();
 
     TypeAdapter<?> adapter = gson.getAdapter(requestedType);
     assertThat(adapterInstancesCreated.get()).isEqualTo(2);
@@ -167,18 +211,18 @@ public final class GsonTest {
   }
 
   /**
-   * Verifies that two threads calling {@link Gson#getAdapter(TypeToken)} do not see the
-   * same unresolved {@link FutureTypeAdapter} instance, since that would not be thread-safe.
+   * Verifies that two threads calling {@link Gson#getAdapter(TypeToken)} do not see the same
+   * unresolved {@link FutureTypeAdapter} instance, since that would not be thread-safe.
    *
-   * This test constructs the cyclic dependency {@literal CustomClass1 -> CustomClass2 -> CustomClass1}
-   * and lets one thread wait after the adapter for CustomClass2 has been obtained (which still
-   * refers to the nested unresolved FutureTypeAdapter for CustomClass1).
+   * <p>This test constructs the cyclic dependency {@literal CustomClass1 -> CustomClass2 ->
+   * CustomClass1} and lets one thread wait after the adapter for CustomClass2 has been obtained
+   * (which still refers to the nested unresolved FutureTypeAdapter for CustomClass1).
    */
   @Test
   public void testGetAdapter_FutureAdapterConcurrency() throws Exception {
     /**
-     * Adapter which wraps another adapter. Can be imagined as a simplified version of the
-     * {@code ReflectiveTypeAdapterFactory$Adapter}.
+     * Adapter which wraps another adapter. Can be imagined as a simplified version of the {@code
+     * ReflectiveTypeAdapterFactory$Adapter}.
      */
     class WrappingAdapter<T> extends TypeAdapter<T> {
       final TypeAdapter<?> wrapped;
@@ -188,7 +232,8 @@ public final class GsonTest {
         this.wrapped = wrapped;
       }
 
-      @Override public void write(JsonWriter out, T value) throws IOException {
+      @Override
+      public void write(JsonWriter out, T value) throws IOException {
         // Due to how this test is set up there is infinite recursion, therefore
         // need to track how deeply nested this call is
         if (isFirstCall) {
@@ -202,7 +247,8 @@ public final class GsonTest {
         }
       }
 
-      @Override public T read(JsonReader in) throws IOException {
+      @Override
+      public T read(JsonReader in) throws IOException {
         throw new AssertionError("not needed for this test");
       }
     }
@@ -210,54 +256,56 @@ public final class GsonTest {
     final CountDownLatch isThreadWaiting = new CountDownLatch(1);
     final CountDownLatch canThreadProceed = new CountDownLatch(1);
 
-    final Gson gson = new GsonBuilder()
-      .registerTypeAdapterFactory(new TypeAdapterFactory() {
-        // volatile instead of AtomicBoolean is safe here because CountDownLatch prevents
-        // "true" concurrency
-        volatile boolean isFirstCaller = true;
+    final Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapterFactory(
+                new TypeAdapterFactory() {
+                  // volatile instead of AtomicBoolean is safe here because CountDownLatch prevents
+                  // "true" concurrency
+                  volatile boolean isFirstCaller = true;
 
-        @Override
-        public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
-          Class<?> raw = type.getRawType();
+                  @Override
+                  public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+                    Class<?> raw = type.getRawType();
 
-          if (raw == CustomClass1.class) {
-            // Retrieves a WrappingAdapter containing a nested FutureAdapter for CustomClass1
-            TypeAdapter<?> adapter = gson.getAdapter(CustomClass2.class);
+                    if (raw == CustomClass1.class) {
+                      // Retrieves a WrappingAdapter containing a nested FutureAdapter for
+                      // CustomClass1
+                      TypeAdapter<?> adapter = gson.getAdapter(CustomClass2.class);
 
-            // Let thread wait so the FutureAdapter for CustomClass1 nested in the adapter
-            // for CustomClass2 is not resolved yet
-            if (isFirstCaller) {
-              isFirstCaller = false;
-              isThreadWaiting.countDown();
+                      // Let thread wait so the FutureAdapter for CustomClass1 nested in the adapter
+                      // for CustomClass2 is not resolved yet
+                      if (isFirstCaller) {
+                        isFirstCaller = false;
+                        isThreadWaiting.countDown();
 
-              try {
-                canThreadProceed.await();
-              } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-              }
-            }
+                        try {
+                          canThreadProceed.await();
+                        } catch (InterruptedException e) {
+                          throw new RuntimeException(e);
+                        }
+                      }
 
-            return new WrappingAdapter<>(adapter);
-          }
-          else if (raw == CustomClass2.class) {
-            TypeAdapter<?> adapter = gson.getAdapter(CustomClass1.class);
-            assertThat(adapter).isInstanceOf(FutureTypeAdapter.class);
-            return new WrappingAdapter<>(adapter);
-          }
-          else {
-            throw new AssertionError("Adapter for unexpected type requested: " + raw);
-          }
-        }
-      })
-      .create();
+                      return new WrappingAdapter<>(adapter);
+                    } else if (raw == CustomClass2.class) {
+                      TypeAdapter<?> adapter = gson.getAdapter(CustomClass1.class);
+                      assertThat(adapter).isInstanceOf(FutureTypeAdapter.class);
+                      return new WrappingAdapter<>(adapter);
+                    } else {
+                      throw new AssertionError("Adapter for unexpected type requested: " + raw);
+                    }
+                  }
+                })
+            .create();
 
     final AtomicReference<TypeAdapter<?>> otherThreadAdapter = new AtomicReference<>();
-    Thread thread = new Thread() {
-      @Override
-      public void run() {
-        otherThreadAdapter.set(gson.getAdapter(CustomClass1.class));
-      }
-    };
+    Thread thread =
+        new Thread() {
+          @Override
+          public void run() {
+            otherThreadAdapter.set(gson.getAdapter(CustomClass1.class));
+          }
+        };
     thread.start();
 
     // Wait until other thread has obtained FutureAdapter
@@ -329,11 +377,12 @@ public final class GsonTest {
     DummyAdapter adapter2 = new DummyAdapter(2);
     DummyFactory factory2 = new DummyFactory(adapter2);
 
-    Gson gson = new GsonBuilder()
-        // Note: This is 'last in, first out' order; Gson will first use factory2, then factory1
-        .registerTypeAdapterFactory(factory1)
-        .registerTypeAdapterFactory(factory2)
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            // Note: This is 'last in, first out' order; Gson will first use factory2, then factory1
+            .registerTypeAdapterFactory(factory1)
+            .registerTypeAdapterFactory(factory2)
+            .create();
 
     TypeToken<?> type = TypeToken.get(Number.class);
 
@@ -341,7 +390,8 @@ public final class GsonTest {
     assertThrows(NullPointerException.class, () -> gson.getDelegateAdapter(factory1, null));
 
     // For unknown factory the first adapter for that type should be returned
-    assertThat(gson.getDelegateAdapter(new DummyFactory(new DummyAdapter(0)), type)).isEqualTo(adapter2);
+    assertThat(gson.getDelegateAdapter(new DummyFactory(new DummyAdapter(0)), type))
+        .isEqualTo(adapter2);
 
     assertThat(gson.getDelegateAdapter(factory2, type)).isEqualTo(adapter1);
     // Default Gson adapter should be returned
@@ -379,14 +429,15 @@ public final class GsonTest {
   @Test
   public void testNewJsonWriter_Custom() throws IOException {
     StringWriter writer = new StringWriter();
-    JsonWriter jsonWriter = new GsonBuilder()
-      .disableHtmlEscaping()
-      .generateNonExecutableJson()
-      .setPrettyPrinting()
-      .serializeNulls()
-      .setLenient()
-      .create()
-      .newJsonWriter(writer);
+    JsonWriter jsonWriter =
+        new GsonBuilder()
+            .disableHtmlEscaping()
+            .generateNonExecutableJson()
+            .setPrettyPrinting()
+            .serializeNulls()
+            .setLenient()
+            .create()
+            .newJsonWriter(writer);
     jsonWriter.beginObject();
     jsonWriter.name("test");
     jsonWriter.nullValue();
@@ -413,17 +464,15 @@ public final class GsonTest {
   @Test
   public void testNewJsonReader_Custom() throws IOException {
     String json = "test"; // String without quotes
-    JsonReader jsonReader = new GsonBuilder()
-      .setLenient()
-      .create()
-      .newJsonReader(new StringReader(json));
+    JsonReader jsonReader =
+        new GsonBuilder().setLenient().create().newJsonReader(new StringReader(json));
     assertThat(jsonReader.nextString()).isEqualTo("test");
     jsonReader.close();
   }
 
   /**
-   * Modifying a GsonBuilder obtained from {@link Gson#newBuilder()} of a
-   * {@code new Gson()} should not affect the Gson instance it came from.
+   * Modifying a GsonBuilder obtained from {@link Gson#newBuilder()} of a {@code new Gson()} should
+   * not affect the Gson instance it came from.
    */
   @Test
   public void testDefaultGsonNewBuilderModification() {
@@ -431,25 +480,36 @@ public final class GsonTest {
     GsonBuilder gsonBuilder = gson.newBuilder();
 
     // Modifications of `gsonBuilder` should not affect `gson` object
-    gsonBuilder.registerTypeAdapter(CustomClass1.class, new TypeAdapter<CustomClass1>() {
-      @Override public CustomClass1 read(JsonReader in) throws IOException {
-        throw new UnsupportedOperationException();
-      }
+    gsonBuilder.registerTypeAdapter(
+        CustomClass1.class,
+        new TypeAdapter<CustomClass1>() {
+          @Override
+          public CustomClass1 read(JsonReader in) throws IOException {
+            throw new UnsupportedOperationException();
+          }
 
-      @Override public void write(JsonWriter out, CustomClass1 value) throws IOException {
-        out.value("custom-adapter");
-      }
-    });
-    gsonBuilder.registerTypeHierarchyAdapter(CustomClass2.class, new JsonSerializer<CustomClass2>() {
-      @Override public JsonElement serialize(CustomClass2 src, Type typeOfSrc, JsonSerializationContext context) {
-        return new JsonPrimitive("custom-hierarchy-adapter");
-      }
-    });
-    gsonBuilder.registerTypeAdapter(CustomClass3.class, new InstanceCreator<CustomClass3>() {
-      @Override public CustomClass3 createInstance(Type type) {
-        return new CustomClass3("custom-instance");
-      }
-    });
+          @Override
+          public void write(JsonWriter out, CustomClass1 value) throws IOException {
+            out.value("custom-adapter");
+          }
+        });
+    gsonBuilder.registerTypeHierarchyAdapter(
+        CustomClass2.class,
+        new JsonSerializer<CustomClass2>() {
+          @Override
+          public JsonElement serialize(
+              CustomClass2 src, Type typeOfSrc, JsonSerializationContext context) {
+            return new JsonPrimitive("custom-hierarchy-adapter");
+          }
+        });
+    gsonBuilder.registerTypeAdapter(
+        CustomClass3.class,
+        new InstanceCreator<CustomClass3>() {
+          @Override
+          public CustomClass3 createInstance(Type type) {
+            return new CustomClass3("custom-instance");
+          }
+        });
 
     assertDefaultGson(gson);
     // New GsonBuilder created from `gson` should not have been affected by changes either
@@ -474,57 +534,79 @@ public final class GsonTest {
   }
 
   /**
-   * Modifying a GsonBuilder obtained from {@link Gson#newBuilder()} of a custom
-   * Gson instance (created using a GsonBuilder) should not affect the Gson instance
-   * it came from.
+   * Modifying a GsonBuilder obtained from {@link Gson#newBuilder()} of a custom Gson instance
+   * (created using a GsonBuilder) should not affect the Gson instance it came from.
    */
   @Test
   public void testNewBuilderModification() {
-    Gson gson = new GsonBuilder()
-      .registerTypeAdapter(CustomClass1.class, new TypeAdapter<CustomClass1>() {
-        @Override public CustomClass1 read(JsonReader in) throws IOException {
-          throw new UnsupportedOperationException();
-        }
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                CustomClass1.class,
+                new TypeAdapter<CustomClass1>() {
+                  @Override
+                  public CustomClass1 read(JsonReader in) throws IOException {
+                    throw new UnsupportedOperationException();
+                  }
 
-        @Override public void write(JsonWriter out, CustomClass1 value) throws IOException {
-          out.value("custom-adapter");
-        }
-      })
-      .registerTypeHierarchyAdapter(CustomClass2.class, new JsonSerializer<CustomClass2>() {
-        @Override public JsonElement serialize(CustomClass2 src, Type typeOfSrc, JsonSerializationContext context) {
-          return new JsonPrimitive("custom-hierarchy-adapter");
-        }
-      })
-      .registerTypeAdapter(CustomClass3.class, new InstanceCreator<CustomClass3>() {
-        @Override public CustomClass3 createInstance(Type type) {
-          return new CustomClass3("custom-instance");
-        }
-      })
-      .create();
+                  @Override
+                  public void write(JsonWriter out, CustomClass1 value) throws IOException {
+                    out.value("custom-adapter");
+                  }
+                })
+            .registerTypeHierarchyAdapter(
+                CustomClass2.class,
+                new JsonSerializer<CustomClass2>() {
+                  @Override
+                  public JsonElement serialize(
+                      CustomClass2 src, Type typeOfSrc, JsonSerializationContext context) {
+                    return new JsonPrimitive("custom-hierarchy-adapter");
+                  }
+                })
+            .registerTypeAdapter(
+                CustomClass3.class,
+                new InstanceCreator<CustomClass3>() {
+                  @Override
+                  public CustomClass3 createInstance(Type type) {
+                    return new CustomClass3("custom-instance");
+                  }
+                })
+            .create();
 
     assertCustomGson(gson);
 
     // Modify `gson.newBuilder()`
     GsonBuilder gsonBuilder = gson.newBuilder();
-    gsonBuilder.registerTypeAdapter(CustomClass1.class, new TypeAdapter<CustomClass1>() {
-      @Override public CustomClass1 read(JsonReader in) throws IOException {
-        throw new UnsupportedOperationException();
-      }
+    gsonBuilder.registerTypeAdapter(
+        CustomClass1.class,
+        new TypeAdapter<CustomClass1>() {
+          @Override
+          public CustomClass1 read(JsonReader in) throws IOException {
+            throw new UnsupportedOperationException();
+          }
 
-      @Override public void write(JsonWriter out, CustomClass1 value) throws IOException {
-        out.value("overwritten custom-adapter");
-      }
-    });
-    gsonBuilder.registerTypeHierarchyAdapter(CustomClass2.class, new JsonSerializer<CustomClass2>() {
-      @Override public JsonElement serialize(CustomClass2 src, Type typeOfSrc, JsonSerializationContext context) {
-        return new JsonPrimitive("overwritten custom-hierarchy-adapter");
-      }
-    });
-    gsonBuilder.registerTypeAdapter(CustomClass3.class, new InstanceCreator<CustomClass3>() {
-      @Override public CustomClass3 createInstance(Type type) {
-        return new CustomClass3("overwritten custom-instance");
-      }
-    });
+          @Override
+          public void write(JsonWriter out, CustomClass1 value) throws IOException {
+            out.value("overwritten custom-adapter");
+          }
+        });
+    gsonBuilder.registerTypeHierarchyAdapter(
+        CustomClass2.class,
+        new JsonSerializer<CustomClass2>() {
+          @Override
+          public JsonElement serialize(
+              CustomClass2 src, Type typeOfSrc, JsonSerializationContext context) {
+            return new JsonPrimitive("overwritten custom-hierarchy-adapter");
+          }
+        });
+    gsonBuilder.registerTypeAdapter(
+        CustomClass3.class,
+        new InstanceCreator<CustomClass3>() {
+          @Override
+          public CustomClass3 createInstance(Type type) {
+            return new CustomClass3("overwritten custom-instance");
+          }
+        });
 
     // `gson` object should not have been affected by changes to new GsonBuilder
     assertCustomGson(gson);
@@ -554,8 +636,10 @@ public final class GsonTest {
     assertThat(customClass3.s).isEqualTo("custom-instance");
   }
 
-  private static class CustomClass1 { }
-  private static class CustomClass2 { }
+  private static class CustomClass1 {}
+
+  private static class CustomClass2 {}
+
   private static class CustomClass3 {
     static final String NO_ARG_CONSTRUCTOR_VALUE = "default instance";
 

--- a/gson/src/test/java/com/google/gson/GsonTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/GsonTypeAdapterTest.java
@@ -37,10 +37,11 @@ public class GsonTypeAdapterTest {
 
   @Before
   public void setUp() throws Exception {
-    gson = new GsonBuilder()
-        .registerTypeAdapter(AtomicLong.class, new ExceptionTypeAdapter())
-        .registerTypeAdapter(AtomicInteger.class, new AtomicIntegerTypeAdapter())
-        .create();
+    gson =
+        new GsonBuilder()
+            .registerTypeAdapter(AtomicLong.class, new ExceptionTypeAdapter())
+            .registerTypeAdapter(AtomicInteger.class, new AtomicIntegerTypeAdapter())
+            .create();
   }
 
   @Test
@@ -48,7 +49,8 @@ public class GsonTypeAdapterTest {
     try {
       gson.fromJson("{\"abc\":123}", BigInteger.class);
       fail("Should have thrown a JsonParseException");
-    } catch (JsonParseException expected) { }
+    } catch (JsonParseException expected) {
+    }
   }
 
   @Test
@@ -56,7 +58,8 @@ public class GsonTypeAdapterTest {
     try {
       gson.toJson(new AtomicLong(0));
       fail("Type Adapter should have thrown an exception");
-    } catch (IllegalStateException expected) { }
+    } catch (IllegalStateException expected) {
+    }
 
     // Verify that serializer is made null-safe, i.e. it is not called for null
     assertThat(gson.toJson(null, AtomicLong.class)).isEqualTo("null");
@@ -64,7 +67,8 @@ public class GsonTypeAdapterTest {
     try {
       gson.fromJson("123", AtomicLong.class);
       fail("Type Adapter should have thrown an exception");
-    } catch (JsonParseException expected) { }
+    } catch (JsonParseException expected) {
+    }
 
     // Verify that deserializer is made null-safe, i.e. it is not called for null
     assertThat(gson.fromJson(JsonNull.INSTANCE, AtomicLong.class)).isNull();
@@ -93,11 +97,13 @@ public class GsonTypeAdapterTest {
 
   private static class ExceptionTypeAdapter
       implements JsonSerializer<AtomicLong>, JsonDeserializer<AtomicLong> {
-    @Override public JsonElement serialize(
-        AtomicLong src, Type typeOfSrc, JsonSerializationContext context) {
+    @Override
+    public JsonElement serialize(AtomicLong src, Type typeOfSrc, JsonSerializationContext context) {
       throw new IllegalStateException();
     }
-    @Override public AtomicLong deserialize(
+
+    @Override
+    public AtomicLong deserialize(
         JsonElement json, Type typeOfT, JsonDeserializationContext context)
         throws JsonParseException {
       throw new IllegalStateException();
@@ -106,18 +112,22 @@ public class GsonTypeAdapterTest {
 
   private static class AtomicIntegerTypeAdapter
       implements JsonSerializer<AtomicInteger>, JsonDeserializer<AtomicInteger> {
-    @Override public JsonElement serialize(AtomicInteger src, Type typeOfSrc, JsonSerializationContext context) {
+    @Override
+    public JsonElement serialize(
+        AtomicInteger src, Type typeOfSrc, JsonSerializationContext context) {
       return new JsonPrimitive(src.incrementAndGet());
     }
 
-    @Override public AtomicInteger deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+    @Override
+    public AtomicInteger deserialize(
+        JsonElement json, Type typeOfT, JsonDeserializationContext context)
         throws JsonParseException {
       int intValue = json.getAsInt();
       return new AtomicInteger(--intValue);
     }
   }
 
-  static abstract class Abstract {
+  abstract static class Abstract {
     String a;
   }
 
@@ -141,14 +151,21 @@ public class GsonTypeAdapterTest {
     assertSerialized("{\"b\":\"beep\",\"a\":\"android\"}", Concrete.class, false, false, instance);
   }
 
-  private void assertSerialized(String expected, Class<?> instanceType, boolean registerAbstractDeserializer,
-      boolean registerAbstractHierarchyDeserializer, Object instance) {
-    JsonDeserializer<Abstract> deserializer = new JsonDeserializer<Abstract>() {
-      @Override public Abstract deserialize(JsonElement json, Type typeOfT,
-          JsonDeserializationContext context) throws JsonParseException {
-        throw new AssertionError();
-      }
-    };
+  private void assertSerialized(
+      String expected,
+      Class<?> instanceType,
+      boolean registerAbstractDeserializer,
+      boolean registerAbstractHierarchyDeserializer,
+      Object instance) {
+    JsonDeserializer<Abstract> deserializer =
+        new JsonDeserializer<Abstract>() {
+          @Override
+          public Abstract deserialize(
+              JsonElement json, Type typeOfT, JsonDeserializationContext context)
+              throws JsonParseException {
+            throw new AssertionError();
+          }
+        };
     GsonBuilder builder = new GsonBuilder();
     if (registerAbstractDeserializer) {
       builder.registerTypeAdapter(Abstract.class, deserializer);

--- a/gson/src/test/java/com/google/gson/InnerClassExclusionStrategyTest.java
+++ b/gson/src/test/java/com/google/gson/InnerClassExclusionStrategyTest.java
@@ -57,9 +57,7 @@ public class InnerClassExclusionStrategyTest {
   }
 
   @SuppressWarnings("ClassCanBeStatic")
-  class InnerClass {
-  }
+  class InnerClass {}
 
-  static class StaticNestedClass {
-  }
+  static class StaticNestedClass {}
 }

--- a/gson/src/test/java/com/google/gson/JsonArrayAsListTest.java
+++ b/gson/src/test/java/com/google/gson/JsonArrayAsListTest.java
@@ -25,9 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import org.junit.Test;
 
-/**
- * Tests for {@link JsonArray#asList()}.
- */
+/** Tests for {@link JsonArray#asList()}. */
 public class JsonArrayAsListTest {
   @Test
   public void testGet() {
@@ -84,17 +82,18 @@ public class JsonArrayAsListTest {
     assertThat(list.add(new JsonPrimitive(4))).isTrue();
     assertThat(list.add(JsonNull.INSTANCE)).isTrue();
 
-    List<JsonElement> expectedList = Arrays.<JsonElement>asList(
-        new JsonPrimitive(2),
-        new JsonPrimitive(3),
-        new JsonPrimitive(1),
-        new JsonPrimitive(4),
-        JsonNull.INSTANCE
-    );
+    List<JsonElement> expectedList =
+        Arrays.<JsonElement>asList(
+            new JsonPrimitive(2),
+            new JsonPrimitive(3),
+            new JsonPrimitive(1),
+            new JsonPrimitive(4),
+            JsonNull.INSTANCE);
     assertThat(list).isEqualTo(expectedList);
 
     assertThrows(IndexOutOfBoundsException.class, () -> list.set(-1, new JsonPrimitive(1)));
-    assertThrows(IndexOutOfBoundsException.class, () -> list.set(list.size(), new JsonPrimitive(1)));
+    assertThrows(
+        IndexOutOfBoundsException.class, () -> list.set(list.size(), new JsonPrimitive(1)));
 
     NullPointerException e = assertThrows(NullPointerException.class, () -> list.add(0, null));
     assertThat(e).hasMessageThat().isEqualTo("Element must be non-null");
@@ -111,18 +110,22 @@ public class JsonArrayAsListTest {
     List<JsonElement> list = a.asList();
     list.addAll(Arrays.asList(new JsonPrimitive(2), new JsonPrimitive(3)));
 
-    List<JsonElement> expectedList = Arrays.<JsonElement>asList(
-        new JsonPrimitive(1),
-        new JsonPrimitive(2),
-        new JsonPrimitive(3)
-    );
+    List<JsonElement> expectedList =
+        Arrays.<JsonElement>asList(
+            new JsonPrimitive(1), new JsonPrimitive(2), new JsonPrimitive(3));
     assertThat(list).isEqualTo(expectedList);
     assertThat(list).isEqualTo(expectedList);
 
-    NullPointerException e = assertThrows(NullPointerException.class, () -> list.addAll(0, Collections.<JsonElement>singletonList(null)));
+    NullPointerException e =
+        assertThrows(
+            NullPointerException.class,
+            () -> list.addAll(0, Collections.<JsonElement>singletonList(null)));
     assertThat(e).hasMessageThat().isEqualTo("Element must be non-null");
 
-    e = assertThrows(NullPointerException.class, () -> list.addAll(Collections.<JsonElement>singletonList(null)));
+    e =
+        assertThrows(
+            NullPointerException.class,
+            () -> list.addAll(Collections.<JsonElement>singletonList(null)));
     assertThat(e).hasMessageThat().isEqualTo("Element must be non-null");
   }
 

--- a/gson/src/test/java/com/google/gson/JsonArrayTest.java
+++ b/gson/src/test/java/com/google/gson/JsonArrayTest.java
@@ -65,7 +65,8 @@ public final class JsonArrayTest {
     try {
       array.remove(0);
       fail();
-    } catch (IndexOutOfBoundsException expected) {}
+    } catch (IndexOutOfBoundsException expected) {
+    }
     JsonPrimitive a = new JsonPrimitive("a");
     array.add(a);
     assertThat(array.remove(a)).isTrue();
@@ -83,7 +84,8 @@ public final class JsonArrayTest {
     try {
       array.set(0, new JsonPrimitive(1));
       fail();
-    } catch (IndexOutOfBoundsException expected) {}
+    } catch (IndexOutOfBoundsException expected) {
+    }
     JsonPrimitive a = new JsonPrimitive("a");
     array.add(a);
 
@@ -134,7 +136,14 @@ public final class JsonArrayTest {
   @Test
   public void testFailedGetArrayValues() {
     JsonArray jsonArray = new JsonArray();
-    jsonArray.add(JsonParser.parseString("{" + "\"key1\":\"value1\"," + "\"key2\":\"value2\"," + "\"key3\":\"value3\"," + "\"key4\":\"value4\"" + "}"));
+    jsonArray.add(
+        JsonParser.parseString(
+            "{"
+                + "\"key1\":\"value1\","
+                + "\"key2\":\"value2\","
+                + "\"key3\":\"value3\","
+                + "\"key4\":\"value4\""
+                + "}"));
     try {
       jsonArray.getAsBoolean();
       fail("expected getBoolean to fail");
@@ -218,7 +227,8 @@ public final class JsonArrayTest {
     jsonArray.add((String) null);
     jsonArray.add("Yes");
 
-    assertThat(jsonArray.toString()).isEqualTo("[\"Hello\",\"Goodbye\",\"Thank you\",null,\"Yes\"]");
+    assertThat(jsonArray.toString())
+        .isEqualTo("[\"Hello\",\"Goodbye\",\"Thank you\",null,\"Yes\"]");
   }
 
   @Test
@@ -294,7 +304,8 @@ public final class JsonArrayTest {
     jsonArray.add('u');
     jsonArray.add("and sometimes Y");
 
-    assertThat(jsonArray.toString()).isEqualTo("[\"a\",\"e\",\"i\",\"o\",null,\"u\",\"and sometimes Y\"]");
+    assertThat(jsonArray.toString())
+        .isEqualTo("[\"a\",\"e\",\"i\",\"o\",null,\"u\",\"and sometimes Y\"]");
   }
 
   @Test
@@ -315,7 +326,8 @@ public final class JsonArrayTest {
     jsonArray.add(12.232);
     jsonArray.add(BigInteger.valueOf(2323));
 
-    assertThat(jsonArray.toString()).isEqualTo("[\"a\",\"apple\",12121,\"o\",null,null,12.232,2323]");
+    assertThat(jsonArray.toString())
+        .isEqualTo("[\"a\",\"apple\",12121,\"o\",null,null,12.232,2323]");
   }
 
   @Test
@@ -361,6 +373,7 @@ public final class JsonArrayTest {
     jsonArray.add((Boolean) null);
     jsonArray.add((Boolean) null);
 
-    assertThat(jsonArray.toString()).isEqualTo("[\"a\",\"a\",true,true,1212,1212,34.34,34.34,null,null]");
+    assertThat(jsonArray.toString())
+        .isEqualTo("[\"a\",\"a\",true,true,1212,1212,34.34,34.34,null,null]");
   }
 }

--- a/gson/src/test/java/com/google/gson/JsonObjectAsMapTest.java
+++ b/gson/src/test/java/com/google/gson/JsonObjectAsMapTest.java
@@ -32,9 +32,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import org.junit.Test;
 
-/**
- * Tests for {@link JsonObject#asMap()}.
- */
+/** Tests for {@link JsonObject#asMap()}. */
 public class JsonObjectAsMapTest {
   @Test
   public void testSize() {
@@ -223,7 +221,8 @@ public class JsonObjectAsMapTest {
     }
 
     assertThat(values.remove(new JsonPrimitive(2))).isTrue();
-    assertThat(new ArrayList<>(map.values())).isEqualTo(Collections.singletonList(new JsonPrimitive(1)));
+    assertThat(new ArrayList<>(map.values()))
+        .isEqualTo(Collections.singletonList(new JsonPrimitive(1)));
     assertThat(o.size()).isEqualTo(1);
     assertThat(o.get("b")).isEqualTo(new JsonPrimitive(1));
   }
@@ -237,10 +236,10 @@ public class JsonObjectAsMapTest {
     Map<String, JsonElement> map = o.asMap();
     Set<Entry<String, JsonElement>> entrySet = map.entrySet();
 
-    List<Entry<?, ?>> expectedEntrySet = Arrays.<Entry<?, ?>>asList(
-        new SimpleEntry<>("b", new JsonPrimitive(2)),
-        new SimpleEntry<>("a", new JsonPrimitive(1))
-    );
+    List<Entry<?, ?>> expectedEntrySet =
+        Arrays.<Entry<?, ?>>asList(
+            new SimpleEntry<>("b", new JsonPrimitive(2)),
+            new SimpleEntry<>("a", new JsonPrimitive(1)));
     // Should contain entries in same order
     assertThat(new ArrayList<>(entrySet)).isEqualTo(expectedEntrySet);
 
@@ -251,8 +250,10 @@ public class JsonObjectAsMapTest {
     }
 
     assertThat(entrySet.remove(new SimpleEntry<>("a", new JsonPrimitive(1)))).isTrue();
-    assertThat(map.entrySet()).isEqualTo(Collections.singleton(new SimpleEntry<>("b", new JsonPrimitive(2))));
-    assertThat(o.entrySet()).isEqualTo(Collections.singleton(new SimpleEntry<>("b", new JsonPrimitive(2))));
+    assertThat(map.entrySet())
+        .isEqualTo(Collections.singleton(new SimpleEntry<>("b", new JsonPrimitive(2))));
+    assertThat(o.entrySet())
+        .isEqualTo(Collections.singleton(new SimpleEntry<>("b", new JsonPrimitive(2))));
 
     // Should return false because entry has already been removed
     assertThat(entrySet.remove(new SimpleEntry<>("a", new JsonPrimitive(1)))).isFalse();
@@ -260,8 +261,10 @@ public class JsonObjectAsMapTest {
     Entry<String, JsonElement> entry = entrySet.iterator().next();
     JsonElement old = entry.setValue(new JsonPrimitive(3));
     assertThat(old).isEqualTo(new JsonPrimitive(2));
-    assertThat(map.entrySet()).isEqualTo(Collections.singleton(new SimpleEntry<>("b", new JsonPrimitive(3))));
-    assertThat(o.entrySet()).isEqualTo(Collections.singleton(new SimpleEntry<>("b", new JsonPrimitive(3))));
+    assertThat(map.entrySet())
+        .isEqualTo(Collections.singleton(new SimpleEntry<>("b", new JsonPrimitive(3))));
+    assertThat(o.entrySet())
+        .isEqualTo(Collections.singleton(new SimpleEntry<>("b", new JsonPrimitive(3))));
 
     try {
       entry.setValue(null);

--- a/gson/src/test/java/com/google/gson/JsonObjectTest.java
+++ b/gson/src/test/java/com/google/gson/JsonObjectTest.java
@@ -78,7 +78,8 @@ public class JsonObjectTest {
     try {
       jsonObj.add(null, JsonNull.INSTANCE);
       fail("Should not allow null property names.");
-    } catch (NullPointerException expected) { }
+    } catch (NullPointerException expected) {
+    }
 
     jsonObj.add("", JsonNull.INSTANCE);
     jsonObj.add("   \t", JsonNull.INSTANCE);
@@ -131,9 +132,7 @@ public class JsonObjectTest {
     assertThat(character).isEqualTo(value);
   }
 
-  /**
-   * From bug report http://code.google.com/p/google-gson/issues/detail?id=182
-   */
+  /** From bug report http://code.google.com/p/google-gson/issues/detail?id=182 */
   @Test
   public void testPropertyWithQuotes() {
     JsonObject jsonObj = new JsonObject();
@@ -142,9 +141,7 @@ public class JsonObjectTest {
     assertThat(json).isEqualTo("{\"a\\\"b\":\"c\\\"d\"}");
   }
 
-  /**
-   * From issue 227.
-   */
+  /** From issue 227. */
   @Test
   public void testWritePropertyWithEmptyStringName() {
     JsonObject jsonObj = new JsonObject();
@@ -243,9 +240,7 @@ public class JsonObjectTest {
     assertThat(copy.get("key").getAsJsonArray()).hasSize(0);
   }
 
-  /**
-   * From issue 941
-   */
+  /** From issue 941 */
   @Test
   public void testKeySet() {
     JsonObject a = new JsonObject();
@@ -291,10 +286,10 @@ public class JsonObjectTest {
 
     o.addProperty("a", false);
     // Insertion order should be preserved by entrySet()
-    List<?> expectedEntriesList = Arrays.asList(
-        new SimpleEntry<>("b", new JsonPrimitive(true)),
-        new SimpleEntry<>("a", new JsonPrimitive(false))
-      );
+    List<?> expectedEntriesList =
+        Arrays.asList(
+            new SimpleEntry<>("b", new JsonPrimitive(true)),
+            new SimpleEntry<>("a", new JsonPrimitive(false)));
     assertThat(new ArrayList<>(o.entrySet())).isEqualTo(expectedEntriesList);
 
     Iterator<Entry<String, JsonElement>> iterator = o.entrySet().iterator();
@@ -306,10 +301,10 @@ public class JsonObjectTest {
       assertThat(entry.getValue()).isEqualTo(new JsonPrimitive(i));
     }
 
-    expectedEntriesList = Arrays.asList(
-        new SimpleEntry<>("b", new JsonPrimitive(0)),
-        new SimpleEntry<>("a", new JsonPrimitive(1))
-      );
+    expectedEntriesList =
+        Arrays.asList(
+            new SimpleEntry<>("b", new JsonPrimitive(0)),
+            new SimpleEntry<>("a", new JsonPrimitive(1)));
     assertThat(new ArrayList<>(o.entrySet())).isEqualTo(expectedEntriesList);
 
     Entry<String, JsonElement> entry = o.entrySet().iterator().next();
@@ -327,12 +322,13 @@ public class JsonObjectTest {
     o.addProperty("key1", 1);
     o.addProperty("key2", 2);
 
-    Deque<?> expectedEntriesQueue = new ArrayDeque<>(Arrays.asList(
-        new SimpleEntry<>("b", new JsonPrimitive(0)),
-        new SimpleEntry<>("a", new JsonPrimitive(1)),
-        new SimpleEntry<>("key1", new JsonPrimitive(1)),
-        new SimpleEntry<>("key2", new JsonPrimitive(2))
-      ));
+    Deque<?> expectedEntriesQueue =
+        new ArrayDeque<>(
+            Arrays.asList(
+                new SimpleEntry<>("b", new JsonPrimitive(0)),
+                new SimpleEntry<>("a", new JsonPrimitive(1)),
+                new SimpleEntry<>("key1", new JsonPrimitive(1)),
+                new SimpleEntry<>("key2", new JsonPrimitive(2))));
     // Note: Must wrap in ArrayList because Deque implementations do not implement `equals`
     assertThat(new ArrayList<>(o.entrySet())).isEqualTo(new ArrayList<>(expectedEntriesQueue));
     iterator = o.entrySet().iterator();

--- a/gson/src/test/java/com/google/gson/JsonParserParameterizedTest.java
+++ b/gson/src/test/java/com/google/gson/JsonParserParameterizedTest.java
@@ -30,20 +30,18 @@ public class JsonParserParameterizedTest {
   @Parameters
   public static Iterable<String> data() {
     return Arrays.asList(
-      "[]",
-      "{}",
-      "null",
-      "1.0",
-      "true",
-      "\"string\"",
-      "[true,1.0,null,{},2.0,{\"a\":[false]},[3.0,\"test\"],4.0]",
-      "{\"\":1.0,\"a\":true,\"b\":null,\"c\":[],\"d\":{\"a1\":2.0,\"b2\":[true,{\"a3\":3.0}]},\"e\":[{\"f\":4.0},\"test\"]}"
-    );
+        "[]",
+        "{}",
+        "null",
+        "1.0",
+        "true",
+        "\"string\"",
+        "[true,1.0,null,{},2.0,{\"a\":[false]},[3.0,\"test\"],4.0]",
+        "{\"\":1.0,\"a\":true,\"b\":null,\"c\":[],\"d\":{\"a1\":2.0,\"b2\":[true,{\"a3\":3.0}]},\"e\":[{\"f\":4.0},\"test\"]}");
   }
 
   private final TypeAdapter<JsonElement> adapter = new Gson().getAdapter(JsonElement.class);
-  @Parameter
-  public String json;
+  @Parameter public String json;
 
   @Test
   public void testParse() {

--- a/gson/src/test/java/com/google/gson/JsonParserTest.java
+++ b/gson/src/test/java/com/google/gson/JsonParserTest.java
@@ -78,7 +78,8 @@ public class JsonParserTest {
 
   @Test
   public void testParseUnquotedMultiWordStringFails() {
-    assertThrows(JsonSyntaxException.class, () -> JsonParser.parseString("Test is a test..blah blah"));
+    assertThrows(
+        JsonSyntaxException.class, () -> JsonParser.parseString("Test is a test..blah blah"));
   }
 
   @Test
@@ -87,7 +88,7 @@ public class JsonParserTest {
     JsonElement e = JsonParser.parseString(json);
     assertThat(e.isJsonArray()).isTrue();
 
-    JsonArray  array = e.getAsJsonArray();
+    JsonArray array = e.getAsJsonArray();
     assertThat(array.get(0).toString()).isEqualTo("{}");
     assertThat(array.get(1).getAsInt()).isEqualTo(13);
     assertThat(array.get(2).getAsString()).isEqualTo("stringValue");

--- a/gson/src/test/java/com/google/gson/JsonPrimitiveTest.java
+++ b/gson/src/test/java/com/google/gson/JsonPrimitiveTest.java
@@ -151,7 +151,8 @@ public class JsonPrimitiveTest {
     try {
       json.getAsInt();
       fail("Integers can not handle exponents like this.");
-    } catch (NumberFormatException expected) { }
+    } catch (NumberFormatException expected) {
+    }
   }
 
   @Test
@@ -274,15 +275,16 @@ public class JsonPrimitiveTest {
     MoreAsserts.assertEqualsAndHashCode(new JsonPrimitive(5L), new JsonPrimitive(5L));
     MoreAsserts.assertEqualsAndHashCode(new JsonPrimitive('a'), new JsonPrimitive('a'));
     MoreAsserts.assertEqualsAndHashCode(new JsonPrimitive(Float.NaN), new JsonPrimitive(Float.NaN));
-    MoreAsserts.assertEqualsAndHashCode(new JsonPrimitive(Float.NEGATIVE_INFINITY),
-        new JsonPrimitive(Float.NEGATIVE_INFINITY));
-    MoreAsserts.assertEqualsAndHashCode(new JsonPrimitive(Float.POSITIVE_INFINITY),
-        new JsonPrimitive(Float.POSITIVE_INFINITY));
-    MoreAsserts.assertEqualsAndHashCode(new JsonPrimitive(Double.NaN), new JsonPrimitive(Double.NaN));
-    MoreAsserts.assertEqualsAndHashCode(new JsonPrimitive(Double.NEGATIVE_INFINITY),
-        new JsonPrimitive(Double.NEGATIVE_INFINITY));
-    MoreAsserts.assertEqualsAndHashCode(new JsonPrimitive(Double.POSITIVE_INFINITY),
-        new JsonPrimitive(Double.POSITIVE_INFINITY));
+    MoreAsserts.assertEqualsAndHashCode(
+        new JsonPrimitive(Float.NEGATIVE_INFINITY), new JsonPrimitive(Float.NEGATIVE_INFINITY));
+    MoreAsserts.assertEqualsAndHashCode(
+        new JsonPrimitive(Float.POSITIVE_INFINITY), new JsonPrimitive(Float.POSITIVE_INFINITY));
+    MoreAsserts.assertEqualsAndHashCode(
+        new JsonPrimitive(Double.NaN), new JsonPrimitive(Double.NaN));
+    MoreAsserts.assertEqualsAndHashCode(
+        new JsonPrimitive(Double.NEGATIVE_INFINITY), new JsonPrimitive(Double.NEGATIVE_INFINITY));
+    MoreAsserts.assertEqualsAndHashCode(
+        new JsonPrimitive(Double.POSITIVE_INFINITY), new JsonPrimitive(Double.POSITIVE_INFINITY));
     assertThat(new JsonPrimitive("a").equals(new JsonPrimitive("b"))).isFalse();
     assertThat(new JsonPrimitive(true).equals(new JsonPrimitive(false))).isFalse();
     assertThat(new JsonPrimitive(0).equals(new JsonPrimitive(1))).isFalse();
@@ -291,10 +293,13 @@ public class JsonPrimitiveTest {
   @Test
   public void testEqualsAcrossTypes() {
     MoreAsserts.assertEqualsAndHashCode(new JsonPrimitive("a"), new JsonPrimitive('a'));
-    MoreAsserts.assertEqualsAndHashCode(new JsonPrimitive(new BigInteger("0")), new JsonPrimitive(0));
+    MoreAsserts.assertEqualsAndHashCode(
+        new JsonPrimitive(new BigInteger("0")), new JsonPrimitive(0));
     MoreAsserts.assertEqualsAndHashCode(new JsonPrimitive(0), new JsonPrimitive(0L));
-    MoreAsserts.assertEqualsAndHashCode(new JsonPrimitive(new BigInteger("0")), new JsonPrimitive(0));
-    MoreAsserts.assertEqualsAndHashCode(new JsonPrimitive(Float.NaN), new JsonPrimitive(Double.NaN));
+    MoreAsserts.assertEqualsAndHashCode(
+        new JsonPrimitive(new BigInteger("0")), new JsonPrimitive(0));
+    MoreAsserts.assertEqualsAndHashCode(
+        new JsonPrimitive(Float.NaN), new JsonPrimitive(Double.NaN));
   }
 
   @Test

--- a/gson/src/test/java/com/google/gson/LongSerializationPolicyTest.java
+++ b/gson/src/test/java/com/google/gson/LongSerializationPolicyTest.java
@@ -41,11 +41,10 @@ public class LongSerializationPolicyTest {
 
   @Test
   public void testDefaultLongSerializationIntegration() {
-    Gson gson = new GsonBuilder()
-      .setLongSerializationPolicy(LongSerializationPolicy.DEFAULT)
-      .create();
-    assertThat(gson.toJson(new long[] { 1L }, long[].class)).isEqualTo("[1]");
-    assertThat(gson.toJson(new Long[] { 1L }, Long[].class)).isEqualTo("[1]");
+    Gson gson =
+        new GsonBuilder().setLongSerializationPolicy(LongSerializationPolicy.DEFAULT).create();
+    assertThat(gson.toJson(new long[] {1L}, long[].class)).isEqualTo("[1]");
+    assertThat(gson.toJson(new Long[] {1L}, Long[].class)).isEqualTo("[1]");
   }
 
   @Test
@@ -53,9 +52,7 @@ public class LongSerializationPolicyTest {
     LongSerializationPolicy policy = LongSerializationPolicy.DEFAULT;
     assertThat(policy.serialize(null).isJsonNull()).isTrue();
 
-    Gson gson = new GsonBuilder()
-      .setLongSerializationPolicy(policy)
-      .create();
+    Gson gson = new GsonBuilder().setLongSerializationPolicy(policy).create();
     assertThat(gson.toJson(null, Long.class)).isEqualTo("null");
   }
 
@@ -72,11 +69,10 @@ public class LongSerializationPolicyTest {
 
   @Test
   public void testStringLongSerializationIntegration() {
-    Gson gson = new GsonBuilder()
-      .setLongSerializationPolicy(LongSerializationPolicy.STRING)
-      .create();
-    assertThat(gson.toJson(new long[] { 1L }, long[].class)).isEqualTo("[\"1\"]");
-    assertThat(gson.toJson(new Long[] { 1L }, long[].class)).isEqualTo("[\"1\"]");
+    Gson gson =
+        new GsonBuilder().setLongSerializationPolicy(LongSerializationPolicy.STRING).create();
+    assertThat(gson.toJson(new long[] {1L}, long[].class)).isEqualTo("[\"1\"]");
+    assertThat(gson.toJson(new Long[] {1L}, long[].class)).isEqualTo("[\"1\"]");
   }
 
   @Test
@@ -84,9 +80,7 @@ public class LongSerializationPolicyTest {
     LongSerializationPolicy policy = LongSerializationPolicy.STRING;
     assertThat(policy.serialize(null).isJsonNull()).isTrue();
 
-    Gson gson = new GsonBuilder()
-      .setLongSerializationPolicy(policy)
-      .create();
+    Gson gson = new GsonBuilder().setLongSerializationPolicy(policy).create();
     assertThat(gson.toJson(null, Long.class)).isEqualTo("null");
   }
 }

--- a/gson/src/test/java/com/google/gson/MixedStreamTest.java
+++ b/gson/src/test/java/com/google/gson/MixedStreamTest.java
@@ -35,20 +35,21 @@ public final class MixedStreamTest {
   private static final Car BLUE_MUSTANG = new Car("mustang", 0x0000FF);
   private static final Car BLACK_BMW = new Car("bmw", 0x000000);
   private static final Car RED_MIATA = new Car("miata", 0xFF0000);
-  private static final String CARS_JSON = "[\n"
-      + "  {\n"
-      + "    \"name\": \"mustang\",\n"
-      + "    \"color\": 255\n"
-      + "  },\n"
-      + "  {\n"
-      + "    \"name\": \"bmw\",\n"
-      + "    \"color\": 0\n"
-      + "  },\n"
-      + "  {\n"
-      + "    \"name\": \"miata\",\n"
-      + "    \"color\": 16711680\n"
-      + "  }\n"
-      + "]";
+  private static final String CARS_JSON =
+      "[\n"
+          + "  {\n"
+          + "    \"name\": \"mustang\",\n"
+          + "    \"color\": 255\n"
+          + "  },\n"
+          + "  {\n"
+          + "    \"name\": \"bmw\",\n"
+          + "    \"color\": 0\n"
+          + "  },\n"
+          + "  {\n"
+          + "    \"name\": \"miata\",\n"
+          + "    \"color\": 16711680\n"
+          + "  }\n"
+          + "]";
 
   @Test
   public void testWriteMixedStreamed() throws IOException {
@@ -208,21 +209,22 @@ public final class MixedStreamTest {
         .isEqualTo("[\"\\u003c\",\"\\u003e\",\"\\u0026\",\"\\u003d\",\"\\u0027\"]");
 
     writer = new StringWriter();
-    new GsonBuilder().disableHtmlEscaping().create()
-        .toJson(contents, type, new JsonWriter(writer));
-    assertThat(writer.toString())
-        .isEqualTo("[\"<\",\">\",\"&\",\"=\",\"'\"]");
+    new GsonBuilder().disableHtmlEscaping().create().toJson(contents, type, new JsonWriter(writer));
+    assertThat(writer.toString()).isEqualTo("[\"<\",\">\",\"&\",\"=\",\"'\"]");
   }
 
   @Test
   public void testWriteLenient() {
-    List<Double> doubles = Arrays.asList(Double.NaN, Double.NEGATIVE_INFINITY,
-        Double.POSITIVE_INFINITY, -0.0d, 0.5d, 0.0d);
+    List<Double> doubles =
+        Arrays.asList(
+            Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, -0.0d, 0.5d, 0.0d);
     Type type = new TypeToken<List<Double>>() {}.getType();
 
     StringWriter writer = new StringWriter();
     JsonWriter jsonWriter = new JsonWriter(writer);
-    new GsonBuilder().serializeSpecialFloatingPointValues().create()
+    new GsonBuilder()
+        .serializeSpecialFloatingPointValues()
+        .create()
         .toJson(doubles, type, jsonWriter);
     assertThat(writer.toString()).isEqualTo("[NaN,-Infinity,Infinity,-0.0,0.5,0.0]");
 
@@ -245,14 +247,14 @@ public final class MixedStreamTest {
     // used by Gson
     Car() {}
 
-    @Override public int hashCode() {
+    @Override
+    public int hashCode() {
       return name.hashCode() ^ color;
     }
 
-    @Override public boolean equals(Object o) {
-      return o instanceof Car
-          && ((Car) o).name.equals(name)
-          && ((Car) o).color == color;
+    @Override
+    public boolean equals(Object o) {
+      return o instanceof Car && ((Car) o).name.equals(name) && ((Car) o).color == color;
     }
   }
 }

--- a/gson/src/test/java/com/google/gson/MockExclusionStrategy.java
+++ b/gson/src/test/java/com/google/gson/MockExclusionStrategy.java
@@ -17,8 +17,7 @@
 package com.google.gson;
 
 /**
- * This is a configurable {@link ExclusionStrategy} that can be used for
- * unit testing.
+ * This is a configurable {@link ExclusionStrategy} that can be used for unit testing.
  *
  * @author Joel Leitch
  */

--- a/gson/src/test/java/com/google/gson/ObjectTypeAdapterParameterizedTest.java
+++ b/gson/src/test/java/com/google/gson/ObjectTypeAdapterParameterizedTest.java
@@ -31,20 +31,18 @@ public class ObjectTypeAdapterParameterizedTest {
   @Parameters
   public static Iterable<String> data() {
     return Arrays.asList(
-      "[]",
-      "{}",
-      "null",
-      "1.0",
-      "true",
-      "\"string\"",
-      "[true,1.0,null,{},2.0,{\"a\":[false]},[3.0,\"test\"],4.0]",
-      "{\"\":1.0,\"a\":true,\"b\":null,\"c\":[],\"d\":{\"a1\":2.0,\"b2\":[true,{\"a3\":3.0}]},\"e\":[{\"f\":4.0},\"test\"]}"
-    );
+        "[]",
+        "{}",
+        "null",
+        "1.0",
+        "true",
+        "\"string\"",
+        "[true,1.0,null,{},2.0,{\"a\":[false]},[3.0,\"test\"],4.0]",
+        "{\"\":1.0,\"a\":true,\"b\":null,\"c\":[],\"d\":{\"a1\":2.0,\"b2\":[true,{\"a3\":3.0}]},\"e\":[{\"f\":4.0},\"test\"]}");
   }
 
   private final TypeAdapter<Object> adapter = new Gson().getAdapter(Object.class);
-  @Parameter
-  public String json;
+  @Parameter public String json;
 
   @Test
   public void testReadWrite() throws IOException {

--- a/gson/src/test/java/com/google/gson/OverrideCoreTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/OverrideCoreTypeAdaptersTest.java
@@ -30,30 +30,36 @@ import org.junit.Test;
  * @author Jesse Wilson
  */
 public class OverrideCoreTypeAdaptersTest {
-  private static final TypeAdapter<Boolean> booleanAsIntAdapter = new TypeAdapter<Boolean>() {
-    @Override public void write(JsonWriter out, Boolean value) throws IOException {
-      out.value(value ? 1 : 0);
-    }
-    @Override public Boolean read(JsonReader in) throws IOException {
-      int value = in.nextInt();
-      return value != 0;
-    }
-  };
+  private static final TypeAdapter<Boolean> booleanAsIntAdapter =
+      new TypeAdapter<Boolean>() {
+        @Override
+        public void write(JsonWriter out, Boolean value) throws IOException {
+          out.value(value ? 1 : 0);
+        }
 
-  private static final TypeAdapter<String> swapCaseStringAdapter = new TypeAdapter<String>() {
-    @Override public void write(JsonWriter out, String value) throws IOException {
-      out.value(value.toUpperCase(Locale.US));
-    }
-    @Override public String read(JsonReader in) throws IOException {
-      return in.nextString().toLowerCase(Locale.US);
-    }
-  };
+        @Override
+        public Boolean read(JsonReader in) throws IOException {
+          int value = in.nextInt();
+          return value != 0;
+        }
+      };
+
+  private static final TypeAdapter<String> swapCaseStringAdapter =
+      new TypeAdapter<String>() {
+        @Override
+        public void write(JsonWriter out, String value) throws IOException {
+          out.value(value.toUpperCase(Locale.US));
+        }
+
+        @Override
+        public String read(JsonReader in) throws IOException {
+          return in.nextString().toLowerCase(Locale.US);
+        }
+      };
 
   @Test
   public void testOverrideWrapperBooleanAdapter() {
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(Boolean.class, booleanAsIntAdapter)
-        .create();
+    Gson gson = new GsonBuilder().registerTypeAdapter(Boolean.class, booleanAsIntAdapter).create();
     assertThat(gson.toJson(true, boolean.class)).isEqualTo("true");
     assertThat(gson.toJson(true, Boolean.class)).isEqualTo("1");
     assertThat(gson.fromJson("true", boolean.class)).isEqualTo(Boolean.TRUE);
@@ -63,9 +69,7 @@ public class OverrideCoreTypeAdaptersTest {
 
   @Test
   public void testOverridePrimitiveBooleanAdapter() {
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(boolean.class, booleanAsIntAdapter)
-        .create();
+    Gson gson = new GsonBuilder().registerTypeAdapter(boolean.class, booleanAsIntAdapter).create();
     assertThat(gson.toJson(true, boolean.class)).isEqualTo("1");
     assertThat(gson.toJson(true, Boolean.class)).isEqualTo("true");
     assertThat(gson.fromJson("1", boolean.class)).isEqualTo(Boolean.TRUE);
@@ -75,9 +79,7 @@ public class OverrideCoreTypeAdaptersTest {
 
   @Test
   public void testOverrideStringAdapter() {
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(String.class, swapCaseStringAdapter)
-        .create();
+    Gson gson = new GsonBuilder().registerTypeAdapter(String.class, swapCaseStringAdapter).create();
     assertThat(gson.toJson("Hello", String.class)).isEqualTo("\"HELLO\"");
     assertThat(gson.fromJson("\"Hello\"", String.class)).isEqualTo("hello");
   }

--- a/gson/src/test/java/com/google/gson/ParameterizedTypeFixtures.java
+++ b/gson/src/test/java/com/google/gson/ParameterizedTypeFixtures.java
@@ -18,13 +18,11 @@ package com.google.gson;
 
 import com.google.common.base.Objects;
 import com.google.gson.internal.$Gson$Types;
-
 import com.google.gson.internal.Primitives;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-
 
 /**
  * This class contains some test fixtures for Parameterized types. These classes should ideally
@@ -38,9 +36,11 @@ public class ParameterizedTypeFixtures {
 
   public static final class MyParameterizedType<T> {
     public final T value;
+
     public MyParameterizedType(T value) {
       this.value = value;
     }
+
     public T getValue() {
       return value;
     }
@@ -95,26 +95,28 @@ public class ParameterizedTypeFixtures {
   }
 
   public static class MyParameterizedTypeInstanceCreator<T>
-      implements InstanceCreator<MyParameterizedType<T>>{
+      implements InstanceCreator<MyParameterizedType<T>> {
     private final T instanceOfT;
+
     /**
-     * Caution the specified instance is reused by the instance creator for each call.
-     * This means that the fields of the same objects will be overwritten by Gson.
-     * This is usually fine in tests since there we deserialize just once, but quite
-     * dangerous in practice.
+     * Caution the specified instance is reused by the instance creator for each call. This means
+     * that the fields of the same objects will be overwritten by Gson. This is usually fine in
+     * tests since there we deserialize just once, but quite dangerous in practice.
      */
     public MyParameterizedTypeInstanceCreator(T instanceOfT) {
       this.instanceOfT = instanceOfT;
     }
-    @Override public MyParameterizedType<T> createInstance(Type type) {
+
+    @Override
+    public MyParameterizedType<T> createInstance(Type type) {
       return new MyParameterizedType<>(instanceOfT);
     }
   }
 
   public static final class MyParameterizedTypeAdapter<T>
-  implements JsonSerializer<MyParameterizedType<T>>, JsonDeserializer<MyParameterizedType<T>> {
+      implements JsonSerializer<MyParameterizedType<T>>, JsonDeserializer<MyParameterizedType<T>> {
     @SuppressWarnings("unchecked")
-    public static<T> String getExpectedJson(MyParameterizedType<T> obj) {
+    public static <T> String getExpectedJson(MyParameterizedType<T> obj) {
       Class<T> clazz = (Class<T>) obj.value.getClass();
       boolean addQuotes = !clazz.isArray() && !Primitives.unwrap(clazz).isPrimitive();
       StringBuilder sb = new StringBuilder("{\"");
@@ -130,8 +132,9 @@ public class ParameterizedTypeFixtures {
       return sb.toString();
     }
 
-    @Override public JsonElement serialize(MyParameterizedType<T> src, Type classOfSrc,
-        JsonSerializationContext context) {
+    @Override
+    public JsonElement serialize(
+        MyParameterizedType<T> src, Type classOfSrc, JsonSerializationContext context) {
       JsonObject json = new JsonObject();
       T value = src.getValue();
       json.add(value.getClass().getSimpleName(), context.serialize(value));
@@ -139,8 +142,10 @@ public class ParameterizedTypeFixtures {
     }
 
     @SuppressWarnings("unchecked")
-    @Override public MyParameterizedType<T> deserialize(JsonElement json, Type typeOfT,
-        JsonDeserializationContext context) throws JsonParseException {
+    @Override
+    public MyParameterizedType<T> deserialize(
+        JsonElement json, Type typeOfT, JsonDeserializationContext context)
+        throws JsonParseException {
       Type genericClass = ((ParameterizedType) typeOfT).getActualTypeArguments()[0];
       Class<?> rawType = $Gson$Types.getRawType(genericClass);
       String className = rawType.getSimpleName();

--- a/gson/src/test/java/com/google/gson/PrimitiveTypeAdapter.java
+++ b/gson/src/test/java/com/google/gson/PrimitiveTypeAdapter.java
@@ -22,8 +22,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 /**
- * Handles type conversion from some object to some primitive (or primitive
- * wrapper instance).
+ * Handles type conversion from some object to some primitive (or primitive wrapper instance).
  *
  * @author Joel Leitch
  */

--- a/gson/src/test/java/com/google/gson/ToNumberPolicyTest.java
+++ b/gson/src/test/java/com/google/gson/ToNumberPolicyTest.java
@@ -32,22 +32,27 @@ public class ToNumberPolicyTest {
   public void testDouble() throws IOException {
     ToNumberStrategy strategy = ToNumberPolicy.DOUBLE;
     assertThat(strategy.readNumber(fromString("10.1"))).isEqualTo(10.1);
-    assertThat(strategy.readNumber(fromString("3.141592653589793238462643383279"))).isEqualTo(3.141592653589793D);
+    assertThat(strategy.readNumber(fromString("3.141592653589793238462643383279")))
+        .isEqualTo(3.141592653589793D);
 
-    MalformedJsonException e = assertThrows(MalformedJsonException.class, () -> strategy.readNumber(fromString("1e400")));
-    assertThat(e).hasMessageThat().isEqualTo(
-        "JSON forbids NaN and infinities: Infinity at line 1 column 6 path $"
-        + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json"
-    );
+    MalformedJsonException e =
+        assertThrows(MalformedJsonException.class, () -> strategy.readNumber(fromString("1e400")));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "JSON forbids NaN and infinities: Infinity at line 1 column 6 path $\n"
+                + "See https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
 
-    assertThrows(NumberFormatException.class, () -> strategy.readNumber(fromString("\"not-a-number\"")));
+    assertThrows(
+        NumberFormatException.class, () -> strategy.readNumber(fromString("\"not-a-number\"")));
   }
 
   @Test
   public void testLazilyParsedNumber() throws IOException {
     ToNumberStrategy strategy = ToNumberPolicy.LAZILY_PARSED_NUMBER;
     assertThat(strategy.readNumber(fromString("10.1"))).isEqualTo(new LazilyParsedNumber("10.1"));
-    assertThat(strategy.readNumber(fromString("3.141592653589793238462643383279"))).isEqualTo(new LazilyParsedNumber("3.141592653589793238462643383279"));
+    assertThat(strategy.readNumber(fromString("3.141592653589793238462643383279")))
+        .isEqualTo(new LazilyParsedNumber("3.141592653589793238462643383279"));
     assertThat(strategy.readNumber(fromString("1e400"))).isEqualTo(new LazilyParsedNumber("1e400"));
   }
 
@@ -56,62 +61,110 @@ public class ToNumberPolicyTest {
     ToNumberStrategy strategy = ToNumberPolicy.LONG_OR_DOUBLE;
     assertThat(strategy.readNumber(fromString("10"))).isEqualTo(10L);
     assertThat(strategy.readNumber(fromString("10.1"))).isEqualTo(10.1);
-    assertThat(strategy.readNumber(fromString("3.141592653589793238462643383279"))).isEqualTo(3.141592653589793D);
+    assertThat(strategy.readNumber(fromString("3.141592653589793238462643383279")))
+        .isEqualTo(3.141592653589793D);
 
-    Exception e = assertThrows(MalformedJsonException.class, () -> strategy.readNumber(fromString("1e400")));
-    assertThat(e).hasMessageThat().isEqualTo("JSON forbids NaN and infinities: Infinity; at path $");
+    Exception e =
+        assertThrows(MalformedJsonException.class, () -> strategy.readNumber(fromString("1e400")));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo("JSON forbids NaN and infinities: Infinity; at path $");
 
-    e = assertThrows(JsonParseException.class, () -> strategy.readNumber(fromString("\"not-a-number\"")));
+    e =
+        assertThrows(
+            JsonParseException.class, () -> strategy.readNumber(fromString("\"not-a-number\"")));
     assertThat(e).hasMessageThat().isEqualTo("Cannot parse not-a-number; at path $");
 
     assertThat(strategy.readNumber(fromStringLenient("NaN"))).isEqualTo(Double.NaN);
-    assertThat(strategy.readNumber(fromStringLenient("Infinity"))).isEqualTo(Double.POSITIVE_INFINITY);
-    assertThat(strategy.readNumber(fromStringLenient("-Infinity"))).isEqualTo(Double.NEGATIVE_INFINITY);
+    assertThat(strategy.readNumber(fromStringLenient("Infinity")))
+        .isEqualTo(Double.POSITIVE_INFINITY);
+    assertThat(strategy.readNumber(fromStringLenient("-Infinity")))
+        .isEqualTo(Double.NEGATIVE_INFINITY);
 
     e = assertThrows(MalformedJsonException.class, () -> strategy.readNumber(fromString("NaN")));
-    assertThat(e).hasMessageThat().isEqualTo(
-        "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON at line 1 column 1 path $"
-        + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON at line 1"
+                + " column 1 path $\n"
+                + "See https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
 
-    e = assertThrows(MalformedJsonException.class, () -> strategy.readNumber(fromString("Infinity")));
-    assertThat(e).hasMessageThat().isEqualTo(
-        "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON at line 1 column 1 path $"
-        + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
+    e =
+        assertThrows(
+            MalformedJsonException.class, () -> strategy.readNumber(fromString("Infinity")));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON at line 1"
+                + " column 1 path $\n"
+                + "See https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
 
-    e = assertThrows(MalformedJsonException.class, () -> strategy.readNumber(fromString("-Infinity")));
-    assertThat(e).hasMessageThat().isEqualTo(
-        "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON at line 1 column 1 path $"
-        + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
+    e =
+        assertThrows(
+            MalformedJsonException.class, () -> strategy.readNumber(fromString("-Infinity")));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON at line 1"
+                + " column 1 path $\n"
+                + "See https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
   }
 
   @Test
   public void testBigDecimal() throws IOException {
     ToNumberStrategy strategy = ToNumberPolicy.BIG_DECIMAL;
     assertThat(strategy.readNumber(fromString("10.1"))).isEqualTo(new BigDecimal("10.1"));
-    assertThat(strategy.readNumber(fromString("3.141592653589793238462643383279"))).isEqualTo(new BigDecimal("3.141592653589793238462643383279"));
+    assertThat(strategy.readNumber(fromString("3.141592653589793238462643383279")))
+        .isEqualTo(new BigDecimal("3.141592653589793238462643383279"));
     assertThat(strategy.readNumber(fromString("1e400"))).isEqualTo(new BigDecimal("1e400"));
 
-    JsonParseException e = assertThrows(JsonParseException.class, () -> strategy.readNumber(fromString("\"not-a-number\"")));
+    JsonParseException e =
+        assertThrows(
+            JsonParseException.class, () -> strategy.readNumber(fromString("\"not-a-number\"")));
     assertThat(e).hasMessageThat().isEqualTo("Cannot parse not-a-number; at path $");
   }
 
   @Test
   public void testNullsAreNeverExpected() throws IOException {
-    IllegalStateException e = assertThrows(IllegalStateException.class, () -> ToNumberPolicy.DOUBLE.readNumber(fromString("null")));
-    assertThat(e).hasMessageThat().isEqualTo("Expected a double but was NULL at line 1 column 5 path $"
-        + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#adapter-not-null-safe");
+    IllegalStateException e =
+        assertThrows(
+            IllegalStateException.class,
+            () -> ToNumberPolicy.DOUBLE.readNumber(fromString("null")));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "Expected a double but was NULL at line 1 column 5 path $\n"
+                + "See https://github.com/google/gson/blob/main/Troubleshooting.md#adapter-not-null-safe");
 
-    e = assertThrows(IllegalStateException.class, () -> ToNumberPolicy.LAZILY_PARSED_NUMBER.readNumber(fromString("null")));
-    assertThat(e).hasMessageThat().isEqualTo("Expected a string but was NULL at line 1 column 5 path $"
-        + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#adapter-not-null-safe");
+    e =
+        assertThrows(
+            IllegalStateException.class,
+            () -> ToNumberPolicy.LAZILY_PARSED_NUMBER.readNumber(fromString("null")));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "Expected a string but was NULL at line 1 column 5 path $\n"
+                + "See https://github.com/google/gson/blob/main/Troubleshooting.md#adapter-not-null-safe");
 
-    e = assertThrows(IllegalStateException.class, () -> ToNumberPolicy.LONG_OR_DOUBLE.readNumber(fromString("null")));
-    assertThat(e).hasMessageThat().isEqualTo("Expected a string but was NULL at line 1 column 5 path $"
-        + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#adapter-not-null-safe");
+    e =
+        assertThrows(
+            IllegalStateException.class,
+            () -> ToNumberPolicy.LONG_OR_DOUBLE.readNumber(fromString("null")));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "Expected a string but was NULL at line 1 column 5 path $\n"
+                + "See https://github.com/google/gson/blob/main/Troubleshooting.md#adapter-not-null-safe");
 
-    e = assertThrows(IllegalStateException.class, () -> ToNumberPolicy.BIG_DECIMAL.readNumber(fromString("null")));
-    assertThat(e).hasMessageThat().isEqualTo("Expected a string but was NULL at line 1 column 5 path $"
-        + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#adapter-not-null-safe");
+    e =
+        assertThrows(
+            IllegalStateException.class,
+            () -> ToNumberPolicy.BIG_DECIMAL.readNumber(fromString("null")));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "Expected a string but was NULL at line 1 column 5 path $\n"
+                + "See https://github.com/google/gson/blob/main/Troubleshooting.md#adapter-not-null-safe");
   }
 
   private static JsonReader fromString(String json) {

--- a/gson/src/test/java/com/google/gson/TypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/TypeAdapterTest.java
@@ -28,36 +28,42 @@ import org.junit.Test;
 public class TypeAdapterTest {
   @Test
   public void testNullSafe() throws IOException {
-    TypeAdapter<String> adapter = new TypeAdapter<String>() {
-      @Override public void write(JsonWriter out, String value) {
-        throw new AssertionError("unexpected call");
-      }
+    TypeAdapter<String> adapter =
+        new TypeAdapter<String>() {
+          @Override
+          public void write(JsonWriter out, String value) {
+            throw new AssertionError("unexpected call");
+          }
 
-      @Override public String read(JsonReader in) {
-        throw new AssertionError("unexpected call");
-      }
-    }.nullSafe();
+          @Override
+          public String read(JsonReader in) {
+            throw new AssertionError("unexpected call");
+          }
+        }.nullSafe();
 
     assertThat(adapter.toJson(null)).isEqualTo("null");
     assertThat(adapter.fromJson("null")).isNull();
   }
 
   /**
-   * Tests behavior when {@link TypeAdapter#write(JsonWriter, Object)} manually throws
-   * {@link IOException} which is not caused by writer usage.
+   * Tests behavior when {@link TypeAdapter#write(JsonWriter, Object)} manually throws {@link
+   * IOException} which is not caused by writer usage.
    */
   @Test
   public void testToJson_ThrowingIOException() {
     final IOException exception = new IOException("test");
-    TypeAdapter<Integer> adapter = new TypeAdapter<Integer>() {
-      @Override public void write(JsonWriter out, Integer value) throws IOException {
-        throw exception;
-      }
+    TypeAdapter<Integer> adapter =
+        new TypeAdapter<Integer>() {
+          @Override
+          public void write(JsonWriter out, Integer value) throws IOException {
+            throw exception;
+          }
 
-      @Override public Integer read(JsonReader in) {
-        throw new AssertionError("not needed by this test");
-      }
-    };
+          @Override
+          public Integer read(JsonReader in) {
+            throw new AssertionError("not needed by this test");
+          }
+        };
 
     JsonIOException e = assertThrows(JsonIOException.class, () -> adapter.toJson(1));
     assertThat(e).hasCauseThat().isEqualTo(exception);
@@ -66,15 +72,18 @@ public class TypeAdapterTest {
     assertThat(e).hasCauseThat().isEqualTo(exception);
   }
 
-  private static final TypeAdapter<String> adapter = new TypeAdapter<String>() {
-    @Override public void write(JsonWriter out, String value) throws IOException {
-      out.value(value);
-    }
+  private static final TypeAdapter<String> adapter =
+      new TypeAdapter<String>() {
+        @Override
+        public void write(JsonWriter out, String value) throws IOException {
+          out.value(value);
+        }
 
-    @Override public String read(JsonReader in) throws IOException {
-      return in.nextString();
-    }
-  };
+        @Override
+        public String read(JsonReader in) throws IOException {
+          return in.nextString();
+        }
+      };
 
   // Note: This test just verifies the current behavior; it is a bit questionable
   // whether that behavior is actually desired

--- a/gson/src/test/java/com/google/gson/common/MoreAsserts.java
+++ b/gson/src/test/java/com/google/gson/common/MoreAsserts.java
@@ -25,8 +25,7 @@ import java.util.Set;
 import org.junit.Assert;
 
 /**
- * Handy asserts that we wish were present in {@link Assert}
- * so that we didn't have to write them.
+ * Handy asserts that we wish were present in {@link Assert} so that we didn't have to write them.
  *
  * @author Inderjeet Singh
  */
@@ -34,6 +33,7 @@ public class MoreAsserts {
 
   /**
    * Asserts that the specified {@code value} is not present in {@code collection}
+   *
    * @param collection the collection to look into
    * @param value the value that needs to be checked for presence
    */
@@ -74,14 +74,15 @@ public class MoreAsserts {
   }
 
   /**
-   * Asserts that {@code subClass} overrides all protected and public methods declared by
-   * {@code baseClass} except for the ones whose signatures are in {@code ignoredMethods}.
+   * Asserts that {@code subClass} overrides all protected and public methods declared by {@code
+   * baseClass} except for the ones whose signatures are in {@code ignoredMethods}.
    */
-  public static void assertOverridesMethods(Class<?> baseClass, Class<?> subClass, List<String> ignoredMethods) {
+  public static void assertOverridesMethods(
+      Class<?> baseClass, Class<?> subClass, List<String> ignoredMethods) {
     Set<String> requiredOverriddenMethods = new LinkedHashSet<>();
     for (Method method : baseClass.getDeclaredMethods()) {
-      // Note: Do not filter out `final` methods; maybe they should not be `final` and subclass needs
-      // to override them
+      // Note: Do not filter out `final` methods; maybe they should not be `final` and subclass
+      // needs to override them
       if (isProtectedOrPublic(method)) {
         requiredOverriddenMethods.add(getMethodSignature(method));
       }
@@ -94,12 +95,14 @@ public class MoreAsserts {
     for (String ignoredMethod : ignoredMethods) {
       boolean foundIgnored = requiredOverriddenMethods.remove(ignoredMethod);
       if (!foundIgnored) {
-        throw new IllegalArgumentException("Method '" + ignoredMethod + "' does not exist or is already overridden");
+        throw new IllegalArgumentException(
+            "Method '" + ignoredMethod + "' does not exist or is already overridden");
       }
     }
 
     if (!requiredOverriddenMethods.isEmpty()) {
-      Assert.fail(subClass.getSimpleName() + " must override these methods: " + requiredOverriddenMethods);
+      Assert.fail(
+          subClass.getSimpleName() + " must override these methods: " + requiredOverriddenMethods);
     }
   }
 }

--- a/gson/src/test/java/com/google/gson/common/TestTypes.java
+++ b/gson/src/test/java/com/google/gson/common/TestTypes.java
@@ -54,6 +54,7 @@ public class TestTypes {
   public static class ClassWithBaseField {
     public static final String FIELD_KEY = "base";
     public final Base base;
+
     public ClassWithBaseField(Base base) {
       this.base = base;
     }
@@ -62,6 +63,7 @@ public class TestTypes {
   public static class ClassWithBaseArrayField {
     public static final String FIELD_KEY = "base";
     public final Base[] base;
+
     public ClassWithBaseArrayField(Base[] base) {
       this.base = base;
     }
@@ -70,6 +72,7 @@ public class TestTypes {
   public static class ClassWithBaseCollectionField {
     public static final String FIELD_KEY = "base";
     public final Collection<Base> base;
+
     public ClassWithBaseCollectionField(Collection<Base> base) {
       this.base = base;
     }
@@ -77,6 +80,7 @@ public class TestTypes {
 
   public static class BaseSerializer implements JsonSerializer<Base> {
     public static final String NAME = BaseSerializer.class.getSimpleName();
+
     @Override
     public JsonElement serialize(Base src, Type typeOfSrc, JsonSerializationContext context) {
       JsonObject obj = new JsonObject();
@@ -84,8 +88,10 @@ public class TestTypes {
       return obj;
     }
   }
+
   public static class SubSerializer implements JsonSerializer<Sub> {
     public static final String NAME = SubSerializer.class.getSimpleName();
+
     @Override
     public JsonElement serialize(Sub src, Type typeOfSrc, JsonSerializationContext context) {
       JsonObject obj = new JsonObject();
@@ -163,7 +169,8 @@ public class TestTypes {
 
     @Override
     public String toString() {
-      return String.format("(longValue=%d,intValue=%d,booleanValue=%b,stringValue=%s)",
+      return String.format(
+          "(longValue=%d,intValue=%d,booleanValue=%b,stringValue=%s)",
           longValue, intValue, booleanValue, stringValue);
     }
   }
@@ -274,7 +281,7 @@ public class TestTypes {
     }
 
     public ClassWithTransientFields(long value) {
-      longValue = new long[] { value };
+      longValue = new long[] {value};
       transientLongValue = value + 1;
     }
 
@@ -319,12 +326,14 @@ public class TestTypes {
 
   public static class ArrayOfObjects {
     private final BagOfPrimitives[] elements;
+
     public ArrayOfObjects() {
       elements = new BagOfPrimitives[3];
       for (int i = 0; i < elements.length; ++i) {
-        elements[i] = new BagOfPrimitives(i, i+2, false, "i"+i);
+        elements[i] = new BagOfPrimitives(i, i + 2, false, "i" + i);
       }
     }
+
     public String getExpectedJson() {
       StringBuilder sb = new StringBuilder("{\"elements\":[");
       boolean first = true;
@@ -350,6 +359,7 @@ public class TestTypes {
       }
       return "{\"ref\":" + ref.getExpectedJson() + "}";
     }
+
     @Override
     public boolean equals(Object obj) {
       return true;
@@ -363,6 +373,7 @@ public class TestTypes {
 
   public static class ClassWithArray {
     public final Object[] array;
+
     public ClassWithArray() {
       array = null;
     }
@@ -374,21 +385,27 @@ public class TestTypes {
 
   public static class ClassWithObjects {
     public final BagOfPrimitives bag;
+
     public ClassWithObjects() {
       this(new BagOfPrimitives());
     }
+
     public ClassWithObjects(BagOfPrimitives bag) {
       this.bag = bag;
     }
   }
 
   public static class ClassWithSerializedNameFields {
-    @SerializedName("fooBar") public final int f;
-    @SerializedName("Another Foo") public final int g;
+    @SerializedName("fooBar")
+    public final int f;
+
+    @SerializedName("Another Foo")
+    public final int g;
 
     public ClassWithSerializedNameFields() {
       this(1, 4);
     }
+
     public ClassWithSerializedNameFields(int f, int g) {
       this.f = f;
       this.g = g;
@@ -399,13 +416,14 @@ public class TestTypes {
     }
   }
 
-  public static class CrazyLongTypeAdapter
-      implements JsonSerializer<Long>, JsonDeserializer<Long> {
+  public static class CrazyLongTypeAdapter implements JsonSerializer<Long>, JsonDeserializer<Long> {
     public static final long DIFFERENCE = 5L;
+
     @Override
     public JsonElement serialize(Long src, Type typeOfSrc, JsonSerializationContext context) {
       return new JsonPrimitive(src + DIFFERENCE);
     }
+
     @Override
     public Long deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
         throws JsonParseException {

--- a/gson/src/test/java/com/google/gson/functional/ArrayTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ArrayTest.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import org.junit.Before;
 import org.junit.Test;
+
 /**
  * Functional tests for Json serialization and deserialization of arrays.
  *
@@ -140,7 +141,7 @@ public class ArrayTest {
 
   @Test
   public void testSingleStringArraySerialization() {
-    String[] s = { "hello" };
+    String[] s = {"hello"};
     String output = gson.toJson(s);
     assertThat(output).isEqualTo("[\"hello\"]");
   }
@@ -202,11 +203,11 @@ public class ArrayTest {
   public void testArrayOfPrimitivesAsObjectsDeserialization() {
     String json = "[1,'abc',0.3,1.1,5]";
     Object[] objs = gson.fromJson(json, Object[].class);
-    assertThat(((Number)objs[0]).intValue()).isEqualTo(1);
+    assertThat(((Number) objs[0]).intValue()).isEqualTo(1);
     assertThat(objs[1]).isEqualTo("abc");
-    assertThat(((Number)objs[2]).doubleValue()).isEqualTo(0.3);
+    assertThat(((Number) objs[2]).doubleValue()).isEqualTo(0.3);
     assertThat(new BigDecimal(objs[3].toString())).isEqualTo(new BigDecimal("1.1"));
-    assertThat(((Number)objs[4]).shortValue()).isEqualTo(5);
+    assertThat(((Number) objs[4]).shortValue()).isEqualTo(5);
   }
 
   @Test
@@ -236,14 +237,12 @@ public class ArrayTest {
     assertThat(values[0]).isNull();
   }
 
-  /**
-   * Regression tests for Issue 272
-   */
+  /** Regression tests for Issue 272 */
   @Test
   public void testMultidimensionalArraysSerialization() {
     String[][] items = {
-        {"3m Co", "71.72", "0.02", "0.03", "4/2 12:00am", "Manufacturing"},
-        {"Alcoa Inc", "29.01", "0.42", "1.47", "4/1 12:00am", "Manufacturing"}
+      {"3m Co", "71.72", "0.02", "0.03", "4/2 12:00am", "Manufacturing"},
+      {"Alcoa Inc", "29.01", "0.42", "1.47", "4/1 12:00am", "Manufacturing"}
     };
     String json = gson.toJson(items);
     assertThat(json).contains("[[\"3m Co");
@@ -252,7 +251,7 @@ public class ArrayTest {
 
   @Test
   public void testMultidimensionalObjectArraysSerialization() {
-    Object[][] array = {new Object[] { 1, 2 }};
+    Object[][] array = {new Object[] {1, 2}};
     assertThat(gson.toJson(array)).isEqualTo("[[1,2]]");
   }
 
@@ -262,22 +261,19 @@ public class ArrayTest {
     assertThat(gson.toJson(array)).isEqualTo("[[1,2],[3,4]]");
   }
 
-  /**
-   * Regression test for Issue 205
-   */
+  /** Regression test for Issue 205 */
   @Test
   public void testMixingTypesInObjectArraySerialization() {
     Object[] array = {1, 2, new Object[] {"one", "two", 3}};
     assertThat(gson.toJson(array)).isEqualTo("[1,2,[\"one\",\"two\",3]]");
   }
 
-  /**
-   * Regression tests for Issue 272
-   */
+  /** Regression tests for Issue 272 */
   @Test
   public void testMultidimensionalArraysDeserialization() {
-    String json = "[['3m Co','71.72','0.02','0.03','4/2 12:00am','Manufacturing'],"
-      + "['Alcoa Inc','29.01','0.42','1.47','4/1 12:00am','Manufacturing']]";
+    String json =
+        "[['3m Co','71.72','0.02','0.03','4/2 12:00am','Manufacturing'],"
+            + "['Alcoa Inc','29.01','0.42','1.47','4/1 12:00am','Manufacturing']]";
     String[][] items = gson.fromJson(json, String[][].class);
     assertThat(items[0][0]).isEqualTo("3m Co");
     assertThat(items[1][5]).isEqualTo("Manufacturing");
@@ -294,9 +290,10 @@ public class ArrayTest {
   @Test
   public void testArrayElementsAreArrays() {
     Object[] stringArrays = {
-        new String[] {"test1", "test2"},
-        new String[] {"test3", "test4"}
+      new String[] {"test1", "test2"},
+      new String[] {"test3", "test4"}
     };
-    assertThat(new Gson().toJson(stringArrays)).isEqualTo("[[\"test1\",\"test2\"],[\"test3\",\"test4\"]]");
+    assertThat(new Gson().toJson(stringArrays))
+        .isEqualTo("[[\"test1\",\"test2\"],[\"test3\",\"test4\"]]");
   }
 }

--- a/gson/src/test/java/com/google/gson/functional/CircularReferenceTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CircularReferenceTest.java
@@ -70,7 +70,7 @@ public class CircularReferenceTest {
   @Test
   public void testSelfReferenceArrayFieldSerialization() {
     ClassWithSelfReferenceArray objA = new ClassWithSelfReferenceArray();
-    objA.children = new ClassWithSelfReferenceArray[]{objA};
+    objA.children = new ClassWithSelfReferenceArray[] {objA};
 
     try {
       gson.toJson(objA);
@@ -83,15 +83,23 @@ public class CircularReferenceTest {
   public void testSelfReferenceCustomHandlerSerialization() {
     ClassWithSelfReference obj = new ClassWithSelfReference();
     obj.child = obj;
-    Gson gson = new GsonBuilder().registerTypeAdapter(ClassWithSelfReference.class, new JsonSerializer<ClassWithSelfReference>() {
-      @Override public JsonElement serialize(ClassWithSelfReference src, Type typeOfSrc,
-          JsonSerializationContext context) {
-        JsonObject obj = new JsonObject();
-        obj.addProperty("property", "value");
-        obj.add("child", context.serialize(src.child));
-        return obj;
-      }
-    }).create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                ClassWithSelfReference.class,
+                new JsonSerializer<ClassWithSelfReference>() {
+                  @Override
+                  public JsonElement serialize(
+                      ClassWithSelfReference src,
+                      Type typeOfSrc,
+                      JsonSerializationContext context) {
+                    JsonObject obj = new JsonObject();
+                    obj.addProperty("property", "value");
+                    obj.add("child", context.serialize(src.child));
+                    return obj;
+                  }
+                })
+            .create();
     try {
       gson.toJson(obj);
       fail("Circular reference to self can not be serialized!");

--- a/gson/src/test/java/com/google/gson/functional/CollectionTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CollectionTest.java
@@ -68,7 +68,7 @@ public class CollectionTest {
   @Test
   public void testTopLevelCollectionOfIntegersDeserialization() {
     String json = "[0,1,2,3,4,5,6,7,8,9]";
-    Type collectionType = new TypeToken<Collection<Integer>>() { }.getType();
+    Type collectionType = new TypeToken<Collection<Integer>>() {}.getType();
     Collection<Integer> target = gson.fromJson(json, collectionType);
     int[] expected = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     assertThat(toIntArray(target)).isEqualTo(expected);
@@ -137,7 +137,7 @@ public class CollectionTest {
 
   @Test
   public void testPriorityQueue() {
-    Type type = new TypeToken<PriorityQueue<Integer>>(){}.getType();
+    Type type = new TypeToken<PriorityQueue<Integer>>() {}.getType();
     PriorityQueue<Integer> queue = gson.fromJson("[10, 20, 22]", type);
     assertThat(queue.size()).isEqualTo(3);
     String json = gson.toJson(queue);
@@ -149,7 +149,7 @@ public class CollectionTest {
 
   @Test
   public void testVector() {
-    Type type = new TypeToken<Vector<Integer>>(){}.getType();
+    Type type = new TypeToken<Vector<Integer>>() {}.getType();
     Vector<Integer> target = gson.fromJson("[10, 20, 31]", type);
     assertThat(target.size()).isEqualTo(3);
     assertThat(target.get(0)).isEqualTo(10);
@@ -161,7 +161,7 @@ public class CollectionTest {
 
   @Test
   public void testStack() {
-    Type type = new TypeToken<Stack<Integer>>(){}.getType();
+    Type type = new TypeToken<Stack<Integer>>() {}.getType();
     Stack<Integer> target = gson.fromJson("[11, 13, 17]", type);
     assertThat(target.size()).isEqualTo(3);
     String json = gson.toJson(target);
@@ -247,7 +247,7 @@ public class CollectionTest {
   @Test
   public void testCollectionOfStringsDeserialization() {
     String json = "[\"Hello\",\"World\"]";
-    Type collectionType = new TypeToken<Collection<String>>() { }.getType();
+    Type collectionType = new TypeToken<Collection<String>>() {}.getType();
     Collection<String> target = gson.fromJson(json, collectionType);
 
     assertThat(target).containsExactly("Hello", "World").inOrder();
@@ -272,7 +272,9 @@ public class CollectionTest {
     String json = "[0,1,2,3,4,5,6,7,8,9]";
     Collection<?> integers = gson.fromJson(json, Collection.class);
     // JsonReader converts numbers to double by default so we need a floating point comparison
-    assertThat(integers).containsExactly(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0).inOrder();
+    assertThat(integers)
+        .containsExactly(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0)
+        .inOrder();
 
     json = "[\"Hello\", \"World\"]";
     Collection<?> strings = gson.fromJson(json, Collection.class);
@@ -298,7 +300,7 @@ public class CollectionTest {
   @Test
   public void testWildcardPrimitiveCollectionSerilaization() {
     Collection<? extends Integer> target = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9);
-    Type collectionType = new TypeToken<Collection<? extends Integer>>() { }.getType();
+    Type collectionType = new TypeToken<Collection<? extends Integer>>() {}.getType();
     String json = gson.toJson(target, collectionType);
     assertThat(json).isEqualTo("[1,2,3,4,5,6,7,8,9]");
 
@@ -309,7 +311,7 @@ public class CollectionTest {
   @Test
   public void testWildcardPrimitiveCollectionDeserilaization() {
     String json = "[1,2,3,4,5,6,7,8,9]";
-    Type collectionType = new TypeToken<Collection<? extends Integer>>() { }.getType();
+    Type collectionType = new TypeToken<Collection<? extends Integer>>() {}.getType();
     Collection<? extends Integer> target = gson.fromJson(json, collectionType);
     assertThat(target.size()).isEqualTo(9);
     assertThat(target).contains(1);
@@ -350,15 +352,15 @@ public class CollectionTest {
   @Test
   public void testUserCollectionTypeAdapter() {
     Type listOfString = new TypeToken<List<String>>() {}.getType();
-    Object stringListSerializer = new JsonSerializer<List<String>>() {
-      @Override public JsonElement serialize(List<String> src, Type typeOfSrc,
-          JsonSerializationContext context) {
-        return new JsonPrimitive(src.get(0) + ";" + src.get(1));
-      }
-    };
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(listOfString, stringListSerializer)
-        .create();
+    Object stringListSerializer =
+        new JsonSerializer<List<String>>() {
+          @Override
+          public JsonElement serialize(
+              List<String> src, Type typeOfSrc, JsonSerializationContext context) {
+            return new JsonPrimitive(src.get(0) + ";" + src.get(1));
+          }
+        };
+    Gson gson = new GsonBuilder().registerTypeAdapter(listOfString, stringListSerializer).create();
     assertThat(gson.toJson(Arrays.asList("ab", "cd"), listOfString)).isEqualTo("\"ab;cd\"");
   }
 
@@ -374,7 +376,7 @@ public class CollectionTest {
       if (obj instanceof Integer) {
         ints[i] = (Integer) obj;
       } else if (obj instanceof Long) {
-        ints[i] = ((Long)obj).intValue();
+        ints[i] = ((Long) obj).intValue();
       }
     }
     return ints;
@@ -394,10 +396,12 @@ public class CollectionTest {
 
   private static class Entry {
     int value;
+
     Entry(int value) {
       this.value = value;
     }
   }
+
   @Test
   public void testSetSerialization() {
     Set<Entry> set = new HashSet<>();
@@ -407,6 +411,7 @@ public class CollectionTest {
     assertThat(json).contains("1");
     assertThat(json).contains("2");
   }
+
   @Test
   public void testSetDeserialization() {
     String json = "[{value:1},{value:2}]";
@@ -418,23 +423,27 @@ public class CollectionTest {
     }
   }
 
-  private static class BigClass { private Map<String, ? extends List<SmallClass>> inBig; }
+  private static class BigClass {
+    private Map<String, ? extends List<SmallClass>> inBig;
+  }
 
-  private static class SmallClass { private String inSmall; }
+  private static class SmallClass {
+    private String inSmall;
+  }
 
   @Test
   public void testIssue1107() {
-    String json = "{\n" +
-            "  \"inBig\": {\n" +
-            "    \"key\": [\n" +
-            "      { \"inSmall\": \"hello\" }\n" +
-            "    ]\n" +
-            "  }\n" +
-            "}";
+    String json =
+        "{\n"
+            + "  \"inBig\": {\n"
+            + "    \"key\": [\n"
+            + "      { \"inSmall\": \"hello\" }\n"
+            + "    ]\n"
+            + "  }\n"
+            + "}";
     BigClass bigClass = new Gson().fromJson(json, BigClass.class);
     SmallClass small = bigClass.inBig.get("key").get(0);
     assertThat(small).isNotNull();
     assertThat(small.inSmall).isEqualTo("hello");
   }
-
 }

--- a/gson/src/test/java/com/google/gson/functional/ConcurrencyTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ConcurrencyTest.java
@@ -73,21 +73,23 @@ public class ConcurrencyTest {
     final AtomicBoolean failed = new AtomicBoolean(false);
     ExecutorService executor = Executors.newFixedThreadPool(10);
     for (int taskCount = 0; taskCount < 10; taskCount++) {
-      executor.execute(new Runnable() {
-        @Override public void run() {
-          MyObject myObj = new MyObject();
-          try {
-            startLatch.await();
-            for (int i = 0; i < 10; i++) {
-              String unused = gson.toJson(myObj);
+      executor.execute(
+          new Runnable() {
+            @Override
+            public void run() {
+              MyObject myObj = new MyObject();
+              try {
+                startLatch.await();
+                for (int i = 0; i < 10; i++) {
+                  String unused = gson.toJson(myObj);
+                }
+              } catch (Throwable t) {
+                failed.set(true);
+              } finally {
+                finishedLatch.countDown();
+              }
             }
-          } catch (Throwable t) {
-            failed.set(true);
-          } finally {
-            finishedLatch.countDown();
-          }
-        }
-      });
+          });
     }
     startLatch.countDown();
     finishedLatch.await();
@@ -105,20 +107,23 @@ public class ConcurrencyTest {
     final AtomicBoolean failed = new AtomicBoolean(false);
     ExecutorService executor = Executors.newFixedThreadPool(10);
     for (int taskCount = 0; taskCount < 10; taskCount++) {
-      executor.execute(new Runnable() {
-        @Override public void run() {
-          try {
-            startLatch.await();
-            for (int i = 0; i < 10; i++) {
-              MyObject unused = gson.fromJson("{'a':'hello','b':'world','i':1}", MyObject.class);
+      executor.execute(
+          new Runnable() {
+            @Override
+            public void run() {
+              try {
+                startLatch.await();
+                for (int i = 0; i < 10; i++) {
+                  MyObject unused =
+                      gson.fromJson("{'a':'hello','b':'world','i':1}", MyObject.class);
+                }
+              } catch (Throwable t) {
+                failed.set(true);
+              } finally {
+                finishedLatch.countDown();
+              }
             }
-          } catch (Throwable t) {
-            failed.set(true);
-          } finally {
-            finishedLatch.countDown();
-          }
-        }
-      });
+          });
     }
     startLatch.countDown();
     finishedLatch.await();

--- a/gson/src/test/java/com/google/gson/functional/CustomDeserializerTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CustomDeserializerTest.java
@@ -32,8 +32,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Functional Test exercising custom deserialization only. When test applies to both
- * serialization and deserialization then add it to CustomTypeAdapterTest.
+ * Functional Test exercising custom deserialization only. When test applies to both serialization
+ * and deserialization then add it to CustomTypeAdapterTest.
  *
  * @author Joel Leitch
  */
@@ -45,7 +45,10 @@ public class CustomDeserializerTest {
 
   @Before
   public void setUp() throws Exception {
-    gson = new GsonBuilder().registerTypeAdapter(DataHolder.class, new DataHolderDeserializer()).create();
+    gson =
+        new GsonBuilder()
+            .registerTypeAdapter(DataHolder.class, new DataHolderDeserializer())
+            .create();
   }
 
   @Test
@@ -104,7 +107,8 @@ public class CustomDeserializerTest {
 
   private static class DataHolderDeserializer implements JsonDeserializer<DataHolder> {
     @Override
-    public DataHolder deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+    public DataHolder deserialize(
+        JsonElement json, Type typeOfT, JsonDeserializationContext context)
         throws JsonParseException {
       JsonObject jsonObj = json.getAsJsonObject();
       String dataString = jsonObj.get("data").getAsString();
@@ -115,13 +119,20 @@ public class CustomDeserializerTest {
   @Test
   public void testJsonTypeFieldBasedDeserialization() {
     String json = "{field1:'abc',field2:'def',__type__:'SUB_TYPE1'}";
-    Gson gson = new GsonBuilder().registerTypeAdapter(MyBase.class, new JsonDeserializer<MyBase>() {
-      @Override public MyBase deserialize(JsonElement json, Type pojoType,
-          JsonDeserializationContext context) throws JsonParseException {
-        String type = json.getAsJsonObject().get(MyBase.TYPE_ACCESS).getAsString();
-        return context.deserialize(json, SubTypes.valueOf(type).getSubclass());
-      }
-    }).create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                MyBase.class,
+                new JsonDeserializer<MyBase>() {
+                  @Override
+                  public MyBase deserialize(
+                      JsonElement json, Type pojoType, JsonDeserializationContext context)
+                      throws JsonParseException {
+                    String type = json.getAsJsonObject().get(MyBase.TYPE_ACCESS).getAsString();
+                    return context.deserialize(json, SubTypes.valueOf(type).getSubclass());
+                  }
+                })
+            .create();
     SubType1 target = (SubType1) gson.fromJson(json, MyBase.class);
     assertThat(target.field1).isEqualTo("abc");
   }
@@ -135,9 +146,11 @@ public class CustomDeserializerTest {
     SUB_TYPE1(SubType1.class),
     SUB_TYPE2(SubType2.class);
     private final Type subClass;
+
     private SubTypes(Type subClass) {
       this.subClass = subClass;
     }
+
     public Type getSubclass() {
       return subClass;
     }
@@ -154,14 +167,19 @@ public class CustomDeserializerTest {
 
   @Test
   public void testCustomDeserializerReturnsNullForTopLevelObject() {
-    Gson gson = new GsonBuilder()
-      .registerTypeAdapter(Base.class, new JsonDeserializer<Base>() {
-        @Override
-        public Base deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
-            throws JsonParseException {
-          return null;
-        }
-      }).create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                Base.class,
+                new JsonDeserializer<Base>() {
+                  @Override
+                  public Base deserialize(
+                      JsonElement json, Type typeOfT, JsonDeserializationContext context)
+                      throws JsonParseException {
+                    return null;
+                  }
+                })
+            .create();
     String json = "{baseName:'Base',subName:'SubRevised'}";
     Base target = gson.fromJson(json, Base.class);
     assertThat(target).isNull();
@@ -169,14 +187,19 @@ public class CustomDeserializerTest {
 
   @Test
   public void testCustomDeserializerReturnsNull() {
-    Gson gson = new GsonBuilder()
-      .registerTypeAdapter(Base.class, new JsonDeserializer<Base>() {
-        @Override
-        public Base deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
-            throws JsonParseException {
-          return null;
-        }
-      }).create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                Base.class,
+                new JsonDeserializer<Base>() {
+                  @Override
+                  public Base deserialize(
+                      JsonElement json, Type typeOfT, JsonDeserializationContext context)
+                      throws JsonParseException {
+                    return null;
+                  }
+                })
+            .create();
     String json = "{base:{baseName:'Base',subName:'SubRevised'}}";
     ClassWithBaseField target = gson.fromJson(json, ClassWithBaseField.class);
     assertThat(target.base).isNull();
@@ -184,14 +207,19 @@ public class CustomDeserializerTest {
 
   @Test
   public void testCustomDeserializerReturnsNullForArrayElements() {
-    Gson gson = new GsonBuilder()
-      .registerTypeAdapter(Base.class, new JsonDeserializer<Base>() {
-        @Override
-        public Base deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
-            throws JsonParseException {
-          return null;
-        }
-      }).create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                Base.class,
+                new JsonDeserializer<Base>() {
+                  @Override
+                  public Base deserialize(
+                      JsonElement json, Type typeOfT, JsonDeserializationContext context)
+                      throws JsonParseException {
+                    return null;
+                  }
+                })
+            .create();
     String json = "[{baseName:'Base'},{baseName:'Base'}]";
     Base[] target = gson.fromJson(json, Base[].class);
     assertThat(target[0]).isNull();
@@ -200,14 +228,19 @@ public class CustomDeserializerTest {
 
   @Test
   public void testCustomDeserializerReturnsNullForArrayElementsForArrayField() {
-    Gson gson = new GsonBuilder()
-      .registerTypeAdapter(Base.class, new JsonDeserializer<Base>() {
-        @Override
-        public Base deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
-            throws JsonParseException {
-          return null;
-        }
-      }).create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                Base.class,
+                new JsonDeserializer<Base>() {
+                  @Override
+                  public Base deserialize(
+                      JsonElement json, Type typeOfT, JsonDeserializationContext context)
+                      throws JsonParseException {
+                    return null;
+                  }
+                })
+            .create();
     String json = "{bases:[{baseName:'Base'},{baseName:'Base'}]}";
     ClassWithBaseArray target = gson.fromJson(json, ClassWithBaseArray.class);
     assertThat(target.bases[0]).isNull();

--- a/gson/src/test/java/com/google/gson/functional/CustomSerializerTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CustomSerializerTest.java
@@ -35,8 +35,8 @@ import java.lang.reflect.Type;
 import org.junit.Test;
 
 /**
- * Functional Test exercising custom serialization only.  When test applies to both
- * serialization and deserialization then add it to CustomTypeAdapterTest.
+ * Functional Test exercising custom serialization only. When test applies to both serialization and
+ * deserialization then add it to CustomTypeAdapterTest.
  *
  * @author Inderjeet Singh
  */
@@ -44,64 +44,70 @@ public class CustomSerializerTest {
 
   @Test
   public void testBaseClassSerializerInvokedForBaseClassFields() {
-     Gson gson = new GsonBuilder()
-         .registerTypeAdapter(Base.class, new BaseSerializer())
-         .registerTypeAdapter(Sub.class, new SubSerializer())
-         .create();
-     ClassWithBaseField target = new ClassWithBaseField(new Base());
-     JsonObject json = (JsonObject) gson.toJsonTree(target);
-     JsonObject base = json.get("base").getAsJsonObject();
-     assertThat(base.get(Base.SERIALIZER_KEY).getAsString()).isEqualTo(BaseSerializer.NAME);
-   }
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(Base.class, new BaseSerializer())
+            .registerTypeAdapter(Sub.class, new SubSerializer())
+            .create();
+    ClassWithBaseField target = new ClassWithBaseField(new Base());
+    JsonObject json = (JsonObject) gson.toJsonTree(target);
+    JsonObject base = json.get("base").getAsJsonObject();
+    assertThat(base.get(Base.SERIALIZER_KEY).getAsString()).isEqualTo(BaseSerializer.NAME);
+  }
 
   @Test
   public void testSubClassSerializerInvokedForBaseClassFieldsHoldingSubClassInstances() {
-     Gson gson = new GsonBuilder()
-         .registerTypeAdapter(Base.class, new BaseSerializer())
-         .registerTypeAdapter(Sub.class, new SubSerializer())
-         .create();
-     ClassWithBaseField target = new ClassWithBaseField(new Sub());
-     JsonObject json = (JsonObject) gson.toJsonTree(target);
-     JsonObject base = json.get("base").getAsJsonObject();
-     assertThat(base.get(Base.SERIALIZER_KEY).getAsString()).isEqualTo(SubSerializer.NAME);
-   }
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(Base.class, new BaseSerializer())
+            .registerTypeAdapter(Sub.class, new SubSerializer())
+            .create();
+    ClassWithBaseField target = new ClassWithBaseField(new Sub());
+    JsonObject json = (JsonObject) gson.toJsonTree(target);
+    JsonObject base = json.get("base").getAsJsonObject();
+    assertThat(base.get(Base.SERIALIZER_KEY).getAsString()).isEqualTo(SubSerializer.NAME);
+  }
 
   @Test
   public void testSubClassSerializerInvokedForBaseClassFieldsHoldingArrayOfSubClassInstances() {
-     Gson gson = new GsonBuilder()
-         .registerTypeAdapter(Base.class, new BaseSerializer())
-         .registerTypeAdapter(Sub.class, new SubSerializer())
-         .create();
-     ClassWithBaseArrayField target = new ClassWithBaseArrayField(new Base[] {new Sub(), new Sub()});
-     JsonObject json = (JsonObject) gson.toJsonTree(target);
-     JsonArray array = json.get("base").getAsJsonArray();
-     for (JsonElement element : array) {
-       JsonElement serializerKey = element.getAsJsonObject().get(Base.SERIALIZER_KEY);
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(Base.class, new BaseSerializer())
+            .registerTypeAdapter(Sub.class, new SubSerializer())
+            .create();
+    ClassWithBaseArrayField target = new ClassWithBaseArrayField(new Base[] {new Sub(), new Sub()});
+    JsonObject json = (JsonObject) gson.toJsonTree(target);
+    JsonArray array = json.get("base").getAsJsonArray();
+    for (JsonElement element : array) {
+      JsonElement serializerKey = element.getAsJsonObject().get(Base.SERIALIZER_KEY);
       assertThat(serializerKey.getAsString()).isEqualTo(SubSerializer.NAME);
-     }
-   }
+    }
+  }
 
   @Test
   public void testBaseClassSerializerInvokedForBaseClassFieldsHoldingSubClassInstances() {
-     Gson gson = new GsonBuilder()
-         .registerTypeAdapter(Base.class, new BaseSerializer())
-         .create();
-     ClassWithBaseField target = new ClassWithBaseField(new Sub());
-     JsonObject json = (JsonObject) gson.toJsonTree(target);
-     JsonObject base = json.get("base").getAsJsonObject();
-     assertThat(base.get(Base.SERIALIZER_KEY).getAsString()).isEqualTo(BaseSerializer.NAME);
-   }
+    Gson gson = new GsonBuilder().registerTypeAdapter(Base.class, new BaseSerializer()).create();
+    ClassWithBaseField target = new ClassWithBaseField(new Sub());
+    JsonObject json = (JsonObject) gson.toJsonTree(target);
+    JsonObject base = json.get("base").getAsJsonObject();
+    assertThat(base.get(Base.SERIALIZER_KEY).getAsString()).isEqualTo(BaseSerializer.NAME);
+  }
 
   @Test
   public void testSerializerReturnsNull() {
-     Gson gson = new GsonBuilder()
-       .registerTypeAdapter(Base.class, new JsonSerializer<Base>() {
-         @Override public JsonElement serialize(Base src, Type typeOfSrc, JsonSerializationContext context) {
-           return null;
-         }
-       })
-       .create();
-       JsonElement json = gson.toJsonTree(new Base());
-       assertThat(json.isJsonNull()).isTrue();
-   }
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                Base.class,
+                new JsonSerializer<Base>() {
+                  @Override
+                  public JsonElement serialize(
+                      Base src, Type typeOfSrc, JsonSerializationContext context) {
+                    return null;
+                  }
+                })
+            .create();
+    JsonElement json = gson.toJsonTree(new Base());
+    assertThat(json.isJsonNull()).isTrue();
+  }
 }

--- a/gson/src/test/java/com/google/gson/functional/CustomTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CustomTypeAdaptersTest.java
@@ -59,32 +59,44 @@ public class CustomTypeAdaptersTest {
 
   @Test
   public void testCustomSerializers() {
-    Gson gson = builder.registerTypeAdapter(
-        ClassWithCustomTypeConverter.class, new JsonSerializer<ClassWithCustomTypeConverter>() {
-          @Override public JsonElement serialize(ClassWithCustomTypeConverter src, Type typeOfSrc,
-              JsonSerializationContext context) {
-        JsonObject json = new JsonObject();
-        json.addProperty("bag", 5);
-        json.addProperty("value", 25);
-        return json;
-      }
-    }).create();
+    Gson gson =
+        builder
+            .registerTypeAdapter(
+                ClassWithCustomTypeConverter.class,
+                new JsonSerializer<ClassWithCustomTypeConverter>() {
+                  @Override
+                  public JsonElement serialize(
+                      ClassWithCustomTypeConverter src,
+                      Type typeOfSrc,
+                      JsonSerializationContext context) {
+                    JsonObject json = new JsonObject();
+                    json.addProperty("bag", 5);
+                    json.addProperty("value", 25);
+                    return json;
+                  }
+                })
+            .create();
     ClassWithCustomTypeConverter target = new ClassWithCustomTypeConverter();
     assertThat(gson.toJson(target)).isEqualTo("{\"bag\":5,\"value\":25}");
   }
 
   @Test
   public void testCustomDeserializers() {
-    Gson gson = new GsonBuilder().registerTypeAdapter(
-        ClassWithCustomTypeConverter.class, new JsonDeserializer<ClassWithCustomTypeConverter>() {
-          @Override public ClassWithCustomTypeConverter deserialize(JsonElement json, Type typeOfT,
-              JsonDeserializationContext context) {
-        JsonObject jsonObject = json.getAsJsonObject();
-        int value = jsonObject.get("bag").getAsInt();
-        return new ClassWithCustomTypeConverter(new BagOfPrimitives(value,
-            value, false, ""), value);
-      }
-    }).create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                ClassWithCustomTypeConverter.class,
+                new JsonDeserializer<ClassWithCustomTypeConverter>() {
+                  @Override
+                  public ClassWithCustomTypeConverter deserialize(
+                      JsonElement json, Type typeOfT, JsonDeserializationContext context) {
+                    JsonObject jsonObject = json.getAsJsonObject();
+                    int value = jsonObject.get("bag").getAsInt();
+                    return new ClassWithCustomTypeConverter(
+                        new BagOfPrimitives(value, value, false, ""), value);
+                  }
+                })
+            .create();
     String json = "{\"bag\":5,\"value\":25}";
     ClassWithCustomTypeConverter target = gson.fromJson(json, ClassWithCustomTypeConverter.class);
     assertThat(target.getBag().getIntValue()).isEqualTo(5);
@@ -117,27 +129,38 @@ public class CustomTypeAdaptersTest {
 
   @Test
   public void testCustomNestedSerializers() {
-    Gson gson = new GsonBuilder().registerTypeAdapter(
-        BagOfPrimitives.class, new JsonSerializer<BagOfPrimitives>() {
-          @Override public JsonElement serialize(BagOfPrimitives src, Type typeOfSrc,
-          JsonSerializationContext context) {
-        return new JsonPrimitive(6);
-      }
-    }).create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                BagOfPrimitives.class,
+                new JsonSerializer<BagOfPrimitives>() {
+                  @Override
+                  public JsonElement serialize(
+                      BagOfPrimitives src, Type typeOfSrc, JsonSerializationContext context) {
+                    return new JsonPrimitive(6);
+                  }
+                })
+            .create();
     ClassWithCustomTypeConverter target = new ClassWithCustomTypeConverter();
     assertThat(gson.toJson(target)).isEqualTo("{\"bag\":6,\"value\":10}");
   }
 
   @Test
   public void testCustomNestedDeserializers() {
-    Gson gson = new GsonBuilder().registerTypeAdapter(
-        BagOfPrimitives.class, new JsonDeserializer<BagOfPrimitives>() {
-          @Override public BagOfPrimitives deserialize(JsonElement json, Type typeOfT,
-          JsonDeserializationContext context) throws JsonParseException {
-        int value = json.getAsInt();
-        return new BagOfPrimitives(value, value, false, "");
-      }
-    }).create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                BagOfPrimitives.class,
+                new JsonDeserializer<BagOfPrimitives>() {
+                  @Override
+                  public BagOfPrimitives deserialize(
+                      JsonElement json, Type typeOfT, JsonDeserializationContext context)
+                      throws JsonParseException {
+                    int value = json.getAsInt();
+                    return new BagOfPrimitives(value, value, false, "");
+                  }
+                })
+            .create();
     String json = "{\"bag\":7,\"value\":25}";
     ClassWithCustomTypeConverter target = gson.fromJson(json, ClassWithCustomTypeConverter.class);
     assertThat(target.getBag().getIntValue()).isEqualTo(7);
@@ -145,14 +168,20 @@ public class CustomTypeAdaptersTest {
 
   @Test
   public void testCustomTypeAdapterDoesNotAppliesToSubClasses() {
-    Gson gson = new GsonBuilder().registerTypeAdapter(Base.class, new JsonSerializer<Base> () {
-      @Override
-      public JsonElement serialize(Base src, Type typeOfSrc, JsonSerializationContext context) {
-        JsonObject json = new JsonObject();
-        json.addProperty("value", src.baseValue);
-        return json;
-      }
-    }).create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                Base.class,
+                new JsonSerializer<Base>() {
+                  @Override
+                  public JsonElement serialize(
+                      Base src, Type typeOfSrc, JsonSerializationContext context) {
+                    JsonObject json = new JsonObject();
+                    json.addProperty("value", src.baseValue);
+                    return json;
+                  }
+                })
+            .create();
     Base b = new Base();
     String json = gson.toJson(b);
     assertThat(json).contains("value");
@@ -163,14 +192,20 @@ public class CustomTypeAdaptersTest {
 
   @Test
   public void testCustomTypeAdapterAppliesToSubClassesSerializedAsBaseClass() {
-    Gson gson = new GsonBuilder().registerTypeAdapter(Base.class, new JsonSerializer<Base> () {
-      @Override
-      public JsonElement serialize(Base src, Type typeOfSrc, JsonSerializationContext context) {
-        JsonObject json = new JsonObject();
-        json.addProperty("value", src.baseValue);
-        return json;
-      }
-    }).create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                Base.class,
+                new JsonSerializer<Base>() {
+                  @Override
+                  public JsonElement serialize(
+                      Base src, Type typeOfSrc, JsonSerializationContext context) {
+                    JsonObject json = new JsonObject();
+                    json.addProperty("value", src.baseValue);
+                    return json;
+                  }
+                })
+            .create();
     Base b = new Base();
     String json = gson.toJson(b);
     assertThat(json).contains("value");
@@ -188,7 +223,6 @@ public class CustomTypeAdaptersTest {
     @SuppressWarnings("unused")
     int derivedValue = 3;
   }
-
 
   private Gson createGsonObjectWithFooTypeAdapter() {
     return new GsonBuilder().registerTypeAdapter(Foo.class, new FooTypeAdapter()).create();
@@ -223,43 +257,57 @@ public class CustomTypeAdaptersTest {
 
   @Test
   public void testCustomSerializerInvokedForPrimitives() {
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(boolean.class, new JsonSerializer<Boolean>() {
-          @Override public JsonElement serialize(Boolean s, Type t, JsonSerializationContext c) {
-            return new JsonPrimitive(s ? 1 : 0);
-          }
-        })
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                boolean.class,
+                new JsonSerializer<Boolean>() {
+                  @Override
+                  public JsonElement serialize(Boolean s, Type t, JsonSerializationContext c) {
+                    return new JsonPrimitive(s ? 1 : 0);
+                  }
+                })
+            .create();
     assertThat(gson.toJson(true, boolean.class)).isEqualTo("1");
     assertThat(gson.toJson(true, Boolean.class)).isEqualTo("true");
   }
 
   @Test
   public void testCustomDeserializerInvokedForPrimitives() {
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(boolean.class, new JsonDeserializer<Boolean>() {
-          @Override
-          public Boolean deserialize(JsonElement json, Type t, JsonDeserializationContext context) {
-            return json.getAsInt() != 0;
-          }
-        })
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                boolean.class,
+                new JsonDeserializer<Boolean>() {
+                  @Override
+                  public Boolean deserialize(
+                      JsonElement json, Type t, JsonDeserializationContext context) {
+                    return json.getAsInt() != 0;
+                  }
+                })
+            .create();
     assertThat(gson.fromJson("1", boolean.class)).isEqualTo(Boolean.TRUE);
     assertThat(gson.fromJson("true", Boolean.class)).isEqualTo(Boolean.TRUE);
   }
 
   @Test
   public void testCustomByteArraySerializer() {
-    Gson gson = new GsonBuilder().registerTypeAdapter(byte[].class, new JsonSerializer<byte[]>() {
-      @Override
-      public JsonElement serialize(byte[] src, Type typeOfSrc, JsonSerializationContext context) {
-        StringBuilder sb = new StringBuilder(src.length);
-        for (byte b : src) {
-          sb.append(b);
-        }
-        return new JsonPrimitive(sb.toString());
-      }
-    }).create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                byte[].class,
+                new JsonSerializer<byte[]>() {
+                  @Override
+                  public JsonElement serialize(
+                      byte[] src, Type typeOfSrc, JsonSerializationContext context) {
+                    StringBuilder sb = new StringBuilder(src.length);
+                    for (byte b : src) {
+                      sb.append(b);
+                    }
+                    return new JsonPrimitive(sb.toString());
+                  }
+                })
+            .create();
     byte[] data = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     String json = gson.toJson(data);
     assertThat(json).isEqualTo("\"0123456789\"");
@@ -267,18 +315,23 @@ public class CustomTypeAdaptersTest {
 
   @Test
   public void testCustomByteArrayDeserializerAndInstanceCreator() {
-    GsonBuilder gsonBuilder = new GsonBuilder().registerTypeAdapter(byte[].class,
-        new JsonDeserializer<byte[]>() {
-          @Override public byte[] deserialize(JsonElement json,
-              Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-        String str = json.getAsString();
-        byte[] data = new byte[str.length()];
-        for (int i = 0; i < data.length; ++i) {
-          data[i] = Byte.parseByte(""+str.charAt(i));
-        }
-        return data;
-      }
-    });
+    GsonBuilder gsonBuilder =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                byte[].class,
+                new JsonDeserializer<byte[]>() {
+                  @Override
+                  public byte[] deserialize(
+                      JsonElement json, Type typeOfT, JsonDeserializationContext context)
+                      throws JsonParseException {
+                    String str = json.getAsString();
+                    byte[] data = new byte[str.length()];
+                    for (int i = 0; i < data.length; ++i) {
+                      data[i] = Byte.parseByte("" + str.charAt(i));
+                    }
+                    return data;
+                  }
+                });
     Gson gson = gsonBuilder.create();
     String json = "'0123456789'";
     byte[] actual = gson.fromJson(json, byte[].class);
@@ -297,27 +350,33 @@ public class CustomTypeAdaptersTest {
       part1 = parts.get(0);
       part2 = parts.get(1);
     }
+
     public StringHolder(String part1, String part2) {
       this.part1 = part1;
       this.part2 = part2;
     }
   }
 
-  private static class StringHolderTypeAdapter implements JsonSerializer<StringHolder>,
-      JsonDeserializer<StringHolder>, InstanceCreator<StringHolder> {
+  private static class StringHolderTypeAdapter
+      implements JsonSerializer<StringHolder>,
+          JsonDeserializer<StringHolder>,
+          InstanceCreator<StringHolder> {
 
-    @Override public StringHolder createInstance(Type type) {
-      //Fill up with objects that will be thrown away
+    @Override
+    public StringHolder createInstance(Type type) {
+      // Fill up with objects that will be thrown away
       return new StringHolder("unknown:thing");
     }
 
-    @Override public StringHolder deserialize(JsonElement src, Type type,
-        JsonDeserializationContext context) {
+    @Override
+    public StringHolder deserialize(
+        JsonElement src, Type type, JsonDeserializationContext context) {
       return new StringHolder(src.getAsString());
     }
 
-    @Override public JsonElement serialize(StringHolder src, Type typeOfSrc,
-        JsonSerializationContext context) {
+    @Override
+    public JsonElement serialize(
+        StringHolder src, Type typeOfSrc, JsonSerializationContext context) {
       String contents = src.part1 + ':' + src.part2;
       return new JsonPrimitive(contents);
     }
@@ -326,9 +385,10 @@ public class CustomTypeAdaptersTest {
   // Test created from Issue 70
   @Test
   public void testCustomAdapterInvokedForCollectionElementSerializationWithType() {
-    Gson gson = new GsonBuilder()
-      .registerTypeAdapter(StringHolder.class, new StringHolderTypeAdapter())
-      .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(StringHolder.class, new StringHolderTypeAdapter())
+            .create();
     Type setType = new TypeToken<Set<StringHolder>>() {}.getType();
     StringHolder holder = new StringHolder("Jacob", "Tomaw");
     Set<StringHolder> setOfHolders = new HashSet<>();
@@ -340,9 +400,10 @@ public class CustomTypeAdaptersTest {
   // Test created from Issue 70
   @Test
   public void testCustomAdapterInvokedForCollectionElementSerialization() {
-    Gson gson = new GsonBuilder()
-      .registerTypeAdapter(StringHolder.class, new StringHolderTypeAdapter())
-      .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(StringHolder.class, new StringHolderTypeAdapter())
+            .create();
     StringHolder holder = new StringHolder("Jacob", "Tomaw");
     Set<StringHolder> setOfHolders = new HashSet<>();
     setOfHolders.add(holder);
@@ -353,9 +414,10 @@ public class CustomTypeAdaptersTest {
   // Test created from Issue 70
   @Test
   public void testCustomAdapterInvokedForCollectionElementDeserialization() {
-    Gson gson = new GsonBuilder()
-      .registerTypeAdapter(StringHolder.class, new StringHolderTypeAdapter())
-      .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(StringHolder.class, new StringHolderTypeAdapter())
+            .create();
     Type setType = new TypeToken<Set<StringHolder>>() {}.getType();
     Set<StringHolder> setOfHolders = gson.fromJson("['Jacob:Tomaw']", setType);
     assertThat(setOfHolders.size()).isEqualTo(1);
@@ -367,10 +429,11 @@ public class CustomTypeAdaptersTest {
   // Test created from Issue 70
   @Test
   public void testCustomAdapterInvokedForMapElementSerializationWithType() {
-    Gson gson = new GsonBuilder()
-      .registerTypeAdapter(StringHolder.class, new StringHolderTypeAdapter())
-      .create();
-    Type mapType = new TypeToken<Map<String,StringHolder>>() {}.getType();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(StringHolder.class, new StringHolderTypeAdapter())
+            .create();
+    Type mapType = new TypeToken<Map<String, StringHolder>>() {}.getType();
     StringHolder holder = new StringHolder("Jacob", "Tomaw");
     Map<String, StringHolder> mapOfHolders = new HashMap<>();
     mapOfHolders.put("foo", holder);
@@ -381,9 +444,10 @@ public class CustomTypeAdaptersTest {
   // Test created from Issue 70
   @Test
   public void testCustomAdapterInvokedForMapElementSerialization() {
-    Gson gson = new GsonBuilder()
-      .registerTypeAdapter(StringHolder.class, new StringHolderTypeAdapter())
-      .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(StringHolder.class, new StringHolderTypeAdapter())
+            .create();
     StringHolder holder = new StringHolder("Jacob", "Tomaw");
     Map<String, StringHolder> mapOfHolders = new HashMap<>();
     mapOfHolders.put("foo", holder);
@@ -394,9 +458,10 @@ public class CustomTypeAdaptersTest {
   // Test created from Issue 70
   @Test
   public void testCustomAdapterInvokedForMapElementDeserialization() {
-    Gson gson = new GsonBuilder()
-      .registerTypeAdapter(StringHolder.class, new StringHolderTypeAdapter())
-      .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(StringHolder.class, new StringHolderTypeAdapter())
+            .create();
     Type mapType = new TypeToken<Map<String, StringHolder>>() {}.getType();
     Map<String, StringHolder> mapOfFoo = gson.fromJson("{'foo':'Jacob:Tomaw'}", mapType);
     assertThat(mapOfFoo.size()).isEqualTo(1);
@@ -407,9 +472,10 @@ public class CustomTypeAdaptersTest {
 
   @Test
   public void testEnsureCustomSerializerNotInvokedForNullValues() {
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(DataHolder.class, new DataHolderSerializer())
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(DataHolder.class, new DataHolderSerializer())
+            .create();
     DataHolderWrapper target = new DataHolderWrapper(new DataHolder("abc"));
     String json = gson.toJson(target);
     assertThat(json).isEqualTo("{\"wrappedData\":{\"myData\":\"abc\"}}");
@@ -417,9 +483,10 @@ public class CustomTypeAdaptersTest {
 
   @Test
   public void testEnsureCustomDeserializerNotInvokedForNullValues() {
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(DataHolder.class, new DataHolderDeserializer())
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(DataHolder.class, new DataHolderDeserializer())
+            .create();
     String json = "{wrappedData:null}";
     DataHolderWrapper actual = gson.fromJson(json, DataHolderWrapper.class);
     assertThat(actual.wrappedData).isNull();
@@ -429,9 +496,8 @@ public class CustomTypeAdaptersTest {
   @Test
   @SuppressWarnings({"JavaUtilDate", "UndefinedEquals"})
   public void testRegisterHierarchyAdapterForDate() {
-    Gson gson = new GsonBuilder()
-        .registerTypeHierarchyAdapter(Date.class, new DateTypeAdapter())
-        .create();
+    Gson gson =
+        new GsonBuilder().registerTypeHierarchyAdapter(Date.class, new DateTypeAdapter()).create();
     assertThat(gson.toJson(new Date(0))).isEqualTo("0");
     assertThat(gson.toJson(new java.sql.Date(0))).isEqualTo("0");
     assertThat(gson.fromJson("0", Date.class)).isEqualTo(new Date(0));
@@ -465,7 +531,8 @@ public class CustomTypeAdaptersTest {
 
   private static class DataHolderDeserializer implements JsonDeserializer<DataHolder> {
     @Override
-    public DataHolder deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+    public DataHolder deserialize(
+        JsonElement json, Type typeOfT, JsonDeserializationContext context)
         throws JsonParseException {
       JsonObject jsonObj = json.getAsJsonObject();
       JsonElement jsonElement = jsonObj.get("data");
@@ -484,6 +551,7 @@ public class CustomTypeAdaptersTest {
           ? new Date(json.getAsLong())
           : new java.sql.Date(json.getAsLong());
     }
+
     @Override
     public JsonElement serialize(Date src, Type typeOfSrc, JsonSerializationContext context) {
       return new JsonPrimitive(src.getTime());

--- a/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
@@ -30,7 +30,6 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.TypeAdapter;
-import com.google.gson.internal.JavaVersion;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
@@ -95,8 +94,12 @@ public class DefaultTypeAdaptersTest {
       gson.toJson(String.class);
       fail();
     } catch (UnsupportedOperationException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Attempted to serialize java.lang.Class: java.lang.String. Forgot to register a type adapter?"
-          + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#java-lang-class-unsupported");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Attempted to serialize java.lang.Class: java.lang.String. Forgot to register a type"
+                  + " adapter?\n"
+                  + "See https://github.com/google/gson/blob/main/Troubleshooting.md#java-lang-class-unsupported");
     }
     // Override with a custom type adapter for class.
     gson = new GsonBuilder().registerTypeAdapter(Class.class, new MyClassTypeAdapter()).create();
@@ -109,8 +112,11 @@ public class DefaultTypeAdaptersTest {
       gson.fromJson("String.class", Class.class);
       fail();
     } catch (UnsupportedOperationException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Attempted to deserialize a java.lang.Class. Forgot to register a type adapter?"
-          + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#java-lang-class-unsupported");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Attempted to deserialize a java.lang.Class. Forgot to register a type adapter?\n"
+                  + "See https://github.com/google/gson/blob/main/Troubleshooting.md#java-lang-class-unsupported");
     }
     // Override with a custom type adapter for class.
     gson = new GsonBuilder().registerTypeAdapter(Class.class, new MyClassTypeAdapter()).create();
@@ -286,7 +292,8 @@ public class DefaultTypeAdaptersTest {
     try {
       gson.fromJson("{\"value\"=1.5e-1.0031}", ClassWithBigDecimal.class);
       fail("Exponent of a BigDecimal must be an integer value.");
-    } catch (JsonParseException expected) { }
+    } catch (JsonParseException expected) {
+    }
   }
 
   @Test
@@ -306,18 +313,20 @@ public class DefaultTypeAdaptersTest {
 
   @Test
   public void testOverrideBigIntegerTypeAdapter() throws Exception {
-    gson = new GsonBuilder()
-        .registerTypeAdapter(BigInteger.class, new NumberAsStringAdapter(BigInteger.class))
-        .create();
+    gson =
+        new GsonBuilder()
+            .registerTypeAdapter(BigInteger.class, new NumberAsStringAdapter(BigInteger.class))
+            .create();
     assertThat(gson.toJson(new BigInteger("123"), BigInteger.class)).isEqualTo("\"123\"");
     assertThat(gson.fromJson("\"123\"", BigInteger.class)).isEqualTo(new BigInteger("123"));
   }
 
   @Test
   public void testOverrideBigDecimalTypeAdapter() throws Exception {
-    gson = new GsonBuilder()
-        .registerTypeAdapter(BigDecimal.class, new NumberAsStringAdapter(BigDecimal.class))
-        .create();
+    gson =
+        new GsonBuilder()
+            .registerTypeAdapter(BigDecimal.class, new NumberAsStringAdapter(BigDecimal.class))
+            .create();
     assertThat(gson.toJson(new BigDecimal("1.1"), BigDecimal.class)).isEqualTo("\"1.1\"");
     assertThat(gson.fromJson("\"1.1\"", BigDecimal.class)).isEqualTo(new BigDecimal("1.1"));
   }
@@ -369,14 +378,18 @@ public class DefaultTypeAdaptersTest {
       gson.fromJson("[1, []]", BitSet.class);
       fail();
     } catch (JsonSyntaxException e) {
-      assertThat(e).hasMessageThat().isEqualTo("Invalid bitset value type: BEGIN_ARRAY; at path $[1]");
+      assertThat(e)
+          .hasMessageThat()
+          .isEqualTo("Invalid bitset value type: BEGIN_ARRAY; at path $[1]");
     }
 
     try {
       gson.fromJson("[1, 2]", BitSet.class);
       fail();
     } catch (JsonSyntaxException e) {
-      assertThat(e).hasMessageThat().isEqualTo("Invalid bitset value 2, expected 0 or 1; at path $[1]");
+      assertThat(e)
+          .hasMessageThat()
+          .isEqualTo("Invalid bitset value 2, expected 0 or 1; at path $[1]");
     }
   }
 
@@ -399,7 +412,7 @@ public class DefaultTypeAdaptersTest {
   // millisecond portion.
   @SuppressWarnings("deprecation")
   public static void assertEqualsDate(Date date, int year, int month, int day) {
-    assertThat(date.getYear()).isEqualTo(year-1900);
+    assertThat(date.getYear()).isEqualTo(year - 1900);
     assertThat(date.getMonth()).isEqualTo(month);
     assertThat(date.getDate()).isEqualTo(day);
   }
@@ -504,16 +517,20 @@ public class DefaultTypeAdaptersTest {
   @Test
   public void testDateSerializationWithPatternNotOverridenByTypeAdapter() {
     String pattern = "yyyy-MM-dd";
-    Gson gson = new GsonBuilder()
-        .setDateFormat(pattern)
-        .registerTypeAdapter(Date.class, new JsonDeserializer<Date>() {
-          @Override public Date deserialize(JsonElement json, Type typeOfT,
-              JsonDeserializationContext context)
-              throws JsonParseException {
-            return new Date(1315806903103L);
-          }
-        })
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .setDateFormat(pattern)
+            .registerTypeAdapter(
+                Date.class,
+                new JsonDeserializer<Date>() {
+                  @Override
+                  public Date deserialize(
+                      JsonElement json, Type typeOfT, JsonDeserializationContext context)
+                      throws JsonParseException {
+                    return new Date(1315806903103L);
+                  }
+                })
+            .create();
 
     Date now = new Date(1315806903103L);
     String json = gson.toJson(now);
@@ -533,7 +550,8 @@ public class DefaultTypeAdaptersTest {
       List<Date> dates = Arrays.asList(new Date(0));
       String json = gson.toJson(dates, listOfDates);
       assertThat(json).isEqualTo("[\"1970-01-01\"]");
-      assertThat(gson.<List<Date>>fromJson("[\"1970-01-01\"]", listOfDates).get(0).getTime()).isEqualTo(0L);
+      assertThat(gson.<List<Date>>fromJson("[\"1970-01-01\"]", listOfDates).get(0).getTime())
+          .isEqualTo(0L);
     } finally {
       TimeZone.setDefault(defaultTimeZone);
       Locale.setDefault(defaultLocale);
@@ -627,15 +645,21 @@ public class DefaultTypeAdaptersTest {
       gson.fromJson("\"abc\"", JsonObject.class);
       fail();
     } catch (JsonSyntaxException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected a com.google.gson.JsonObject but was com.google.gson.JsonPrimitive; at path $");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Expected a com.google.gson.JsonObject but was com.google.gson.JsonPrimitive; at path"
+                  + " $");
     }
   }
 
   private static class ClassWithBigDecimal {
     BigDecimal value;
+
     ClassWithBigDecimal(String value) {
       this.value = new BigDecimal(value);
     }
+
     String getExpectedJson() {
       return "{\"value\":" + value.toEngineeringString() + "}";
     }
@@ -643,9 +667,11 @@ public class DefaultTypeAdaptersTest {
 
   private static class ClassWithBigInteger {
     BigInteger value;
+
     ClassWithBigInteger(String value) {
       this.value = new BigInteger(value);
     }
+
     String getExpectedJson() {
       return "{\"value\":" + value + "}";
     }
@@ -716,6 +742,7 @@ public class DefaultTypeAdaptersTest {
     public void write(JsonWriter out, Class<?> value) throws IOException {
       out.value(value.getName());
     }
+
     @Override
     public Class<?> read(JsonReader in) throws IOException {
       String className = in.nextString();
@@ -729,13 +756,18 @@ public class DefaultTypeAdaptersTest {
 
   static class NumberAsStringAdapter extends TypeAdapter<Number> {
     private final Constructor<? extends Number> constructor;
+
     NumberAsStringAdapter(Class<? extends Number> type) throws Exception {
       this.constructor = type.getConstructor(String.class);
     }
-    @Override public void write(JsonWriter out, Number value) throws IOException {
+
+    @Override
+    public void write(JsonWriter out, Number value) throws IOException {
       out.value(value.toString());
     }
-    @Override public Number read(JsonReader in) throws IOException {
+
+    @Override
+    public Number read(JsonReader in) throws IOException {
       try {
         return constructor.newInstance(in.nextString());
       } catch (Exception e) {

--- a/gson/src/test/java/com/google/gson/functional/DelegateTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DelegateTypeAdapterTest.java
@@ -44,9 +44,7 @@ public class DelegateTypeAdapterTest {
   @Before
   public void setUp() throws Exception {
     stats = new StatsTypeAdapterFactory();
-    gson = new GsonBuilder()
-      .registerTypeAdapterFactory(stats)
-      .create();
+    gson = new GsonBuilder().registerTypeAdapterFactory(stats).create();
   }
 
   @Test
@@ -56,7 +54,7 @@ public class DelegateTypeAdapterTest {
       bags.add(new BagOfPrimitives(i, i, i % 2 == 0, String.valueOf(i)));
     }
     String json = gson.toJson(bags);
-    gson.fromJson(json, new TypeToken<List<BagOfPrimitives>>(){}.getType());
+    gson.fromJson(json, new TypeToken<List<BagOfPrimitives>>() {}.getType());
     // 11: 1 list object, and 10 entries. stats invoked on all 5 fields
     assertThat(stats.numReads).isEqualTo(51);
     assertThat(stats.numWrites).isEqualTo(51);
@@ -76,7 +74,8 @@ public class DelegateTypeAdapterTest {
     public int numReads = 0;
     public int numWrites = 0;
 
-    @Override public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
       final TypeAdapter<T> delegate = gson.getDelegateAdapter(this, type);
       return new TypeAdapter<T>() {
         @Override

--- a/gson/src/test/java/com/google/gson/functional/EnumTest.java
+++ b/gson/src/test/java/com/google/gson/functional/EnumTest.java
@@ -105,45 +105,51 @@ public class EnumTest {
   }
 
   private static enum MyEnum {
-    VALUE1, VALUE2
+    VALUE1,
+    VALUE2
   }
 
   private static class ClassWithEnumFields {
     private final MyEnum value1 = MyEnum.VALUE1;
     private final MyEnum value2 = MyEnum.VALUE2;
+
     public String getExpectedJson() {
       return "{\"value1\":\"" + value1 + "\",\"value2\":\"" + value2 + "\"}";
     }
   }
 
-  /**
-   * Test for issue 226.
-   */
+  /** Test for issue 226. */
   @Test
   @SuppressWarnings("GetClassOnEnum")
   public void testEnumSubclass() {
     assertThat(Roshambo.ROCK.getClass()).isNotEqualTo(Roshambo.class);
     assertThat(gson.toJson(Roshambo.ROCK)).isEqualTo("\"ROCK\"");
-    assertThat(gson.toJson(EnumSet.allOf(Roshambo.class))).isEqualTo("[\"ROCK\",\"PAPER\",\"SCISSORS\"]");
+    assertThat(gson.toJson(EnumSet.allOf(Roshambo.class)))
+        .isEqualTo("[\"ROCK\",\"PAPER\",\"SCISSORS\"]");
     assertThat(gson.fromJson("\"ROCK\"", Roshambo.class)).isEqualTo(Roshambo.ROCK);
-    assertThat(EnumSet.allOf(Roshambo.class)).isEqualTo(
-        gson.fromJson("[\"ROCK\",\"PAPER\",\"SCISSORS\"]", new TypeToken<Set<Roshambo>>() {}.getType())
-    );
+    assertThat(EnumSet.allOf(Roshambo.class))
+        .isEqualTo(
+            gson.fromJson(
+                "[\"ROCK\",\"PAPER\",\"SCISSORS\"]", new TypeToken<Set<Roshambo>>() {}.getType()));
   }
 
   @Test
   @SuppressWarnings("GetClassOnEnum")
   public void testEnumSubclassWithRegisteredTypeAdapter() {
-    gson = new GsonBuilder()
-        .registerTypeHierarchyAdapter(Roshambo.class, new MyEnumTypeAdapter())
-        .create();
+    gson =
+        new GsonBuilder()
+            .registerTypeHierarchyAdapter(Roshambo.class, new MyEnumTypeAdapter())
+            .create();
     assertThat(Roshambo.ROCK.getClass()).isNotEqualTo(Roshambo.class);
     assertThat(gson.toJson(Roshambo.ROCK)).isEqualTo("\"123ROCK\"");
-    assertThat(gson.toJson(EnumSet.allOf(Roshambo.class))).isEqualTo("[\"123ROCK\",\"123PAPER\",\"123SCISSORS\"]");
+    assertThat(gson.toJson(EnumSet.allOf(Roshambo.class)))
+        .isEqualTo("[\"123ROCK\",\"123PAPER\",\"123SCISSORS\"]");
     assertThat(gson.fromJson("\"123ROCK\"", Roshambo.class)).isEqualTo(Roshambo.ROCK);
-    assertThat(EnumSet.allOf(Roshambo.class)).isEqualTo(
-        gson.fromJson("[\"123ROCK\",\"123PAPER\",\"123SCISSORS\"]", new TypeToken<Set<Roshambo>>() {}.getType())
-    );
+    assertThat(EnumSet.allOf(Roshambo.class))
+        .isEqualTo(
+            gson.fromJson(
+                "[\"123ROCK\",\"123PAPER\",\"123SCISSORS\"]",
+                new TypeToken<Set<Roshambo>>() {}.getType()));
   }
 
   @Test
@@ -194,17 +200,20 @@ public class EnumTest {
 
   private enum Roshambo {
     ROCK {
-      @Override Roshambo defeats() {
+      @Override
+      Roshambo defeats() {
         return SCISSORS;
       }
     },
     PAPER {
-      @Override Roshambo defeats() {
+      @Override
+      Roshambo defeats() {
         return ROCK;
       }
     },
     SCISSORS {
-      @Override Roshambo defeats() {
+      @Override
+      Roshambo defeats() {
         return PAPER;
       }
     };
@@ -215,11 +224,13 @@ public class EnumTest {
 
   private static class MyEnumTypeAdapter
       implements JsonSerializer<Roshambo>, JsonDeserializer<Roshambo> {
-    @Override public JsonElement serialize(Roshambo src, Type typeOfSrc, JsonSerializationContext context) {
+    @Override
+    public JsonElement serialize(Roshambo src, Type typeOfSrc, JsonSerializationContext context) {
       return new JsonPrimitive("123" + src.name());
     }
 
-    @Override public Roshambo deserialize(JsonElement json, Type classOfT, JsonDeserializationContext context)
+    @Override
+    public Roshambo deserialize(JsonElement json, Type classOfT, JsonDeserializationContext context)
         throws JsonParseException {
       return Roshambo.valueOf(json.getAsString().substring(3));
     }
@@ -241,9 +252,12 @@ public class EnumTest {
   }
 
   private enum Color {
-    RED("red", 1), BLUE("blue", 2), GREEN("green", 3);
+    RED("red", 1),
+    BLUE("blue", 2),
+    GREEN("green", 3);
     final String value;
     final int index;
+
     private Color(String value, int index) {
       this.value = value;
       this.index = index;
@@ -269,14 +283,13 @@ public class EnumTest {
     }
   }
 
-  /**
-   * Test that enum constant names have higher precedence than {@code toString()}
-   * result.
-   */
+  /** Test that enum constant names have higher precedence than {@code toString()} result. */
   @Test
   public void testEnumToStringReadInterchanged() {
-    assertThat(gson.fromJson("\"A\"", InterchangedToString.class)).isEqualTo(InterchangedToString.A);
-    assertThat(gson.fromJson("\"B\"", InterchangedToString.class)).isEqualTo(InterchangedToString.B);
+    assertThat(gson.fromJson("\"A\"", InterchangedToString.class))
+        .isEqualTo(InterchangedToString.A);
+    assertThat(gson.fromJson("\"B\"", InterchangedToString.class))
+        .isEqualTo(InterchangedToString.B);
   }
 
   private enum InterchangedToString {

--- a/gson/src/test/java/com/google/gson/functional/EnumWithObfuscatedTest.java
+++ b/gson/src/test/java/com/google/gson/functional/EnumWithObfuscatedTest.java
@@ -47,7 +47,7 @@ public class EnumWithObfuscatedTest {
 
   @Test
   public void testEnumClassWithObfuscated() {
-    for (Gender enumConstant: Gender.class.getEnumConstants()) {
+    for (Gender enumConstant : Gender.class.getEnumConstants()) {
       try {
         Gender.class.getField(enumConstant.name());
         fail("Enum is not obfuscated");

--- a/gson/src/test/java/com/google/gson/functional/EscapingTest.java
+++ b/gson/src/test/java/com/google/gson/functional/EscapingTest.java
@@ -42,7 +42,7 @@ public class EscapingTest {
 
   @Test
   public void testEscapingQuotesInStringArray() {
-    String[] valueWithQuotes = { "beforeQuote\"afterQuote" };
+    String[] valueWithQuotes = {"beforeQuote\"afterQuote"};
     String jsonRepresentation = gson.toJson(valueWithQuotes);
     String[] target = gson.fromJson(jsonRepresentation, String[].class);
     assertThat(target.length).isEqualTo(1);
@@ -58,7 +58,8 @@ public class EscapingTest {
     strings.add("&");
     strings.add("'");
     strings.add("\"");
-    assertThat(gson.toJson(strings)).isEqualTo("[\"\\u003c\",\"\\u003e\",\"\\u003d\",\"\\u0026\",\"\\u0027\",\"\\\"\"]");
+    assertThat(gson.toJson(strings))
+        .isEqualTo("[\"\\u003c\",\"\\u003e\",\"\\u003d\",\"\\u0026\",\"\\u0027\",\"\\\"\"]");
   }
 
   @Test
@@ -72,19 +73,20 @@ public class EscapingTest {
     BagOfPrimitives expectedObject = gson.fromJson(jsonRepresentation, BagOfPrimitives.class);
     assertThat(objWithPrimitives.getExpectedJson()).isEqualTo(expectedObject.getExpectedJson());
   }
-  
+
   @Test
   public void testGsonAcceptsEscapedAndNonEscapedJsonDeserialization() {
     Gson escapeHtmlGson = new GsonBuilder().create();
     Gson noEscapeHtmlGson = new GsonBuilder().disableHtmlEscaping().create();
-    
+
     BagOfPrimitives target = new BagOfPrimitives(1L, 1, true, "test' / w'ith\" / \\ <script>");
     String escapedJsonForm = escapeHtmlGson.toJson(target);
     String nonEscapedJsonForm = noEscapeHtmlGson.toJson(target);
     assertThat(escapedJsonForm.equals(nonEscapedJsonForm)).isFalse();
-    
+
     assertThat(noEscapeHtmlGson.fromJson(escapedJsonForm, BagOfPrimitives.class)).isEqualTo(target);
-    assertThat(escapeHtmlGson.fromJson(nonEscapedJsonForm, BagOfPrimitives.class)).isEqualTo(target);
+    assertThat(escapeHtmlGson.fromJson(nonEscapedJsonForm, BagOfPrimitives.class))
+        .isEqualTo(target);
   }
 
   @Test

--- a/gson/src/test/java/com/google/gson/functional/ExclusionStrategyFunctionalTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ExclusionStrategyFunctionalTest.java
@@ -32,21 +32,25 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Performs some functional tests when Gson is instantiated with some common user defined
- * {@link ExclusionStrategy} objects.
+ * Performs some functional tests when Gson is instantiated with some common user defined {@link
+ * ExclusionStrategy} objects.
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
  */
 public class ExclusionStrategyFunctionalTest {
-  private static final ExclusionStrategy EXCLUDE_SAMPLE_OBJECT_FOR_TEST = new ExclusionStrategy() {
-    @Override public boolean shouldSkipField(FieldAttributes f) {
-      return false;
-    }
-    @Override public boolean shouldSkipClass(Class<?> clazz) {
-      return clazz == SampleObjectForTest.class;
-    }
-  };
+  private static final ExclusionStrategy EXCLUDE_SAMPLE_OBJECT_FOR_TEST =
+      new ExclusionStrategy() {
+        @Override
+        public boolean shouldSkipField(FieldAttributes f) {
+          return false;
+        }
+
+        @Override
+        public boolean shouldSkipClass(Class<?> clazz) {
+          return clazz == SampleObjectForTest.class;
+        }
+      };
 
   private SampleObjectForTest src;
 
@@ -101,9 +105,9 @@ public class ExclusionStrategyFunctionalTest {
 
   @Test
   public void testExclusionStrategyWithMode() {
-    SampleObjectForTest testObj = new SampleObjectForTest(
-        src.annotatedField + 5, src.stringField + "blah,blah",
-        src.longField + 655L);
+    SampleObjectForTest testObj =
+        new SampleObjectForTest(
+            src.annotatedField + 5, src.stringField + "blah,blah", src.longField + 655L);
 
     Gson gson = createGson(new MyExclusionStrategy(String.class), false);
     JsonObject json = gson.toJsonTree(testObj).getAsJsonObject();
@@ -121,17 +125,19 @@ public class ExclusionStrategyFunctionalTest {
 
   @Test
   public void testExcludeTopLevelClassSerialization() {
-    Gson gson = new GsonBuilder()
-        .addSerializationExclusionStrategy(EXCLUDE_SAMPLE_OBJECT_FOR_TEST)
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .addSerializationExclusionStrategy(EXCLUDE_SAMPLE_OBJECT_FOR_TEST)
+            .create();
     assertThat(gson.toJson(new SampleObjectForTest(), SampleObjectForTest.class)).isEqualTo("null");
   }
 
   @Test
   public void testExcludeTopLevelClassSerializationDoesNotImpactDeserialization() {
-    Gson gson = new GsonBuilder()
-        .addSerializationExclusionStrategy(EXCLUDE_SAMPLE_OBJECT_FOR_TEST)
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .addSerializationExclusionStrategy(EXCLUDE_SAMPLE_OBJECT_FOR_TEST)
+            .create();
     String json = "{\"annotatedField\":1,\"stringField\":\"x\",\"longField\":2}";
     SampleObjectForTest value = gson.fromJson(json, SampleObjectForTest.class);
     assertThat(value.annotatedField).isEqualTo(1);
@@ -141,9 +147,10 @@ public class ExclusionStrategyFunctionalTest {
 
   @Test
   public void testExcludeTopLevelClassDeserialization() {
-    Gson gson = new GsonBuilder()
-        .addDeserializationExclusionStrategy(EXCLUDE_SAMPLE_OBJECT_FOR_TEST)
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .addDeserializationExclusionStrategy(EXCLUDE_SAMPLE_OBJECT_FOR_TEST)
+            .create();
     String json = "{\"annotatedField\":1,\"stringField\":\"x\",\"longField\":2}";
     SampleObjectForTest value = gson.fromJson(json, SampleObjectForTest.class);
     assertThat(value).isNull();
@@ -151,9 +158,10 @@ public class ExclusionStrategyFunctionalTest {
 
   @Test
   public void testExcludeTopLevelClassDeserializationDoesNotImpactSerialization() {
-    Gson gson = new GsonBuilder()
-        .addDeserializationExclusionStrategy(EXCLUDE_SAMPLE_OBJECT_FOR_TEST)
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .addDeserializationExclusionStrategy(EXCLUDE_SAMPLE_OBJECT_FOR_TEST)
+            .create();
     String json = gson.toJson(new SampleObjectForTest(), SampleObjectForTest.class);
     assertThat(json).contains("\"stringField\"");
     assertThat(json).contains("\"annotatedField\"");
@@ -167,9 +175,7 @@ public class ExclusionStrategyFunctionalTest {
     } else {
       gsonBuilder.addDeserializationExclusionStrategy(exclusionStrategy);
     }
-    return gsonBuilder
-        .serializeNulls()
-        .create();
+    return gsonBuilder.serializeNulls().create();
   }
 
   @Retention(RetentionPolicy.RUNTIME)
@@ -179,8 +185,7 @@ public class ExclusionStrategyFunctionalTest {
   }
 
   private static class SampleObjectForTest {
-    @Foo
-    private final int annotatedField;
+    @Foo private final int annotatedField;
     private final String stringField;
     private final long longField;
 
@@ -202,11 +207,13 @@ public class ExclusionStrategyFunctionalTest {
       this.typeToSkip = typeToSkip;
     }
 
-    @Override public boolean shouldSkipClass(Class<?> clazz) {
+    @Override
+    public boolean shouldSkipClass(Class<?> clazz) {
       return (clazz == typeToSkip);
     }
 
-    @Override public boolean shouldSkipField(FieldAttributes f) {
+    @Override
+    public boolean shouldSkipField(FieldAttributes f) {
       return f.getAnnotation(Foo.class) != null;
     }
   }

--- a/gson/src/test/java/com/google/gson/functional/ExposeFieldsTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ExposeFieldsTest.java
@@ -38,10 +38,11 @@ public class ExposeFieldsTest {
 
   @Before
   public void setUp() throws Exception {
-    gson = new GsonBuilder()
-        .excludeFieldsWithoutExposeAnnotation()
-        .registerTypeAdapter(SomeInterface.class, new SomeInterfaceInstanceCreator())
-        .create();
+    gson =
+        new GsonBuilder()
+            .excludeFieldsWithoutExposeAnnotation()
+            .registerTypeAdapter(SomeInterface.class, new SomeInterfaceInstanceCreator())
+            .create();
   }
 
   @Test
@@ -57,7 +58,7 @@ public class ExposeFieldsTest {
     ClassWithExposedFields object1 = new ClassWithExposedFields(1, 1);
     ClassWithExposedFields object2 = new ClassWithExposedFields(null, 1);
     ClassWithExposedFields object3 = new ClassWithExposedFields(2, 2);
-    ClassWithExposedFields[] objects = { object1, object2, object3 };
+    ClassWithExposedFields[] objects = {object1, object2, object3};
 
     String json = gson.toJson(objects);
     String expected =
@@ -104,16 +105,16 @@ public class ExposeFieldsTest {
     assertThat(obj.a).isEqualTo(0);
     assertThat(obj.b).isEqualTo(1);
   }
-  
+
   @Test
   public void testExposedInterfaceFieldSerialization() {
     String expected = "{\"interfaceField\":{}}";
     ClassWithInterfaceField target = new ClassWithInterfaceField(new SomeObject());
     String actual = gson.toJson(target);
-    
+
     assertThat(actual).isEqualTo(expected);
   }
-  
+
   @Test
   public void testExposedInterfaceFieldDeserialization() {
     String json = "{\"interfaceField\":{}}";
@@ -125,11 +126,14 @@ public class ExposeFieldsTest {
   private static class ClassWithExposedFields {
     @Expose private final Integer a;
     private final Integer b;
+
     @Expose(serialize = false)
     @Keep
     final long c;
+
     @Expose(deserialize = false)
     final double d;
+
     @Expose(serialize = false, deserialize = false)
     @Keep
     final char e;
@@ -137,6 +141,7 @@ public class ExposeFieldsTest {
     public ClassWithExposedFields(Integer a, Integer b) {
       this(a, b, 1L, 2.0, 'a');
     }
+
     public ClassWithExposedFields(Integer a, Integer b, long c, double d, char e) {
       this.a = a;
       this.b = b;
@@ -160,27 +165,27 @@ public class ExposeFieldsTest {
     private final int a = 0;
     private final int b = 1;
   }
-  
+
   private static interface SomeInterface {
     // Empty interface
   }
-  
+
   private static class SomeObject implements SomeInterface {
     // Do nothing
   }
-  
+
   private static class SomeInterfaceInstanceCreator implements InstanceCreator<SomeInterface> {
-    @Override public SomeInterface createInstance(Type type) {
+    @Override
+    public SomeInterface createInstance(Type type) {
       return new SomeObject();
     }
   }
-  
+
   private static class ClassWithInterfaceField {
-    @Expose
-    private final SomeInterface interfaceField;
+    @Expose private final SomeInterface interfaceField;
 
     public ClassWithInterfaceField(SomeInterface interfaceField) {
       this.interfaceField = interfaceField;
     }
-  }  
+  }
 }

--- a/gson/src/test/java/com/google/gson/functional/FieldExclusionTest.java
+++ b/gson/src/test/java/com/google/gson/functional/FieldExclusionTest.java
@@ -82,11 +82,11 @@ public class FieldExclusionTest {
         super(value);
       }
     }
-
   }
 
   private static class NestedClass {
     private final String value;
+
     public NestedClass(String value) {
       this.value = value;
     }

--- a/gson/src/test/java/com/google/gson/functional/FieldNamingTest.java
+++ b/gson/src/test/java/com/google/gson/functional/FieldNamingTest.java
@@ -16,13 +16,13 @@
 
 package com.google.gson.functional;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.google.gson.FieldNamingPolicy.IDENTITY;
 import static com.google.gson.FieldNamingPolicy.LOWER_CASE_WITH_DASHES;
 import static com.google.gson.FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES;
 import static com.google.gson.FieldNamingPolicy.UPPER_CAMEL_CASE;
 import static com.google.gson.FieldNamingPolicy.UPPER_CAMEL_CASE_WITH_SPACES;
 import static com.google.gson.FieldNamingPolicy.UPPER_CASE_WITH_UNDERSCORES;
-import static com.google.common.truth.Truth.assertThat;
 
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
@@ -35,60 +35,64 @@ public final class FieldNamingTest {
   public void testIdentity() {
     Gson gson = getGsonWithNamingPolicy(IDENTITY);
     assertThat(gson.toJson(new TestNames()).replace('\"', '\''))
-        .isEqualTo("{'lowerCamel':1,'UpperCamel':2,'_lowerCamelLeadingUnderscore':3," +
-            "'_UpperCamelLeadingUnderscore':4,'lower_words':5,'UPPER_WORDS':6," +
-            "'annotatedName':7,'lowerId':8,'_9':9}");
+        .isEqualTo(
+            "{'lowerCamel':1,'UpperCamel':2,'_lowerCamelLeadingUnderscore':3,"
+                + "'_UpperCamelLeadingUnderscore':4,'lower_words':5,'UPPER_WORDS':6,"
+                + "'annotatedName':7,'lowerId':8,'_9':9}");
   }
 
   @Test
   public void testUpperCamelCase() {
     Gson gson = getGsonWithNamingPolicy(UPPER_CAMEL_CASE);
     assertThat(gson.toJson(new TestNames()).replace('\"', '\''))
-        .isEqualTo("{'LowerCamel':1,'UpperCamel':2,'_LowerCamelLeadingUnderscore':3," +
-            "'_UpperCamelLeadingUnderscore':4,'Lower_words':5,'UPPER_WORDS':6," +
-            "'annotatedName':7,'LowerId':8,'_9':9}");
+        .isEqualTo(
+            "{'LowerCamel':1,'UpperCamel':2,'_LowerCamelLeadingUnderscore':3,"
+                + "'_UpperCamelLeadingUnderscore':4,'Lower_words':5,'UPPER_WORDS':6,"
+                + "'annotatedName':7,'LowerId':8,'_9':9}");
   }
 
   @Test
   public void testUpperCamelCaseWithSpaces() {
     Gson gson = getGsonWithNamingPolicy(UPPER_CAMEL_CASE_WITH_SPACES);
     assertThat(gson.toJson(new TestNames()).replace('\"', '\''))
-        .isEqualTo("{'Lower Camel':1,'Upper Camel':2,'_Lower Camel Leading Underscore':3," +
-            "'_ Upper Camel Leading Underscore':4,'Lower_words':5,'U P P E R_ W O R D S':6," +
-            "'annotatedName':7,'Lower Id':8,'_9':9}");
+        .isEqualTo(
+            "{'Lower Camel':1,'Upper Camel':2,'_Lower Camel Leading Underscore':3,"
+                + "'_ Upper Camel Leading Underscore':4,'Lower_words':5,'U P P E R_ W O R D S':6,"
+                + "'annotatedName':7,'Lower Id':8,'_9':9}");
   }
 
   @Test
   public void testUpperCaseWithUnderscores() {
     Gson gson = getGsonWithNamingPolicy(UPPER_CASE_WITH_UNDERSCORES);
     assertThat(gson.toJson(new TestNames()).replace('\"', '\''))
-        .isEqualTo("{'LOWER_CAMEL':1,'UPPER_CAMEL':2,'_LOWER_CAMEL_LEADING_UNDERSCORE':3," +
-            "'__UPPER_CAMEL_LEADING_UNDERSCORE':4,'LOWER_WORDS':5,'U_P_P_E_R__W_O_R_D_S':6," +
-            "'annotatedName':7,'LOWER_ID':8,'_9':9}");
+        .isEqualTo(
+            "{'LOWER_CAMEL':1,'UPPER_CAMEL':2,'_LOWER_CAMEL_LEADING_UNDERSCORE':3,"
+                + "'__UPPER_CAMEL_LEADING_UNDERSCORE':4,'LOWER_WORDS':5,'U_P_P_E_R__W_O_R_D_S':6,"
+                + "'annotatedName':7,'LOWER_ID':8,'_9':9}");
   }
 
   @Test
   public void testLowerCaseWithUnderscores() {
     Gson gson = getGsonWithNamingPolicy(LOWER_CASE_WITH_UNDERSCORES);
     assertThat(gson.toJson(new TestNames()).replace('\"', '\''))
-        .isEqualTo("{'lower_camel':1,'upper_camel':2,'_lower_camel_leading_underscore':3," +
-            "'__upper_camel_leading_underscore':4,'lower_words':5,'u_p_p_e_r__w_o_r_d_s':6," +
-            "'annotatedName':7,'lower_id':8,'_9':9}");
+        .isEqualTo(
+            "{'lower_camel':1,'upper_camel':2,'_lower_camel_leading_underscore':3,"
+                + "'__upper_camel_leading_underscore':4,'lower_words':5,'u_p_p_e_r__w_o_r_d_s':6,"
+                + "'annotatedName':7,'lower_id':8,'_9':9}");
   }
 
   @Test
   public void testLowerCaseWithDashes() {
     Gson gson = getGsonWithNamingPolicy(LOWER_CASE_WITH_DASHES);
     assertThat(gson.toJson(new TestNames()).replace('\"', '\''))
-        .isEqualTo("{'lower-camel':1,'upper-camel':2,'_lower-camel-leading-underscore':3," +
-            "'_-upper-camel-leading-underscore':4,'lower_words':5,'u-p-p-e-r_-w-o-r-d-s':6," +
-            "'annotatedName':7,'lower-id':8,'_9':9}");
+        .isEqualTo(
+            "{'lower-camel':1,'upper-camel':2,'_lower-camel-leading-underscore':3,"
+                + "'_-upper-camel-leading-underscore':4,'lower_words':5,'u-p-p-e-r_-w-o-r-d-s':6,"
+                + "'annotatedName':7,'lower-id':8,'_9':9}");
   }
 
-  private Gson getGsonWithNamingPolicy(FieldNamingPolicy fieldNamingPolicy){
-    return new GsonBuilder()
-      .setFieldNamingPolicy(fieldNamingPolicy)
-        .create();
+  private Gson getGsonWithNamingPolicy(FieldNamingPolicy fieldNamingPolicy) {
+    return new GsonBuilder().setFieldNamingPolicy(fieldNamingPolicy).create();
   }
 
   @SuppressWarnings("unused") // fields are used reflectively
@@ -99,7 +103,10 @@ public final class FieldNamingTest {
     int _UpperCamelLeadingUnderscore = 4;
     int lower_words = 5;
     int UPPER_WORDS = 6;
-    @SerializedName("annotatedName") int annotated = 7;
+
+    @SerializedName("annotatedName")
+    int annotated = 7;
+
     int lowerId = 8;
     int _9 = 9;
   }

--- a/gson/src/test/java/com/google/gson/functional/FormattingStyleTest.java
+++ b/gson/src/test/java/com/google/gson/functional/FormattingStyleTest.java
@@ -46,9 +46,12 @@ public class FormattingStyleTest {
   }
 
   private static String buildExpected(String newline, String indent, boolean spaceAfterSeparators) {
-    String expected = "{<EOL><INDENT>\"a\":<COLON_SPACE>[<EOL><INDENT><INDENT>1,<COMMA_SPACE><EOL><INDENT><INDENT>2<EOL><INDENT>]<EOL>}";
+    String expected =
+        "{<EOL><INDENT>\"a\":<COLON_SPACE>[<EOL><INDENT><INDENT>1,<COMMA_SPACE><EOL><INDENT><INDENT>2<EOL><INDENT>]<EOL>}";
     String commaSpace = spaceAfterSeparators && newline.isEmpty() ? " " : "";
-    return expected.replace("<EOL>", newline).replace("<INDENT>", indent)
+    return expected
+        .replace("<EOL>", newline)
+        .replace("<INDENT>", indent)
         .replace("<COLON_SPACE>", spaceAfterSeparators ? " " : "")
         .replace("<COMMA_SPACE>", commaSpace);
   }
@@ -57,9 +60,7 @@ public class FormattingStyleTest {
   private static final String[] TEST_NEWLINES = {
     "", "\r", "\n", "\r\n", "\n\r\r\n", System.lineSeparator()
   };
-  private static final String[] TEST_INDENTS = {
-    "", "  ", "    ", "\t", " \t \t"
-  };
+  private static final String[] TEST_INDENTS = {"", "  ", "    ", "\t", " \t \t"};
 
   @Test
   public void testDefault() {
@@ -72,7 +73,8 @@ public class FormattingStyleTest {
   public void testVariousCombinationsParse() {
     // Mixing various indent and newline styles in the same string, to be parsed.
     String jsonStringMix = "{\r\t'a':\r\n[        1,2\t]\n}";
-    TypeToken<Map<String, List<Integer>>> inputType = new TypeToken<Map<String, List<Integer>>>() {};
+    TypeToken<Map<String, List<Integer>>> inputType =
+        new TypeToken<Map<String, List<Integer>>>() {};
 
     Map<String, List<Integer>> actualParsed;
     // Test all that all combinations of newline can be parsed and generate the same INPUT.
@@ -111,13 +113,7 @@ public class FormattingStyleTest {
     String expectedJson = buildExpected("\n", "  ", true);
     assertThat(json).isEqualTo(expectedJson);
     // Sanity check to verify that `buildExpected` works correctly
-    assertThat(json).isEqualTo(
-        "{\n"
-        + "  \"a\": [\n"
-        + "    1,\n"
-        + "    2\n"
-        + "  ]\n"
-        + "}");
+    assertThat(json).isEqualTo("{\n" + "  \"a\": [\n" + "    1,\n" + "    2\n" + "  ]\n" + "}");
   }
 
   @Test
@@ -135,8 +131,11 @@ public class FormattingStyleTest {
     for (String newline : TEST_NEWLINES) {
       for (String indent : TEST_INDENTS) {
         for (boolean spaceAfterSeparators : new boolean[] {true, false}) {
-          FormattingStyle style = FormattingStyle.COMPACT.withNewline(newline)
-              .withIndent(indent).withSpaceAfterSeparators(spaceAfterSeparators);
+          FormattingStyle style =
+              FormattingStyle.COMPACT
+                  .withNewline(newline)
+                  .withIndent(indent)
+                  .withSpaceAfterSeparators(spaceAfterSeparators);
 
           String json = toJson(createInput(), style);
           String expectedJson = buildExpected(newline, indent, spaceAfterSeparators);
@@ -152,8 +151,8 @@ public class FormattingStyleTest {
    */
   @Test
   public void testCompactToPretty() {
-    FormattingStyle style = FormattingStyle.COMPACT.withNewline("\n").withIndent("  ")
-        .withSpaceAfterSeparators(true);
+    FormattingStyle style =
+        FormattingStyle.COMPACT.withNewline("\n").withIndent("  ").withSpaceAfterSeparators(true);
 
     String json = toJson(createInput(), style);
     String expectedJson = toJson(createInput(), FormattingStyle.PRETTY);
@@ -166,8 +165,8 @@ public class FormattingStyleTest {
    */
   @Test
   public void testPrettyToCompact() {
-    FormattingStyle style = FormattingStyle.PRETTY.withNewline("").withIndent("")
-        .withSpaceAfterSeparators(false);
+    FormattingStyle style =
+        FormattingStyle.PRETTY.withNewline("").withIndent("").withSpaceAfterSeparators(false);
 
     String json = toJson(createInput(), style);
     String expectedJson = toJson(createInput(), FormattingStyle.COMPACT);
@@ -182,7 +181,8 @@ public class FormattingStyleTest {
       FormattingStyle.PRETTY.withNewline("\u2028");
       fail("Gson should not accept anything but \\r and \\n for newline");
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat()
+      assertThat(expected)
+          .hasMessageThat()
           .isEqualTo("Only combinations of \\n and \\r are allowed in newline.");
     }
 
@@ -190,7 +190,8 @@ public class FormattingStyleTest {
       FormattingStyle.PRETTY.withNewline("NL");
       fail("Gson should not accept anything but \\r and \\n for newline");
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat()
+      assertThat(expected)
+          .hasMessageThat()
           .isEqualTo("Only combinations of \\n and \\r are allowed in newline.");
     }
 
@@ -198,7 +199,8 @@ public class FormattingStyleTest {
       FormattingStyle.PRETTY.withIndent("\f");
       fail("Gson should not accept anything but space and tab for indent");
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat()
+      assertThat(expected)
+          .hasMessageThat()
           .isEqualTo("Only combinations of spaces and tabs are allowed in indent.");
     }
   }

--- a/gson/src/test/java/com/google/gson/functional/GsonVersionDiagnosticsTest.java
+++ b/gson/src/test/java/com/google/gson/functional/GsonVersionDiagnosticsTest.java
@@ -41,14 +41,22 @@ public class GsonVersionDiagnosticsTest {
 
   @Before
   public void setUp() {
-    gson = new GsonBuilder().registerTypeAdapter(TestType.class, new TypeAdapter<TestType>() {
-      @Override public void write(JsonWriter out, TestType value) {
-        throw new AssertionError("Expected during serialization");
-      }
-      @Override public TestType read(JsonReader in) {
-        throw new AssertionError("Expected during deserialization");
-      }
-    }).create();
+    gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                TestType.class,
+                new TypeAdapter<TestType>() {
+                  @Override
+                  public void write(JsonWriter out, TestType value) {
+                    throw new AssertionError("Expected during serialization");
+                  }
+
+                  @Override
+                  public TestType read(JsonReader in) {
+                    throw new AssertionError("Expected during deserialization");
+                  }
+                })
+            .create();
   }
 
   @Test
@@ -65,8 +73,8 @@ public class GsonVersionDiagnosticsTest {
 
   @Test
   public void testAssertionErrorInDeserializationPrintsVersion() {
-    AssertionError e = assertThrows(AssertionError.class,
-        () -> gson.fromJson("{'a':'abc'}", TestType.class));
+    AssertionError e =
+        assertThrows(AssertionError.class, () -> gson.fromJson("{'a':'abc'}", TestType.class));
 
     ensureAssertionErrorPrintsGsonVersion(e);
   }

--- a/gson/src/test/java/com/google/gson/functional/InheritanceTest.java
+++ b/gson/src/test/java/com/google/gson/functional/InheritanceTest.java
@@ -41,8 +41,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Functional tests for Json serialization and deserialization of classes with
- * inheritance hierarchies.
+ * Functional tests for Json serialization and deserialization of classes with inheritance
+ * hierarchies.
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
@@ -57,17 +57,20 @@ public class InheritanceTest {
 
   @Test
   public void testSubClassSerialization() {
-    SubTypeOfNested target = new SubTypeOfNested(new BagOfPrimitives(10, 20, false, "stringValue"),
-        new BagOfPrimitives(30, 40, true, "stringValue"));
+    SubTypeOfNested target =
+        new SubTypeOfNested(
+            new BagOfPrimitives(10, 20, false, "stringValue"),
+            new BagOfPrimitives(30, 40, true, "stringValue"));
     assertThat(gson.toJson(target)).isEqualTo(target.getExpectedJson());
   }
 
   @Test
   public void testSubClassDeserialization() {
-    String json = "{\"value\":5,\"primitive1\":{\"longValue\":10,\"intValue\":20,"
-        + "\"booleanValue\":false,\"stringValue\":\"stringValue\"},\"primitive2\":"
-        + "{\"longValue\":30,\"intValue\":40,\"booleanValue\":true,"
-        + "\"stringValue\":\"stringValue\"}}";
+    String json =
+        "{\"value\":5,\"primitive1\":{\"longValue\":10,\"intValue\":20,"
+            + "\"booleanValue\":false,\"stringValue\":\"stringValue\"},\"primitive2\":"
+            + "{\"longValue\":30,\"intValue\":40,\"booleanValue\":true,"
+            + "\"stringValue\":\"stringValue\"}}";
     SubTypeOfNested target = gson.fromJson(json, SubTypeOfNested.class);
     assertThat(target.getExpectedJson()).isEqualTo(json);
   }
@@ -82,12 +85,13 @@ public class InheritanceTest {
 
   @Test
   public void testClassWithBaseArrayFieldSerialization() {
-    Base[] baseClasses = new Base[]{ new Sub(), new Sub()};
+    Base[] baseClasses = new Base[] {new Sub(), new Sub()};
     ClassWithBaseArrayField sub = new ClassWithBaseArrayField(baseClasses);
     JsonObject json = gson.toJsonTree(sub).getAsJsonObject();
     JsonArray bases = json.get(ClassWithBaseArrayField.FIELD_KEY).getAsJsonArray();
     for (JsonElement element : bases) {
-      assertThat(element.getAsJsonObject().get(Sub.SUB_FIELD_KEY).getAsString()).isEqualTo(Sub.SUB_NAME);
+      assertThat(element.getAsJsonObject().get(Sub.SUB_FIELD_KEY).getAsString())
+          .isEqualTo(Sub.SUB_NAME);
     }
   }
 
@@ -100,7 +104,8 @@ public class InheritanceTest {
     JsonObject json = gson.toJsonTree(sub).getAsJsonObject();
     JsonArray bases = json.get(ClassWithBaseArrayField.FIELD_KEY).getAsJsonArray();
     for (JsonElement element : bases) {
-      assertThat(element.getAsJsonObject().get(Sub.SUB_FIELD_KEY).getAsString()).isEqualTo(Sub.SUB_NAME);
+      assertThat(element.getAsJsonObject().get(Sub.SUB_FIELD_KEY).getAsString())
+          .isEqualTo(Sub.SUB_NAME);
     }
   }
 
@@ -192,11 +197,12 @@ public class InheritanceTest {
 
   @Test
   public void testSubInterfacesOfCollectionDeserialization() {
-    String json = "{\"list\":[0,1,2,3],\"queue\":[0,1,2,3],\"set\":[0.1,0.2,0.3,0.4],"
-        + "\"sortedSet\":[\"a\",\"b\",\"c\",\"d\"]"
-        + "}";
+    String json =
+        "{\"list\":[0,1,2,3],\"queue\":[0,1,2,3],\"set\":[0.1,0.2,0.3,0.4],"
+            + "\"sortedSet\":[\"a\",\"b\",\"c\",\"d\"]"
+            + "}";
     ClassWithSubInterfacesOfCollection target =
-      gson.fromJson(json, ClassWithSubInterfacesOfCollection.class);
+        gson.fromJson(json, ClassWithSubInterfacesOfCollection.class);
     assertThat(target.listContains(0, 1, 2, 3)).isTrue();
     assertThat(target.queueContains(0, 1, 2, 3)).isTrue();
     assertThat(target.setContains(0.1F, 0.2F, 0.3F, 0.4F)).isTrue();
@@ -209,8 +215,8 @@ public class InheritanceTest {
     private Set<Float> set;
     private SortedSet<Character> sortedSet;
 
-    public ClassWithSubInterfacesOfCollection(List<Integer> list, Queue<Long> queue, Set<Float> set,
-        SortedSet<Character> sortedSet) {
+    public ClassWithSubInterfacesOfCollection(
+        List<Integer> list, Queue<Long> queue, Set<Float> set, SortedSet<Character> sortedSet) {
       this.list = list;
       this.queue = queue;
       this.set = set;

--- a/gson/src/test/java/com/google/gson/functional/InstanceCreatorTest.java
+++ b/gson/src/test/java/com/google/gson/functional/InstanceCreatorTest.java
@@ -33,8 +33,8 @@ import java.util.TreeSet;
 import org.junit.Test;
 
 /**
- * Functional Test exercising custom deserialization only. When test applies to both
- * serialization and deserialization then add it to CustomTypeAdapterTest.
+ * Functional Test exercising custom deserialization only. When test applies to both serialization
+ * and deserialization then add it to CustomTypeAdapterTest.
  *
  * @author Inderjeet Singh
  */
@@ -42,13 +42,17 @@ public class InstanceCreatorTest {
 
   @Test
   public void testInstanceCreatorReturnsBaseType() {
-    Gson gson = new GsonBuilder()
-      .registerTypeAdapter(Base.class, new InstanceCreator<Base>() {
-        @Override public Base createInstance(Type type) {
-         return new Base();
-       }
-      })
-      .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                Base.class,
+                new InstanceCreator<Base>() {
+                  @Override
+                  public Base createInstance(Type type) {
+                    return new Base();
+                  }
+                })
+            .create();
     String json = "{baseName:'BaseRevised',subName:'Sub'}";
     Base base = gson.fromJson(json, Base.class);
     assertThat(base.baseName).isEqualTo("BaseRevised");
@@ -56,13 +60,17 @@ public class InstanceCreatorTest {
 
   @Test
   public void testInstanceCreatorReturnsSubTypeForTopLevelObject() {
-    Gson gson = new GsonBuilder()
-    .registerTypeAdapter(Base.class, new InstanceCreator<Base>() {
-      @Override public Base createInstance(Type type) {
-        return new Sub();
-      }
-    })
-    .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                Base.class,
+                new InstanceCreator<Base>() {
+                  @Override
+                  public Base createInstance(Type type) {
+                    return new Sub();
+                  }
+                })
+            .create();
 
     String json = "{baseName:'Base',subName:'SubRevised'}";
     Base base = gson.fromJson(json, Base.class);
@@ -75,17 +83,21 @@ public class InstanceCreatorTest {
 
   @Test
   public void testInstanceCreatorReturnsSubTypeForField() {
-    Gson gson = new GsonBuilder()
-    .registerTypeAdapter(Base.class, new InstanceCreator<Base>() {
-      @Override public Base createInstance(Type type) {
-        return new Sub();
-      }
-    })
-    .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                Base.class,
+                new InstanceCreator<Base>() {
+                  @Override
+                  public Base createInstance(Type type) {
+                    return new Sub();
+                  }
+                })
+            .create();
     String json = "{base:{baseName:'Base',subName:'SubRevised'}}";
     ClassWithBaseField target = gson.fromJson(json, ClassWithBaseField.class);
     assertThat(target.base instanceof Sub).isTrue();
-    assertThat(((Sub)target.base).subName).isEqualTo(Sub.SUB_NAME);
+    assertThat(((Sub) target.base).subName).isEqualTo(Sub.SUB_NAME);
   }
 
   // This regressed in Gson 2.0 and 2.1
@@ -93,15 +105,15 @@ public class InstanceCreatorTest {
   public void testInstanceCreatorForCollectionType() {
     @SuppressWarnings("serial")
     class SubArrayList<T> extends ArrayList<T> {}
-    InstanceCreator<List<String>> listCreator = new InstanceCreator<List<String>>() {
-      @Override public List<String> createInstance(Type type) {
-        return new SubArrayList<>();
-      }
-    };
+    InstanceCreator<List<String>> listCreator =
+        new InstanceCreator<List<String>>() {
+          @Override
+          public List<String> createInstance(Type type) {
+            return new SubArrayList<>();
+          }
+        };
     Type listOfStringType = new TypeToken<List<String>>() {}.getType();
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(listOfStringType, listCreator)
-        .create();
+    Gson gson = new GsonBuilder().registerTypeAdapter(listOfStringType, listCreator).create();
     List<String> list = gson.fromJson("[\"a\"]", listOfStringType);
     assertThat(list.getClass()).isEqualTo(SubArrayList.class);
   }
@@ -111,14 +123,14 @@ public class InstanceCreatorTest {
   public void testInstanceCreatorForParametrizedType() {
     @SuppressWarnings("serial")
     class SubTreeSet<T> extends TreeSet<T> {}
-    InstanceCreator<SortedSet<?>> sortedSetCreator = new InstanceCreator<SortedSet<?>>() {
-      @Override public SortedSet<?> createInstance(Type type) {
-        return new SubTreeSet<>();
-      }
-    };
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(SortedSet.class, sortedSetCreator)
-        .create();
+    InstanceCreator<SortedSet<?>> sortedSetCreator =
+        new InstanceCreator<SortedSet<?>>() {
+          @Override
+          public SortedSet<?> createInstance(Type type) {
+            return new SubTreeSet<>();
+          }
+        };
+    Gson gson = new GsonBuilder().registerTypeAdapter(SortedSet.class, sortedSetCreator).create();
 
     Type sortedSetType = new TypeToken<SortedSet<String>>() {}.getType();
     SortedSet<String> set = gson.fromJson("[\"a\"]", sortedSetType);

--- a/gson/src/test/java/com/google/gson/functional/InterfaceTest.java
+++ b/gson/src/test/java/com/google/gson/functional/InterfaceTest.java
@@ -44,7 +44,7 @@ public class InterfaceTest {
   public void testSerializingObjectImplementingInterface() {
     assertThat(gson.toJson(obj)).isEqualTo(OBJ_JSON);
   }
-  
+
   @Test
   public void testSerializingInterfaceObjectField() {
     TestObjectWrapper objWrapper = new TestObjectWrapper(obj);
@@ -54,11 +54,11 @@ public class InterfaceTest {
   private static interface TestObjectInterface {
     // Holder
   }
-  
+
   private static class TestObject implements TestObjectInterface {
     @SuppressWarnings("unused")
     private String someStringValue;
-    
+
     private TestObject(String value) {
       this.someStringValue = value;
     }
@@ -67,7 +67,7 @@ public class InterfaceTest {
   private static class TestObjectWrapper {
     @SuppressWarnings("unused")
     private TestObjectInterface obj;
-    
+
     private TestObjectWrapper(TestObjectInterface obj) {
       this.obj = obj;
     }

--- a/gson/src/test/java/com/google/gson/functional/Java17RecordTest.java
+++ b/gson/src/test/java/com/google/gson/functional/Java17RecordTest.java
@@ -60,21 +60,31 @@ public final class Java17RecordTest {
     assertThat(gson.fromJson("{'name':'v1'}", RecordWithCustomNames.class).a).isEqualTo("v1");
 
     // Both name1 and name2 gets deserialized to b
-    assertThat(gson.fromJson("{'name': 'v1', 'name1':'v11'}", RecordWithCustomNames.class).b).isEqualTo("v11");
-    assertThat(gson.fromJson("{'name': 'v1', 'name2':'v2'}", RecordWithCustomNames.class).b).isEqualTo("v2");
-    assertThat(gson.fromJson("{'name': 'v1', 'name3':'v3'}", RecordWithCustomNames.class).b).isEqualTo("v3");
+    assertThat(gson.fromJson("{'name': 'v1', 'name1':'v11'}", RecordWithCustomNames.class).b)
+        .isEqualTo("v11");
+    assertThat(gson.fromJson("{'name': 'v1', 'name2':'v2'}", RecordWithCustomNames.class).b)
+        .isEqualTo("v2");
+    assertThat(gson.fromJson("{'name': 'v1', 'name3':'v3'}", RecordWithCustomNames.class).b)
+        .isEqualTo("v3");
   }
 
   @Test
   public void testMultipleNamesInTheSameString() {
     // The last value takes precedence
-    assertThat(gson.fromJson("{'name': 'foo', 'name1':'v1','name2':'v2','name3':'v3'}", RecordWithCustomNames.class).b)
+    assertThat(
+            gson.fromJson(
+                    "{'name': 'foo', 'name1':'v1','name2':'v2','name3':'v3'}",
+                    RecordWithCustomNames.class)
+                .b)
         .isEqualTo("v3");
   }
 
   private record RecordWithCustomNames(
       @SerializedName("name") String a,
-      @SerializedName(value = "name1", alternate = {"name2", "name3"}) String b) {}
+      @SerializedName(
+              value = "name1",
+              alternate = {"name2", "name3"})
+          String b) {}
 
   @Test
   public void testSerializedNameOnAccessor() {
@@ -87,17 +97,17 @@ public final class Java17RecordTest {
     }
 
     var exception = assertThrows(JsonIOException.class, () -> gson.getAdapter(LocalRecord.class));
-    assertThat(exception).hasMessageThat()
-        .isEqualTo("@SerializedName on method '" + LocalRecord.class.getName() + "#i()' is not supported");
+    assertThat(exception)
+        .hasMessageThat()
+        .isEqualTo(
+            "@SerializedName on method '" + LocalRecord.class.getName() + "#i()' is not supported");
   }
 
   @Test
   public void testFieldNamingStrategy() {
     record LocalRecord(int i) {}
 
-    Gson gson = new GsonBuilder()
-        .setFieldNamingStrategy(f -> f.getName() + "-custom")
-        .create();
+    Gson gson = new GsonBuilder().setFieldNamingStrategy(f -> f.getName() + "-custom").create();
 
     assertThat(gson.toJson(new LocalRecord(1))).isEqualTo("{\"i-custom\":1}");
     assertThat(gson.fromJson("{\"i-custom\":2}", LocalRecord.class)).isEqualTo(new LocalRecord(2));
@@ -152,8 +162,12 @@ public final class Java17RecordTest {
     }
     // TODO: Adjust this once Gson throws more specific exception type
     catch (RuntimeException e) {
-      assertThat(e).hasMessageThat()
-          .isEqualTo("Failed to invoke constructor '" + LocalRecord.class.getName() + "(String)' with args [value]");
+      assertThat(e)
+          .hasMessageThat()
+          .isEqualTo(
+              "Failed to invoke constructor '"
+                  + LocalRecord.class.getName()
+                  + "(String)' with args [value]");
       assertThat(e).hasCauseThat().isSameInstanceAs(LocalRecord.thrownException);
     }
   }
@@ -187,7 +201,8 @@ public final class Java17RecordTest {
       gson.toJson(new LocalRecord("a"));
       fail();
     } catch (JsonIOException e) {
-      assertThat(e).hasMessageThat()
+      assertThat(e)
+          .hasMessageThat()
           .isEqualTo("Accessor method '" + LocalRecord.class.getName() + "#s()' threw exception");
       assertThat(e).hasCauseThat().isSameInstanceAs(LocalRecord.thrownException);
     }
@@ -203,8 +218,8 @@ public final class Java17RecordTest {
   }
 
   /**
-   * Tests behavior when {@code null} is serialized / deserialized as record value;
-   * basically makes sure the adapter is 'null-safe'
+   * Tests behavior when {@code null} is serialized / deserialized as record value; basically makes
+   * sure the adapter is 'null-safe'
    */
   @Test
   public void testRecordNull() throws IOException {
@@ -217,46 +232,68 @@ public final class Java17RecordTest {
 
   @Test
   public void testPrimitiveDefaultValues() {
-    RecordWithPrimitives expected = new RecordWithPrimitives("s", (byte) 0, (short) 0, 0, 0, 0, 0, '\0', false);
+    RecordWithPrimitives expected =
+        new RecordWithPrimitives("s", (byte) 0, (short) 0, 0, 0, 0, 0, '\0', false);
     assertThat(gson.fromJson("{'aString': 's'}", RecordWithPrimitives.class)).isEqualTo(expected);
   }
 
   @Test
   public void testPrimitiveJsonNullValue() {
     String s = "{'aString': 's', 'aByte': null, 'aShort': 0}";
-    var e = assertThrows(JsonParseException.class, () -> gson.fromJson(s, RecordWithPrimitives.class));
-    assertThat(e).hasMessageThat()
-        .isEqualTo("null is not allowed as value for record component 'aByte' of primitive type; at path $.aByte");
+    var e =
+        assertThrows(JsonParseException.class, () -> gson.fromJson(s, RecordWithPrimitives.class));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "null is not allowed as value for record component 'aByte' of primitive type; at path"
+                + " $.aByte");
   }
 
   /**
-   * Tests behavior when JSON contains non-null value, but custom adapter returns null
-   * for primitive component
+   * Tests behavior when JSON contains non-null value, but custom adapter returns null for primitive
+   * component
    */
   @Test
   public void testPrimitiveAdapterNullValue() {
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(byte.class, new TypeAdapter<Byte>() {
-          @Override public Byte read(JsonReader in) throws IOException {
-            in.skipValue();
-            // Always return null
-            return null;
-          }
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                byte.class,
+                new TypeAdapter<Byte>() {
+                  @Override
+                  public Byte read(JsonReader in) throws IOException {
+                    in.skipValue();
+                    // Always return null
+                    return null;
+                  }
 
-          @Override public void write(JsonWriter out, Byte value) {
-            throw new AssertionError("not needed for test");
-          }
-        })
-        .create();
+                  @Override
+                  public void write(JsonWriter out, Byte value) {
+                    throw new AssertionError("not needed for test");
+                  }
+                })
+            .create();
 
     String s = "{'aString': 's', 'aByte': 0}";
-    var exception = assertThrows(JsonParseException.class, () -> gson.fromJson(s, RecordWithPrimitives.class));
-    assertThat(exception).hasMessageThat()
-        .isEqualTo("null is not allowed as value for record component 'aByte' of primitive type; at path $.aByte");
+    var exception =
+        assertThrows(JsonParseException.class, () -> gson.fromJson(s, RecordWithPrimitives.class));
+    assertThat(exception)
+        .hasMessageThat()
+        .isEqualTo(
+            "null is not allowed as value for record component 'aByte' of primitive type; at path"
+                + " $.aByte");
   }
 
   private record RecordWithPrimitives(
-      String aString, byte aByte, short aShort, int anInt, long aLong, float aFloat, double aDouble, char aChar, boolean aBoolean) {}
+      String aString,
+      byte aByte,
+      short aShort,
+      int anInt,
+      long aLong,
+      float aFloat,
+      double aDouble,
+      char aChar,
+      boolean aBoolean) {}
 
   /** Tests behavior when value of Object component is missing; should default to null */
   @Test
@@ -269,18 +306,19 @@ public final class Java17RecordTest {
   /**
    * Tests serialization of a record with {@code static} field.
    *
-   * <p>Important: It is not documented that this is officially supported; this
-   * test just checks the current behavior.
+   * <p>Important: It is not documented that this is officially supported; this test just checks the
+   * current behavior.
    */
   @Test
   public void testStaticFieldSerialization() {
     // By default Gson should ignore static fields
     assertThat(gson.toJson(new RecordWithStaticField())).isEqualTo("{}");
 
-    Gson gson = new GsonBuilder()
-        // Include static fields
-        .excludeFieldsWithModifiers(0)
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            // Include static fields
+            .excludeFieldsWithModifiers(0)
+            .create();
 
     String json = gson.toJson(new RecordWithStaticField());
     assertThat(json).isEqualTo("{\"s\":\"initial\"}");
@@ -289,8 +327,8 @@ public final class Java17RecordTest {
   /**
    * Tests deserialization of a record with {@code static} field.
    *
-   * <p>Important: It is not documented that this is officially supported; this
-   * test just checks the current behavior.
+   * <p>Important: It is not documented that this is officially supported; this test just checks the
+   * current behavior.
    */
   @Test
   public void testStaticFieldDeserialization() {
@@ -298,10 +336,11 @@ public final class Java17RecordTest {
     gson.fromJson("{\"s\":\"custom\"}", RecordWithStaticField.class);
     assertThat(RecordWithStaticField.s).isEqualTo("initial");
 
-    Gson gson = new GsonBuilder()
-        // Include static fields
-        .excludeFieldsWithModifiers(0)
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            // Include static fields
+            .excludeFieldsWithModifiers(0)
+            .create();
 
     String oldValue = RecordWithStaticField.s;
     try {
@@ -320,10 +359,7 @@ public final class Java17RecordTest {
 
   @Test
   public void testExposeAnnotation() {
-    record RecordWithExpose(
-        @Expose int a,
-        int b
-    ) {}
+    record RecordWithExpose(@Expose int a, int b) {}
 
     Gson gson = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
     String json = gson.toJson(new RecordWithExpose(1, 2));
@@ -334,17 +370,21 @@ public final class Java17RecordTest {
   public void testFieldExclusionStrategy() {
     record LocalRecord(int a, int b, double c) {}
 
-    Gson gson = new GsonBuilder()
-        .setExclusionStrategies(new ExclusionStrategy() {
-          @Override public boolean shouldSkipField(FieldAttributes f) {
-            return f.getName().equals("a");
-          }
+    Gson gson =
+        new GsonBuilder()
+            .setExclusionStrategies(
+                new ExclusionStrategy() {
+                  @Override
+                  public boolean shouldSkipField(FieldAttributes f) {
+                    return f.getName().equals("a");
+                  }
 
-          @Override public boolean shouldSkipClass(Class<?> clazz) {
-            return clazz == double.class;
-          }
-        })
-        .create();
+                  @Override
+                  public boolean shouldSkipClass(Class<?> clazz) {
+                    return clazz == double.class;
+                  }
+                })
+            .create();
 
     assertThat(gson.toJson(new LocalRecord(1, 2, 3.0))).isEqualTo("{\"b\":2}");
   }
@@ -352,20 +392,22 @@ public final class Java17RecordTest {
   @Test
   public void testJsonAdapterAnnotation() {
     record Adapter() implements JsonSerializer<String>, JsonDeserializer<String> {
-      @Override public String deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
+      @Override
+      public String deserialize(
+          JsonElement json, Type typeOfT, JsonDeserializationContext context) {
         return "deserializer-" + json.getAsString();
       }
 
-      @Override public JsonElement serialize(String src, Type typeOfSrc, JsonSerializationContext context) {
+      @Override
+      public JsonElement serialize(String src, Type typeOfSrc, JsonSerializationContext context) {
         return new JsonPrimitive("serializer-" + src);
       }
     }
-    record LocalRecord(
-        @JsonAdapter(Adapter.class) String s
-    ) {}
+    record LocalRecord(@JsonAdapter(Adapter.class) String s) {}
 
     assertThat(gson.toJson(new LocalRecord("a"))).isEqualTo("{\"s\":\"serializer-a\"}");
-    assertThat(gson.fromJson("{\"s\":\"a\"}", LocalRecord.class)).isEqualTo(new LocalRecord("deserializer-a"));
+    assertThat(gson.fromJson("{\"s\":\"a\"}", LocalRecord.class))
+        .isEqualTo(new LocalRecord("deserializer-a"));
   }
 
   @Test
@@ -373,47 +415,58 @@ public final class Java17RecordTest {
     record Allowed(int a) {}
     record Blocked(int b) {}
 
-    Gson gson = new GsonBuilder()
-        .addReflectionAccessFilter(c -> c == Allowed.class ? FilterResult.ALLOW : FilterResult.BLOCK_ALL)
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .addReflectionAccessFilter(
+                c -> c == Allowed.class ? FilterResult.ALLOW : FilterResult.BLOCK_ALL)
+            .create();
 
     String json = gson.toJson(new Allowed(1));
     assertThat(json).isEqualTo("{\"a\":1}");
 
     var exception = assertThrows(JsonIOException.class, () -> gson.toJson(new Blocked(1)));
-    assertThat(exception).hasMessageThat()
-        .isEqualTo("ReflectionAccessFilter does not permit using reflection for class " + Blocked.class.getName() +
-            ". Register a TypeAdapter for this type or adjust the access filter.");
+    assertThat(exception)
+        .hasMessageThat()
+        .isEqualTo(
+            "ReflectionAccessFilter does not permit using reflection for class "
+                + Blocked.class.getName()
+                + ". Register a TypeAdapter for this type or adjust the access filter.");
   }
 
   @Test
   public void testReflectionFilterBlockInaccessible() {
-    Gson gson = new GsonBuilder()
-        .addReflectionAccessFilter(c -> FilterResult.BLOCK_INACCESSIBLE)
-        .create();
+    Gson gson =
+        new GsonBuilder().addReflectionAccessFilter(c -> FilterResult.BLOCK_INACCESSIBLE).create();
 
     var exception = assertThrows(JsonIOException.class, () -> gson.toJson(new PrivateRecord(1)));
-    assertThat(exception).hasMessageThat()
-        .isEqualTo("Constructor 'com.google.gson.functional.Java17RecordTest$PrivateRecord(int)' is not accessible and"
-            + " ReflectionAccessFilter does not permit making it accessible. Register a TypeAdapter for the declaring"
-            + " type, adjust the access filter or increase the visibility of the element and its declaring type.");
+    assertThat(exception)
+        .hasMessageThat()
+        .isEqualTo(
+            "Constructor 'com.google.gson.functional.Java17RecordTest$PrivateRecord(int)' is not"
+                + " accessible and ReflectionAccessFilter does not permit making it accessible."
+                + " Register a TypeAdapter for the declaring type, adjust the access filter or"
+                + " increase the visibility of the element and its declaring type.");
 
     exception = assertThrows(JsonIOException.class, () -> gson.fromJson("{}", PrivateRecord.class));
-    assertThat(exception).hasMessageThat()
-        .isEqualTo("Constructor 'com.google.gson.functional.Java17RecordTest$PrivateRecord(int)' is not accessible and"
-            + " ReflectionAccessFilter does not permit making it accessible. Register a TypeAdapter for the declaring"
-            + " type, adjust the access filter or increase the visibility of the element and its declaring type.");
+    assertThat(exception)
+        .hasMessageThat()
+        .isEqualTo(
+            "Constructor 'com.google.gson.functional.Java17RecordTest$PrivateRecord(int)' is not"
+                + " accessible and ReflectionAccessFilter does not permit making it accessible."
+                + " Register a TypeAdapter for the declaring type, adjust the access filter or"
+                + " increase the visibility of the element and its declaring type.");
 
     assertThat(gson.toJson(new PublicRecord(1))).isEqualTo("{\"i\":1}");
     assertThat(gson.fromJson("{\"i\":2}", PublicRecord.class)).isEqualTo(new PublicRecord(2));
   }
 
   private record PrivateRecord(int i) {}
+
   public record PublicRecord(int i) {}
 
   /**
-   * Tests behavior when {@code java.lang.Record} is used as type for serialization
-   * and deserialization.
+   * Tests behavior when {@code java.lang.Record} is used as type for serialization and
+   * deserialization.
    */
   @Test
   public void testRecordBaseClass() {
@@ -422,9 +475,11 @@ public final class Java17RecordTest {
     assertThat(gson.toJson(new LocalRecord(1), Record.class)).isEqualTo("{}");
 
     var exception = assertThrows(JsonIOException.class, () -> gson.fromJson("{}", Record.class));
-    assertThat(exception).hasMessageThat()
-        .isEqualTo("Abstract classes can't be instantiated! Adjust the R8 configuration or register an InstanceCreator"
-            + " or a TypeAdapter for this type. Class name: java.lang.Record"
-            + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#r8-abstract-class");
+    assertThat(exception)
+        .hasMessageThat()
+        .isEqualTo(
+            "Abstract classes can't be instantiated! Adjust the R8 configuration or register an"
+                + " InstanceCreator or a TypeAdapter for this type. Class name: java.lang.Record\n"
+                + "See https://github.com/google/gson/blob/main/Troubleshooting.md#r8-abstract-class");
   }
 }

--- a/gson/src/test/java/com/google/gson/functional/JavaUtilConcurrentAtomicTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JavaUtilConcurrentAtomicTest.java
@@ -30,7 +30,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Functional test for Json serialization and deserialization for classes in java.util.concurrent.atomic
+ * Functional test for Json serialization and deserialization for classes in
+ * java.util.concurrent.atomic
  */
 public class JavaUtilConcurrentAtomicTest {
   private Gson gson;
@@ -66,9 +67,8 @@ public class JavaUtilConcurrentAtomicTest {
 
   @Test
   public void testAtomicLongWithStringSerializationPolicy() {
-    Gson gson = new GsonBuilder()
-        .setLongSerializationPolicy(LongSerializationPolicy.STRING)
-        .create();
+    Gson gson =
+        new GsonBuilder().setLongSerializationPolicy(LongSerializationPolicy.STRING).create();
     AtomicLongHolder target = gson.fromJson("{'value':'10'}", AtomicLongHolder.class);
     assertThat(target.value.get()).isEqualTo(10);
     String json = gson.toJson(target);
@@ -99,9 +99,8 @@ public class JavaUtilConcurrentAtomicTest {
 
   @Test
   public void testAtomicLongArrayWithStringSerializationPolicy() {
-    Gson gson = new GsonBuilder()
-        .setLongSerializationPolicy(LongSerializationPolicy.STRING)
-        .create();
+    Gson gson =
+        new GsonBuilder().setLongSerializationPolicy(LongSerializationPolicy.STRING).create();
     AtomicLongArray target = gson.fromJson("['10', '13', '14']", AtomicLongArray.class);
     assertThat(target.length()).isEqualTo(3);
     assertThat(target.get(0)).isEqualTo(10);

--- a/gson/src/test/java/com/google/gson/functional/JavaUtilTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JavaUtilTest.java
@@ -24,9 +24,7 @@ import java.util.Properties;
 import org.junit.Before;
 import org.junit.Test;
 
-/**
- * Functional test for Json serialization and deserialization for classes in java.util
- */
+/** Functional test for Json serialization and deserialization for classes in java.util */
 public class JavaUtilTest {
   private Gson gson;
 

--- a/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java
@@ -43,9 +43,7 @@ import java.util.List;
 import java.util.Locale;
 import org.junit.Test;
 
-/**
- * Functional tests for the {@link JsonAdapter} annotation on classes.
- */
+/** Functional tests for the {@link JsonAdapter} annotation on classes. */
 public final class JsonAdapterAnnotationOnClassesTest {
 
   @Test
@@ -54,7 +52,7 @@ public final class JsonAdapterAnnotationOnClassesTest {
     String json = gson.toJson(new A("bar"));
     assertThat(json).isEqualTo("\"jsonAdapter\"");
 
-   // Also invoke the JsonAdapter javadoc sample
+    // Also invoke the JsonAdapter javadoc sample
     json = gson.toJson(new User("Inderjeet", "Singh"));
     assertThat(json).isEqualTo("{\"name\":\"Inderjeet Singh\"}");
     User user = gson.fromJson("{'name':'Joel Leitch'}", User.class);
@@ -78,55 +76,52 @@ public final class JsonAdapterAnnotationOnClassesTest {
 
   @Test
   public void testRegisteredAdapterOverridesJsonAdapter() {
-    TypeAdapter<A> typeAdapter = new TypeAdapter<A>() {
-      @Override public void write(JsonWriter out, A value) throws IOException {
-        out.value("registeredAdapter");
-      }
-      @Override public A read(JsonReader in) throws IOException {
-        return new A(in.nextString());
-      }
-    };
-    Gson gson = new GsonBuilder()
-      .registerTypeAdapter(A.class, typeAdapter)
-      .create();
+    TypeAdapter<A> typeAdapter =
+        new TypeAdapter<A>() {
+          @Override
+          public void write(JsonWriter out, A value) throws IOException {
+            out.value("registeredAdapter");
+          }
+
+          @Override
+          public A read(JsonReader in) throws IOException {
+            return new A(in.nextString());
+          }
+        };
+    Gson gson = new GsonBuilder().registerTypeAdapter(A.class, typeAdapter).create();
     String json = gson.toJson(new A("abcd"));
     assertThat(json).isEqualTo("\"registeredAdapter\"");
   }
 
-  /**
-   * The serializer overrides field adapter, but for deserializer the fieldAdapter is used.
-   */
+  /** The serializer overrides field adapter, but for deserializer the fieldAdapter is used. */
   @Test
   public void testRegisteredSerializerOverridesJsonAdapter() {
-    JsonSerializer<A> serializer = new JsonSerializer<A>() {
-      @Override public JsonElement serialize(A src, Type typeOfSrc,
-          JsonSerializationContext context) {
-        return new JsonPrimitive("registeredSerializer");
-      }
-    };
-    Gson gson = new GsonBuilder()
-      .registerTypeAdapter(A.class, serializer)
-      .create();
+    JsonSerializer<A> serializer =
+        new JsonSerializer<A>() {
+          @Override
+          public JsonElement serialize(A src, Type typeOfSrc, JsonSerializationContext context) {
+            return new JsonPrimitive("registeredSerializer");
+          }
+        };
+    Gson gson = new GsonBuilder().registerTypeAdapter(A.class, serializer).create();
     String json = gson.toJson(new A("abcd"));
     assertThat(json).isEqualTo("\"registeredSerializer\"");
     A target = gson.fromJson("abcd", A.class);
     assertThat(target.value).isEqualTo("jsonAdapter");
   }
 
-  /**
-   * The deserializer overrides Json adapter, but for serializer the jsonAdapter is used.
-   */
+  /** The deserializer overrides Json adapter, but for serializer the jsonAdapter is used. */
   @Test
   public void testRegisteredDeserializerOverridesJsonAdapter() {
-    JsonDeserializer<A> deserializer = new JsonDeserializer<A>() {
-      @Override public A deserialize(JsonElement json, Type typeOfT,
-          JsonDeserializationContext context) throws JsonParseException {
-        return new A("registeredDeserializer");
-      }
-    };
-    Gson gson = new GsonBuilder()
-      .registerTypeAdapter(A.class, deserializer)
-      .create();
+    JsonDeserializer<A> deserializer =
+        new JsonDeserializer<A>() {
+          @Override
+          public A deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+              throws JsonParseException {
+            return new A("registeredDeserializer");
+          }
+        };
+    Gson gson = new GsonBuilder().registerTypeAdapter(A.class, deserializer).create();
     String json = gson.toJson(new A("abcd"));
     assertThat(json).isEqualTo("\"jsonAdapter\"");
     A target = gson.fromJson("abcd", A.class);
@@ -138,7 +133,8 @@ public final class JsonAdapterAnnotationOnClassesTest {
     try {
       String json = new Gson().toJson(new ClassWithIncorrectJsonAdapter("bar"));
       fail(json);
-    } catch (ClassCastException expected) {}
+    } catch (ClassCastException expected) {
+    }
   }
 
   @Test
@@ -175,19 +171,25 @@ public final class JsonAdapterAnnotationOnClassesTest {
     assertThat(gson.fromJson("null", WithNullReturningFactory.class)).isNull();
     assertThat(gson.toJson(null, WithNullReturningFactory.class)).isEqualTo("null");
 
-    TypeToken<WithNullReturningFactory<String>> stringTypeArg = new TypeToken<WithNullReturningFactory<String>>() {};
+    TypeToken<WithNullReturningFactory<String>> stringTypeArg =
+        new TypeToken<WithNullReturningFactory<String>>() {};
     WithNullReturningFactory<?> deserialized = gson.fromJson("\"a\"", stringTypeArg);
     assertThat(deserialized.t).isEqualTo("custom-read:a");
     assertThat(gson.fromJson("null", stringTypeArg)).isNull();
-    assertThat(gson.toJson(new WithNullReturningFactory<>("b"), stringTypeArg.getType())).isEqualTo("\"custom-write:b\"");
+    assertThat(gson.toJson(new WithNullReturningFactory<>("b"), stringTypeArg.getType()))
+        .isEqualTo("\"custom-write:b\"");
     assertThat(gson.toJson(null, stringTypeArg.getType())).isEqualTo("null");
 
-    // Factory should return `null` for this type and Gson should fall back to reflection-based adapter
-    TypeToken<WithNullReturningFactory<Integer>> numberTypeArg = new TypeToken<WithNullReturningFactory<Integer>>() {};
+    // Factory should return `null` for this type and Gson should fall back to reflection-based
+    // adapter
+    TypeToken<WithNullReturningFactory<Integer>> numberTypeArg =
+        new TypeToken<WithNullReturningFactory<Integer>>() {};
     deserialized = gson.fromJson("{\"t\":1}", numberTypeArg);
     assertThat(deserialized.t).isEqualTo(1);
-    assertThat(gson.toJson(new WithNullReturningFactory<>(2), numberTypeArg.getType())).isEqualTo("{\"t\":2}");
+    assertThat(gson.toJson(new WithNullReturningFactory<>(2), numberTypeArg.getType()))
+        .isEqualTo("{\"t\":2}");
   }
+
   // Also set `nullSafe = true` to verify that this does not cause a NullPointerException if the
   // factory would accidentally call `nullSafe()` on null adapter
   @JsonAdapter(value = WithNullReturningFactory.NullReturningFactory.class, nullSafe = true)
@@ -206,23 +208,27 @@ public final class JsonAdapterAnnotationOnClassesTest {
           return null;
         }
         ParameterizedType parameterizedType = (ParameterizedType) type.getType();
-        // Makes this test a bit more realistic by only conditionally returning null (instead of always)
+        // Makes this test a bit more realistic by only conditionally returning null (instead of
+        // always)
         if (parameterizedType.getActualTypeArguments()[0] != String.class) {
           return null;
         }
 
         @SuppressWarnings("unchecked")
-        TypeAdapter<T> adapter = (TypeAdapter<T>) new TypeAdapter<WithNullReturningFactory<String>>() {
-          @Override
-          public void write(JsonWriter out, WithNullReturningFactory<String> value) throws IOException {
-            out.value("custom-write:" + value.t);
-          }
+        TypeAdapter<T> adapter =
+            (TypeAdapter<T>)
+                new TypeAdapter<WithNullReturningFactory<String>>() {
+                  @Override
+                  public void write(JsonWriter out, WithNullReturningFactory<String> value)
+                      throws IOException {
+                    out.value("custom-write:" + value.t);
+                  }
 
-          @Override
-          public WithNullReturningFactory<String> read(JsonReader in) throws IOException {
-            return new WithNullReturningFactory<>("custom-read:" + in.nextString());
-          }
-        };
+                  @Override
+                  public WithNullReturningFactory<String> read(JsonReader in) throws IOException {
+                    return new WithNullReturningFactory<>("custom-read:" + in.nextString());
+                  }
+                };
         return adapter;
       }
     }
@@ -231,14 +237,19 @@ public final class JsonAdapterAnnotationOnClassesTest {
   @JsonAdapter(A.JsonAdapter.class)
   private static class A {
     final String value;
+
     A(String value) {
       this.value = value;
     }
+
     static final class JsonAdapter extends TypeAdapter<A> {
-      @Override public void write(JsonWriter out, A value) throws IOException {
+      @Override
+      public void write(JsonWriter out, A value) throws IOException {
         out.value("jsonAdapter");
       }
-      @Override public A read(JsonReader in) throws IOException {
+
+      @Override
+      public A read(JsonReader in) throws IOException {
         in.nextString();
         return new A("jsonAdapter");
       }
@@ -248,17 +259,23 @@ public final class JsonAdapterAnnotationOnClassesTest {
   @JsonAdapter(C.JsonAdapterFactory.class)
   private static class C {
     final String value;
+
     C(String value) {
       this.value = value;
     }
+
     static final class JsonAdapterFactory implements TypeAdapterFactory {
-      @Override public <T> TypeAdapter<T> create(Gson gson, final TypeToken<T> type) {
+      @Override
+      public <T> TypeAdapter<T> create(Gson gson, final TypeToken<T> type) {
         return new TypeAdapter<T>() {
-          @Override public void write(JsonWriter out, T value) throws IOException {
+          @Override
+          public void write(JsonWriter out, T value) throws IOException {
             out.value("jsonAdapterFactory");
           }
+
           @SuppressWarnings("unchecked")
-          @Override public T read(JsonReader in) throws IOException {
+          @Override
+          public T read(JsonReader in) throws IOException {
             in.nextString();
             return (T) new C("jsonAdapterFactory");
           }
@@ -272,11 +289,14 @@ public final class JsonAdapterAnnotationOnClassesTest {
       super(value);
     }
   }
+
   // Note that the type is NOT TypeAdapter<ClassWithIncorrectJsonAdapter> so this
   // should cause error
   @JsonAdapter(A.JsonAdapter.class)
   private static final class ClassWithIncorrectJsonAdapter {
-    @SuppressWarnings("unused") final String value;
+    @SuppressWarnings("unused")
+    final String value;
+
     ClassWithIncorrectJsonAdapter(String value) {
       this.value = value;
     }
@@ -286,20 +306,25 @@ public final class JsonAdapterAnnotationOnClassesTest {
   @JsonAdapter(UserJsonAdapter.class)
   private static class User {
     final String firstName, lastName;
+
     User(String firstName, String lastName) {
       this.firstName = firstName;
       this.lastName = lastName;
     }
   }
+
   private static class UserJsonAdapter extends TypeAdapter<User> {
-    @Override public void write(JsonWriter out, User user) throws IOException {
+    @Override
+    public void write(JsonWriter out, User user) throws IOException {
       // implement write: combine firstName and lastName into name
       out.beginObject();
       out.name("name");
       out.value(user.firstName + " " + user.lastName);
       out.endObject();
     }
-    @Override public User read(JsonReader in) throws IOException {
+
+    @Override
+    public User read(JsonReader in) throws IOException {
       // implement read: split name into firstName and lastName
       in.beginObject();
       in.nextName();
@@ -311,8 +336,7 @@ public final class JsonAdapterAnnotationOnClassesTest {
 
   // Implicit `nullSafe=true`
   @JsonAdapter(value = NullableClassJsonAdapter.class)
-  private static class NullableClass {
-  }
+  private static class NullableClass {}
 
   private static class NullableClassJsonAdapter extends TypeAdapter<NullableClass> {
     @Override
@@ -328,13 +352,19 @@ public final class JsonAdapterAnnotationOnClassesTest {
   }
 
   @JsonAdapter(FooJsonAdapter.class)
-  private static enum Foo { BAR, BAZ }
+  private static enum Foo {
+    BAR,
+    BAZ
+  }
+
   private static class FooJsonAdapter extends TypeAdapter<Foo> {
-    @Override public void write(JsonWriter out, Foo value) throws IOException {
+    @Override
+    public void write(JsonWriter out, Foo value) throws IOException {
       out.value(value.name().toLowerCase(Locale.US));
     }
 
-    @Override public Foo read(JsonReader in) throws IOException {
+    @Override
+    public Foo read(JsonReader in) throws IOException {
       return Foo.valueOf(in.nextString().toUpperCase(Locale.US));
     }
   }
@@ -344,30 +374,38 @@ public final class JsonAdapterAnnotationOnClassesTest {
     try {
       new Gson().toJson(new D());
       fail();
-    } catch (IllegalArgumentException expected) {}
+    } catch (IllegalArgumentException expected) {
+    }
   }
+
   @JsonAdapter(Integer.class)
   private static final class D {
-    @SuppressWarnings("unused") final String value = "a";
+    @SuppressWarnings("unused")
+    final String value = "a";
   }
 
   /**
-   * Verifies that {@link TypeAdapterFactory} specified by {@code @JsonAdapter} can
-   * call {@link Gson#getDelegateAdapter} without any issues, despite the factory
-   * not being directly registered on Gson.
+   * Verifies that {@link TypeAdapterFactory} specified by {@code @JsonAdapter} can call {@link
+   * Gson#getDelegateAdapter} without any issues, despite the factory not being directly registered
+   * on Gson.
    */
   @Test
   public void testDelegatingAdapterFactory() {
     @SuppressWarnings("unchecked")
-    WithDelegatingFactory<String> deserialized = new Gson().fromJson("{\"custom\":{\"f\":\"de\"}}", WithDelegatingFactory.class);
+    WithDelegatingFactory<String> deserialized =
+        new Gson().fromJson("{\"custom\":{\"f\":\"de\"}}", WithDelegatingFactory.class);
     assertThat(deserialized.f).isEqualTo("de");
 
-    deserialized = new Gson().fromJson("{\"custom\":{\"f\":\"de\"}}", new TypeToken<WithDelegatingFactory<String>>() {});
+    deserialized =
+        new Gson()
+            .fromJson(
+                "{\"custom\":{\"f\":\"de\"}}", new TypeToken<WithDelegatingFactory<String>>() {});
     assertThat(deserialized.f).isEqualTo("de");
 
     WithDelegatingFactory<String> serialized = new WithDelegatingFactory<>("se");
     assertThat(new Gson().toJson(serialized)).isEqualTo("{\"custom\":{\"f\":\"se\"}}");
   }
+
   @JsonAdapter(WithDelegatingFactory.Factory.class)
   private static class WithDelegatingFactory<T> {
     T f;
@@ -411,17 +449,19 @@ public final class JsonAdapterAnnotationOnClassesTest {
   }
 
   /**
-   * Similar to {@link #testDelegatingAdapterFactory}, except that the delegate is not
-   * looked up in {@code create} but instead in the adapter methods.
+   * Similar to {@link #testDelegatingAdapterFactory}, except that the delegate is not looked up in
+   * {@code create} but instead in the adapter methods.
    */
   @Test
   public void testDelegatingAdapterFactory_Delayed() {
-    WithDelayedDelegatingFactory deserialized = new Gson().fromJson("{\"custom\":{\"f\":\"de\"}}", WithDelayedDelegatingFactory.class);
+    WithDelayedDelegatingFactory deserialized =
+        new Gson().fromJson("{\"custom\":{\"f\":\"de\"}}", WithDelayedDelegatingFactory.class);
     assertThat(deserialized.f).isEqualTo("de");
 
     WithDelayedDelegatingFactory serialized = new WithDelayedDelegatingFactory("se");
     assertThat(new Gson().toJson(serialized)).isEqualTo("{\"custom\":{\"f\":\"se\"}}");
   }
+
   @JsonAdapter(WithDelayedDelegatingFactory.Factory.class)
   private static class WithDelayedDelegatingFactory {
     String f;
@@ -434,7 +474,9 @@ public final class JsonAdapterAnnotationOnClassesTest {
       @Override
       public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
         return new TypeAdapter<T>() {
-          @SuppressWarnings("SameNameButDifferent") // suppress Error Prone warning; should be clear that `Factory` refers to enclosing class
+          @SuppressWarnings(
+              "SameNameButDifferent") // suppress Error Prone warning; should be clear that
+          // `Factory` refers to enclosing class
           private TypeAdapter<T> delegate() {
             return gson.getDelegateAdapter(Factory.this, type);
           }
@@ -470,12 +512,12 @@ public final class JsonAdapterAnnotationOnClassesTest {
    */
   @Test
   public void testDelegating_SameFactoryClass() {
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapterFactory(new WithDelegatingFactory.Factory())
-        .create();
+    Gson gson =
+        new GsonBuilder().registerTypeAdapterFactory(new WithDelegatingFactory.Factory()).create();
 
     // Should use both factories, and therefore have `{"custom": ... }` twice
-    WithDelegatingFactory<?> deserialized = gson.fromJson("{\"custom\":{\"custom\":{\"f\":\"de\"}}}", WithDelegatingFactory.class);
+    WithDelegatingFactory<?> deserialized =
+        gson.fromJson("{\"custom\":{\"custom\":{\"f\":\"de\"}}}", WithDelegatingFactory.class);
     assertThat(deserialized.f).isEqualTo("de");
 
     WithDelegatingFactory<String> serialized = new WithDelegatingFactory<>("se");
@@ -483,28 +525,33 @@ public final class JsonAdapterAnnotationOnClassesTest {
   }
 
   /**
-   * Tests behavior of {@link Gson#getDelegateAdapter} when the <i>same</i> instance of a factory
-   * is used (through {@link InstanceCreator}).
+   * Tests behavior of {@link Gson#getDelegateAdapter} when the <i>same</i> instance of a factory is
+   * used (through {@link InstanceCreator}).
    *
    * <p><b>Important:</b> This situation is likely a rare corner case; the purpose of this test is
-   * to verify that Gson behaves reasonable, mainly that it does not cause a {@link StackOverflowError}
-   * due to infinite recursion. This test is not intended to dictate an expected behavior.
+   * to verify that Gson behaves reasonable, mainly that it does not cause a {@link
+   * StackOverflowError} due to infinite recursion. This test is not intended to dictate an expected
+   * behavior.
    */
   @Test
   public void testDelegating_SameFactoryInstance() {
     WithDelegatingFactory.Factory factory = new WithDelegatingFactory.Factory();
 
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapterFactory(factory)
-        // Always provides same instance for factory
-        .registerTypeAdapter(WithDelegatingFactory.Factory.class, (InstanceCreator<?>) type -> factory)
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapterFactory(factory)
+            // Always provides same instance for factory
+            .registerTypeAdapter(
+                WithDelegatingFactory.Factory.class, (InstanceCreator<?>) type -> factory)
+            .create();
 
-    // Current Gson.getDelegateAdapter implementation cannot tell when call is related to @JsonAdapter
-    // or not, it can only work based on the `skipPast` factory, so if the same factory instance is used
-    // the one registered with `GsonBuilder.registerTypeAdapterFactory` actually skips past the @JsonAdapter
-    // one, so the JSON string is `{"custom": ...}` instead of `{"custom":{"custom":...}}`
-    WithDelegatingFactory<?> deserialized = gson.fromJson("{\"custom\":{\"f\":\"de\"}}", WithDelegatingFactory.class);
+    // Current Gson.getDelegateAdapter implementation cannot tell when call is related to
+    // @JsonAdapter or not, it can only work based on the `skipPast` factory, so if the same factory
+    // instance is used the one registered with `GsonBuilder.registerTypeAdapterFactory` actually
+    // skips past the @JsonAdapter one, so the JSON string is `{"custom": ...}` instead of
+    // `{"custom":{"custom":...}}`
+    WithDelegatingFactory<?> deserialized =
+        gson.fromJson("{\"custom\":{\"f\":\"de\"}}", WithDelegatingFactory.class);
     assertThat(deserialized.f).isEqualTo("de");
 
     WithDelegatingFactory<String> serialized = new WithDelegatingFactory<>("se");
@@ -513,82 +560,100 @@ public final class JsonAdapterAnnotationOnClassesTest {
 
   /**
    * Tests behavior of {@link Gson#getDelegateAdapter} when <i>different</i> instances of the same
-   * factory class are used; one specified with {@code @JsonAdapter} on a class, and the other specified
-   * with {@code @JsonAdapter} on a field of that class.
+   * factory class are used; one specified with {@code @JsonAdapter} on a class, and the other
+   * specified with {@code @JsonAdapter} on a field of that class.
    *
    * <p><b>Important:</b> This situation is likely a rare corner case; the purpose of this test is
-   * to verify that Gson behaves reasonable, mainly that it does not cause a {@link StackOverflowError}
-   * due to infinite recursion. This test is not intended to dictate an expected behavior.
+   * to verify that Gson behaves reasonable, mainly that it does not cause a {@link
+   * StackOverflowError} due to infinite recursion. This test is not intended to dictate an expected
+   * behavior.
    */
   @Test
   public void testDelegating_SameFactoryClass_OnClassAndField() {
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(String.class, new TypeAdapter<String>() {
-          @Override
-          public String read(JsonReader in) throws IOException {
-            return in.nextString() + "-str";
-          }
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                String.class,
+                new TypeAdapter<String>() {
+                  @Override
+                  public String read(JsonReader in) throws IOException {
+                    return in.nextString() + "-str";
+                  }
 
-          @Override
-          public void write(JsonWriter out, String value) throws IOException {
-            out.value(value + "-str");
-          }
-        })
-        .create();
+                  @Override
+                  public void write(JsonWriter out, String value) throws IOException {
+                    out.value(value + "-str");
+                  }
+                })
+            .create();
 
-    // Should use both factories, and therefore have `{"custom": ... }` once for class and once for the field,
-    // and for field also properly delegate to custom String adapter defined above
-    WithDelegatingFactoryOnClassAndField deserialized = gson.fromJson("{\"custom\":{\"f\":{\"custom\":\"de\"}}}",
-        WithDelegatingFactoryOnClassAndField.class);
+    // Should use both factories, and therefore have `{"custom": ... }` once for class and once for
+    // the field, and for field also properly delegate to custom String adapter defined above
+    WithDelegatingFactoryOnClassAndField deserialized =
+        gson.fromJson(
+            "{\"custom\":{\"f\":{\"custom\":\"de\"}}}", WithDelegatingFactoryOnClassAndField.class);
     assertThat(deserialized.f).isEqualTo("de-str");
 
-    WithDelegatingFactoryOnClassAndField serialized = new WithDelegatingFactoryOnClassAndField("se");
+    WithDelegatingFactoryOnClassAndField serialized =
+        new WithDelegatingFactoryOnClassAndField("se");
     assertThat(gson.toJson(serialized)).isEqualTo("{\"custom\":{\"f\":{\"custom\":\"se-str\"}}}");
   }
 
   /**
-   * Tests behavior of {@link Gson#getDelegateAdapter} when the <i>same</i> instance of a factory
-   * is used (through {@link InstanceCreator}); specified with {@code @JsonAdapter} on a class,
-   * and also specified with {@code @JsonAdapter} on a field of that class.
+   * Tests behavior of {@link Gson#getDelegateAdapter} when the <i>same</i> instance of a factory is
+   * used (through {@link InstanceCreator}); specified with {@code @JsonAdapter} on a class, and
+   * also specified with {@code @JsonAdapter} on a field of that class.
    *
    * <p><b>Important:</b> This situation is likely a rare corner case; the purpose of this test is
-   * to verify that Gson behaves reasonable, mainly that it does not cause a {@link StackOverflowError}
-   * due to infinite recursion. This test is not intended to dictate an expected behavior.
+   * to verify that Gson behaves reasonable, mainly that it does not cause a {@link
+   * StackOverflowError} due to infinite recursion. This test is not intended to dictate an expected
+   * behavior.
    */
   @Test
   public void testDelegating_SameFactoryInstance_OnClassAndField() {
-    WithDelegatingFactoryOnClassAndField.Factory factory = new WithDelegatingFactoryOnClassAndField.Factory();
+    WithDelegatingFactoryOnClassAndField.Factory factory =
+        new WithDelegatingFactoryOnClassAndField.Factory();
 
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(String.class, new TypeAdapter<String>() {
-          @Override
-          public String read(JsonReader in) throws IOException {
-            return in.nextString() + "-str";
-          }
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                String.class,
+                new TypeAdapter<String>() {
+                  @Override
+                  public String read(JsonReader in) throws IOException {
+                    return in.nextString() + "-str";
+                  }
 
-          @Override
-          public void write(JsonWriter out, String value) throws IOException {
-            out.value(value + "-str");
-          }
-        })
-        // Always provides same instance for factory
-        .registerTypeAdapter(WithDelegatingFactoryOnClassAndField.Factory.class, (InstanceCreator<?>) type -> factory)
-        .create();
+                  @Override
+                  public void write(JsonWriter out, String value) throws IOException {
+                    out.value(value + "-str");
+                  }
+                })
+            // Always provides same instance for factory
+            .registerTypeAdapter(
+                WithDelegatingFactoryOnClassAndField.Factory.class,
+                (InstanceCreator<?>) type -> factory)
+            .create();
 
-    // Because field type (`String`) differs from declaring class, JsonAdapterAnnotationTypeAdapterFactory does
-    // not confuse factories and this behaves as expected: Both the declaring class and the field each have
-    // `{"custom": ...}` and delegation for the field to the custom String adapter defined above works properly
-    WithDelegatingFactoryOnClassAndField deserialized = gson.fromJson("{\"custom\":{\"f\":{\"custom\":\"de\"}}}",
-        WithDelegatingFactoryOnClassAndField.class);
+    // Because field type (`String`) differs from declaring class,
+    // JsonAdapterAnnotationTypeAdapterFactory does not confuse factories and this behaves as
+    // expected: Both the declaring class and the field each have `{"custom": ...}` and delegation
+    // for the field to the custom String adapter defined above works properly
+    WithDelegatingFactoryOnClassAndField deserialized =
+        gson.fromJson(
+            "{\"custom\":{\"f\":{\"custom\":\"de\"}}}", WithDelegatingFactoryOnClassAndField.class);
     assertThat(deserialized.f).isEqualTo("de-str");
 
-    WithDelegatingFactoryOnClassAndField serialized = new WithDelegatingFactoryOnClassAndField("se");
+    WithDelegatingFactoryOnClassAndField serialized =
+        new WithDelegatingFactoryOnClassAndField("se");
     assertThat(gson.toJson(serialized)).isEqualTo("{\"custom\":{\"f\":{\"custom\":\"se-str\"}}}");
   }
+
   // Same factory class specified on class and one of its fields
   @JsonAdapter(WithDelegatingFactoryOnClassAndField.Factory.class)
   private static class WithDelegatingFactoryOnClassAndField {
-    @SuppressWarnings("SameNameButDifferent") // suppress Error Prone warning; should be clear that `Factory` refers to nested class
+    // suppress Error Prone warning; should be clear that `Factory` refers to nested class
+    @SuppressWarnings("SameNameButDifferent")
     @JsonAdapter(Factory.class)
     String f;
 
@@ -626,9 +691,7 @@ public final class JsonAdapterAnnotationOnClassesTest {
     }
   }
 
-  /**
-   * Tests usage of {@link JsonSerializer} as {@link JsonAdapter} value
-   */
+  /** Tests usage of {@link JsonSerializer} as {@link JsonAdapter} value */
   @Test
   public void testJsonSerializer() {
     Gson gson = new Gson();
@@ -640,25 +703,26 @@ public final class JsonAdapterAnnotationOnClassesTest {
     // Uses custom serializer which always returns `true`
     assertThat(json).isEqualTo("true");
   }
+
   @JsonAdapter(WithJsonSerializer.Serializer.class)
   private static class WithJsonSerializer {
     String f = "";
 
     static class Serializer implements JsonSerializer<WithJsonSerializer> {
       @Override
-      public JsonElement serialize(WithJsonSerializer src, Type typeOfSrc, JsonSerializationContext context) {
+      public JsonElement serialize(
+          WithJsonSerializer src, Type typeOfSrc, JsonSerializationContext context) {
         return new JsonPrimitive(true);
       }
     }
   }
 
-  /**
-   * Tests usage of {@link JsonDeserializer} as {@link JsonAdapter} value
-   */
+  /** Tests usage of {@link JsonDeserializer} as {@link JsonAdapter} value */
   @Test
   public void testJsonDeserializer() {
     Gson gson = new Gson();
-    WithJsonDeserializer deserialized = gson.fromJson("{\"f\":\"test\"}", WithJsonDeserializer.class);
+    WithJsonDeserializer deserialized =
+        gson.fromJson("{\"f\":\"test\"}", WithJsonDeserializer.class);
     // Uses custom deserializer which always uses "123" as field value
     assertThat(deserialized.f).isEqualTo("123");
 
@@ -666,6 +730,7 @@ public final class JsonAdapterAnnotationOnClassesTest {
     String json = gson.toJson(new WithJsonDeserializer("abc"));
     assertThat(json).isEqualTo("{\"f\":\"abc\"}");
   }
+
   @JsonAdapter(WithJsonDeserializer.Deserializer.class)
   private static class WithJsonDeserializer {
     String f;
@@ -676,25 +741,31 @@ public final class JsonAdapterAnnotationOnClassesTest {
 
     static class Deserializer implements JsonDeserializer<WithJsonDeserializer> {
       @Override
-      public WithJsonDeserializer deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
+      public WithJsonDeserializer deserialize(
+          JsonElement json, Type typeOfT, JsonDeserializationContext context) {
         return new WithJsonDeserializer("123");
       }
     }
   }
 
   /**
-   * Tests creation of the adapter referenced by {@code @JsonAdapter} using an {@link InstanceCreator}.
+   * Tests creation of the adapter referenced by {@code @JsonAdapter} using an {@link
+   * InstanceCreator}.
    */
   @Test
   public void testAdapterCreatedByInstanceCreator() {
-    CreatedByInstanceCreator.Serializer serializer = new CreatedByInstanceCreator.Serializer("custom");
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(CreatedByInstanceCreator.Serializer.class, (InstanceCreator<?>) t -> serializer)
-        .create();
+    CreatedByInstanceCreator.Serializer serializer =
+        new CreatedByInstanceCreator.Serializer("custom");
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                CreatedByInstanceCreator.Serializer.class, (InstanceCreator<?>) t -> serializer)
+            .create();
 
     String json = gson.toJson(new CreatedByInstanceCreator());
     assertThat(json).isEqualTo("\"custom\"");
   }
+
   @JsonAdapter(CreatedByInstanceCreator.Serializer.class)
   private static class CreatedByInstanceCreator {
     static class Serializer implements JsonSerializer<CreatedByInstanceCreator> {
@@ -710,20 +781,20 @@ public final class JsonAdapterAnnotationOnClassesTest {
       }
 
       @Override
-      public JsonElement serialize(CreatedByInstanceCreator src, Type typeOfSrc, JsonSerializationContext context) {
+      public JsonElement serialize(
+          CreatedByInstanceCreator src, Type typeOfSrc, JsonSerializationContext context) {
         return new JsonPrimitive(value);
       }
     }
   }
 
-  /**
-   * Tests creation of the adapter referenced by {@code @JsonAdapter} using JDK Unsafe.
-   */
+  /** Tests creation of the adapter referenced by {@code @JsonAdapter} using JDK Unsafe. */
   @Test
   public void testAdapterCreatedByJdkUnsafe() {
     String json = new Gson().toJson(new CreatedByJdkUnsafe());
     assertThat(json).isEqualTo("false");
   }
+
   @JsonAdapter(CreatedByJdkUnsafe.Serializer.class)
   private static class CreatedByJdkUnsafe {
     static class Serializer implements JsonSerializer<CreatedByJdkUnsafe> {
@@ -737,7 +808,8 @@ public final class JsonAdapterAnnotationOnClassesTest {
       }
 
       @Override
-      public JsonElement serialize(CreatedByJdkUnsafe src, Type typeOfSrc, JsonSerializationContext context) {
+      public JsonElement serialize(
+          CreatedByJdkUnsafe src, Type typeOfSrc, JsonSerializationContext context) {
         return new JsonPrimitive(wasInitialized);
       }
     }

--- a/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnFieldsTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnFieldsTest.java
@@ -42,9 +42,7 @@ import java.util.Collections;
 import java.util.List;
 import org.junit.Test;
 
-/**
- * Functional tests for the {@link JsonAdapter} annotation on fields.
- */
+/** Functional tests for the {@link JsonAdapter} annotation on fields. */
 public final class JsonAdapterAnnotationOnFieldsTest {
   @Test
   public void testClassAnnotationAdapterTakesPrecedenceOverDefault() {
@@ -66,9 +64,8 @@ public final class JsonAdapterAnnotationOnFieldsTest {
 
   @Test
   public void testRegisteredTypeAdapterTakesPrecedenceOverClassAnnotationAdapter() {
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(User.class, new RegisteredUserAdapter())
-        .create();
+    Gson gson =
+        new GsonBuilder().registerTypeAdapter(User.class, new RegisteredUserAdapter()).create();
     String json = gson.toJson(new Computer(new User("Inderjeet Singh")));
     assertThat(json).isEqualTo("{\"user\":\"RegisteredUserAdapter\"}");
     Computer computer = gson.fromJson("{'user':'Inderjeet Singh'}", Computer.class);
@@ -77,15 +74,22 @@ public final class JsonAdapterAnnotationOnFieldsTest {
 
   @Test
   public void testFieldAnnotationTakesPrecedenceOverRegisteredTypeAdapter() {
-    Gson gson = new GsonBuilder()
-      .registerTypeAdapter(Part.class, new TypeAdapter<Part>() {
-        @Override public void write(JsonWriter out, Part part) {
-          throw new AssertionError();
-        }
-        @Override public Part read(JsonReader in) {
-          throw new AssertionError();
-        }
-      }).create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                Part.class,
+                new TypeAdapter<Part>() {
+                  @Override
+                  public void write(JsonWriter out, Part part) {
+                    throw new AssertionError();
+                  }
+
+                  @Override
+                  public Part read(JsonReader in) {
+                    throw new AssertionError();
+                  }
+                })
+            .create();
     String json = gson.toJson(new Gadget(new Part("screen")));
     assertThat(json).isEqualTo("{\"part\":\"PartJsonFieldAnnotationAdapter\"}");
     Gadget gadget = gson.fromJson("{'part':'screen'}", Gadget.class);
@@ -104,6 +108,7 @@ public final class JsonAdapterAnnotationOnFieldsTest {
   private static final class Gadget {
     @JsonAdapter(PartJsonFieldAnnotationAdapter.class)
     final Part part;
+
     Gadget(Part part) {
       this.part = part;
     }
@@ -112,6 +117,7 @@ public final class JsonAdapterAnnotationOnFieldsTest {
   private static final class Gizmo {
     @JsonAdapter(GizmoPartTypeAdapterFactory.class)
     final Part part;
+
     Gizmo(Part part) {
       this.part = part;
     }
@@ -119,29 +125,37 @@ public final class JsonAdapterAnnotationOnFieldsTest {
 
   private static final class Part {
     final String name;
+
     public Part(String name) {
       this.name = name;
     }
   }
 
   private static class PartJsonFieldAnnotationAdapter extends TypeAdapter<Part> {
-    @Override public void write(JsonWriter out, Part part) throws IOException {
+    @Override
+    public void write(JsonWriter out, Part part) throws IOException {
       out.value("PartJsonFieldAnnotationAdapter");
     }
-    @Override public Part read(JsonReader in) throws IOException {
+
+    @Override
+    public Part read(JsonReader in) throws IOException {
       String unused = in.nextString();
       return new Part("PartJsonFieldAnnotationAdapter");
     }
   }
 
   private static class GizmoPartTypeAdapterFactory implements TypeAdapterFactory {
-    @Override public <T> TypeAdapter<T> create(Gson gson, final TypeToken<T> type) {
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, final TypeToken<T> type) {
       return new TypeAdapter<T>() {
-        @Override public void write(JsonWriter out, T value) throws IOException {
+        @Override
+        public void write(JsonWriter out, T value) throws IOException {
           out.value("GizmoPartTypeAdapterFactory");
         }
+
         @SuppressWarnings("unchecked")
-        @Override public T read(JsonReader in) throws IOException {
+        @Override
+        public T read(JsonReader in) throws IOException {
           String unused = in.nextString();
           return (T) new Part("GizmoPartTypeAdapterFactory");
         }
@@ -151,6 +165,7 @@ public final class JsonAdapterAnnotationOnFieldsTest {
 
   private static final class Computer {
     final User user;
+
     Computer(User user) {
       this.user = user;
     }
@@ -159,16 +174,20 @@ public final class JsonAdapterAnnotationOnFieldsTest {
   @JsonAdapter(UserClassAnnotationAdapter.class)
   private static class User {
     public final String name;
+
     private User(String name) {
       this.name = name;
     }
   }
 
   private static class UserClassAnnotationAdapter extends TypeAdapter<User> {
-    @Override public void write(JsonWriter out, User user) throws IOException {
+    @Override
+    public void write(JsonWriter out, User user) throws IOException {
       out.value("UserClassAnnotationAdapter");
     }
-    @Override public User read(JsonReader in) throws IOException {
+
+    @Override
+    public User read(JsonReader in) throws IOException {
       String unused = in.nextString();
       return new User("UserClassAnnotationAdapter");
     }
@@ -178,26 +197,33 @@ public final class JsonAdapterAnnotationOnFieldsTest {
     // overrides the JsonAdapter annotation of User with this
     @JsonAdapter(UserFieldAnnotationAdapter.class)
     final User user;
+
     Computer2(User user) {
       this.user = user;
     }
   }
 
   private static final class UserFieldAnnotationAdapter extends TypeAdapter<User> {
-    @Override public void write(JsonWriter out, User user) throws IOException {
+    @Override
+    public void write(JsonWriter out, User user) throws IOException {
       out.value("UserFieldAnnotationAdapter");
     }
-    @Override public User read(JsonReader in) throws IOException {
+
+    @Override
+    public User read(JsonReader in) throws IOException {
       String unused = in.nextString();
       return new User("UserFieldAnnotationAdapter");
     }
   }
 
   private static final class RegisteredUserAdapter extends TypeAdapter<User> {
-    @Override public void write(JsonWriter out, User user) throws IOException {
+    @Override
+    public void write(JsonWriter out, User user) throws IOException {
       out.value("RegisteredUserAdapter");
     }
-    @Override public User read(JsonReader in) throws IOException {
+
+    @Override
+    public User read(JsonReader in) throws IOException {
       String unused = in.nextString();
       return new User("RegisteredUserAdapter");
     }
@@ -213,9 +239,13 @@ public final class JsonAdapterAnnotationOnFieldsTest {
   }
 
   private static final class GadgetWithTwoParts {
-    @JsonAdapter(PartJsonFieldAnnotationAdapter.class) final Part part1;
+    @JsonAdapter(PartJsonFieldAnnotationAdapter.class)
+    final Part part1;
+
     final Part part2; // Doesn't have the JsonAdapter annotation
-    @SuppressWarnings("unused") GadgetWithTwoParts(Part part1, Part part2) {
+
+    @SuppressWarnings("unused")
+    GadgetWithTwoParts(Part part1, Part part2) {
       this.part1 = part1;
       this.part2 = part2;
     }
@@ -272,24 +302,32 @@ public final class JsonAdapterAnnotationOnFieldsTest {
   }
 
   private static final class LongToStringTypeAdapterFactory implements TypeAdapterFactory {
-    static final TypeAdapter<Long> ADAPTER = new TypeAdapter<Long>() {
-      @Override public void write(JsonWriter out, Long value) throws IOException {
-        out.value(value.toString());
-      }
-      @Override public Long read(JsonReader in) throws IOException {
-        return in.nextLong();
-      }
-    };
+    static final TypeAdapter<Long> ADAPTER =
+        new TypeAdapter<Long>() {
+          @Override
+          public void write(JsonWriter out, Long value) throws IOException {
+            out.value(value.toString());
+          }
+
+          @Override
+          public Long read(JsonReader in) throws IOException {
+            return in.nextLong();
+          }
+        };
+
     @SuppressWarnings("unchecked")
-    @Override public <T> TypeAdapter<T> create(Gson gson, final TypeToken<T> type) {
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, final TypeToken<T> type) {
       Class<?> cls = type.getRawType();
       if (Long.class.isAssignableFrom(cls)) {
         return (TypeAdapter<T>) ADAPTER;
       } else if (long.class.isAssignableFrom(cls)) {
         return (TypeAdapter<T>) ADAPTER;
       }
-      throw new IllegalStateException("Non-long field of type " + type
-          + " annotated with @JsonAdapter(LongToStringTypeAdapterFactory.class)");
+      throw new IllegalStateException(
+          "Non-long field of type "
+              + type
+              + " annotated with @JsonAdapter(LongToStringTypeAdapterFactory.class)");
     }
   }
 
@@ -305,19 +343,24 @@ public final class JsonAdapterAnnotationOnFieldsTest {
   private static final class Gizmo2 {
     @JsonAdapter(Gizmo2PartTypeAdapterFactory.class)
     List<Part> part;
+
     Gizmo2(List<Part> part) {
       this.part = part;
     }
   }
 
   private static class Gizmo2PartTypeAdapterFactory implements TypeAdapterFactory {
-    @Override public <T> TypeAdapter<T> create(Gson gson, final TypeToken<T> type) {
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, final TypeToken<T> type) {
       return new TypeAdapter<T>() {
-        @Override public void write(JsonWriter out, T value) throws IOException {
+        @Override
+        public void write(JsonWriter out, T value) throws IOException {
           out.value("GizmoPartTypeAdapterFactory");
         }
+
         @SuppressWarnings("unchecked")
-        @Override public T read(JsonReader in) throws IOException {
+        @Override
+        public T read(JsonReader in) throws IOException {
           String unused = in.nextString();
           return (T) Arrays.asList(new Part("GizmoPartTypeAdapterFactory"));
         }
@@ -326,8 +369,8 @@ public final class JsonAdapterAnnotationOnFieldsTest {
   }
 
   /**
-   * Verify that {@link JsonAdapter} annotation can overwrite adapters which
-   * can normally not be overwritten (in this case adapter for {@link JsonElement}).
+   * Verify that {@link JsonAdapter} annotation can overwrite adapters which can normally not be
+   * overwritten (in this case adapter for {@link JsonElement}).
    */
   @Test
   public void testOverwriteBuiltIn() {
@@ -347,33 +390,42 @@ public final class JsonAdapterAnnotationOnFieldsTest {
 
   private static class JsonElementAdapter extends TypeAdapter<JsonElement> {
     static final JsonPrimitive DESERIALIZED = new JsonPrimitive("deserialized hardcoded");
-    @Override public JsonElement read(JsonReader in) throws IOException {
+
+    @Override
+    public JsonElement read(JsonReader in) throws IOException {
       in.skipValue();
       return DESERIALIZED;
     }
 
     static final String SERIALIZED = "serialized hardcoded";
-    @Override public void write(JsonWriter out, JsonElement value) throws IOException {
+
+    @Override
+    public void write(JsonWriter out, JsonElement value) throws IOException {
       out.value(SERIALIZED);
     }
   }
 
   /**
-   * Verify that exclusion strategy preventing serialization has higher precedence than
-   * {@link JsonAdapter} annotation.
+   * Verify that exclusion strategy preventing serialization has higher precedence than {@link
+   * JsonAdapter} annotation.
    */
   @Test
   public void testExcludeSerializePrecedence() {
-    Gson gson = new GsonBuilder()
-        .addSerializationExclusionStrategy(new ExclusionStrategy() {
-          @Override public boolean shouldSkipField(FieldAttributes f) {
-            return true;
-          }
-          @Override public boolean shouldSkipClass(Class<?> clazz) {
-            return false;
-          }
-        })
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .addSerializationExclusionStrategy(
+                new ExclusionStrategy() {
+                  @Override
+                  public boolean shouldSkipField(FieldAttributes f) {
+                    return true;
+                  }
+
+                  @Override
+                  public boolean shouldSkipClass(Class<?> clazz) {
+                    return false;
+                  }
+                })
+            .create();
 
     DelegatingAndOverwriting obj = new DelegatingAndOverwriting();
     obj.f = 1;
@@ -382,7 +434,8 @@ public final class JsonAdapterAnnotationOnFieldsTest {
     String json = gson.toJson(obj);
     assertThat(json).isEqualTo("{}");
 
-    DelegatingAndOverwriting deserialized = gson.fromJson("{\"f\":1,\"f2\":2,\"f3\":3}", DelegatingAndOverwriting.class);
+    DelegatingAndOverwriting deserialized =
+        gson.fromJson("{\"f\":1,\"f2\":2,\"f3\":3}", DelegatingAndOverwriting.class);
     assertThat(deserialized.f).isEqualTo(Integer.valueOf(1));
     assertThat(deserialized.f2).isEqualTo(new JsonPrimitive(2));
     // Verify that for deserialization type adapter specified by @JsonAdapter is used
@@ -390,21 +443,26 @@ public final class JsonAdapterAnnotationOnFieldsTest {
   }
 
   /**
-   * Verify that exclusion strategy preventing deserialization has higher precedence than
-   * {@link JsonAdapter} annotation.
+   * Verify that exclusion strategy preventing deserialization has higher precedence than {@link
+   * JsonAdapter} annotation.
    */
   @Test
   public void testExcludeDeserializePrecedence() {
-    Gson gson = new GsonBuilder()
-        .addDeserializationExclusionStrategy(new ExclusionStrategy() {
-          @Override public boolean shouldSkipField(FieldAttributes f) {
-            return true;
-          }
-          @Override public boolean shouldSkipClass(Class<?> clazz) {
-            return false;
-          }
-        })
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .addDeserializationExclusionStrategy(
+                new ExclusionStrategy() {
+                  @Override
+                  public boolean shouldSkipField(FieldAttributes f) {
+                    return true;
+                  }
+
+                  @Override
+                  public boolean shouldSkipClass(Class<?> clazz) {
+                    return false;
+                  }
+                })
+            .create();
 
     DelegatingAndOverwriting obj = new DelegatingAndOverwriting();
     obj.f = 1;
@@ -412,33 +470,40 @@ public final class JsonAdapterAnnotationOnFieldsTest {
     obj.f3 = new JsonPrimitive(true);
     String json = gson.toJson(obj);
     // Verify that for serialization type adapters specified by @JsonAdapter are used
-    assertThat(json).isEqualTo("{\"f\":1,\"f2\":2,\"f3\":\"" + JsonElementAdapter.SERIALIZED + "\"}");
+    assertThat(json)
+        .isEqualTo("{\"f\":1,\"f2\":2,\"f3\":\"" + JsonElementAdapter.SERIALIZED + "\"}");
 
-    DelegatingAndOverwriting deserialized = gson.fromJson("{\"f\":1,\"f2\":2,\"f3\":3}", DelegatingAndOverwriting.class);
+    DelegatingAndOverwriting deserialized =
+        gson.fromJson("{\"f\":1,\"f2\":2,\"f3\":3}", DelegatingAndOverwriting.class);
     assertThat(deserialized.f).isNull();
     assertThat(deserialized.f2).isNull();
     assertThat(deserialized.f3).isNull();
   }
 
   /**
-   * Verify that exclusion strategy preventing serialization and deserialization has
-   * higher precedence than {@link JsonAdapter} annotation.
+   * Verify that exclusion strategy preventing serialization and deserialization has higher
+   * precedence than {@link JsonAdapter} annotation.
    *
-   * <p>This is a separate test method because {@link ReflectiveTypeAdapterFactory} handles
-   * this case differently.
+   * <p>This is a separate test method because {@link ReflectiveTypeAdapterFactory} handles this
+   * case differently.
    */
   @Test
   public void testExcludePrecedence() {
-    Gson gson = new GsonBuilder()
-        .setExclusionStrategies(new ExclusionStrategy() {
-          @Override public boolean shouldSkipField(FieldAttributes f) {
-            return true;
-          }
-          @Override public boolean shouldSkipClass(Class<?> clazz) {
-            return false;
-          }
-        })
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .setExclusionStrategies(
+                new ExclusionStrategy() {
+                  @Override
+                  public boolean shouldSkipField(FieldAttributes f) {
+                    return true;
+                  }
+
+                  @Override
+                  public boolean shouldSkipClass(Class<?> clazz) {
+                    return false;
+                  }
+                })
+            .create();
 
     DelegatingAndOverwriting obj = new DelegatingAndOverwriting();
     obj.f = 1;
@@ -447,7 +512,8 @@ public final class JsonAdapterAnnotationOnFieldsTest {
     String json = gson.toJson(obj);
     assertThat(json).isEqualTo("{}");
 
-    DelegatingAndOverwriting deserialized = gson.fromJson("{\"f\":1,\"f2\":2,\"f3\":3}", DelegatingAndOverwriting.class);
+    DelegatingAndOverwriting deserialized =
+        gson.fromJson("{\"f\":1,\"f2\":2,\"f3\":3}", DelegatingAndOverwriting.class);
     assertThat(deserialized.f).isNull();
     assertThat(deserialized.f2).isNull();
     assertThat(deserialized.f3).isNull();
@@ -456,8 +522,10 @@ public final class JsonAdapterAnnotationOnFieldsTest {
   private static class DelegatingAndOverwriting {
     @JsonAdapter(DelegatingAdapterFactory.class)
     Integer f;
+
     @JsonAdapter(DelegatingAdapterFactory.class)
     JsonElement f2;
+
     // Also have non-delegating adapter to make tests handle both cases
     @JsonAdapter(JsonElementAdapter.class)
     JsonElement f3;
@@ -471,25 +539,29 @@ public final class JsonAdapterAnnotationOnFieldsTest {
   }
 
   /**
-   * Verifies that {@link TypeAdapterFactory} specified by {@code @JsonAdapter} can
-   * call {@link Gson#getDelegateAdapter} without any issues, despite the factory
-   * not being directly registered on Gson.
+   * Verifies that {@link TypeAdapterFactory} specified by {@code @JsonAdapter} can call {@link
+   * Gson#getDelegateAdapter} without any issues, despite the factory not being directly registered
+   * on Gson.
    */
   @Test
   public void testDelegatingAdapterFactory() {
     @SuppressWarnings("unchecked")
-    WithDelegatingFactory<String> deserialized = new Gson().fromJson("{\"f\":\"test\"}", WithDelegatingFactory.class);
+    WithDelegatingFactory<String> deserialized =
+        new Gson().fromJson("{\"f\":\"test\"}", WithDelegatingFactory.class);
     assertThat(deserialized.f).isEqualTo("test-custom");
 
-    deserialized = new Gson().fromJson("{\"f\":\"test\"}", new TypeToken<WithDelegatingFactory<String>>() {});
+    deserialized =
+        new Gson().fromJson("{\"f\":\"test\"}", new TypeToken<WithDelegatingFactory<String>>() {});
     assertThat(deserialized.f).isEqualTo("test-custom");
 
     WithDelegatingFactory<String> serialized = new WithDelegatingFactory<>();
     serialized.f = "value";
     assertThat(new Gson().toJson(serialized)).isEqualTo("{\"f\":\"value-custom\"}");
   }
+
   private static class WithDelegatingFactory<T> {
-    @SuppressWarnings("SameNameButDifferent") // suppress Error Prone warning; should be clear that `Factory` refers to nested class
+    // suppress Error Prone warning; should be clear that `Factory` refers to nested class
+    @SuppressWarnings("SameNameButDifferent")
     @JsonAdapter(Factory.class)
     T f;
 
@@ -499,37 +571,42 @@ public final class JsonAdapterAnnotationOnFieldsTest {
       public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
         TypeAdapter<String> delegate = (TypeAdapter<String>) gson.getDelegateAdapter(this, type);
 
-        return (TypeAdapter<T>) new TypeAdapter<String>() {
-          @Override
-          public String read(JsonReader in) throws IOException {
-            // Perform custom deserialization
-            return delegate.read(in) + "-custom";
-          }
+        return (TypeAdapter<T>)
+            new TypeAdapter<String>() {
+              @Override
+              public String read(JsonReader in) throws IOException {
+                // Perform custom deserialization
+                return delegate.read(in) + "-custom";
+              }
 
-          @Override
-          public void write(JsonWriter out, String value) throws IOException {
-            // Perform custom serialization
-            delegate.write(out, value + "-custom");
-          }
-        };
+              @Override
+              public void write(JsonWriter out, String value) throws IOException {
+                // Perform custom serialization
+                delegate.write(out, value + "-custom");
+              }
+            };
       }
     }
   }
 
   /**
-   * Similar to {@link #testDelegatingAdapterFactory}, except that the delegate is not
-   * looked up in {@code create} but instead in the adapter methods.
+   * Similar to {@link #testDelegatingAdapterFactory}, except that the delegate is not looked up in
+   * {@code create} but instead in the adapter methods.
    */
   @Test
   public void testDelegatingAdapterFactory_Delayed() {
-    WithDelayedDelegatingFactory deserialized = new Gson().fromJson("{\"f\":\"test\"}", WithDelayedDelegatingFactory.class);
+    WithDelayedDelegatingFactory deserialized =
+        new Gson().fromJson("{\"f\":\"test\"}", WithDelayedDelegatingFactory.class);
     assertThat(deserialized.f).isEqualTo("test-custom");
 
     WithDelayedDelegatingFactory serialized = new WithDelayedDelegatingFactory();
     serialized.f = "value";
     assertThat(new Gson().toJson(serialized)).isEqualTo("{\"f\":\"value-custom\"}");
   }
-  @SuppressWarnings("SameNameButDifferent") // suppress Error Prone warning; should be clear that `Factory` refers to nested class
+
+  // suppress Error Prone warning; should be clear that `Factory` refers to nested class to nested
+  // class
+  @SuppressWarnings("SameNameButDifferent")
   private static class WithDelayedDelegatingFactory {
     @JsonAdapter(Factory.class)
     String f;
@@ -538,23 +615,24 @@ public final class JsonAdapterAnnotationOnFieldsTest {
       @SuppressWarnings("unchecked")
       @Override
       public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
-        return (TypeAdapter<T>) new TypeAdapter<String>() {
-          private TypeAdapter<String> delegate() {
-            return (TypeAdapter<String>) gson.getDelegateAdapter(Factory.this, type);
-          }
+        return (TypeAdapter<T>)
+            new TypeAdapter<String>() {
+              private TypeAdapter<String> delegate() {
+                return (TypeAdapter<String>) gson.getDelegateAdapter(Factory.this, type);
+              }
 
-          @Override
-          public String read(JsonReader in) throws IOException {
-            // Perform custom deserialization
-            return delegate().read(in) + "-custom";
-          }
+              @Override
+              public String read(JsonReader in) throws IOException {
+                // Perform custom deserialization
+                return delegate().read(in) + "-custom";
+              }
 
-          @Override
-          public void write(JsonWriter out, String value) throws IOException {
-            // Perform custom serialization
-            delegate().write(out, value + "-custom");
-          }
-        };
+              @Override
+              public void write(JsonWriter out, String value) throws IOException {
+                // Perform custom serialization
+                delegate().write(out, value + "-custom");
+              }
+            };
       }
     }
   }
@@ -562,7 +640,8 @@ public final class JsonAdapterAnnotationOnFieldsTest {
   /**
    * Tests usage of {@link Gson#getAdapter(TypeToken)} in the {@code create} method of the factory.
    * Existing code was using that as workaround because {@link Gson#getDelegateAdapter} previously
-   * did not work in combination with {@code @JsonAdapter}, see https://github.com/google/gson/issues/1028.
+   * did not work in combination with {@code @JsonAdapter}, see
+   * https://github.com/google/gson/issues/1028.
    */
   @Test
   public void testGetAdapterDelegation() {
@@ -573,8 +652,10 @@ public final class JsonAdapterAnnotationOnFieldsTest {
     String json = gson.toJson(new GetAdapterDelegation("se"));
     assertThat(json).isEqualTo("{\"f\":\"se-custom\"}");
   }
+
   private static class GetAdapterDelegation {
-    @SuppressWarnings("SameNameButDifferent") // suppress Error Prone warning; should be clear that `Factory` refers to nested class
+    // suppress Error Prone warning; should be clear that `Factory` refers to nested class
+    @SuppressWarnings("SameNameButDifferent")
     @JsonAdapter(Factory.class)
     String f;
 
@@ -589,24 +670,23 @@ public final class JsonAdapterAnnotationOnFieldsTest {
         // Uses `Gson.getAdapter` instead of `Gson.getDelegateAdapter`
         TypeAdapter<String> delegate = (TypeAdapter<String>) gson.getAdapter(type);
 
-        return (TypeAdapter<T>) new TypeAdapter<String>() {
-          @Override
-          public String read(JsonReader in) throws IOException {
-            return delegate.read(in) + "-custom";
-          }
+        return (TypeAdapter<T>)
+            new TypeAdapter<String>() {
+              @Override
+              public String read(JsonReader in) throws IOException {
+                return delegate.read(in) + "-custom";
+              }
 
-          @Override
-          public void write(JsonWriter out, String value) throws IOException {
-            delegate.write(out, value + "-custom");
-          }
-        };
+              @Override
+              public void write(JsonWriter out, String value) throws IOException {
+                delegate.write(out, value + "-custom");
+              }
+            };
       }
     }
   }
 
-  /**
-   * Tests usage of {@link JsonSerializer} as {@link JsonAdapter} value on a field
-   */
+  /** Tests usage of {@link JsonSerializer} as {@link JsonAdapter} value on a field */
   @Test
   public void testJsonSerializer() {
     Gson gson = new Gson();
@@ -618,21 +698,21 @@ public final class JsonAdapterAnnotationOnFieldsTest {
     // Uses custom serializer which always returns `true`
     assertThat(json).isEqualTo("{\"f\":true}");
   }
+
   private static class WithJsonSerializer {
     @JsonAdapter(Serializer.class)
     List<Integer> f = Collections.emptyList();
 
     static class Serializer implements JsonSerializer<List<Integer>> {
       @Override
-      public JsonElement serialize(List<Integer> src, Type typeOfSrc, JsonSerializationContext context) {
+      public JsonElement serialize(
+          List<Integer> src, Type typeOfSrc, JsonSerializationContext context) {
         return new JsonPrimitive(true);
       }
     }
   }
 
-  /**
-   * Tests usage of {@link JsonDeserializer} as {@link JsonAdapter} value on a field
-   */
+  /** Tests usage of {@link JsonDeserializer} as {@link JsonAdapter} value on a field */
   @Test
   public void testJsonDeserializer() {
     Gson gson = new Gson();
@@ -644,6 +724,7 @@ public final class JsonAdapterAnnotationOnFieldsTest {
     String json = gson.toJson(new WithJsonDeserializer(Arrays.asList(4, 5, 6)));
     assertThat(json).isEqualTo("{\"f\":[4,5,6]}");
   }
+
   private static class WithJsonDeserializer {
     @JsonAdapter(Deserializer.class)
     List<Integer> f;
@@ -654,7 +735,8 @@ public final class JsonAdapterAnnotationOnFieldsTest {
 
     static class Deserializer implements JsonDeserializer<List<Integer>> {
       @Override
-      public List<Integer> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
+      public List<Integer> deserialize(
+          JsonElement json, Type typeOfT, JsonDeserializationContext context) {
         return Arrays.asList(3, 2, 1);
       }
     }

--- a/gson/src/test/java/com/google/gson/functional/JsonAdapterSerializerDeserializerTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonAdapterSerializerDeserializerTest.java
@@ -37,17 +37,20 @@ import java.lang.reflect.Type;
 import org.junit.Test;
 
 /**
- * Functional tests for the {@link JsonAdapter} annotation on fields where the value is of
- * type {@link JsonSerializer} or {@link JsonDeserializer}.
+ * Functional tests for the {@link JsonAdapter} annotation on fields where the value is of type
+ * {@link JsonSerializer} or {@link JsonDeserializer}.
  */
 public final class JsonAdapterSerializerDeserializerTest {
 
   @Test
   public void testJsonSerializerDeserializerBasedJsonAdapterOnFields() {
     Gson gson = new Gson();
-    String json = gson.toJson(new Computer(new User("Inderjeet Singh"), null, new User("Jesse Wilson")));
-    assertThat(json).isEqualTo("{\"user1\":\"UserSerializer\",\"user3\":\"UserSerializerDeserializer\"}");
-    Computer computer = gson.fromJson("{'user2':'Jesse Wilson','user3':'Jake Wharton'}", Computer.class);
+    String json =
+        gson.toJson(new Computer(new User("Inderjeet Singh"), null, new User("Jesse Wilson")));
+    assertThat(json)
+        .isEqualTo("{\"user1\":\"UserSerializer\",\"user3\":\"UserSerializerDeserializer\"}");
+    Computer computer =
+        gson.fromJson("{'user2':'Jesse Wilson','user3':'Jake Wharton'}", Computer.class);
     assertThat(computer.user2.name).isEqualTo("UserDeserializer");
     assertThat(computer.user3.name).isEqualTo("UserSerializerDeserializer");
   }
@@ -56,12 +59,15 @@ public final class JsonAdapterSerializerDeserializerTest {
     @JsonAdapter(UserSerializer.class)
     @Keep
     final User user1;
+
     @JsonAdapter(UserDeserializer.class)
     @Keep
     final User user2;
+
     @JsonAdapter(UserSerializerDeserializer.class)
     @Keep
     final User user3;
+
     Computer(User user1, User user2, User user3) {
       this.user1 = user1;
       this.user2 = user2;
@@ -71,6 +77,7 @@ public final class JsonAdapterSerializerDeserializerTest {
 
   private static final class User {
     public final String name;
+
     private User(String name) {
       this.name = name;
     }
@@ -91,11 +98,13 @@ public final class JsonAdapterSerializerDeserializerTest {
     }
   }
 
-  private static final class UserSerializerDeserializer implements JsonSerializer<User>, JsonDeserializer<User> {
+  private static final class UserSerializerDeserializer
+      implements JsonSerializer<User>, JsonDeserializer<User> {
     @Override
     public JsonElement serialize(User src, Type typeOfSrc, JsonSerializationContext context) {
       return new JsonPrimitive("UserSerializerDeserializer");
     }
+
     @Override
     public User deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
         throws JsonParseException {
@@ -114,6 +123,7 @@ public final class JsonAdapterSerializerDeserializerTest {
 
   private static final class Computer2 {
     final User2 user;
+
     Computer2(User2 user) {
       this.user = user;
     }
@@ -122,16 +132,19 @@ public final class JsonAdapterSerializerDeserializerTest {
   @JsonAdapter(UserSerializerDeserializer2.class)
   private static final class User2 {
     public final String name;
+
     private User2(String name) {
       this.name = name;
     }
   }
 
-  private static final class UserSerializerDeserializer2 implements JsonSerializer<User2>, JsonDeserializer<User2> {
+  private static final class UserSerializerDeserializer2
+      implements JsonSerializer<User2>, JsonDeserializer<User2> {
     @Override
     public JsonElement serialize(User2 src, Type typeOfSrc, JsonSerializationContext context) {
       return new JsonPrimitive("UserSerializerDeserializer2");
     }
+
     @Override
     public User2 deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
         throws JsonParseException {
@@ -152,9 +165,11 @@ public final class JsonAdapterSerializerDeserializerTest {
     @JsonAdapter(BaseStringAdapter.class)
     @Keep
     Base<String> a;
+
     @JsonAdapter(BaseIntegerAdapter.class)
     @Keep
     Base<Integer> b;
+
     Container(String a, int b) {
       this.a = new Base<>(a);
       this.b = new Base<>(b);
@@ -164,46 +179,60 @@ public final class JsonAdapterSerializerDeserializerTest {
   private static final class Base<T> {
     @SuppressWarnings("unused")
     T value;
+
     Base(T value) {
       this.value = value;
     }
   }
 
   private static final class BaseStringAdapter implements JsonSerializer<Base<String>> {
-    @Override public JsonElement serialize(Base<String> src, Type typeOfSrc, JsonSerializationContext context) {
+    @Override
+    public JsonElement serialize(
+        Base<String> src, Type typeOfSrc, JsonSerializationContext context) {
       return new JsonPrimitive("BaseStringAdapter");
     }
   }
 
   private static final class BaseIntegerAdapter implements JsonSerializer<Base<Integer>> {
-    @Override public JsonElement serialize(Base<Integer> src, Type typeOfSrc, JsonSerializationContext context) {
+    @Override
+    public JsonElement serialize(
+        Base<Integer> src, Type typeOfSrc, JsonSerializationContext context) {
       return new JsonPrimitive("BaseIntegerAdapter");
     }
   }
 
   @Test
   public void testJsonAdapterNullSafe() {
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(User.class, new TypeAdapter<User>() {
-          @Override
-          public User read(JsonReader in) throws IOException {
-            in.nextNull();
-            return new User("fallback-read");
-          }
-          @Override
-          public void write(JsonWriter out, User value) throws IOException {
-            assertThat(value).isNull();
-            out.value("fallback-write");
-          }
-        })
-        .serializeNulls()
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                User.class,
+                new TypeAdapter<User>() {
+                  @Override
+                  public User read(JsonReader in) throws IOException {
+                    in.nextNull();
+                    return new User("fallback-read");
+                  }
+
+                  @Override
+                  public void write(JsonWriter out, User value) throws IOException {
+                    assertThat(value).isNull();
+                    out.value("fallback-write");
+                  }
+                })
+            .serializeNulls()
+            .create();
 
     String json = gson.toJson(new WithNullSafe(null, null, null, null));
-    // Only nullSafe=true serializer writes null; for @JsonAdapter with deserializer nullSafe is ignored when serializing
-    assertThat(json).isEqualTo("{\"userS\":\"UserSerializer\",\"userSN\":null,\"userD\":\"fallback-write\",\"userDN\":\"fallback-write\"}");
+    // Only nullSafe=true serializer writes null; for @JsonAdapter with deserializer nullSafe is
+    // ignored when serializing
+    assertThat(json)
+        .isEqualTo(
+            "{\"userS\":\"UserSerializer\",\"userSN\":null,\"userD\":\"fallback-write\",\"userDN\":\"fallback-write\"}");
 
-    WithNullSafe deserialized = gson.fromJson("{\"userS\":null,\"userSN\":null,\"userD\":null,\"userDN\":null}", WithNullSafe.class);
+    WithNullSafe deserialized =
+        gson.fromJson(
+            "{\"userS\":null,\"userSN\":null,\"userD\":null,\"userDN\":null}", WithNullSafe.class);
     // For @JsonAdapter with serializer nullSafe is ignored when deserializing
     assertThat(deserialized.userS.name).isEqualTo("fallback-read");
     assertThat(deserialized.userSN.name).isEqualTo("fallback-read");
@@ -213,12 +242,18 @@ public final class JsonAdapterSerializerDeserializerTest {
 
   private static final class WithNullSafe {
     // "userS..." uses JsonSerializer
-    @JsonAdapter(value = UserSerializer.class, nullSafe = false) final User userS;
-    @JsonAdapter(value = UserSerializer.class, nullSafe = true) final User userSN;
+    @JsonAdapter(value = UserSerializer.class, nullSafe = false)
+    final User userS;
+
+    @JsonAdapter(value = UserSerializer.class, nullSafe = true)
+    final User userSN;
 
     // "userD..." uses JsonDeserializer
-    @JsonAdapter(value = UserDeserializer.class, nullSafe = false) final User userD;
-    @JsonAdapter(value = UserDeserializer.class, nullSafe = true) final User userDN;
+    @JsonAdapter(value = UserDeserializer.class, nullSafe = false)
+    final User userD;
+
+    @JsonAdapter(value = UserDeserializer.class, nullSafe = true)
+    final User userDN;
 
     WithNullSafe(User userS, User userSN, User userD, User userDN) {
       this.userS = userS;

--- a/gson/src/test/java/com/google/gson/functional/JsonParserTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonParserTest.java
@@ -56,7 +56,8 @@ public class JsonParserTest {
     try {
       gson.fromJson("[[]", Object[].class);
       fail();
-    } catch (JsonSyntaxException expected) { }
+    } catch (JsonSyntaxException expected) {
+    }
   }
 
   @Test
@@ -79,7 +80,8 @@ public class JsonParserTest {
     try {
       gson.fromJson(array, BagOfPrimitives.class);
       fail("BagOfPrimitives is not an array");
-    } catch (JsonParseException expected) { }
+    } catch (JsonParseException expected) {
+    }
   }
 
   @Test
@@ -94,7 +96,8 @@ public class JsonParserTest {
     try {
       gson.fromJson(obj, BagOfPrimitives.class);
       fail("BagOfPrimitives is not an array");
-    } catch (JsonParseException expected) { }
+    } catch (JsonParseException expected) {
+    }
   }
 
   @Test
@@ -112,13 +115,14 @@ public class JsonParserTest {
     try {
       gson.fromJson(obj, Nested.class);
       fail("Nested has field BagOfPrimitives which is not an array");
-    } catch (JsonParseException expected) { }
+    } catch (JsonParseException expected) {
+    }
   }
 
   @Test
   public void testChangingCustomTreeAndDeserializing() {
     StringReader json =
-      new StringReader("{'stringValue':'no message','intValue':10,'longValue':20}");
+        new StringReader("{'stringValue':'no message','intValue':10,'longValue':20}");
     JsonObject obj = (JsonObject) JsonParser.parseReader(json);
     obj.remove("stringValue");
     obj.addProperty("stringValue", "fooBar");
@@ -131,7 +135,8 @@ public class JsonParserTest {
   @Test
   public void testExtraCommasInArrays() {
     Type type = new TypeToken<List<String>>() {}.getType();
-    assertThat(Arrays.asList("a", null, "b", null, null)).isEqualTo(gson.fromJson("[a,,b,,]", type));
+    assertThat(Arrays.asList("a", null, "b", null, null))
+        .isEqualTo(gson.fromJson("[a,,b,,]", type));
     assertThat(Arrays.asList(null, null)).isEqualTo(gson.fromJson("[,]", type));
     assertThat(Arrays.asList("a", null)).isEqualTo(gson.fromJson("[a,]", type));
   }

--- a/gson/src/test/java/com/google/gson/functional/JsonTreeTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonTreeTest.java
@@ -31,9 +31,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Functional tests for {@link Gson#toJsonTree(Object)} and 
- * {@link Gson#toJsonTree(Object, java.lang.reflect.Type)}
- * 
+ * Functional tests for {@link Gson#toJsonTree(Object)} and {@link Gson#toJsonTree(Object,
+ * java.lang.reflect.Type)}
+ *
  * @author Inderjeet Singh
  * @author Joel Leitch
  */
@@ -79,7 +79,7 @@ public class JsonTreeTest {
     String json1 = gson.toJson(bag);
     JsonElement jsonElement = gson.toJsonTree(bag, SubTypeOfBagOfPrimitives.class);
     String json2 = gson.toJson(jsonElement);
-   assertThat(json2).isEqualTo(json1);
+    assertThat(json2).isEqualTo(json1);
   }
 
   @Test
@@ -100,10 +100,11 @@ public class JsonTreeTest {
     }
     fail();
   }
-  
+
   private static class SubTypeOfBagOfPrimitives extends BagOfPrimitives {
     @SuppressWarnings("unused")
     float f = 1.2F;
+
     public SubTypeOfBagOfPrimitives(long l, int i, boolean b, String string, float f) {
       super(l, i, b, string);
       this.f = f;

--- a/gson/src/test/java/com/google/gson/functional/LeniencyTest.java
+++ b/gson/src/test/java/com/google/gson/functional/LeniencyTest.java
@@ -25,9 +25,7 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
-/**
- * Functional tests for leniency option.
- */
+/** Functional tests for leniency option. */
 public class LeniencyTest {
 
   private Gson gson;
@@ -40,10 +38,10 @@ public class LeniencyTest {
 
   @Test
   public void testLenientFromJson() {
-    List<String> json = gson.fromJson(""
-        + "[ # One!\n"
-        + "  'Hi' #Element!\n"
-        + "] # Array!", new TypeToken<List<String>>() {}.getType());
+    List<String> json =
+        gson.fromJson(
+            "" + "[ # One!\n" + "  'Hi' #Element!\n" + "] # Array!",
+            new TypeToken<List<String>>() {}.getType());
     assertThat(json).isEqualTo(singletonList("Hi"));
   }
 }

--- a/gson/src/test/java/com/google/gson/functional/MapAsArrayTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MapAsArrayTypeAdapterTest.java
@@ -35,9 +35,7 @@ public class MapAsArrayTypeAdapterTest {
   @Test
   public void testSerializeComplexMapWithTypeAdapter() {
     Type type = new TypeToken<Map<Point, String>>() {}.getType();
-    Gson gson = new GsonBuilder()
-        .enableComplexMapKeySerialization()
-        .create();
+    Gson gson = new GsonBuilder().enableComplexMapKeySerialization().create();
 
     Map<Point, String> original = new LinkedHashMap<>();
     original.put(new Point(5, 5), "a");
@@ -53,16 +51,16 @@ public class MapAsArrayTypeAdapterTest {
     assertThat(gson.toJson(otherMap, Map.class)).isEqualTo("{\"t\":true,\"f\":false}");
     assertThat(gson.toJson(otherMap, new TypeToken<Map<String, Boolean>>() {}.getType()))
         .isEqualTo("{\"t\":true,\"f\":false}");
-    assertThat(gson.<Object>fromJson("{\"t\":true,\"f\":false}", new TypeToken<Map<String, Boolean>>() {}.getType()))
+    assertThat(
+            gson.<Object>fromJson(
+                "{\"t\":true,\"f\":false}", new TypeToken<Map<String, Boolean>>() {}.getType()))
         .isEqualTo(otherMap);
   }
 
   @Test
   @Ignore
   public void testTwoTypesCollapseToOneSerialize() {
-    Gson gson = new GsonBuilder()
-        .enableComplexMapKeySerialization()
-        .create();
+    Gson gson = new GsonBuilder().enableComplexMapKeySerialization().create();
 
     Map<Number, String> original = new LinkedHashMap<>();
     original.put(1.0D, "a");
@@ -76,9 +74,7 @@ public class MapAsArrayTypeAdapterTest {
 
   @Test
   public void testTwoTypesCollapseToOneDeserialize() {
-    Gson gson = new GsonBuilder()
-        .enableComplexMapKeySerialization()
-        .create();
+    Gson gson = new GsonBuilder().enableComplexMapKeySerialization().create();
 
     String s = "[[\"1.00\",\"a\"],[\"1.0\",\"b\"]]";
     try {
@@ -91,10 +87,11 @@ public class MapAsArrayTypeAdapterTest {
   @Test
   public void testMultipleEnableComplexKeyRegistrationHasNoEffect() {
     Type type = new TypeToken<Map<Point, String>>() {}.getType();
-    Gson gson = new GsonBuilder()
-        .enableComplexMapKeySerialization()
-        .enableComplexMapKeySerialization()
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .enableComplexMapKeySerialization()
+            .enableComplexMapKeySerialization()
+            .create();
 
     Map<Point, String> original = new LinkedHashMap<>();
     original.put(new Point(6, 5), "abc");
@@ -109,7 +106,7 @@ public class MapAsArrayTypeAdapterTest {
     Gson gson = new GsonBuilder().enableComplexMapKeySerialization().create();
     PointWithProperty<Point> map = new PointWithProperty<>();
     map.map.put(new Point(2, 3), new Point(4, 5));
-    Type type = new TypeToken<PointWithProperty<Point>>(){}.getType();
+    Type type = new TypeToken<PointWithProperty<Point>>() {}.getType();
     String json = gson.toJson(map, type);
     assertThat(json).isEqualTo("{\"map\":[[{\"x\":2,\"y\":3},{\"x\":4,\"y\":5}]]}");
   }
@@ -118,7 +115,7 @@ public class MapAsArrayTypeAdapterTest {
   public void testMapWithTypeVariableDeserialization() {
     Gson gson = new GsonBuilder().enableComplexMapKeySerialization().create();
     String json = "{map:[[{x:2,y:3},{x:4,y:5}]]}";
-    Type type = new TypeToken<PointWithProperty<Point>>(){}.getType();
+    Type type = new TypeToken<PointWithProperty<Point>>() {}.getType();
     PointWithProperty<Point> map = gson.fromJson(json, type);
     Point key = map.map.keySet().iterator().next();
     Point value = map.map.values().iterator().next();
@@ -129,18 +126,26 @@ public class MapAsArrayTypeAdapterTest {
   static class Point {
     int x;
     int y;
+
     Point(int x, int y) {
       this.x = x;
       this.y = y;
     }
+
     Point() {}
-    @Override public boolean equals(Object o) {
+
+    @Override
+    public boolean equals(Object o) {
       return o instanceof Point && ((Point) o).x == x && ((Point) o).y == y;
     }
-    @Override public int hashCode() {
+
+    @Override
+    public int hashCode() {
       return x * 37 + y;
     }
-    @Override public String toString() {
+
+    @Override
+    public String toString() {
       return "(" + x + "," + y + ")";
     }
   }

--- a/gson/src/test/java/com/google/gson/functional/MapTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MapTest.java
@@ -75,7 +75,7 @@ public class MapTest {
   @Test
   public void testMapDeserialization() {
     String json = "{\"a\":1,\"b\":2}";
-    Type typeOfMap = new TypeToken<Map<String,Integer>>(){}.getType();
+    Type typeOfMap = new TypeToken<Map<String, Integer>>() {}.getType();
     Map<String, Integer> target = gson.fromJson(json, typeOfMap);
     assertThat(target.get("a")).isEqualTo(1);
     assertThat(target.get("b")).isEqualTo(2);
@@ -281,9 +281,10 @@ public class MapTest {
     assertThat(json).contains("\"a\":\"b\"");
   }
 
-  @SuppressWarnings({ "unused", "serial" })
+  @SuppressWarnings({"unused", "serial"})
   private static class MyParameterizedMap<K, V> extends LinkedHashMap<K, V> {
     final int foo;
+
     MyParameterizedMap(int foo) {
       this.foo = foo;
     }
@@ -308,11 +309,17 @@ public class MapTest {
 
   @Test
   public void testMapSubclassDeserialization() {
-    Gson gson = new GsonBuilder().registerTypeAdapter(MyMap.class, new InstanceCreator<MyMap>() {
-      @Override public MyMap createInstance(Type type) {
-        return new MyMap();
-      }
-    }).create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                MyMap.class,
+                new InstanceCreator<MyMap>() {
+                  @Override
+                  public MyMap createInstance(Type type) {
+                    return new MyMap();
+                  }
+                })
+            .create();
     String json = "{\"a\":1,\"b\":2}";
     MyMap map = gson.fromJson(json, MyMap.class);
     assertThat(map.get("a")).isEqualTo("1");
@@ -321,19 +328,24 @@ public class MapTest {
 
   @Test
   public void testCustomSerializerForSpecificMapType() {
-    Type type = $Gson$Types.newParameterizedTypeWithOwner(
-        null, Map.class, String.class, Long.class);
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(type, new JsonSerializer<Map<String, Long>>() {
-          @Override public JsonElement serialize(Map<String, Long> src, Type typeOfSrc,
-              JsonSerializationContext context) {
-            JsonArray array = new JsonArray();
-            for (long value : src.values()) {
-              array.add(new JsonPrimitive(value));
-            }
-            return array;
-          }
-        }).create();
+    Type type =
+        $Gson$Types.newParameterizedTypeWithOwner(null, Map.class, String.class, Long.class);
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                type,
+                new JsonSerializer<Map<String, Long>>() {
+                  @Override
+                  public JsonElement serialize(
+                      Map<String, Long> src, Type typeOfSrc, JsonSerializationContext context) {
+                    JsonArray array = new JsonArray();
+                    for (long value : src.values()) {
+                      array.add(new JsonPrimitive(value));
+                    }
+                    return array;
+                  }
+                })
+            .create();
 
     Map<String, Long> src = new LinkedHashMap<>();
     src.put("one", 1L);
@@ -343,16 +355,12 @@ public class MapTest {
     assertThat(gson.toJson(src, type)).isEqualTo("[1,2,3]");
   }
 
-  /**
-   * Created in response to http://code.google.com/p/google-gson/issues/detail?id=99
-   */
+  /** Created in response to http://code.google.com/p/google-gson/issues/detail?id=99 */
   private static class ClassWithAMap {
     Map<String, String> map = new TreeMap<>();
   }
 
-  /**
-   * Created in response to http://code.google.com/p/google-gson/issues/detail?id=99
-   */
+  /** Created in response to http://code.google.com/p/google-gson/issues/detail?id=99 */
   @Test
   public void testMapSerializationWithNullValues() {
     ClassWithAMap target = new ClassWithAMap();
@@ -363,9 +371,7 @@ public class MapTest {
     assertThat(json).contains("name2");
   }
 
-  /**
-   * Created in response to http://code.google.com/p/google-gson/issues/detail?id=99
-   */
+  /** Created in response to http://code.google.com/p/google-gson/issues/detail?id=99 */
   @Test
   public void testMapSerializationWithNullValuesSerialized() {
     Gson gson = new GsonBuilder().serializeNulls().create();
@@ -396,7 +402,6 @@ public class MapTest {
     assertThat(map.get("test")).isEqualTo(123L);
   }
 
-
   private static class MyMap extends LinkedHashMap<String, String> {
     private static final long serialVersionUID = 1L;
 
@@ -404,9 +409,7 @@ public class MapTest {
     int foo = 10;
   }
 
-  /**
-   * From bug report http://code.google.com/p/google-gson/issues/detail?id=95
-   */
+  /** From bug report http://code.google.com/p/google-gson/issues/detail?id=95 */
   @Test
   public void testMapOfMapSerialization() {
     Map<String, Map<String, String>> map = new HashMap<>();
@@ -420,22 +423,18 @@ public class MapTest {
     assertThat(json).contains("\"2\":\"2\"");
   }
 
-  /**
-   * From bug report http://code.google.com/p/google-gson/issues/detail?id=95
-   */
+  /** From bug report http://code.google.com/p/google-gson/issues/detail?id=95 */
   @Test
   public void testMapOfMapDeserialization() {
     String json = "{nestedMap:{'2':'2','1':'1'}}";
-    Type type = new TypeToken<Map<String, Map<String, String>>>(){}.getType();
+    Type type = new TypeToken<Map<String, Map<String, String>>>() {}.getType();
     Map<String, Map<String, String>> map = gson.fromJson(json, type);
     Map<String, String> nested = map.get("nestedMap");
     assertThat(nested.get("1")).isEqualTo("1");
     assertThat(nested.get("2")).isEqualTo("2");
   }
 
-  /**
-   * From bug report http://code.google.com/p/google-gson/issues/detail?id=178
-   */
+  /** From bug report http://code.google.com/p/google-gson/issues/detail?id=178 */
   @Test
   public void testMapWithQuotes() {
     Map<String, String> map = new HashMap<>();
@@ -444,26 +443,22 @@ public class MapTest {
     assertThat(json).isEqualTo("{\"a\\\"b\":\"c\\\"d\"}");
   }
 
-  /**
-   * From issue 227.
-   */
+  /** From issue 227. */
   @Test
   public void testWriteMapsWithEmptyStringKey() {
     Map<String, Boolean> map = new HashMap<>();
     map.put("", true);
     assertThat(gson.toJson(map)).isEqualTo("{\"\":true}");
-
   }
 
   @Test
   public void testReadMapsWithEmptyStringKey() {
-    Map<String, Boolean> map = gson.fromJson("{\"\":true}", new TypeToken<Map<String, Boolean>>() {}.getType());
+    Map<String, Boolean> map =
+        gson.fromJson("{\"\":true}", new TypeToken<Map<String, Boolean>>() {}.getType());
     assertThat(map.get("")).isEqualTo(Boolean.TRUE);
   }
 
-  /**
-   * From bug report http://code.google.com/p/google-gson/issues/detail?id=204
-   */
+  /** From bug report http://code.google.com/p/google-gson/issues/detail?id=204 */
   @Test
   public void testSerializeMaps() {
     Map<String, Object> map = new LinkedHashMap<>();
@@ -472,24 +467,28 @@ public class MapTest {
 
     LinkedHashMap<String, Object> innerMap = new LinkedHashMap<>();
     innerMap.put("test", 1);
-    innerMap.put("TestStringArray", new String[] { "one", "two" });
+    innerMap.put("TestStringArray", new String[] {"one", "two"});
     map.put("c", innerMap);
 
     assertThat(new GsonBuilder().serializeNulls().create().toJson(map))
-        .isEqualTo("{\"a\":12,\"b\":null,\"c\":{\"test\":1,\"TestStringArray\":[\"one\",\"two\"]}}");
+        .isEqualTo(
+            "{\"a\":12,\"b\":null,\"c\":{\"test\":1,\"TestStringArray\":[\"one\",\"two\"]}}");
     assertThat(new GsonBuilder().setPrettyPrinting().serializeNulls().create().toJson(map))
-        .isEqualTo("{\n  \"a\": 12,\n  \"b\": null,\n  \"c\": "
-            + "{\n    \"test\": 1,\n    \"TestStringArray\": "
-            + "[\n      \"one\",\n      \"two\"\n    ]\n  }\n}");
+        .isEqualTo(
+            "{\n  \"a\": 12,\n  \"b\": null,\n  \"c\": "
+                + "{\n    \"test\": 1,\n    \"TestStringArray\": "
+                + "[\n      \"one\",\n      \"two\"\n    ]\n  }\n}");
     assertThat(new GsonBuilder().create().toJson(map))
         .isEqualTo("{\"a\":12,\"c\":{\"test\":1,\"TestStringArray\":[\"one\",\"two\"]}}");
     assertThat(new GsonBuilder().setPrettyPrinting().create().toJson(map))
-        .isEqualTo("{\n  \"a\": 12,\n  \"c\": "
-            + "{\n    \"test\": 1,\n    \"TestStringArray\": "
-            + "[\n      \"one\",\n      \"two\"\n    ]\n  }\n}");
+        .isEqualTo(
+            "{\n  \"a\": 12,\n  \"c\": "
+                + "{\n    \"test\": 1,\n    \"TestStringArray\": "
+                + "[\n      \"one\",\n      \"two\"\n    ]\n  }\n}");
     innerMap.put("d", "e");
     assertThat(new Gson().toJson(map))
-        .isEqualTo("{\"a\":12,\"c\":{\"test\":1,\"TestStringArray\":[\"one\",\"two\"],\"d\":\"e\"}}");
+        .isEqualTo(
+            "{\"a\":12,\"c\":{\"test\":1,\"TestStringArray\":[\"one\",\"two\"],\"d\":\"e\"}}");
   }
 
   @Test
@@ -500,12 +499,10 @@ public class MapTest {
     element.addSub("Test", subType);
 
     String subTypeJson = new Gson().toJson(subType);
-    String expected = "{\"bases\":{\"Test\":" + subTypeJson + "},"
-      + "\"subs\":{\"Test\":" + subTypeJson + "}}";
+    String expected =
+        "{\"bases\":{\"Test\":" + subTypeJson + "}," + "\"subs\":{\"Test\":" + subTypeJson + "}}";
 
-    Gson gsonWithComplexKeys = new GsonBuilder()
-        .enableComplexMapKeySerialization()
-        .create();
+    Gson gsonWithComplexKeys = new GsonBuilder().enableComplexMapKeySerialization().create();
     String json = gsonWithComplexKeys.toJson(element);
     assertThat(json).isEqualTo(expected);
 
@@ -525,26 +522,27 @@ public class MapTest {
     String subTypeJson = tempGson.toJson(subType);
     final JsonElement baseTypeJsonElement = tempGson.toJsonTree(subType, TestTypes.Base.class);
     String baseTypeJson = tempGson.toJson(baseTypeJsonElement);
-    String expected = "{\"bases\":{\"Test\":" + baseTypeJson + "},"
-        + "\"subs\":{\"Test\":" + subTypeJson + "}}";
+    String expected =
+        "{\"bases\":{\"Test\":" + baseTypeJson + "}," + "\"subs\":{\"Test\":" + subTypeJson + "}}";
 
-    JsonSerializer<TestTypes.Base> baseTypeAdapter = new JsonSerializer<TestTypes.Base>() {
-      @Override public JsonElement serialize(TestTypes.Base src, Type typeOfSrc,
-          JsonSerializationContext context) {
-        return baseTypeJsonElement;
-      }
-    };
+    JsonSerializer<TestTypes.Base> baseTypeAdapter =
+        new JsonSerializer<TestTypes.Base>() {
+          @Override
+          public JsonElement serialize(
+              TestTypes.Base src, Type typeOfSrc, JsonSerializationContext context) {
+            return baseTypeJsonElement;
+          }
+        };
 
-    Gson gson = new GsonBuilder()
-        .enableComplexMapKeySerialization()
-        .registerTypeAdapter(TestTypes.Base.class, baseTypeAdapter)
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .enableComplexMapKeySerialization()
+            .registerTypeAdapter(TestTypes.Base.class, baseTypeAdapter)
+            .create();
     String json = gson.toJson(element);
     assertThat(json).isEqualTo(expected);
 
-    gson = new GsonBuilder()
-        .registerTypeAdapter(TestTypes.Base.class, baseTypeAdapter)
-        .create();
+    gson = new GsonBuilder().registerTypeAdapter(TestTypes.Base.class, baseTypeAdapter).create();
     json = gson.toJson(element);
     assertThat(json).isEqualTo(expected);
   }
@@ -553,16 +551,15 @@ public class MapTest {
   public void testGeneralMapField() {
     MapWithGeneralMapParameters map = new MapWithGeneralMapParameters();
     map.map.put("string", "testString");
-    map.map.put("stringArray", new String[]{"one", "two"});
-    map.map.put("objectArray", new Object[]{1, 2L, "three"});
+    map.map.put("stringArray", new String[] {"one", "two"});
+    map.map.put("objectArray", new Object[] {1, 2L, "three"});
 
-    String expected = "{\"map\":{\"string\":\"testString\",\"stringArray\":"
-        + "[\"one\",\"two\"],\"objectArray\":[1,2,\"three\"]}}";
+    String expected =
+        "{\"map\":{\"string\":\"testString\",\"stringArray\":"
+            + "[\"one\",\"two\"],\"objectArray\":[1,2,\"three\"]}}";
     assertThat(gson.toJson(map)).isEqualTo(expected);
 
-    gson = new GsonBuilder()
-        .enableComplexMapKeySerialization()
-        .create();
+    gson = new GsonBuilder().enableComplexMapKeySerialization().create();
     assertThat(gson.toJson(map)).isEqualTo(expected);
   }
 
@@ -592,7 +589,8 @@ public class MapTest {
     Map<String, String> map = new LinkedHashMap<>();
     map.put("2,3", "a");
     map.put("5,7", "b");
-    assertThat(map).isEqualTo(gson.fromJson(json, new TypeToken<Map<String, String>>() {}.getType()));
+    assertThat(map)
+        .isEqualTo(gson.fromJson(json, new TypeToken<Map<String, String>>() {}.getType()));
   }
 
   @Test
@@ -601,7 +599,8 @@ public class MapTest {
     Map<Double, String> map = new LinkedHashMap<>();
     map.put(2.3, "a");
     map.put(5.7, "b");
-    assertThat(map).isEqualTo(gson.fromJson(json, new TypeToken<Map<Double, String>>() {}.getType()));
+    assertThat(map)
+        .isEqualTo(gson.fromJson(json, new TypeToken<Map<Double, String>>() {}.getType()));
   }
 
   @Test
@@ -610,7 +609,8 @@ public class MapTest {
     Map<Boolean, String> map = new LinkedHashMap<>();
     map.put(true, "a");
     map.put(false, "b");
-    assertThat(map).isEqualTo(gson.fromJson(json, new TypeToken<Map<Boolean, String>>() {}.getType()));
+    assertThat(map)
+        .isEqualTo(gson.fromJson(json, new TypeToken<Map<Boolean, String>>() {}.getType()));
   }
 
   @Test
@@ -625,9 +625,10 @@ public class MapTest {
   @Test
   public void testSerializeMapOfMaps() {
     Type type = new TypeToken<Map<String, Map<String, String>>>() {}.getType();
-    Map<String, Map<String, String>> map = newMap(
-        "a", newMap("ka1", "va1", "ka2", "va2"),
-        "b", newMap("kb1", "vb1", "kb2", "vb2"));
+    Map<String, Map<String, String>> map =
+        newMap(
+            "a", newMap("ka1", "va1", "ka2", "va2"),
+            "b", newMap("kb1", "vb1", "kb2", "vb2"));
     assertThat(gson.toJson(map, type).replace('"', '\''))
         .isEqualTo("{'a':{'ka1':'va1','ka2':'va2'},'b':{'kb1':'vb1','kb2':'vb2'}}");
   }
@@ -635,9 +636,10 @@ public class MapTest {
   @Test
   public void testDeerializeMapOfMaps() {
     Type type = new TypeToken<Map<String, Map<String, String>>>() {}.getType();
-    Map<String, Map<String, String>> map = newMap(
-        "a", newMap("ka1", "va1", "ka2", "va2"),
-        "b", newMap("kb1", "vb1", "kb2", "vb2"));
+    Map<String, Map<String, String>> map =
+        newMap(
+            "a", newMap("ka1", "va1", "ka2", "va2"),
+            "b", newMap("kb1", "vb1", "kb2", "vb2"));
     String json = "{'a':{'ka1':'va1','ka2':'va2'},'b':{'kb1':'vb1','kb2':'vb2'}}";
     assertThat(map).isEqualTo(gson.fromJson(json, type));
   }
@@ -655,7 +657,8 @@ public class MapTest {
     Map<Double, String> map = new LinkedHashMap<>();
     map.put(2.3, "a");
     JsonElement tree = JsonParser.parseString(json);
-    assertThat(map).isEqualTo(gson.fromJson(tree, new TypeToken<Map<Double, String>>() {}.getType()));
+    assertThat(map)
+        .isEqualTo(gson.fromJson(tree, new TypeToken<Map<Double, String>>() {}.getType()));
   }
 
   static class Point {
@@ -667,15 +670,18 @@ public class MapTest {
       this.y = y;
     }
 
-    @Override public boolean equals(Object o) {
+    @Override
+    public boolean equals(Object o) {
       return o instanceof Point && x == ((Point) o).x && y == ((Point) o).y;
     }
 
-    @Override public int hashCode() {
+    @Override
+    public int hashCode() {
       return x * 37 + y;
     }
 
-    @Override public String toString() {
+    @Override
+    public String toString() {
       return x + "," + y;
     }
   }

--- a/gson/src/test/java/com/google/gson/functional/MoreSpecificTypeSerializationTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MoreSpecificTypeSerializationTest.java
@@ -73,21 +73,19 @@ public class MoreSpecificTypeSerializationTest {
     assertThat(sub.get("s").getAsInt()).isEqualTo(3);
   }
 
-  /**
-   * For parameterized type, Gson ignores the more-specific type and sticks to the declared type
-   */
+  /** For parameterized type, Gson ignores the more-specific type and sticks to the declared type */
   @Test
   public void testParameterizedSubclassFields() {
-    ClassWithParameterizedBaseFields target = new ClassWithParameterizedBaseFields(
-        new ParameterizedSub<>("one", "two"));
+    ClassWithParameterizedBaseFields target =
+        new ClassWithParameterizedBaseFields(new ParameterizedSub<>("one", "two"));
     String json = gson.toJson(target);
     assertThat(json).contains("\"t\":\"one\"");
     assertThat(json).doesNotContain("\"s\"");
   }
 
   /**
-   * For parameterized type in a List, Gson ignores the more-specific type and sticks to
-   * the declared type
+   * For parameterized type in a List, Gson ignores the more-specific type and sticks to the
+   * declared type
    */
   @Test
   public void testListOfParameterizedSubclassFields() {
@@ -95,15 +93,15 @@ public class MoreSpecificTypeSerializationTest {
     list.add(new ParameterizedBase<>("one"));
     list.add(new ParameterizedSub<>("two", "three"));
     ClassWithContainersOfParameterizedBaseFields target =
-      new ClassWithContainersOfParameterizedBaseFields(list, null);
+        new ClassWithContainersOfParameterizedBaseFields(list, null);
     String json = gson.toJson(target);
     assertThat(json).contains("{\"t\":\"one\"}");
     assertThat(json).doesNotContain("\"s\":");
   }
 
   /**
-   * For parameterized type in a map, Gson ignores the more-specific type and sticks to the
-   * declared type
+   * For parameterized type in a map, Gson ignores the more-specific type and sticks to the declared
+   * type
    */
   @Test
   public void testMapOfParameterizedSubclassFields() {
@@ -111,7 +109,7 @@ public class MoreSpecificTypeSerializationTest {
     map.put("base", new ParameterizedBase<>("one"));
     map.put("sub", new ParameterizedSub<>("two", "three"));
     ClassWithContainersOfParameterizedBaseFields target =
-      new ClassWithContainersOfParameterizedBaseFields(null, map);
+        new ClassWithContainersOfParameterizedBaseFields(null, map);
     JsonObject json = gson.toJsonTree(target).getAsJsonObject().get("map").getAsJsonObject();
     assertThat(json.get("base").getAsJsonObject().get("t").getAsString()).isEqualTo("one");
     JsonObject sub = json.get("sub").getAsJsonObject();
@@ -121,6 +119,7 @@ public class MoreSpecificTypeSerializationTest {
 
   private static class Base {
     int b;
+
     Base(int b) {
       this.b = b;
     }
@@ -128,6 +127,7 @@ public class MoreSpecificTypeSerializationTest {
 
   private static class Sub extends Base {
     int s;
+
     Sub(int b, int s) {
       super(b);
       this.s = s;
@@ -136,6 +136,7 @@ public class MoreSpecificTypeSerializationTest {
 
   private static class ClassWithBaseFields {
     Base b;
+
     ClassWithBaseFields(Base b) {
       this.b = b;
     }
@@ -144,6 +145,7 @@ public class MoreSpecificTypeSerializationTest {
   private static class ClassWithContainersOfBaseFields {
     Collection<Base> collection;
     Map<String, Base> map;
+
     ClassWithContainersOfBaseFields(Collection<Base> collection, Map<String, Base> map) {
       this.collection = collection;
       this.map = map;
@@ -152,6 +154,7 @@ public class MoreSpecificTypeSerializationTest {
 
   private static class ParameterizedBase<T> {
     T t;
+
     ParameterizedBase(T t) {
       this.t = t;
     }
@@ -159,6 +162,7 @@ public class MoreSpecificTypeSerializationTest {
 
   private static class ParameterizedSub<T> extends ParameterizedBase<T> {
     T s;
+
     ParameterizedSub(T t, T s) {
       super(t);
       this.s = s;
@@ -167,6 +171,7 @@ public class MoreSpecificTypeSerializationTest {
 
   private static class ClassWithParameterizedBaseFields {
     ParameterizedBase<String> b;
+
     ClassWithParameterizedBaseFields(ParameterizedBase<String> b) {
       this.b = b;
     }
@@ -175,7 +180,9 @@ public class MoreSpecificTypeSerializationTest {
   private static class ClassWithContainersOfParameterizedBaseFields {
     Collection<ParameterizedBase<String>> collection;
     Map<String, ParameterizedBase<String>> map;
-    ClassWithContainersOfParameterizedBaseFields(Collection<ParameterizedBase<String>> collection,
+
+    ClassWithContainersOfParameterizedBaseFields(
+        Collection<ParameterizedBase<String>> collection,
         Map<String, ParameterizedBase<String>> map) {
       this.collection = collection;
       this.map = map;

--- a/gson/src/test/java/com/google/gson/functional/NamingPolicyTest.java
+++ b/gson/src/test/java/com/google/gson/functional/NamingPolicyTest.java
@@ -48,8 +48,11 @@ public class NamingPolicyTest {
   public void testGsonWithNonDefaultFieldNamingPolicySerialization() {
     Gson gson = builder.setFieldNamingPolicy(FieldNamingPolicy.UPPER_CAMEL_CASE).create();
     StringWrapper target = new StringWrapper("blah");
-    assertThat(gson.toJson(target)).isEqualTo("{\"SomeConstantStringInstanceField\":\""
-        + target.someConstantStringInstanceField + "\"}");
+    assertThat(gson.toJson(target))
+        .isEqualTo(
+            "{\"SomeConstantStringInstanceField\":\""
+                + target.someConstantStringInstanceField
+                + "\"}");
   }
 
   @Test
@@ -64,16 +67,22 @@ public class NamingPolicyTest {
   public void testGsonWithLowerCaseDashPolicySerialization() {
     Gson gson = builder.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_DASHES).create();
     StringWrapper target = new StringWrapper("blah");
-    assertThat(gson.toJson(target)).isEqualTo("{\"some-constant-string-instance-field\":\""
-        + target.someConstantStringInstanceField + "\"}");
+    assertThat(gson.toJson(target))
+        .isEqualTo(
+            "{\"some-constant-string-instance-field\":\""
+                + target.someConstantStringInstanceField
+                + "\"}");
   }
 
   @Test
   public void testGsonWithLowerCaseDotPolicySerialization() {
     Gson gson = builder.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_DOTS).create();
     StringWrapper target = new StringWrapper("blah");
-    assertThat(gson.toJson(target)).isEqualTo("{\"some.constant.string.instance.field\":\""
-          + target.someConstantStringInstanceField + "\"}");
+    assertThat(gson.toJson(target))
+        .isEqualTo(
+            "{\"some.constant.string.instance.field\":\""
+                + target.someConstantStringInstanceField
+                + "\"}");
   }
 
   @Test
@@ -94,17 +103,20 @@ public class NamingPolicyTest {
 
   @Test
   public void testGsonWithLowerCaseUnderscorePolicySerialization() {
-    Gson gson = builder.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-        .create();
+    Gson gson =
+        builder.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create();
     StringWrapper target = new StringWrapper("blah");
-    assertThat(gson.toJson(target)).isEqualTo("{\"some_constant_string_instance_field\":\""
-        + target.someConstantStringInstanceField + "\"}");
+    assertThat(gson.toJson(target))
+        .isEqualTo(
+            "{\"some_constant_string_instance_field\":\""
+                + target.someConstantStringInstanceField
+                + "\"}");
   }
 
   @Test
   public void testGsonWithLowerCaseUnderscorePolicyDeserialiation() {
-    Gson gson = builder.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-        .create();
+    Gson gson =
+        builder.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create();
     String target = "{\"some_constant_string_instance_field\":\"someValue\"}";
     StringWrapper deserializedObject = gson.fromJson(target, StringWrapper.class);
     assertThat(deserializedObject.someConstantStringInstanceField).isEqualTo("someValue");
@@ -135,48 +147,61 @@ public class NamingPolicyTest {
       gson.toJson(target);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat()
-          .isEqualTo("Class com.google.gson.functional.NamingPolicyTest$ClassWithDuplicateFields declares multiple JSON fields named 'a';"
-          + " conflict is caused by fields com.google.gson.functional.NamingPolicyTest$ClassWithDuplicateFields#a and"
-          + " com.google.gson.functional.NamingPolicyTest$ClassWithDuplicateFields#b"
-          + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#duplicate-fields");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Class com.google.gson.functional.NamingPolicyTest$ClassWithDuplicateFields declares"
+                  + " multiple JSON fields named 'a'; conflict is caused by fields"
+                  + " com.google.gson.functional.NamingPolicyTest$ClassWithDuplicateFields#a and"
+                  + " com.google.gson.functional.NamingPolicyTest$ClassWithDuplicateFields#b\n"
+                  + "See https://github.com/google/gson/blob/main/Troubleshooting.md#duplicate-fields");
     }
   }
 
   @Test
   public void testGsonDuplicateNameDueToBadNamingPolicy() {
-    Gson gson = builder.setFieldNamingStrategy(new FieldNamingStrategy() {
-          @Override
-          public String translateName(Field f) {
-            return "x";
-          }
-        }).create();
+    Gson gson =
+        builder
+            .setFieldNamingStrategy(
+                new FieldNamingStrategy() {
+                  @Override
+                  public String translateName(Field f) {
+                    return "x";
+                  }
+                })
+            .create();
 
     try {
       gson.toJson(new ClassWithTwoFields());
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat()
-          .isEqualTo("Class com.google.gson.functional.NamingPolicyTest$ClassWithTwoFields declares multiple JSON fields named 'x';"
-          + " conflict is caused by fields com.google.gson.functional.NamingPolicyTest$ClassWithTwoFields#a and"
-          + " com.google.gson.functional.NamingPolicyTest$ClassWithTwoFields#b"
-          + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#duplicate-fields");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Class com.google.gson.functional.NamingPolicyTest$ClassWithTwoFields declares"
+                  + " multiple JSON fields named 'x'; conflict is caused by fields"
+                  + " com.google.gson.functional.NamingPolicyTest$ClassWithTwoFields#a and"
+                  + " com.google.gson.functional.NamingPolicyTest$ClassWithTwoFields#b\n"
+                  + "See https://github.com/google/gson/blob/main/Troubleshooting.md#duplicate-fields");
     }
   }
 
   @Test
   public void testGsonWithUpperCamelCaseSpacesPolicySerialiation() {
-    Gson gson = builder.setFieldNamingPolicy(FieldNamingPolicy.UPPER_CAMEL_CASE_WITH_SPACES)
-        .create();
+    Gson gson =
+        builder.setFieldNamingPolicy(FieldNamingPolicy.UPPER_CAMEL_CASE_WITH_SPACES).create();
     StringWrapper target = new StringWrapper("blah");
-    assertThat(gson.toJson(target)).isEqualTo("{\"Some Constant String Instance Field\":\""
-        + target.someConstantStringInstanceField + "\"}");
+    assertThat(gson.toJson(target))
+        .isEqualTo(
+            "{\"Some Constant String Instance Field\":\""
+                + target.someConstantStringInstanceField
+                + "\"}");
   }
 
   @Test
   public void testGsonWithUpperCamelCaseSpacesPolicyDeserialiation() {
-    Gson gson = builder.setFieldNamingPolicy(FieldNamingPolicy.UPPER_CAMEL_CASE_WITH_SPACES)
-        .create();
+    Gson gson =
+        builder.setFieldNamingPolicy(FieldNamingPolicy.UPPER_CAMEL_CASE_WITH_SPACES).create();
     String target = "{\"Some Constant String Instance Field\":\"someValue\"}";
     StringWrapper deserializedObject = gson.fromJson(target, StringWrapper.class);
     assertThat(deserializedObject.someConstantStringInstanceField).isEqualTo("someValue");
@@ -184,17 +209,20 @@ public class NamingPolicyTest {
 
   @Test
   public void testGsonWithUpperCaseUnderscorePolicySerialization() {
-    Gson gson = builder.setFieldNamingPolicy(FieldNamingPolicy.UPPER_CASE_WITH_UNDERSCORES)
-        .create();
+    Gson gson =
+        builder.setFieldNamingPolicy(FieldNamingPolicy.UPPER_CASE_WITH_UNDERSCORES).create();
     StringWrapper target = new StringWrapper("blah");
-    assertThat(gson.toJson(target)).isEqualTo("{\"SOME_CONSTANT_STRING_INSTANCE_FIELD\":\""
-        + target.someConstantStringInstanceField + "\"}");
+    assertThat(gson.toJson(target))
+        .isEqualTo(
+            "{\"SOME_CONSTANT_STRING_INSTANCE_FIELD\":\""
+                + target.someConstantStringInstanceField
+                + "\"}");
   }
 
   @Test
   public void testGsonWithUpperCaseUnderscorePolicyDeserialiation() {
-    Gson gson = builder.setFieldNamingPolicy(FieldNamingPolicy.UPPER_CASE_WITH_UNDERSCORES)
-        .create();
+    Gson gson =
+        builder.setFieldNamingPolicy(FieldNamingPolicy.UPPER_CASE_WITH_UNDERSCORES).create();
     String target = "{\"SOME_CONSTANT_STRING_INSTANCE_FIELD\":\"someValue\"}";
     StringWrapper deserializedObject = gson.fromJson(target, StringWrapper.class);
     assertThat(deserializedObject.someConstantStringInstanceField).isEqualTo("someValue");
@@ -226,7 +254,8 @@ public class NamingPolicyTest {
   }
 
   static final class AtName {
-    @SerializedName("@foo") String f = "bar";
+    @SerializedName("@foo")
+    String f = "bar";
   }
 
   private static final class UpperCaseNamingStrategy implements FieldNamingStrategy {
@@ -239,7 +268,9 @@ public class NamingPolicyTest {
   @SuppressWarnings("unused")
   private static class ClassWithDuplicateFields {
     public Integer a;
-    @SerializedName("a") public Double b;
+
+    @SerializedName("a")
+    public Double b;
 
     public ClassWithDuplicateFields(Integer a) {
       this(a, null);
@@ -256,7 +287,8 @@ public class NamingPolicyTest {
   }
 
   private static class ClassWithComplexFieldName {
-    @SerializedName("@value\"_s$\\") public final long value;
+    @SerializedName("@value\"_s$\\")
+    public final long value;
 
     ClassWithComplexFieldName(long value) {
       this.value = value;

--- a/gson/src/test/java/com/google/gson/functional/NullObjectAndFieldTest.java
+++ b/gson/src/test/java/com/google/gson/functional/NullObjectAndFieldTest.java
@@ -80,7 +80,7 @@ public class NullObjectAndFieldTest {
     ClassWithObjects target = gson.fromJson("{\"bag\":null}", ClassWithObjects.class);
     assertThat(target.bag).isNull();
   }
-  
+
   @Test
   public void testExplicitSerializationOfNullArrayMembers() {
     Gson gson = gsonBuilder.create();
@@ -88,10 +88,8 @@ public class NullObjectAndFieldTest {
     String json = gson.toJson(target);
     assertThat(json).contains("\"array\":null");
   }
-  
-  /** 
-   * Added to verify http://code.google.com/p/google-gson/issues/detail?id=68
-   */
+
+  /** Added to verify http://code.google.com/p/google-gson/issues/detail?id=68 */
   @Test
   public void testNullWrappedPrimitiveMemberSerialization() {
     Gson gson = gsonBuilder.serializeNulls().create();
@@ -99,10 +97,8 @@ public class NullObjectAndFieldTest {
     String json = gson.toJson(target);
     assertThat(json).contains("\"value\":null");
   }
-  
-  /** 
-   * Added to verify http://code.google.com/p/google-gson/issues/detail?id=68
-   */
+
+  /** Added to verify http://code.google.com/p/google-gson/issues/detail?id=68 */
   @Test
   public void testNullWrappedPrimitiveMemberDeserialization() {
     Gson gson = gsonBuilder.create();
@@ -110,7 +106,7 @@ public class NullObjectAndFieldTest {
     ClassWithNullWrappedPrimitive target = gson.fromJson(json, ClassWithNullWrappedPrimitive.class);
     assertThat(target.value).isNull();
   }
-  
+
   @Test
   public void testExplicitSerializationOfNullCollectionMembers() {
     Gson gson = gsonBuilder.create();
@@ -118,7 +114,7 @@ public class NullObjectAndFieldTest {
     String json = gson.toJson(target);
     assertThat(json).contains("\"col\":null");
   }
-  
+
   @Test
   public void testExplicitSerializationOfNullStringMembers() {
     Gson gson = gsonBuilder.create();
@@ -136,7 +132,7 @@ public class NullObjectAndFieldTest {
     String expected = "{\"bag\":null}";
     assertThat(actual).isEqualTo(expected);
   }
-  
+
   @Test
   public void testPrintPrintingObjectWithNulls() {
     gsonBuilder = new GsonBuilder();
@@ -148,16 +144,16 @@ public class NullObjectAndFieldTest {
     result = gson.toJson(new ClassWithMembers());
     assertThat(result).contains("\"str\":null");
   }
-  
+
   @Test
   public void testPrintPrintingArraysWithNulls() {
     gsonBuilder = new GsonBuilder();
     Gson gson = gsonBuilder.create();
-    String result = gson.toJson(new String[] { "1", null, "3" });
+    String result = gson.toJson(new String[] {"1", null, "3"});
     assertThat(result).isEqualTo("[\"1\",null,\"3\"]");
 
     gson = gsonBuilder.serializeNulls().create();
-    result = gson.toJson(new String[] { "1", null, "3" });
+    result = gson.toJson(new String[] {"1", null, "3"});
     assertThat(result).isEqualTo("[\"1\",null,\"3\"]");
   }
 
@@ -172,9 +168,11 @@ public class NullObjectAndFieldTest {
     assertThat(target.str1).isEqualTo(ClassWithInitializedMembers.MY_STRING_DEFAULT);
     assertThat(target.str2).isNull();
     assertThat(target.int1).isEqualTo(ClassWithInitializedMembers.MY_INT_DEFAULT);
-    assertThat(target.int2).isEqualTo(0); // test the default value of a primitive int field per JVM spec
+    // test the default value of a primitive int field per JVM spec
+    assertThat(target.int2).isEqualTo(0);
     assertThat(target.bool1).isEqualTo(ClassWithInitializedMembers.MY_BOOLEAN_DEFAULT);
-    assertThat(target.bool2).isFalse(); // test the default value of a primitive boolean field per JVM spec
+    // test the default value of a primitive boolean field per JVM spec
+    assertThat(target.bool2).isFalse();
   }
 
   public static class ClassWithInitializedMembers {
@@ -189,6 +187,7 @@ public class NullObjectAndFieldTest {
     int int2;
     boolean bool1 = MY_BOOLEAN_DEFAULT;
     boolean bool2;
+
     public ClassWithInitializedMembers() {
       str1 = MY_STRING_DEFAULT;
     }
@@ -204,10 +203,11 @@ public class NullObjectAndFieldTest {
     int[] array;
     Collection<String> col;
   }
-  
+
   private static class ClassWithObjectsSerializer implements JsonSerializer<ClassWithObjects> {
-    @Override public JsonElement serialize(ClassWithObjects src, Type typeOfSrc,
-        JsonSerializationContext context) {
+    @Override
+    public JsonElement serialize(
+        ClassWithObjects src, Type typeOfSrc, JsonSerializationContext context) {
       JsonObject obj = new JsonObject();
       obj.add("bag", JsonNull.INSTANCE);
       return obj;
@@ -224,13 +224,18 @@ public class NullObjectAndFieldTest {
 
   @Test
   public void testCustomTypeAdapterPassesNullSerialization() {
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(ObjectWithField.class, new JsonSerializer<ObjectWithField>() {
-          @Override public JsonElement serialize(ObjectWithField src, Type typeOfSrc,
-              JsonSerializationContext context) {
-            return context.serialize(null);
-          }
-        }).create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                ObjectWithField.class,
+                new JsonSerializer<ObjectWithField>() {
+                  @Override
+                  public JsonElement serialize(
+                      ObjectWithField src, Type typeOfSrc, JsonSerializationContext context) {
+                    return context.serialize(null);
+                  }
+                })
+            .create();
     ObjectWithField target = new ObjectWithField();
     target.value = "value1";
     String json = gson.toJson(target);
@@ -239,13 +244,18 @@ public class NullObjectAndFieldTest {
 
   @Test
   public void testCustomTypeAdapterPassesNullDesrialization() {
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(ObjectWithField.class, new JsonDeserializer<ObjectWithField>() {
-          @Override public ObjectWithField deserialize(JsonElement json, Type type,
-              JsonDeserializationContext context) {
-            return context.deserialize(null, type);
-          }
-        }).create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                ObjectWithField.class,
+                new JsonDeserializer<ObjectWithField>() {
+                  @Override
+                  public ObjectWithField deserialize(
+                      JsonElement json, Type type, JsonDeserializationContext context) {
+                    return context.deserialize(null, type);
+                  }
+                })
+            .create();
     String json = "{value:'value1'}";
     ObjectWithField target = gson.fromJson(json, ObjectWithField.class);
     assertThat(target).isNull();

--- a/gson/src/test/java/com/google/gson/functional/ObjectTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ObjectTest.java
@@ -39,7 +39,6 @@ import com.google.gson.common.TestTypes.ClassWithObjects;
 import com.google.gson.common.TestTypes.ClassWithTransientFields;
 import com.google.gson.common.TestTypes.Nested;
 import com.google.gson.common.TestTypes.PrimitiveArray;
-import com.google.gson.internal.JavaVersion;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -160,12 +159,13 @@ public class ObjectTest {
     assertThat(target).isEqualTo(expected);
   }
 
-  private static class Subclass extends Superclass1 {
-  }
+  private static class Subclass extends Superclass1 {}
+
   private static class Superclass1 extends Superclass2 {
     @SuppressWarnings({"unused", "HidingField"})
     String s;
   }
+
   private static class Superclass2 {
     @SuppressWarnings("unused")
     String s;
@@ -173,10 +173,12 @@ public class ObjectTest {
 
   @Test
   public void testClassWithDuplicateFields() {
-    String expectedMessage = "Class com.google.gson.functional.ObjectTest$Subclass declares multiple JSON fields named 's';"
-        + " conflict is caused by fields com.google.gson.functional.ObjectTest$Superclass1#s and"
-        + " com.google.gson.functional.ObjectTest$Superclass2#s"
-        + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#duplicate-fields";
+    String expectedMessage =
+        "Class com.google.gson.functional.ObjectTest$Subclass declares multiple JSON fields named"
+            + " 's'; conflict is caused by fields"
+            + " com.google.gson.functional.ObjectTest$Superclass1#s and"
+            + " com.google.gson.functional.ObjectTest$Superclass2#s\n"
+            + "See https://github.com/google/gson/blob/main/Troubleshooting.md#duplicate-fields";
 
     try {
       gson.getAdapter(Subclass.class);
@@ -186,20 +188,22 @@ public class ObjectTest {
     }
 
     // Detection should also work properly when duplicate fields exist only for serialization
-    Gson gson = new GsonBuilder()
-        .addDeserializationExclusionStrategy(new ExclusionStrategy() {
-          @Override
-          public boolean shouldSkipField(FieldAttributes f) {
-            // Skip all fields for deserialization
-            return true;
-          }
+    Gson gson =
+        new GsonBuilder()
+            .addDeserializationExclusionStrategy(
+                new ExclusionStrategy() {
+                  @Override
+                  public boolean shouldSkipField(FieldAttributes f) {
+                    // Skip all fields for deserialization
+                    return true;
+                  }
 
-          @Override
-          public boolean shouldSkipClass(Class<?> clazz) {
-            return false;
-          }
-        })
-        .create();
+                  @Override
+                  public boolean shouldSkipClass(Class<?> clazz) {
+                    return false;
+                  }
+                })
+            .create();
 
     try {
       gson.getAdapter(Subclass.class);
@@ -211,16 +215,19 @@ public class ObjectTest {
 
   @Test
   public void testNestedSerialization() {
-    Nested target = new Nested(new BagOfPrimitives(10, 20, false, "stringValue"),
-       new BagOfPrimitives(30, 40, true, "stringValue"));
+    Nested target =
+        new Nested(
+            new BagOfPrimitives(10, 20, false, "stringValue"),
+            new BagOfPrimitives(30, 40, true, "stringValue"));
     assertThat(gson.toJson(target)).isEqualTo(target.getExpectedJson());
   }
 
   @Test
   public void testNestedDeserialization() {
-    String json = "{\"primitive1\":{\"longValue\":10,\"intValue\":20,\"booleanValue\":false,"
-        + "\"stringValue\":\"stringValue\"},\"primitive2\":{\"longValue\":30,\"intValue\":40,"
-        + "\"booleanValue\":true,\"stringValue\":\"stringValue\"}}";
+    String json =
+        "{\"primitive1\":{\"longValue\":10,\"intValue\":20,\"booleanValue\":false,"
+            + "\"stringValue\":\"stringValue\"},\"primitive2\":{\"longValue\":30,\"intValue\":40,"
+            + "\"booleanValue\":true,\"stringValue\":\"stringValue\"}}";
     Nested target = gson.fromJson(json, Nested.class);
     assertThat(target.getExpectedJson()).isEqualTo(json);
   }
@@ -260,8 +267,9 @@ public class ObjectTest {
 
   @Test
   public void testNullFieldsDeserialization() {
-    String json = "{\"primitive1\":{\"longValue\":10,\"intValue\":20,\"booleanValue\":false"
-        + ",\"stringValue\":\"stringValue\"}}";
+    String json =
+        "{\"primitive1\":{\"longValue\":10,\"intValue\":20,\"booleanValue\":false"
+            + ",\"stringValue\":\"stringValue\"}}";
     Nested target = gson.fromJson(json, Nested.class);
     assertThat(target.getExpectedJson()).isEqualTo(json);
   }
@@ -300,8 +308,8 @@ public class ObjectTest {
     String classWithObjectsJson = gson.toJson(classWithObjects);
     String bagOfPrimitivesJson = gson.toJson(bagOfPrimitives);
 
-    ClassWithArray classWithArray = new ClassWithArray(
-        new Object[] { stringValue, classWithObjects, bagOfPrimitives });
+    ClassWithArray classWithArray =
+        new ClassWithArray(new Object[] {stringValue, classWithObjects, bagOfPrimitives});
     String json = gson.toJson(classWithArray);
 
     assertThat(json).contains(classWithObjectsJson);
@@ -309,9 +317,7 @@ public class ObjectTest {
     assertThat(json).contains("\"" + stringValue + "\"");
   }
 
-  /**
-   * Created in response to Issue 14: http://code.google.com/p/google-gson/issues/detail?id=14
-   */
+  /** Created in response to Issue 14: http://code.google.com/p/google-gson/issues/detail?id=14 */
   @Test
   public void testNullArraysDeserialization() {
     String json = "{\"array\": null}";
@@ -319,9 +325,7 @@ public class ObjectTest {
     assertThat(target.array).isNull();
   }
 
-  /**
-   * Created in response to Issue 14: http://code.google.com/p/google-gson/issues/detail?id=14
-   */
+  /** Created in response to Issue 14: http://code.google.com/p/google-gson/issues/detail?id=14 */
   @Test
   public void testNullObjectFieldsDeserialization() {
     String json = "{\"bag\": null}";
@@ -348,9 +352,7 @@ public class ObjectTest {
     assertThat(target.getExpectedJson()).isEqualTo(json);
   }
 
-  /**
-   * Created in response to Issue 14: http://code.google.com/p/google-gson/issues/detail?id=14
-   */
+  /** Created in response to Issue 14: http://code.google.com/p/google-gson/issues/detail?id=14 */
   @Test
   public void testNullPrimitiveFieldsDeserialization() {
     String json = "{\"longValue\":null}";
@@ -367,43 +369,50 @@ public class ObjectTest {
   @Test
   public void testPrivateNoArgConstructorDeserialization() {
     ClassWithPrivateNoArgsConstructor target =
-      gson.fromJson("{\"a\":20}", ClassWithPrivateNoArgsConstructor.class);
+        gson.fromJson("{\"a\":20}", ClassWithPrivateNoArgsConstructor.class);
     assertThat(target.a).isEqualTo(20);
   }
 
   @Test
   public void testAnonymousLocalClassesSerialization() {
-    assertThat(gson.toJson(new ClassWithNoFields() {
-      // empty anonymous class
-    })).isEqualTo("null");
+    assertThat(
+            gson.toJson(
+                new ClassWithNoFields() {
+                  // empty anonymous class
+                }))
+        .isEqualTo("null");
   }
 
   @Test
   public void testAnonymousLocalClassesCustomSerialization() {
-    gson = new GsonBuilder()
-        .registerTypeHierarchyAdapter(ClassWithNoFields.class,
-            new JsonSerializer<ClassWithNoFields>() {
-              @Override public JsonElement serialize(
-                  ClassWithNoFields src, Type typeOfSrc, JsonSerializationContext context) {
-                return new JsonObject();
-              }
-            }).create();
+    gson =
+        new GsonBuilder()
+            .registerTypeHierarchyAdapter(
+                ClassWithNoFields.class,
+                new JsonSerializer<ClassWithNoFields>() {
+                  @Override
+                  public JsonElement serialize(
+                      ClassWithNoFields src, Type typeOfSrc, JsonSerializationContext context) {
+                    return new JsonObject();
+                  }
+                })
+            .create();
 
-    assertThat(gson.toJson(new ClassWithNoFields() {
-      // empty anonymous class
-    })).isEqualTo("null");
+    assertThat(
+            gson.toJson(
+                new ClassWithNoFields() {
+                  // empty anonymous class
+                }))
+        .isEqualTo("null");
   }
 
   @Test
   public void testPrimitiveArrayFieldSerialization() {
-    PrimitiveArray target = new PrimitiveArray(new long[] { 1L, 2L, 3L });
+    PrimitiveArray target = new PrimitiveArray(new long[] {1L, 2L, 3L});
     assertThat(gson.toJson(target)).isEqualTo(target.getExpectedJson());
   }
 
-  /**
-   * Tests that a class field with type Object can be serialized properly.
-   * See issue 54
-   */
+  /** Tests that a class field with type Object can be serialized properly. See issue 54 */
   @Test
   public void testClassWithObjectFieldSerialization() {
     ClassWithObjectField obj = new ClassWithObjectField();
@@ -429,12 +438,17 @@ public class ObjectTest {
   @Test
   public void testInnerClassDeserialization() {
     final Parent p = new Parent();
-    Gson gson = new GsonBuilder().registerTypeAdapter(
-        Parent.Child.class, new InstanceCreator<Parent.Child>() {
-      @Override public Parent.Child createInstance(Type type) {
-        return p.new Child();
-      }
-    }).create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                Parent.Child.class,
+                new InstanceCreator<Parent.Child>() {
+                  @Override
+                  public Parent.Child createInstance(Type type) {
+                    return p.new Child();
+                  }
+                })
+            .create();
     String json = "{'value2':3}";
     Parent.Child c = gson.fromJson(json, Parent.Child.class);
     assertThat(c.value2).isEqualTo(3);
@@ -452,15 +466,17 @@ public class ObjectTest {
 
   private static class ArrayOfArrays {
     private final BagOfPrimitives[][] elements;
+
     public ArrayOfArrays() {
       elements = new BagOfPrimitives[3][2];
       for (int i = 0; i < elements.length; ++i) {
         BagOfPrimitives[] row = elements[i];
         for (int j = 0; j < row.length; ++j) {
-          row[j] = new BagOfPrimitives(i+j, i*j, false, i+"_"+j);
+          row[j] = new BagOfPrimitives(i + j, i * j, false, i + "_" + j);
         }
       }
     }
+
     public String getExpectedJson() {
       StringBuilder sb = new StringBuilder("{\"elements\":[");
       boolean first = true;
@@ -489,14 +505,13 @@ public class ObjectTest {
 
   private static class ClassWithPrivateNoArgsConstructor {
     public int a;
+
     private ClassWithPrivateNoArgsConstructor() {
       a = 10;
     }
   }
 
-  /**
-   * In response to Issue 41 http://code.google.com/p/google-gson/issues/detail?id=41
-   */
+  /** In response to Issue 41 http://code.google.com/p/google-gson/issues/detail?id=41 */
   @Test
   public void testObjectFieldNamesWithoutQuotesDeserialization() {
     String json = "{longValue:1,'booleanValue':true,\"stringValue\":'bar'}";
@@ -521,9 +536,7 @@ public class ObjectTest {
     assertThat(bag.stringValue).isEqualTo("true");
   }
 
-  /**
-   * Created to reproduce issue 140
-   */
+  /** Created to reproduce issue 140 */
   @Test
   public void testStringFieldWithEmptyValueSerialization() {
     ClassWithEmptyStringFields target = new ClassWithEmptyStringFields();
@@ -534,9 +547,7 @@ public class ObjectTest {
     assertThat(json).contains("\"c\":\"\"");
   }
 
-  /**
-   * Created to reproduce issue 140
-   */
+  /** Created to reproduce issue 140 */
   @Test
   public void testStringFieldWithEmptyValueDeserialization() {
     String json = "{a:\"5794749\",b:\"\",c:\"\"}";
@@ -560,9 +571,7 @@ public class ObjectTest {
     assertThat(json).isEqualTo("{}");
   }
 
-  /**
-   * Test for issue 215.
-   */
+  /** Test for issue 215. */
   @Test
   public void testSingletonLists() {
     Gson gson = new Gson();
@@ -577,7 +586,8 @@ public class ObjectTest {
 
     product.attributes.add("456");
     assertThat(gson.toJson(product))
-        .isEqualTo("{\"attributes\":[\"456\"],\"departments\":[{\"name\":\"abc\",\"code\":\"123\"}]}");
+        .isEqualTo(
+            "{\"attributes\":[\"456\"],\"departments\":[{\"name\":\"abc\",\"code\":\"123\"}]}");
     Product unused3 = gson.fromJson(gson.toJson(product), Product.class);
   }
 
@@ -608,18 +618,19 @@ public class ObjectTest {
   /**
    * Tests serialization of a class with {@code static} field.
    *
-   * <p>Important: It is not documented that this is officially supported; this
-   * test just checks the current behavior.
+   * <p>Important: It is not documented that this is officially supported; this test just checks the
+   * current behavior.
    */
   @Test
   public void testStaticFieldSerialization() {
     // By default Gson should ignore static fields
     assertThat(gson.toJson(new ClassWithStaticField())).isEqualTo("{}");
 
-    Gson gson = new GsonBuilder()
-        // Include static fields
-        .excludeFieldsWithModifiers(0)
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            // Include static fields
+            .excludeFieldsWithModifiers(0)
+            .create();
 
     String json = gson.toJson(new ClassWithStaticField());
     assertThat(json).isEqualTo("{\"s\":\"initial\"}");
@@ -631,8 +642,8 @@ public class ObjectTest {
   /**
    * Tests deserialization of a class with {@code static} field.
    *
-   * <p>Important: It is not documented that this is officially supported; this
-   * test just checks the current behavior.
+   * <p>Important: It is not documented that this is officially supported; this test just checks the
+   * current behavior.
    */
   @Test
   public void testStaticFieldDeserialization() {
@@ -640,10 +651,11 @@ public class ObjectTest {
     ClassWithStaticField unused = gson.fromJson("{\"s\":\"custom\"}", ClassWithStaticField.class);
     assertThat(ClassWithStaticField.s).isEqualTo("initial");
 
-    Gson gson = new GsonBuilder()
-        // Include static fields
-        .excludeFieldsWithModifiers(0)
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            // Include static fields
+            .excludeFieldsWithModifiers(0)
+            .create();
 
     String oldValue = ClassWithStaticField.s;
     try {
@@ -658,7 +670,11 @@ public class ObjectTest {
       gson.fromJson("{\"s\":\"custom\"}", ClassWithStaticFinalField.class);
       fail();
     } catch (JsonIOException e) {
-      assertThat(e).hasMessageThat().isEqualTo("Cannot set value of 'static final' field 'com.google.gson.functional.ObjectTest$ClassWithStaticFinalField#s'");
+      assertThat(e)
+          .hasMessageThat()
+          .isEqualTo(
+              "Cannot set value of 'static final' field"
+                  + " 'com.google.gson.functional.ObjectTest$ClassWithStaticFinalField#s'");
     }
   }
 
@@ -678,7 +694,12 @@ public class ObjectTest {
     }
     // TODO: Adjust this once Gson throws more specific exception type
     catch (RuntimeException e) {
-      assertThat(e).hasMessageThat().isEqualTo("Failed to invoke constructor 'com.google.gson.functional.ObjectTest$ClassWithThrowingConstructor()' with no args");
+      assertThat(e)
+          .hasMessageThat()
+          .isEqualTo(
+              "Failed to invoke constructor"
+                  + " 'com.google.gson.functional.ObjectTest$ClassWithThrowingConstructor()' with"
+                  + " no args");
       assertThat(e).hasCauseThat().isSameInstanceAs(ClassWithThrowingConstructor.thrownException);
     }
   }

--- a/gson/src/test/java/com/google/gson/functional/ParameterizedTypesTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ParameterizedTypesTest.java
@@ -69,9 +69,11 @@ public class ParameterizedTypesTest {
     MyParameterizedType<BagOfPrimitives> expected = new MyParameterizedType<>(bag);
     Type expectedType = new TypeToken<MyParameterizedType<BagOfPrimitives>>() {}.getType();
     BagOfPrimitives bagDefaultInstance = new BagOfPrimitives();
-    Gson gson = new GsonBuilder().registerTypeAdapter(
-        expectedType, new MyParameterizedTypeInstanceCreator<>(bagDefaultInstance))
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                expectedType, new MyParameterizedTypeInstanceCreator<>(bagDefaultInstance))
+            .create();
 
     String json = expected.getExpectedJson();
     MyParameterizedType<BagOfPrimitives> actual = gson.fromJson(json, expectedType);
@@ -82,20 +84,24 @@ public class ParameterizedTypesTest {
   public void testTypesWithMultipleParametersSerialization() {
     MultiParameters<Integer, Float, Double, String, BagOfPrimitives> src =
         new MultiParameters<>(10, 1.0F, 2.1D, "abc", new BagOfPrimitives());
-    Type typeOfSrc = new TypeToken<MultiParameters<Integer, Float, Double, String,
-        BagOfPrimitives>>() {}.getType();
+    Type typeOfSrc =
+        new TypeToken<
+            MultiParameters<Integer, Float, Double, String, BagOfPrimitives>>() {}.getType();
     String json = gson.toJson(src, typeOfSrc);
-    String expected = "{\"a\":10,\"b\":1.0,\"c\":2.1,\"d\":\"abc\","
-        + "\"e\":{\"longValue\":0,\"intValue\":0,\"booleanValue\":false,\"stringValue\":\"\"}}";
+    String expected =
+        "{\"a\":10,\"b\":1.0,\"c\":2.1,\"d\":\"abc\","
+            + "\"e\":{\"longValue\":0,\"intValue\":0,\"booleanValue\":false,\"stringValue\":\"\"}}";
     assertThat(json).isEqualTo(expected);
   }
 
   @Test
   public void testTypesWithMultipleParametersDeserialization() {
-    Type typeOfTarget = new TypeToken<MultiParameters<Integer, Float, Double, String,
-        BagOfPrimitives>>() {}.getType();
-    String json = "{\"a\":10,\"b\":1.0,\"c\":2.1,\"d\":\"abc\","
-        + "\"e\":{\"longValue\":0,\"intValue\":0,\"booleanValue\":false,\"stringValue\":\"\"}}";
+    Type typeOfTarget =
+        new TypeToken<
+            MultiParameters<Integer, Float, Double, String, BagOfPrimitives>>() {}.getType();
+    String json =
+        "{\"a\":10,\"b\":1.0,\"c\":2.1,\"d\":\"abc\","
+            + "\"e\":{\"longValue\":0,\"intValue\":0,\"booleanValue\":false,\"stringValue\":\"\"}}";
     MultiParameters<Integer, Float, Double, String, BagOfPrimitives> target =
         gson.fromJson(json, typeOfTarget);
     MultiParameters<Integer, Float, Double, String, BagOfPrimitives> expected =
@@ -107,10 +113,11 @@ public class ParameterizedTypesTest {
   public void testParameterizedTypeWithCustomSerializer() {
     Type ptIntegerType = new TypeToken<MyParameterizedType<Integer>>() {}.getType();
     Type ptStringType = new TypeToken<MyParameterizedType<String>>() {}.getType();
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(ptIntegerType, new MyParameterizedTypeAdapter<Integer>())
-        .registerTypeAdapter(ptStringType, new MyParameterizedTypeAdapter<String>())
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(ptIntegerType, new MyParameterizedTypeAdapter<Integer>())
+            .registerTypeAdapter(ptStringType, new MyParameterizedTypeAdapter<String>())
+            .create();
     MyParameterizedType<Integer> intTarget = new MyParameterizedType<>(10);
     String json = gson.toJson(intTarget, ptIntegerType);
     assertThat(json).isEqualTo(MyParameterizedTypeAdapter.<Integer>getExpectedJson(intTarget));
@@ -124,12 +131,13 @@ public class ParameterizedTypesTest {
   public void testParameterizedTypesWithCustomDeserializer() {
     Type ptIntegerType = new TypeToken<MyParameterizedType<Integer>>() {}.getType();
     Type ptStringType = new TypeToken<MyParameterizedType<String>>() {}.getType();
-    Gson gson = new GsonBuilder().registerTypeAdapter(
-        ptIntegerType, new MyParameterizedTypeAdapter<Integer>())
-        .registerTypeAdapter(ptStringType, new MyParameterizedTypeAdapter<String>())
-        .registerTypeAdapter(ptStringType, new MyParameterizedTypeInstanceCreator<>(""))
-        .registerTypeAdapter(ptIntegerType, new MyParameterizedTypeInstanceCreator<>(0))
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(ptIntegerType, new MyParameterizedTypeAdapter<Integer>())
+            .registerTypeAdapter(ptStringType, new MyParameterizedTypeAdapter<String>())
+            .registerTypeAdapter(ptStringType, new MyParameterizedTypeInstanceCreator<>(""))
+            .registerTypeAdapter(ptIntegerType, new MyParameterizedTypeInstanceCreator<>(0))
+            .create();
 
     MyParameterizedType<Integer> src = new MyParameterizedType<>(10);
     String json = MyParameterizedTypeAdapter.<Integer>getExpectedJson(src);
@@ -157,9 +165,11 @@ public class ParameterizedTypesTest {
     MyParameterizedType<BagOfPrimitives> expected = new MyParameterizedType<>(bag);
     Type expectedType = new TypeToken<MyParameterizedType<BagOfPrimitives>>() {}.getType();
     BagOfPrimitives bagDefaultInstance = new BagOfPrimitives();
-    Gson gson = new GsonBuilder().registerTypeAdapter(
-        expectedType, new MyParameterizedTypeInstanceCreator<>(bagDefaultInstance))
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                expectedType, new MyParameterizedTypeInstanceCreator<>(bagDefaultInstance))
+            .create();
 
     Reader json = new StringReader(expected.getExpectedJson());
     MyParameterizedType<BagOfPrimitives> actual = gson.fromJson(json, expectedType);
@@ -175,7 +185,7 @@ public class ParameterizedTypesTest {
   @Test
   public void testVariableTypeFieldsAndGenericArraysSerialization() {
     Integer obj = 0;
-    Integer[] array = { 1, 2, 3 };
+    Integer[] array = {1, 2, 3};
     List<Integer> list = new ArrayList<>();
     list.add(4);
     list.add(5);
@@ -192,7 +202,7 @@ public class ParameterizedTypesTest {
   @Test
   public void testVariableTypeFieldsAndGenericArraysDeserialization() {
     Integer obj = 0;
-    Integer[] array = { 1, 2, 3 };
+    Integer[] array = {1, 2, 3};
     List<Integer> list = new ArrayList<>();
     list.add(4);
     list.add(5);
@@ -220,7 +230,7 @@ public class ParameterizedTypesTest {
 
   @Test
   public void testVariableTypeArrayDeserialization() {
-    Integer[] array = { 1, 2, 3 };
+    Integer[] array = {1, 2, 3};
 
     Type typeOfSrc = new TypeToken<ObjectWithTypeVariables<Integer>>() {}.getType();
     ObjectWithTypeVariables<Integer> objToSerialize =
@@ -295,8 +305,13 @@ public class ParameterizedTypesTest {
       this(null, null, null, null, null, null);
     }
 
-    public ObjectWithTypeVariables(T obj, T[] array, List<T> list, List<T>[] arrayOfList,
-        List<? extends T> wildcardList, List<? extends T>[] arrayOfWildcardList) {
+    public ObjectWithTypeVariables(
+        T obj,
+        T[] array,
+        List<T> list,
+        List<T>[] arrayOfList,
+        List<? extends T> wildcardList,
+        List<? extends T>[] arrayOfWildcardList) {
       this.typeParameterObj = obj;
       this.typeParameterArray = array;
       this.listOfTypeParameters = list;
@@ -406,10 +421,11 @@ public class ParameterizedTypesTest {
     C c;
     D d;
     E e;
+
     // For use by Gson
     @SuppressWarnings("unused")
-    private MultiParameters() {
-    }
+    private MultiParameters() {}
+
     MultiParameters(A a, B b, C c, D d, E e) {
       super();
       this.a = a;
@@ -418,6 +434,7 @@ public class ParameterizedTypesTest {
       this.d = d;
       this.e = e;
     }
+
     @Override
     public int hashCode() {
       final int prime = 31;
@@ -429,6 +446,7 @@ public class ParameterizedTypesTest {
       result = prime * result + ((e == null) ? 0 : e.hashCode());
       return result;
     }
+
     @Override
     public boolean equals(Object o) {
       if (this == o) {
@@ -451,16 +469,17 @@ public class ParameterizedTypesTest {
     @SuppressWarnings("unused")
     int q = 10;
   }
+
   private static class MyQuantity extends Quantity {
     @SuppressWarnings("unused")
     int q2 = 20;
   }
-  private interface Measurable<T> {
-  }
-  private interface Field<T> {
-  }
-  private interface Immutable {
-  }
+
+  private interface Measurable<T> {}
+
+  private interface Field<T> {}
+
+  private interface Immutable {}
 
   public static final class Amount<Q extends Quantity>
       implements Measurable<Q>, Field<Amount<?>>, Serializable, Immutable {
@@ -484,6 +503,7 @@ public class ParameterizedTypesTest {
     Amount<MyQuantity> amount = gson.fromJson(json, type);
     assertThat(amount.value).isEqualTo(30);
   }
+
   // End: tests to reproduce issue 103
 
   private static void assertCorrectlyDeserialized(Object object) {

--- a/gson/src/test/java/com/google/gson/functional/PrettyPrintingTest.java
+++ b/gson/src/test/java/com/google/gson/functional/PrettyPrintingTest.java
@@ -69,27 +69,30 @@ public class PrettyPrintingTest {
 
   @Test
   public void testPrettyPrintArrayOfPrimitives() {
-    int[] ints = new int[] { 1, 2, 3, 4, 5 };
+    int[] ints = new int[] {1, 2, 3, 4, 5};
     String json = gson.toJson(ints);
     assertThat(json).isEqualTo("[\n  1,\n  2,\n  3,\n  4,\n  5\n]");
   }
 
   @Test
   public void testPrettyPrintArrayOfPrimitiveArrays() {
-    int[][] ints = new int[][] { { 1, 2 }, { 3, 4 }, { 5, 6 }, { 7, 8 },
-        { 9, 0 }, { 10 } };
+    int[][] ints = new int[][] {{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 0}, {10}};
     String json = gson.toJson(ints);
-    assertThat(json).isEqualTo("[\n  [\n    1,\n    2\n  ],\n  [\n    3,\n    4\n  ],\n  [\n    5,\n    6\n  ],"
-        + "\n  [\n    7,\n    8\n  ],\n  [\n    9,\n    0\n  ],\n  [\n    10\n  ]\n]");
+    assertThat(json)
+        .isEqualTo(
+            "[\n  [\n    1,\n    2\n  ],\n  [\n    3,\n    4\n  ],\n  [\n    5,\n    6\n  ],"
+                + "\n  [\n    7,\n    8\n  ],\n  [\n    9,\n    0\n  ],\n  [\n    10\n  ]\n]");
   }
 
   @Test
   public void testPrettyPrintListOfPrimitiveArrays() {
-    List<Integer[]> list = Arrays.asList(new Integer[][] { { 1, 2 }, { 3, 4 },
-        { 5, 6 }, { 7, 8 }, { 9, 0 }, { 10 } });
+    List<Integer[]> list =
+        Arrays.asList(new Integer[][] {{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 0}, {10}});
     String json = gson.toJson(list);
-    assertThat(json).isEqualTo("[\n  [\n    1,\n    2\n  ],\n  [\n    3,\n    4\n  ],\n  [\n    5,\n    6\n  ],"
-        + "\n  [\n    7,\n    8\n  ],\n  [\n    9,\n    0\n  ],\n  [\n    10\n  ]\n]");
+    assertThat(json)
+        .isEqualTo(
+            "[\n  [\n    1,\n    2\n  ],\n  [\n    3,\n    4\n  ],\n  [\n    5,\n    6\n  ],"
+                + "\n  [\n    7,\n    8\n  ],\n  [\n    9,\n    0\n  ],\n  [\n    10\n  ]\n]");
   }
 
   @Test
@@ -118,7 +121,7 @@ public class PrettyPrintingTest {
 
   @Test
   public void testMultipleArrays() {
-    int[][][] ints = new int[][][] { { { 1 }, { 2 } } };
+    int[][][] ints = new int[][][] {{{1}, {2}}};
     String json = gson.toJson(ints);
     assertThat(json).isEqualTo("[\n  [\n    [\n      1\n    ],\n    [\n      2\n    ]\n  ]\n]");
   }

--- a/gson/src/test/java/com/google/gson/functional/PrimitiveTest.java
+++ b/gson/src/test/java/com/google/gson/functional/PrimitiveTest.java
@@ -89,22 +89,29 @@ public class PrimitiveTest {
 
   @Test
   public void testByteDeserializationLossy() {
-    JsonSyntaxException e = assertThrows(JsonSyntaxException.class, () -> gson.fromJson("-129", byte.class));
+    JsonSyntaxException e =
+        assertThrows(JsonSyntaxException.class, () -> gson.fromJson("-129", byte.class));
     assertThat(e).hasMessageThat().isEqualTo("Lossy conversion from -129 to byte; at path $");
 
     e = assertThrows(JsonSyntaxException.class, () -> gson.fromJson("256", byte.class));
     assertThat(e).hasMessageThat().isEqualTo("Lossy conversion from 256 to byte; at path $");
 
     e = assertThrows(JsonSyntaxException.class, () -> gson.fromJson("2147483648", byte.class));
-    assertThat(e).hasMessageThat().isEqualTo("java.lang.NumberFormatException: Expected an int but was 2147483648 at line 1 column 11 path $");
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "java.lang.NumberFormatException: Expected an int but was 2147483648 at line 1 column"
+                + " 11 path $");
   }
 
   @Test
   public void testShortSerialization() {
     assertThat(gson.toJson(1, short.class)).isEqualTo("1");
     assertThat(gson.toJson(1, Short.class)).isEqualTo("1");
-    assertThat(gson.toJson(Short.MIN_VALUE, Short.class)).isEqualTo(Short.toString(Short.MIN_VALUE));
-    assertThat(gson.toJson(Short.MAX_VALUE, Short.class)).isEqualTo(Short.toString(Short.MAX_VALUE));
+    assertThat(gson.toJson(Short.MIN_VALUE, Short.class))
+        .isEqualTo(Short.toString(Short.MIN_VALUE));
+    assertThat(gson.toJson(Short.MAX_VALUE, Short.class))
+        .isEqualTo(Short.toString(Short.MAX_VALUE));
     // Should perform widening conversion
     assertThat(gson.toJson((byte) 1, Short.class)).isEqualTo("1");
     // Should perform narrowing conversion
@@ -125,22 +132,29 @@ public class PrimitiveTest {
 
   @Test
   public void testShortDeserializationLossy() {
-    JsonSyntaxException e = assertThrows(JsonSyntaxException.class, () -> gson.fromJson("-32769", short.class));
+    JsonSyntaxException e =
+        assertThrows(JsonSyntaxException.class, () -> gson.fromJson("-32769", short.class));
     assertThat(e).hasMessageThat().isEqualTo("Lossy conversion from -32769 to short; at path $");
 
     e = assertThrows(JsonSyntaxException.class, () -> gson.fromJson("65536", short.class));
     assertThat(e).hasMessageThat().isEqualTo("Lossy conversion from 65536 to short; at path $");
 
     e = assertThrows(JsonSyntaxException.class, () -> gson.fromJson("2147483648", short.class));
-    assertThat(e).hasMessageThat().isEqualTo("java.lang.NumberFormatException: Expected an int but was 2147483648 at line 1 column 11 path $");
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "java.lang.NumberFormatException: Expected an int but was 2147483648 at line 1 column"
+                + " 11 path $");
   }
 
   @Test
   public void testIntSerialization() {
     assertThat(gson.toJson(1, int.class)).isEqualTo("1");
     assertThat(gson.toJson(1, Integer.class)).isEqualTo("1");
-    assertThat(gson.toJson(Integer.MIN_VALUE, Integer.class)).isEqualTo(Integer.toString(Integer.MIN_VALUE));
-    assertThat(gson.toJson(Integer.MAX_VALUE, Integer.class)).isEqualTo(Integer.toString(Integer.MAX_VALUE));
+    assertThat(gson.toJson(Integer.MIN_VALUE, Integer.class))
+        .isEqualTo(Integer.toString(Integer.MIN_VALUE));
+    assertThat(gson.toJson(Integer.MAX_VALUE, Integer.class))
+        .isEqualTo(Integer.toString(Integer.MAX_VALUE));
     // Should perform widening conversion
     assertThat(gson.toJson((byte) 1, Integer.class)).isEqualTo("1");
     // Should perform narrowing conversion
@@ -164,12 +178,15 @@ public class PrimitiveTest {
   public void testFloatSerialization() {
     assertThat(gson.toJson(1.5f, float.class)).isEqualTo("1.5");
     assertThat(gson.toJson(1.5f, Float.class)).isEqualTo("1.5");
-    assertThat(gson.toJson(Float.MIN_VALUE, Float.class)).isEqualTo(Float.toString(Float.MIN_VALUE));
-    assertThat(gson.toJson(Float.MAX_VALUE, Float.class)).isEqualTo(Float.toString(Float.MAX_VALUE));
+    assertThat(gson.toJson(Float.MIN_VALUE, Float.class))
+        .isEqualTo(Float.toString(Float.MIN_VALUE));
+    assertThat(gson.toJson(Float.MAX_VALUE, Float.class))
+        .isEqualTo(Float.toString(Float.MAX_VALUE));
     // Should perform widening conversion
     assertThat(gson.toJson((byte) 1, Float.class)).isEqualTo("1.0");
     // (This widening conversion is actually lossy)
-    assertThat(gson.toJson(Long.MAX_VALUE - 10L, Float.class)).isEqualTo(Float.toString((float) (Long.MAX_VALUE - 10L)));
+    assertThat(gson.toJson(Long.MAX_VALUE - 10L, Float.class))
+        .isEqualTo(Float.toString((float) (Long.MAX_VALUE - 10L)));
     // Should perform narrowing conversion
     gson = new GsonBuilder().serializeSpecialFloatingPointValues().create();
     assertThat(gson.toJson(Double.MAX_VALUE, Float.class)).isEqualTo("Infinity");
@@ -179,12 +196,15 @@ public class PrimitiveTest {
   public void testDoubleSerialization() {
     assertThat(gson.toJson(1.5, double.class)).isEqualTo("1.5");
     assertThat(gson.toJson(1.5, Double.class)).isEqualTo("1.5");
-    assertThat(gson.toJson(Double.MIN_VALUE, Double.class)).isEqualTo(Double.toString(Double.MIN_VALUE));
-    assertThat(gson.toJson(Double.MAX_VALUE, Double.class)).isEqualTo(Double.toString(Double.MAX_VALUE));
+    assertThat(gson.toJson(Double.MIN_VALUE, Double.class))
+        .isEqualTo(Double.toString(Double.MIN_VALUE));
+    assertThat(gson.toJson(Double.MAX_VALUE, Double.class))
+        .isEqualTo(Double.toString(Double.MAX_VALUE));
     // Should perform widening conversion
     assertThat(gson.toJson((byte) 1, Double.class)).isEqualTo("1.0");
     // (This widening conversion is actually lossy)
-    assertThat(gson.toJson(Long.MAX_VALUE - 10L, Double.class)).isEqualTo(Double.toString((double) (Long.MAX_VALUE - 10L)));
+    assertThat(gson.toJson(Long.MAX_VALUE - 10L, Double.class))
+        .isEqualTo(Double.toString((double) (Long.MAX_VALUE - 10L)));
   }
 
   @Test
@@ -334,17 +354,18 @@ public class PrimitiveTest {
 
   @Test
   public void testDoubleArrayDeserialization() {
-      String json = "[0.0, 0.004761904761904762, 3.4013606962703525E-4, 7.936508173034305E-4,"
-              + "0.0011904761904761906, 0.0]";
-      double[] values = gson.fromJson(json, double[].class);
+    String json =
+        "[0.0, 0.004761904761904762, 3.4013606962703525E-4, 7.936508173034305E-4,"
+            + "0.0011904761904761906, 0.0]";
+    double[] values = gson.fromJson(json, double[].class);
 
-      assertThat(values).hasLength(6);
-      assertThat(values[0]).isEqualTo(0.0);
-      assertThat(values[1]).isEqualTo(0.004761904761904762);
-      assertThat(values[2]).isEqualTo(3.4013606962703525E-4);
-      assertThat(values[3]).isEqualTo(7.936508173034305E-4);
-      assertThat(values[4]).isEqualTo(0.0011904761904761906);
-      assertThat(values[5]).isEqualTo(0.0);
+    assertThat(values).hasLength(6);
+    assertThat(values[0]).isEqualTo(0.0);
+    assertThat(values[1]).isEqualTo(0.004761904761904762);
+    assertThat(values[2]).isEqualTo(3.4013606962703525E-4);
+    assertThat(values[3]).isEqualTo(7.936508173034305E-4);
+    assertThat(values[4]).isEqualTo(0.0011904761904761906);
+    assertThat(values[5]).isEqualTo(0.0);
   }
 
   @Test
@@ -476,7 +497,8 @@ public class PrimitiveTest {
     try {
       gson.fromJson("15.099", BigInteger.class);
       fail("BigInteger can not be decimal values.");
-    } catch (JsonSyntaxException expected) { }
+    } catch (JsonSyntaxException expected) {
+    }
   }
 
   @Test
@@ -892,22 +914,34 @@ public class PrimitiveTest {
 
   @Test
   public void testDeserializingBigDecimalAsIntegerFails() {
-    JsonSyntaxException e = assertThrows(JsonSyntaxException.class, () -> gson.fromJson("-122.08e-213", Integer.class));
-    assertThat(e).hasCauseThat().hasMessageThat().isEqualTo("Expected an int but was -122.08e-213 at line 1 column 13 path $");
+    JsonSyntaxException e =
+        assertThrows(JsonSyntaxException.class, () -> gson.fromJson("-122.08e-213", Integer.class));
+    assertThat(e)
+        .hasCauseThat()
+        .hasMessageThat()
+        .isEqualTo("Expected an int but was -122.08e-213 at line 1 column 13 path $");
   }
 
   @Test
   public void testDeserializingBigIntegerAsInteger() {
     String number = "12121211243123245845384534687435634558945453489543985435";
-    JsonSyntaxException e = assertThrows(JsonSyntaxException.class, () -> gson.fromJson(number, Integer.class));
-    assertThat(e).hasCauseThat().hasMessageThat().isEqualTo("Expected an int but was " + number + " at line 1 column 57 path $");
+    JsonSyntaxException e =
+        assertThrows(JsonSyntaxException.class, () -> gson.fromJson(number, Integer.class));
+    assertThat(e)
+        .hasCauseThat()
+        .hasMessageThat()
+        .isEqualTo("Expected an int but was " + number + " at line 1 column 57 path $");
   }
 
   @Test
   public void testDeserializingBigIntegerAsLong() {
     String number = "12121211243123245845384534687435634558945453489543985435";
-    JsonSyntaxException e = assertThrows(JsonSyntaxException.class, () -> gson.fromJson(number, Long.class));
-    assertThat(e).hasCauseThat().hasMessageThat().isEqualTo("Expected a long but was " + number + " at line 1 column 57 path $");
+    JsonSyntaxException e =
+        assertThrows(JsonSyntaxException.class, () -> gson.fromJson(number, Long.class));
+    assertThat(e)
+        .hasCauseThat()
+        .hasMessageThat()
+        .isEqualTo("Expected a long but was " + number + " at line 1 column 57 path $");
   }
 
   @Test
@@ -930,8 +964,9 @@ public class PrimitiveTest {
   @Test
   public void testDeserializingBigIntegerAsBigDecimal() {
     BigDecimal actual =
-      gson.fromJson("12121211243123245845384534687435634558945453489543985435", BigDecimal.class);
-    assertThat(actual.toPlainString()).isEqualTo("12121211243123245845384534687435634558945453489543985435");
+        gson.fromJson("12121211243123245845384534687435634558945453489543985435", BigDecimal.class);
+    assertThat(actual.toPlainString())
+        .isEqualTo("12121211243123245845384534687435634558945453489543985435");
   }
 
   @Test

--- a/gson/src/test/java/com/google/gson/functional/RawSerializationTest.java
+++ b/gson/src/test/java/com/google/gson/functional/RawSerializationTest.java
@@ -60,7 +60,7 @@ public class RawSerializationTest {
     String json = gson.toJson(bar);
     assertThat(json).isEqualTo(expectedJson);
     // Ensure that serialization also works when the type is specified explicitly
-    json = gson.toJson(bar, new TypeToken<Bar<Foo>>(){}.getType());
+    json = gson.toJson(bar, new TypeToken<Bar<Foo>>() {}.getType());
     assertThat(json).isEqualTo(expectedJson);
   }
 
@@ -72,7 +72,7 @@ public class RawSerializationTest {
     String json = gson.toJson(bar);
     assertThat(json).isEqualTo(expectedJson);
     // Ensure that serialization also works when the type is specified explicitly
-    json = gson.toJson(bar, new TypeToken<Bar<Bar<Foo>>>(){}.getType());
+    json = gson.toJson(bar, new TypeToken<Bar<Bar<Foo>>>() {}.getType());
     assertThat(json).isEqualTo(expectedJson);
   }
 
@@ -84,13 +84,14 @@ public class RawSerializationTest {
     String json = gson.toJson(bar);
     assertThat(json).isEqualTo(expectedJson);
     // Ensure that serialization also works when the type is specified explicitly
-    json = gson.toJson(bar, new TypeToken<Bar<Bar<Bar<Foo>>>>(){}.getType());
+    json = gson.toJson(bar, new TypeToken<Bar<Bar<Bar<Foo>>>>() {}.getType());
     assertThat(json).isEqualTo(expectedJson);
   }
 
   private static class Foo {
     @SuppressWarnings("unused")
     int b;
+
     Foo(int b) {
       this.b = b;
     }
@@ -99,6 +100,7 @@ public class RawSerializationTest {
   private static class Bar<T> {
     @SuppressWarnings("unused")
     T t;
+
     Bar(T t) {
       this.t = t;
     }

--- a/gson/src/test/java/com/google/gson/functional/ReadersWritersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ReadersWritersTest.java
@@ -147,8 +147,8 @@ public class ReadersWritersTest {
   }
 
   /**
-   * Verifies that passing an {@link Appendable} which is not an instance of {@link Writer}
-   * to {@code Gson.toJson} works correctly.
+   * Verifies that passing an {@link Appendable} which is not an instance of {@link Writer} to
+   * {@code Gson.toJson} works correctly.
    */
   @Test
   public void testToJsonAppendable() {

--- a/gson/src/test/java/com/google/gson/functional/ReflectionAccessFilterTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ReflectionAccessFilterTest.java
@@ -52,15 +52,15 @@ public class ReflectionAccessFilterTest {
     }
 
     @Override
-    public void close() throws IOException {
-    }
+    public void close() throws IOException {}
   }
 
   @Test
   public void testBlockInaccessibleJava() throws ReflectiveOperationException {
-    Gson gson = new GsonBuilder()
-      .addReflectionAccessFilter(ReflectionAccessFilter.BLOCK_INACCESSIBLE_JAVA)
-      .create();
+    Gson gson =
+        new GsonBuilder()
+            .addReflectionAccessFilter(ReflectionAccessFilter.BLOCK_INACCESSIBLE_JAVA)
+            .create();
 
     // Serialization should fail for classes with non-public fields
     try {
@@ -68,12 +68,14 @@ public class ReflectionAccessFilterTest {
       fail("Expected exception; test needs to be run with Java >= 9");
     } catch (JsonIOException expected) {
       // Note: This test is rather brittle and depends on the JDK implementation
-      assertThat(expected).hasMessageThat()
-          .isEqualTo("Field 'java.io.File#path' is not accessible and ReflectionAccessFilter does not permit"
-        + " making it accessible. Register a TypeAdapter for the declaring type, adjust the access"
-        + " filter or increase the visibility of the element and its declaring type.");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Field 'java.io.File#path' is not accessible and ReflectionAccessFilter does not"
+                  + " permit making it accessible. Register a TypeAdapter for the declaring type,"
+                  + " adjust the access filter or increase the visibility of the element and its"
+                  + " declaring type.");
     }
-
 
     // But serialization should succeed for classes with only public fields.
     // Not many JDK classes have mutable public fields, thank goodness, but java.awt.Point does.
@@ -91,52 +93,59 @@ public class ReflectionAccessFilterTest {
 
   @Test
   public void testBlockInaccessibleJavaExtendingJdkClass() {
-    Gson gson = new GsonBuilder()
-      .addReflectionAccessFilter(ReflectionAccessFilter.BLOCK_INACCESSIBLE_JAVA)
-      .create();
+    Gson gson =
+        new GsonBuilder()
+            .addReflectionAccessFilter(ReflectionAccessFilter.BLOCK_INACCESSIBLE_JAVA)
+            .create();
 
     try {
       gson.toJson(new ClassExtendingJdkClass());
       fail("Expected exception; test needs to be run with Java >= 9");
     } catch (JsonIOException expected) {
-      assertThat(expected).hasMessageThat()
-          .isEqualTo("Field 'java.io.Reader#lock' is not accessible and ReflectionAccessFilter does not permit"
-              + " making it accessible. Register a TypeAdapter for the declaring type, adjust the access"
-              + " filter or increase the visibility of the element and its declaring type.");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Field 'java.io.Reader#lock' is not accessible and ReflectionAccessFilter does not"
+                  + " permit making it accessible. Register a TypeAdapter for the declaring type,"
+                  + " adjust the access filter or increase the visibility of the element and its"
+                  + " declaring type.");
     }
   }
 
   @Test
   public void testBlockAllJava() {
-    Gson gson = new GsonBuilder()
-      .addReflectionAccessFilter(ReflectionAccessFilter.BLOCK_ALL_JAVA)
-      .create();
+    Gson gson =
+        new GsonBuilder().addReflectionAccessFilter(ReflectionAccessFilter.BLOCK_ALL_JAVA).create();
 
     // Serialization should fail for any Java class
     try {
       gson.toJson(Thread.currentThread());
       fail();
     } catch (JsonIOException expected) {
-      assertThat(expected).hasMessageThat()
-          .isEqualTo("ReflectionAccessFilter does not permit using reflection for class java.lang.Thread."
-              + " Register a TypeAdapter for this type or adjust the access filter.");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "ReflectionAccessFilter does not permit using reflection for class java.lang.Thread."
+                  + " Register a TypeAdapter for this type or adjust the access filter.");
     }
   }
 
   @Test
   public void testBlockAllJavaExtendingJdkClass() {
-    Gson gson = new GsonBuilder()
-      .addReflectionAccessFilter(ReflectionAccessFilter.BLOCK_ALL_JAVA)
-      .create();
+    Gson gson =
+        new GsonBuilder().addReflectionAccessFilter(ReflectionAccessFilter.BLOCK_ALL_JAVA).create();
 
     try {
       gson.toJson(new ClassExtendingJdkClass());
       fail();
     } catch (JsonIOException expected) {
-      assertThat(expected).hasMessageThat()
-          .isEqualTo("ReflectionAccessFilter does not permit using reflection for class java.io.Reader"
-              + " (supertype of class com.google.gson.functional.ReflectionAccessFilterTest$ClassExtendingJdkClass)."
-              + " Register a TypeAdapter for this type or adjust the access filter.");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "ReflectionAccessFilter does not permit using reflection for class java.io.Reader"
+                  + " (supertype of class"
+                  + " com.google.gson.functional.ReflectionAccessFilterTest$ClassExtendingJdkClass)."
+                  + " Register a TypeAdapter for this type or adjust the access filter.");
     }
   }
 
@@ -147,34 +156,40 @@ public class ReflectionAccessFilterTest {
 
   @Test
   public void testBlockInaccessibleStaticField() {
-    Gson gson = new GsonBuilder()
-      .addReflectionAccessFilter(new ReflectionAccessFilter() {
-        @Override public FilterResult check(Class<?> rawClass) {
-          return FilterResult.BLOCK_INACCESSIBLE;
-        }
-      })
-      // Include static fields
-      .excludeFieldsWithModifiers(0)
-      .create();
+    Gson gson =
+        new GsonBuilder()
+            .addReflectionAccessFilter(
+                new ReflectionAccessFilter() {
+                  @Override
+                  public FilterResult check(Class<?> rawClass) {
+                    return FilterResult.BLOCK_INACCESSIBLE;
+                  }
+                })
+            // Include static fields
+            .excludeFieldsWithModifiers(0)
+            .create();
 
-      try {
-        gson.toJson(new ClassWithStaticField());
-        fail("Expected exception; test needs to be run with Java >= 9");
-      } catch (JsonIOException expected) {
-        assertThat(expected).hasMessageThat()
-            .isEqualTo("Field 'com.google.gson.functional.ReflectionAccessFilterTest$ClassWithStaticField#i'"
-                + " is not accessible and ReflectionAccessFilter does not permit making it accessible."
-                + " Register a TypeAdapter for the declaring type, adjust the access filter or increase"
-                + " the visibility of the element and its declaring type.");
-      }
+    try {
+      gson.toJson(new ClassWithStaticField());
+      fail("Expected exception; test needs to be run with Java >= 9");
+    } catch (JsonIOException expected) {
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Field 'com.google.gson.functional.ReflectionAccessFilterTest$ClassWithStaticField#i'"
+                  + " is not accessible and ReflectionAccessFilter does not permit making it"
+                  + " accessible. Register a TypeAdapter for the declaring type, adjust the access"
+                  + " filter or increase the visibility of the element and its declaring type.");
+    }
   }
 
-  private static class SuperTestClass {
-  }
+  private static class SuperTestClass {}
+
   private static class SubTestClass extends SuperTestClass {
     @SuppressWarnings("unused")
     public int i = 1;
   }
+
   private static class OtherClass {
     @SuppressWarnings("unused")
     public int i = 2;
@@ -182,29 +197,41 @@ public class ReflectionAccessFilterTest {
 
   @Test
   public void testDelegation() {
-    Gson gson = new GsonBuilder()
-      .addReflectionAccessFilter(new ReflectionAccessFilter() {
-        @Override public FilterResult check(Class<?> rawClass) {
-          // INDECISIVE in last filter should act like ALLOW
-          return SuperTestClass.class.isAssignableFrom(rawClass) ? FilterResult.BLOCK_ALL : FilterResult.INDECISIVE;
-        }
-      })
-      .addReflectionAccessFilter(new ReflectionAccessFilter() {
-        @Override public FilterResult check(Class<?> rawClass) {
-          // INDECISIVE should delegate to previous filter
-          return rawClass == SubTestClass.class ? FilterResult.ALLOW : FilterResult.INDECISIVE;
-        }
-      })
-      .create();
+    Gson gson =
+        new GsonBuilder()
+            .addReflectionAccessFilter(
+                new ReflectionAccessFilter() {
+                  @Override
+                  public FilterResult check(Class<?> rawClass) {
+                    // INDECISIVE in last filter should act like ALLOW
+                    return SuperTestClass.class.isAssignableFrom(rawClass)
+                        ? FilterResult.BLOCK_ALL
+                        : FilterResult.INDECISIVE;
+                  }
+                })
+            .addReflectionAccessFilter(
+                new ReflectionAccessFilter() {
+                  @Override
+                  public FilterResult check(Class<?> rawClass) {
+                    // INDECISIVE should delegate to previous filter
+                    return rawClass == SubTestClass.class
+                        ? FilterResult.ALLOW
+                        : FilterResult.INDECISIVE;
+                  }
+                })
+            .create();
 
     // Filter disallows SuperTestClass
     try {
       gson.toJson(new SuperTestClass());
       fail();
     } catch (JsonIOException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("ReflectionAccessFilter does not permit using reflection for class"
-        + " com.google.gson.functional.ReflectionAccessFilterTest$SuperTestClass."
-        + " Register a TypeAdapter for this type or adjust the access filter.");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "ReflectionAccessFilter does not permit using reflection for class"
+                  + " com.google.gson.functional.ReflectionAccessFilterTest$SuperTestClass."
+                  + " Register a TypeAdapter for this type or adjust the access filter.");
     }
 
     // But registration order is reversed, so filter for SubTestClass allows reflection
@@ -220,38 +247,50 @@ public class ReflectionAccessFilterTest {
     @SuppressWarnings("unused")
     private int i = 1;
   }
-  private static class ExtendingClassWithPrivateField extends ClassWithPrivateField {
-  }
+
+  private static class ExtendingClassWithPrivateField extends ClassWithPrivateField {}
 
   @Test
   public void testAllowForSupertype() {
-    Gson gson = new GsonBuilder()
-      .addReflectionAccessFilter(new ReflectionAccessFilter() {
-        @Override public FilterResult check(Class<?> rawClass) {
-          return FilterResult.BLOCK_INACCESSIBLE;
-        }
-      })
-      .create();
+    Gson gson =
+        new GsonBuilder()
+            .addReflectionAccessFilter(
+                new ReflectionAccessFilter() {
+                  @Override
+                  public FilterResult check(Class<?> rawClass) {
+                    return FilterResult.BLOCK_INACCESSIBLE;
+                  }
+                })
+            .create();
 
     // First make sure test is implemented correctly and access is blocked
     try {
       gson.toJson(new ExtendingClassWithPrivateField());
       fail("Expected exception; test needs to be run with Java >= 9");
     } catch (JsonIOException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Field 'com.google.gson.functional.ReflectionAccessFilterTest$ClassWithPrivateField#i'"
-        + " is not accessible and ReflectionAccessFilter does not permit making it accessible."
-        + " Register a TypeAdapter for the declaring type, adjust the access filter or increase"
-        + " the visibility of the element and its declaring type.");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Field"
+                  + " 'com.google.gson.functional.ReflectionAccessFilterTest$ClassWithPrivateField#i'"
+                  + " is not accessible and ReflectionAccessFilter does not permit making it"
+                  + " accessible. Register a TypeAdapter for the declaring type, adjust the access"
+                  + " filter or increase the visibility of the element and its declaring type.");
     }
 
-    gson = gson.newBuilder()
-      // Allow reflective access for supertype
-      .addReflectionAccessFilter(new ReflectionAccessFilter() {
-        @Override public FilterResult check(Class<?> rawClass) {
-          return rawClass == ClassWithPrivateField.class ? FilterResult.ALLOW : FilterResult.INDECISIVE;
-        }
-      })
-      .create();
+    gson =
+        gson.newBuilder()
+            // Allow reflective access for supertype
+            .addReflectionAccessFilter(
+                new ReflectionAccessFilter() {
+                  @Override
+                  public FilterResult check(Class<?> rawClass) {
+                    return rawClass == ClassWithPrivateField.class
+                        ? FilterResult.ALLOW
+                        : FilterResult.INDECISIVE;
+                  }
+                })
+            .create();
 
     // Inherited (inaccessible) private field should have been made accessible
     String json = gson.toJson(new ExtendingClassWithPrivateField());
@@ -259,27 +298,34 @@ public class ReflectionAccessFilterTest {
   }
 
   private static class ClassWithPrivateNoArgsConstructor {
-    private ClassWithPrivateNoArgsConstructor() {
-    }
+    private ClassWithPrivateNoArgsConstructor() {}
   }
 
   @Test
   public void testInaccessibleNoArgsConstructor() {
-    Gson gson = new GsonBuilder()
-      .addReflectionAccessFilter(new ReflectionAccessFilter() {
-        @Override public FilterResult check(Class<?> rawClass) {
-          return FilterResult.BLOCK_INACCESSIBLE;
-        }
-      })
-      .create();
+    Gson gson =
+        new GsonBuilder()
+            .addReflectionAccessFilter(
+                new ReflectionAccessFilter() {
+                  @Override
+                  public FilterResult check(Class<?> rawClass) {
+                    return FilterResult.BLOCK_INACCESSIBLE;
+                  }
+                })
+            .create();
 
     try {
       gson.fromJson("{}", ClassWithPrivateNoArgsConstructor.class);
       fail("Expected exception; test needs to be run with Java >= 9");
     } catch (JsonIOException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Unable to invoke no-args constructor of class com.google.gson.functional.ReflectionAccessFilterTest$ClassWithPrivateNoArgsConstructor;"
-        + " constructor is not accessible and ReflectionAccessFilter does not permit making it accessible. Register an"
-        + " InstanceCreator or a TypeAdapter for this type, change the visibility of the constructor or adjust the access filter.");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Unable to invoke no-args constructor of class"
+                  + " com.google.gson.functional.ReflectionAccessFilterTest$ClassWithPrivateNoArgsConstructor;"
+                  + " constructor is not accessible and ReflectionAccessFilter does not permit"
+                  + " making it accessible. Register an InstanceCreator or a TypeAdapter for this"
+                  + " type, change the visibility of the constructor or adjust the access filter.");
     }
   }
 
@@ -293,69 +339,95 @@ public class ReflectionAccessFilterTest {
 
   @Test
   public void testClassWithoutNoArgsConstructor() {
-    GsonBuilder gsonBuilder = new GsonBuilder()
-      .addReflectionAccessFilter(new ReflectionAccessFilter() {
-        @Override public FilterResult check(Class<?> rawClass) {
-          // Even BLOCK_INACCESSIBLE should prevent usage of Unsafe for object creation
-          return FilterResult.BLOCK_INACCESSIBLE;
-        }
-      });
+    GsonBuilder gsonBuilder =
+        new GsonBuilder()
+            .addReflectionAccessFilter(
+                new ReflectionAccessFilter() {
+                  @Override
+                  public FilterResult check(Class<?> rawClass) {
+                    // Even BLOCK_INACCESSIBLE should prevent usage of Unsafe for object creation
+                    return FilterResult.BLOCK_INACCESSIBLE;
+                  }
+                });
     Gson gson = gsonBuilder.create();
 
     try {
       gson.fromJson("{}", ClassWithoutNoArgsConstructor.class);
       fail();
     } catch (JsonIOException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Unable to create instance of class com.google.gson.functional.ReflectionAccessFilterTest$ClassWithoutNoArgsConstructor;"
-        + " ReflectionAccessFilter does not permit using reflection or Unsafe. Register an InstanceCreator"
-        + " or a TypeAdapter for this type or adjust the access filter to allow using reflection.");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Unable to create instance of class"
+                  + " com.google.gson.functional.ReflectionAccessFilterTest$ClassWithoutNoArgsConstructor;"
+                  + " ReflectionAccessFilter does not permit using reflection or Unsafe. Register"
+                  + " an InstanceCreator or a TypeAdapter for this type or adjust the access filter"
+                  + " to allow using reflection.");
     }
 
     // But should not fail when custom TypeAdapter is specified
-    gson = gson.newBuilder()
-      .registerTypeAdapter(ClassWithoutNoArgsConstructor.class, new TypeAdapter<ClassWithoutNoArgsConstructor>() {
-        @Override public ClassWithoutNoArgsConstructor read(JsonReader in) throws IOException {
-          in.skipValue();
-          return new ClassWithoutNoArgsConstructor("TypeAdapter");
-        }
-        @Override public void write(JsonWriter out, ClassWithoutNoArgsConstructor value) {
-          throw new AssertionError("Not needed for test");
-        }
-      })
-      .create();
-    ClassWithoutNoArgsConstructor deserialized = gson.fromJson("{}", ClassWithoutNoArgsConstructor.class);
+    gson =
+        gson.newBuilder()
+            .registerTypeAdapter(
+                ClassWithoutNoArgsConstructor.class,
+                new TypeAdapter<ClassWithoutNoArgsConstructor>() {
+                  @Override
+                  public ClassWithoutNoArgsConstructor read(JsonReader in) throws IOException {
+                    in.skipValue();
+                    return new ClassWithoutNoArgsConstructor("TypeAdapter");
+                  }
+
+                  @Override
+                  public void write(JsonWriter out, ClassWithoutNoArgsConstructor value) {
+                    throw new AssertionError("Not needed for test");
+                  }
+                })
+            .create();
+    ClassWithoutNoArgsConstructor deserialized =
+        gson.fromJson("{}", ClassWithoutNoArgsConstructor.class);
     assertThat(deserialized.s).isEqualTo("TypeAdapter");
 
     // But should not fail when custom InstanceCreator is specified
-    gson = gsonBuilder
-      .registerTypeAdapter(ClassWithoutNoArgsConstructor.class, new InstanceCreator<ClassWithoutNoArgsConstructor>() {
-        @Override public ClassWithoutNoArgsConstructor createInstance(Type type) {
-          return new ClassWithoutNoArgsConstructor("InstanceCreator");
-        }
-      })
-      .create();
+    gson =
+        gsonBuilder
+            .registerTypeAdapter(
+                ClassWithoutNoArgsConstructor.class,
+                new InstanceCreator<ClassWithoutNoArgsConstructor>() {
+                  @Override
+                  public ClassWithoutNoArgsConstructor createInstance(Type type) {
+                    return new ClassWithoutNoArgsConstructor("InstanceCreator");
+                  }
+                })
+            .create();
     deserialized = gson.fromJson("{}", ClassWithoutNoArgsConstructor.class);
     assertThat(deserialized.s).isEqualTo("InstanceCreator");
   }
 
   /**
-   * When using {@link FilterResult#BLOCK_ALL}, registering only a {@link JsonSerializer}
-   * but not performing any deserialization should not throw any exception.
+   * When using {@link FilterResult#BLOCK_ALL}, registering only a {@link JsonSerializer} but not
+   * performing any deserialization should not throw any exception.
    */
   @Test
   public void testBlockAllPartial() {
-    Gson gson = new GsonBuilder()
-      .addReflectionAccessFilter(new ReflectionAccessFilter() {
-        @Override public FilterResult check(Class<?> rawClass) {
-          return FilterResult.BLOCK_ALL;
-        }
-      })
-      .registerTypeAdapter(OtherClass.class, new JsonSerializer<OtherClass>() {
-        @Override public JsonElement serialize(OtherClass src, Type typeOfSrc, JsonSerializationContext context) {
-          return new JsonPrimitive(123);
-        }
-      })
-      .create();
+    Gson gson =
+        new GsonBuilder()
+            .addReflectionAccessFilter(
+                new ReflectionAccessFilter() {
+                  @Override
+                  public FilterResult check(Class<?> rawClass) {
+                    return FilterResult.BLOCK_ALL;
+                  }
+                })
+            .registerTypeAdapter(
+                OtherClass.class,
+                new JsonSerializer<OtherClass>() {
+                  @Override
+                  public JsonElement serialize(
+                      OtherClass src, Type typeOfSrc, JsonSerializationContext context) {
+                    return new JsonPrimitive(123);
+                  }
+                })
+            .create();
 
     String json = gson.toJson(new OtherClass());
     assertThat(json).isEqualTo("123");
@@ -365,65 +437,81 @@ public class ReflectionAccessFilterTest {
       gson.fromJson("{}", OtherClass.class);
       fail();
     } catch (JsonIOException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("ReflectionAccessFilter does not permit using reflection for class com.google.gson.functional.ReflectionAccessFilterTest$OtherClass."
-        + " Register a TypeAdapter for this type or adjust the access filter.");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "ReflectionAccessFilter does not permit using reflection for class"
+                  + " com.google.gson.functional.ReflectionAccessFilterTest$OtherClass. Register a"
+                  + " TypeAdapter for this type or adjust the access filter.");
     }
   }
 
   /**
-   * Should not fail when deserializing collection interface
-   * (Even though this goes through {@link ConstructorConstructor} as well)
+   * Should not fail when deserializing collection interface (Even though this goes through {@link
+   * ConstructorConstructor} as well)
    */
   @Test
   public void testBlockAllCollectionInterface() {
-    Gson gson = new GsonBuilder()
-      .addReflectionAccessFilter(new ReflectionAccessFilter() {
-        @Override public FilterResult check(Class<?> rawClass) {
-          return FilterResult.BLOCK_ALL;
-        }
-      })
-      .create();
+    Gson gson =
+        new GsonBuilder()
+            .addReflectionAccessFilter(
+                new ReflectionAccessFilter() {
+                  @Override
+                  public FilterResult check(Class<?> rawClass) {
+                    return FilterResult.BLOCK_ALL;
+                  }
+                })
+            .create();
     List<?> deserialized = gson.fromJson("[1.0]", List.class);
     assertThat(deserialized.get(0)).isEqualTo(1.0);
   }
 
   /**
-   * Should not fail when deserializing specific collection implementation
-   * (Even though this goes through {@link ConstructorConstructor} as well)
+   * Should not fail when deserializing specific collection implementation (Even though this goes
+   * through {@link ConstructorConstructor} as well)
    */
   @Test
   public void testBlockAllCollectionImplementation() {
-    Gson gson = new GsonBuilder()
-      .addReflectionAccessFilter(new ReflectionAccessFilter() {
-        @Override public FilterResult check(Class<?> rawClass) {
-          return FilterResult.BLOCK_ALL;
-        }
-      })
-      .create();
+    Gson gson =
+        new GsonBuilder()
+            .addReflectionAccessFilter(
+                new ReflectionAccessFilter() {
+                  @Override
+                  public FilterResult check(Class<?> rawClass) {
+                    return FilterResult.BLOCK_ALL;
+                  }
+                })
+            .create();
     List<?> deserialized = gson.fromJson("[1.0]", LinkedList.class);
     assertThat(deserialized.get(0)).isEqualTo(1.0);
   }
 
   /**
-   * When trying to deserialize interface an exception for that should
-   * be thrown, even if {@link FilterResult#BLOCK_INACCESSIBLE} is used
+   * When trying to deserialize interface an exception for that should be thrown, even if {@link
+   * FilterResult#BLOCK_INACCESSIBLE} is used
    */
   @Test
   public void testBlockInaccessibleInterface() {
-    Gson gson = new GsonBuilder()
-      .addReflectionAccessFilter(new ReflectionAccessFilter() {
-        @Override public FilterResult check(Class<?> rawClass) {
-          return FilterResult.BLOCK_INACCESSIBLE;
-        }
-      })
-      .create();
+    Gson gson =
+        new GsonBuilder()
+            .addReflectionAccessFilter(
+                new ReflectionAccessFilter() {
+                  @Override
+                  public FilterResult check(Class<?> rawClass) {
+                    return FilterResult.BLOCK_INACCESSIBLE;
+                  }
+                })
+            .create();
 
     try {
       gson.fromJson("{}", Runnable.class);
       fail();
     } catch (JsonIOException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Interfaces can't be instantiated! Register an InstanceCreator or a TypeAdapter for"
-        + " this type. Interface name: java.lang.Runnable");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Interfaces can't be instantiated! Register an InstanceCreator or a TypeAdapter for"
+                  + " this type. Interface name: java.lang.Runnable");
     }
   }
 }

--- a/gson/src/test/java/com/google/gson/functional/ReflectionAccessTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ReflectionAccessTest.java
@@ -40,36 +40,37 @@ public class ReflectionAccessTest {
   private static class ClassWithPrivateMembers {
     private String s;
 
-    private ClassWithPrivateMembers() {
-    }
+    private ClassWithPrivateMembers() {}
   }
 
   private static Class<?> loadClassWithDifferentClassLoader(Class<?> c) throws Exception {
     URL url = c.getProtectionDomain().getCodeSource().getLocation();
-    URLClassLoader classLoader = new URLClassLoader(new URL[] { url }, null);
+    URLClassLoader classLoader = new URLClassLoader(new URL[] {url}, null);
     return classLoader.loadClass(c.getName());
   }
 
   @SuppressWarnings("removal") // java.lang.SecurityManager deprecation in Java 17
   @Test
   public void testRestrictiveSecurityManager() throws Exception {
-    // Must use separate class loader, otherwise permission is not checked, see Class.getDeclaredFields()
+    // Must use separate class loader, otherwise permission is not checked, see
+    // Class.getDeclaredFields()
     Class<?> clazz = loadClassWithDifferentClassLoader(ClassWithPrivateMembers.class);
 
     final Permission accessDeclaredMembers = new RuntimePermission("accessDeclaredMembers");
     final Permission suppressAccessChecks = new ReflectPermission("suppressAccessChecks");
     SecurityManager original = System.getSecurityManager();
-    SecurityManager restrictiveManager = new SecurityManager() {
-      @Override
-      public void checkPermission(Permission perm) {
-        if (accessDeclaredMembers.equals(perm)) {
-          throw new SecurityException("Gson: no-member-access");
-        }
-        if (suppressAccessChecks.equals(perm)) {
-          throw new SecurityException("Gson: no-suppress-access-check");
-        }
-      }
-    };
+    SecurityManager restrictiveManager =
+        new SecurityManager() {
+          @Override
+          public void checkPermission(Permission perm) {
+            if (accessDeclaredMembers.equals(perm)) {
+              throw new SecurityException("Gson: no-member-access");
+            }
+            if (suppressAccessChecks.equals(perm)) {
+              throw new SecurityException("Gson: no-suppress-access-check");
+            }
+          }
+        };
     System.setSecurityManager(restrictiveManager);
 
     try {
@@ -83,21 +84,24 @@ public class ReflectionAccessTest {
       }
 
       final AtomicBoolean wasReadCalled = new AtomicBoolean(false);
-      gson = new GsonBuilder()
-        .registerTypeAdapter(clazz, new TypeAdapter<Object>() {
-          @Override
-          public void write(JsonWriter out, Object value) throws IOException {
-            out.value("custom-write");
-          }
+      gson =
+          new GsonBuilder()
+              .registerTypeAdapter(
+                  clazz,
+                  new TypeAdapter<Object>() {
+                    @Override
+                    public void write(JsonWriter out, Object value) throws IOException {
+                      out.value("custom-write");
+                    }
 
-          @Override
-          public Object read(JsonReader in) throws IOException {
-            in.skipValue();
-            wasReadCalled.set(true);
-            return null;
-          }}
-        )
-        .create();
+                    @Override
+                    public Object read(JsonReader in) throws IOException {
+                      in.skipValue();
+                      wasReadCalled.set(true);
+                      return null;
+                    }
+                  })
+              .create();
 
       assertThat(gson.toJson(null, clazz)).isEqualTo("\"custom-write\"");
       assertThat(gson.fromJson("{}", clazz)).isNull();
@@ -111,24 +115,29 @@ public class ReflectionAccessTest {
     Gson gson = new Gson();
     try {
       gson.fromJson(json, toDeserialize);
-      throw new AssertionError("Missing exception; test has to be run with `--illegal-access=deny`");
+      throw new AssertionError(
+          "Missing exception; test has to be run with `--illegal-access=deny`");
     } catch (JsonSyntaxException e) {
-      throw new AssertionError("Unexpected exception; test has to be run with `--illegal-access=deny`", e);
+      throw new AssertionError(
+          "Unexpected exception; test has to be run with `--illegal-access=deny`", e);
     } catch (JsonIOException expected) {
-      assertThat(expected).hasMessageThat().endsWith("\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#reflection-inaccessible");
+      assertThat(expected)
+          .hasMessageThat()
+          .endsWith(
+              "\n"
+                  + "See https://github.com/google/gson/blob/main/Troubleshooting.md#reflection-inaccessible");
       // Return exception for further assertions
       return expected;
     }
   }
 
   /**
-   * Test serializing an instance of a non-accessible internal class, but where
-   * Gson supports serializing one of its superinterfaces.
+   * Test serializing an instance of a non-accessible internal class, but where Gson supports
+   * serializing one of its superinterfaces.
    *
-   * <p>Here {@link Collections#emptyList()} is used which returns an instance
-   * of the internal class {@code java.util.Collections.EmptyList}. Gson should
-   * serialize the object as {@code List} despite the internal class not being
-   * accessible.
+   * <p>Here {@link Collections#emptyList()} is used which returns an instance of the internal class
+   * {@code java.util.Collections.EmptyList}. Gson should serialize the object as {@code List}
+   * despite the internal class not being accessible.
    *
    * <p>See https://github.com/google/gson/issues/1875
    */
@@ -143,8 +152,11 @@ public class ReflectionAccessTest {
     JsonIOException exception = assertInaccessibleException("[]", internalClass);
     // Don't check exact class name because it is a JDK implementation detail
     assertThat(exception).hasMessageThat().startsWith("Failed making constructor '");
-    assertThat(exception).hasMessageThat().contains("' accessible; either increase its visibility or"
-        + " write a custom InstanceCreator or TypeAdapter for its declaring type: ");
+    assertThat(exception)
+        .hasMessageThat()
+        .contains(
+            "' accessible; either increase its visibility or"
+                + " write a custom InstanceCreator or TypeAdapter for its declaring type: ");
   }
 
   @Test
@@ -152,7 +164,10 @@ public class ReflectionAccessTest {
     JsonIOException exception = assertInaccessibleException("{}", Throwable.class);
     // Don't check exact field name because it is a JDK implementation detail
     assertThat(exception).hasMessageThat().startsWith("Failed making field 'java.lang.Throwable#");
-    assertThat(exception).hasMessageThat().contains("' accessible; either increase its visibility or"
-        + " write a custom TypeAdapter for its declaring type.");
+    assertThat(exception)
+        .hasMessageThat()
+        .contains(
+            "' accessible; either increase its visibility or"
+                + " write a custom TypeAdapter for its declaring type.");
   }
 }

--- a/gson/src/test/java/com/google/gson/functional/ReusedTypeVariablesFullyResolveTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ReusedTypeVariablesFullyResolveTest.java
@@ -20,16 +20,16 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import org.junit.Before;
-import org.junit.Test;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
- * This test covers the scenario described in #1390 where a type variable needs to be used
- * by a type definition multiple times.  Both type variable references should resolve to the
- * same underlying concrete type.
+ * This test covers the scenario described in #1390 where a type variable needs to be used by a type
+ * definition multiple times. Both type variable references should resolve to the same underlying
+ * concrete type.
  */
 public class ReusedTypeVariablesFullyResolveTest {
 
@@ -40,10 +40,12 @@ public class ReusedTypeVariablesFullyResolveTest {
     gson = new GsonBuilder().create();
   }
 
-  @SuppressWarnings("ConstantConditions") // The instances were being unmarshaled as Strings instead of TestEnums
+  // The instances were being unmarshaled as Strings instead of TestEnums
+  @SuppressWarnings("ConstantConditions")
   @Test
   public void testGenericsPreservation() {
-    TestEnumSetCollection withSet = gson.fromJson("{\"collection\":[\"ONE\",\"THREE\"]}", TestEnumSetCollection.class);
+    TestEnumSetCollection withSet =
+        gson.fromJson("{\"collection\":[\"ONE\",\"THREE\"]}", TestEnumSetCollection.class);
     Iterator<TestEnum> iterator = withSet.collection.iterator();
     assertThat(withSet).isNotNull();
     assertThat(withSet.collection).isNotNull();
@@ -55,15 +57,17 @@ public class ReusedTypeVariablesFullyResolveTest {
     assertThat(second).isInstanceOf(TestEnum.class);
   }
 
-  enum TestEnum { ONE, TWO, THREE }
+  enum TestEnum {
+    ONE,
+    TWO,
+    THREE
+  }
 
   private static class TestEnumSetCollection extends SetCollection<TestEnum> {}
 
   private static class SetCollection<T> extends BaseCollection<T, Set<T>> {}
 
-  private static class BaseCollection<U, C extends Collection<U>>
-  {
+  private static class BaseCollection<U, C extends Collection<U>> {
     public C collection;
   }
-
 }

--- a/gson/src/test/java/com/google/gson/functional/RuntimeTypeAdapterFactoryFunctionalTest.java
+++ b/gson/src/test/java/com/google/gson/functional/RuntimeTypeAdapterFactoryFunctionalTest.java
@@ -35,9 +35,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.Test;
 
-/**
- * Functional tests for the RuntimeTypeAdapterFactory feature in extras.
- */
+/** Functional tests for the RuntimeTypeAdapterFactory feature in extras. */
 public final class RuntimeTypeAdapterFactoryFunctionalTest {
 
   private final Gson gson = new Gson();
@@ -51,19 +49,23 @@ public final class RuntimeTypeAdapterFactoryFunctionalTest {
     Shape shape = new Circle(25);
     String json = gson.toJson(shape);
     shape = gson.fromJson(json, Shape.class);
-    assertThat(((Circle)shape).radius).isEqualTo(25);
+    assertThat(((Circle) shape).radius).isEqualTo(25);
 
     shape = new Square(15);
     json = gson.toJson(shape);
     shape = gson.fromJson(json, Shape.class);
-    assertThat(((Square)shape).side).isEqualTo(15);
+    assertThat(((Square) shape).side).isEqualTo(15);
     assertThat(shape.type).isEqualTo(ShapeType.SQUARE);
   }
 
   @JsonAdapter(Shape.JsonAdapterFactory.class)
   static class Shape {
     final ShapeType type;
-    Shape(ShapeType type) { this.type = type; }
+
+    Shape(ShapeType type) {
+      this.type = type;
+    }
+
     private static final class JsonAdapterFactory extends RuntimeTypeAdapterFactory<Shape> {
       public JsonAdapterFactory() {
         super(Shape.class, "type");
@@ -74,17 +76,26 @@ public final class RuntimeTypeAdapterFactoryFunctionalTest {
   }
 
   public enum ShapeType {
-    SQUARE, CIRCLE
+    SQUARE,
+    CIRCLE
   }
 
   private static final class Circle extends Shape {
     final int radius;
-    Circle(int radius) { super(ShapeType.CIRCLE); this.radius = radius; }
+
+    Circle(int radius) {
+      super(ShapeType.CIRCLE);
+      this.radius = radius;
+    }
   }
 
   private static final class Square extends Shape {
     final int side;
-    Square(int side) { super(ShapeType.SQUARE); this.side = side; }
+
+    Square(int side) {
+      super(ShapeType.SQUARE);
+      this.side = side;
+    }
   }
 
   // Copied from the extras package
@@ -103,27 +114,26 @@ public final class RuntimeTypeAdapterFactoryFunctionalTest {
     }
 
     /**
-     * Creates a new runtime type adapter using for {@code baseType} using {@code
-     * typeFieldName} as the type field name. Type field names are case sensitive.
+     * Creates a new runtime type adapter using for {@code baseType} using {@code typeFieldName} as
+     * the type field name. Type field names are case sensitive.
      */
     public static <T> RuntimeTypeAdapterFactory<T> of(Class<T> baseType, String typeFieldName) {
       return new RuntimeTypeAdapterFactory<>(baseType, typeFieldName);
     }
 
     /**
-     * Creates a new runtime type adapter for {@code baseType} using {@code "type"} as
-     * the type field name.
+     * Creates a new runtime type adapter for {@code baseType} using {@code "type"} as the type
+     * field name.
      */
     public static <T> RuntimeTypeAdapterFactory<T> of(Class<T> baseType) {
       return new RuntimeTypeAdapterFactory<>(baseType, "type");
     }
 
     /**
-     * Registers {@code type} identified by {@code label}. Labels are case
-     * sensitive.
+     * Registers {@code type} identified by {@code label}. Labels are case sensitive.
      *
-     * @throws IllegalArgumentException if either {@code type} or {@code label}
-     *     have already been registered on this type adapter.
+     * @throws IllegalArgumentException if either {@code type} or {@code label} have already been
+     *     registered on this type adapter.
      */
     @CanIgnoreReturnValue
     public RuntimeTypeAdapterFactory<T> registerSubtype(Class<? extends T> type, String label) {
@@ -139,18 +149,19 @@ public final class RuntimeTypeAdapterFactoryFunctionalTest {
     }
 
     /**
-     * Registers {@code type} identified by its {@link Class#getSimpleName simple
-     * name}. Labels are case sensitive.
+     * Registers {@code type} identified by its {@link Class#getSimpleName simple name}. Labels are
+     * case sensitive.
      *
-     * @throws IllegalArgumentException if either {@code type} or its simple name
-     *     have already been registered on this type adapter.
+     * @throws IllegalArgumentException if either {@code type} or its simple name have already been
+     *     registered on this type adapter.
      */
     @CanIgnoreReturnValue
     public RuntimeTypeAdapterFactory<T> registerSubtype(Class<? extends T> type) {
       return registerSubtype(type, type.getSimpleName());
     }
 
-    @Override public <R> TypeAdapter<R> create(Gson gson, TypeToken<R> type) {
+    @Override
+    public <R> TypeAdapter<R> create(Gson gson, TypeToken<R> type) {
       if (type.getRawType() != baseType) {
         return null;
       }
@@ -164,31 +175,42 @@ public final class RuntimeTypeAdapterFactoryFunctionalTest {
       }
 
       return new TypeAdapter<R>() {
-        @Override public R read(JsonReader in) {
+        @Override
+        public R read(JsonReader in) {
           JsonElement jsonElement = Streams.parse(in);
           JsonElement labelJsonElement = jsonElement.getAsJsonObject().get(typeFieldName);
           if (labelJsonElement == null) {
-            throw new JsonParseException("cannot deserialize " + baseType
-                + " because it does not define a field named " + typeFieldName);
+            throw new JsonParseException(
+                "cannot deserialize "
+                    + baseType
+                    + " because it does not define a field named "
+                    + typeFieldName);
           }
           String label = labelJsonElement.getAsString();
           @SuppressWarnings("unchecked") // registration requires that subtype extends T
           TypeAdapter<R> delegate = (TypeAdapter<R>) labelToDelegate.get(label);
           if (delegate == null) {
-            throw new JsonParseException("cannot deserialize " + baseType + " subtype named "
-                + label + "; did you forget to register a subtype?");
+            throw new JsonParseException(
+                "cannot deserialize "
+                    + baseType
+                    + " subtype named "
+                    + label
+                    + "; did you forget to register a subtype?");
           }
           return delegate.fromJsonTree(jsonElement);
         }
 
-        @Override public void write(JsonWriter out, R value) throws IOException {
+        @Override
+        public void write(JsonWriter out, R value) throws IOException {
           Class<?> srcType = value.getClass();
           String label = subtypeToLabel.get(srcType);
           @SuppressWarnings("unchecked") // registration requires that subtype extends T
           TypeAdapter<R> delegate = (TypeAdapter<R>) subtypeToDelegate.get(srcType);
           if (delegate == null) {
-            throw new JsonParseException("cannot serialize " + srcType.getName()
-                + "; did you forget to register a subtype?");
+            throw new JsonParseException(
+                "cannot serialize "
+                    + srcType.getName()
+                    + "; did you forget to register a subtype?");
           }
           JsonObject jsonObject = delegate.toJsonTree(value).getAsJsonObject();
           if (!jsonObject.has(typeFieldName)) {

--- a/gson/src/test/java/com/google/gson/functional/SecurityTest.java
+++ b/gson/src/test/java/com/google/gson/functional/SecurityTest.java
@@ -26,13 +26,11 @@ import org.junit.Test;
 
 /**
  * Tests for security-related aspects of Gson
- * 
+ *
  * @author Inderjeet Singh
  */
 public class SecurityTest {
-  /**
-   * Keep this in sync with Gson.JSON_NON_EXECUTABLE_PREFIX
-   */
+  /** Keep this in sync with Gson.JSON_NON_EXECUTABLE_PREFIX */
   private static final String JSON_NON_EXECUTABLE_PREFIX = ")]}'\n";
 
   private GsonBuilder gsonBuilder;
@@ -48,7 +46,7 @@ public class SecurityTest {
     String json = gson.toJson(new BagOfPrimitives());
     assertThat(json.startsWith(JSON_NON_EXECUTABLE_PREFIX)).isTrue();
   }
-  
+
   @Test
   public void testNonExecutableJsonDeserialization() {
     String json = JSON_NON_EXECUTABLE_PREFIX + "{longValue:1}";
@@ -56,17 +54,17 @@ public class SecurityTest {
     BagOfPrimitives target = gson.fromJson(json, BagOfPrimitives.class);
     assertThat(target.longValue).isEqualTo(1);
   }
-  
+
   @Test
   public void testJsonWithNonExectuableTokenSerialization() {
     Gson gson = gsonBuilder.generateNonExecutableJson().create();
     String json = gson.toJson(JSON_NON_EXECUTABLE_PREFIX);
     assertThat(json).contains(")]}'\n");
   }
-  
+
   /**
-   *  Gson should be able to deserialize a stream with non-exectuable token even if it is created
-   *  without {@link GsonBuilder#generateNonExecutableJson()}.
+   * Gson should be able to deserialize a stream with non-exectuable token even if it is created
+   * without {@link GsonBuilder#generateNonExecutableJson()}.
    */
   @Test
   public void testJsonWithNonExectuableTokenWithRegularGsonDeserialization() {
@@ -74,19 +72,19 @@ public class SecurityTest {
     String json = JSON_NON_EXECUTABLE_PREFIX + "{stringValue:')]}\\u0027\\n'}";
     BagOfPrimitives target = gson.fromJson(json, BagOfPrimitives.class);
     assertThat(target.stringValue).isEqualTo(")]}'\n");
-  }  
-  
+  }
+
   /**
-   *  Gson should be able to deserialize a stream with non-exectuable token if it is created
-   *  with {@link GsonBuilder#generateNonExecutableJson()}.
+   * Gson should be able to deserialize a stream with non-exectuable token if it is created with
+   * {@link GsonBuilder#generateNonExecutableJson()}.
    */
   @Test
   public void testJsonWithNonExectuableTokenWithConfiguredGsonDeserialization() {
-    // Gson should be able to deserialize a stream with non-exectuable token even if it is created 
+    // Gson should be able to deserialize a stream with non-exectuable token even if it is created
     Gson gson = gsonBuilder.generateNonExecutableJson().create();
     String json = JSON_NON_EXECUTABLE_PREFIX + "{intValue:2,stringValue:')]}\\u0027\\n'}";
     BagOfPrimitives target = gson.fromJson(json, BagOfPrimitives.class);
     assertThat(target.stringValue).isEqualTo(")]}'\n");
     assertThat(target.intValue).isEqualTo(2);
-  }  
+  }
 }

--- a/gson/src/test/java/com/google/gson/functional/SerializedNameTest.java
+++ b/gson/src/test/java/com/google/gson/functional/SerializedNameTest.java
@@ -44,12 +44,19 @@ public final class SerializedNameTest {
   @Test
   public void testMultipleNamesInTheSameString() {
     // The last value takes precedence
-    assertThat(gson.fromJson("{'name1':'v1','name2':'v2','name3':'v3'}", MyClass.class).b).isEqualTo("v3");
+    assertThat(gson.fromJson("{'name1':'v1','name2':'v2','name3':'v3'}", MyClass.class).b)
+        .isEqualTo("v3");
   }
 
   private static final class MyClass {
-    @SerializedName("name") String a;
-    @SerializedName(value="name1", alternate={"name2", "name3"}) String b;
+    @SerializedName("name")
+    String a;
+
+    @SerializedName(
+        value = "name1",
+        alternate = {"name2", "name3"})
+    String b;
+
     MyClass(String a, String b) {
       this.a = a;
       this.b = b;

--- a/gson/src/test/java/com/google/gson/functional/StreamingTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/StreamingTypeAdaptersTest.java
@@ -42,8 +42,8 @@ import org.junit.Test;
 public final class StreamingTypeAdaptersTest {
   private Gson miniGson = new GsonBuilder().create();
   private TypeAdapter<Truck> truckAdapter = miniGson.getAdapter(Truck.class);
-  private TypeAdapter<Map<String, Double>> mapAdapter
-      = miniGson.getAdapter(new TypeToken<Map<String, Double>>() {});
+  private TypeAdapter<Map<String, Double>> mapAdapter =
+      miniGson.getAdapter(new TypeToken<Map<String, Double>>() {});
 
   @Test
   public void testSerialize() {
@@ -52,14 +52,16 @@ public final class StreamingTypeAdaptersTest {
     truck.horsePower = 300;
 
     assertThat(truckAdapter.toJson(truck).replace('\"', '\''))
-        .isEqualTo("{'horsePower':300.0,"
-        + "'passengers':[{'age':29,'name':'Jesse'},{'age':29,'name':'Jodie'}]}");
+        .isEqualTo(
+            "{'horsePower':300.0,"
+                + "'passengers':[{'age':29,'name':'Jesse'},{'age':29,'name':'Jodie'}]}");
   }
 
   @Test
   public void testDeserialize() throws IOException {
-    String json = "{'horsePower':300.0,"
-        + "'passengers':[{'age':29,'name':'Jesse'},{'age':29,'name':'Jodie'}]}";
+    String json =
+        "{'horsePower':300.0,"
+            + "'passengers':[{'age':29,'name':'Jesse'},{'age':29,'name':'Jodie'}]}";
     Truck truck = truckAdapter.fromJson(json.replace('\'', '\"'));
     assertThat(truck.horsePower).isEqualTo(300.0);
     assertThat(truck.passengers)
@@ -90,7 +92,8 @@ public final class StreamingTypeAdaptersTest {
 
   @Test
   public void testDeserializeNullObject() throws IOException {
-    Truck truck = truckAdapter.fromJson("{'horsePower':0.0,'passengers':[null]}".replace('\'', '\"'));
+    Truck truck =
+        truckAdapter.fromJson("{'horsePower':0.0,'passengers':[null]}".replace('\'', '\"'));
     assertThat(truck.passengers).isEqualTo(Arrays.asList((Person) null));
   }
 
@@ -106,20 +109,27 @@ public final class StreamingTypeAdaptersTest {
   @Test
   public void testDeserializeWithCustomTypeAdapter() throws IOException {
     usePersonNameAdapter();
-    Truck truck = truckAdapter.fromJson("{'horsePower':0.0,'passengers':['Jesse','Jodie']}".replace('\'', '\"'));
-    assertThat(truck.passengers).isEqualTo(Arrays.asList(new Person("Jesse", -1), new Person("Jodie", -1)));
+    Truck truck =
+        truckAdapter.fromJson(
+            "{'horsePower':0.0,'passengers':['Jesse','Jodie']}".replace('\'', '\"'));
+    assertThat(truck.passengers)
+        .isEqualTo(Arrays.asList(new Person("Jesse", -1), new Person("Jodie", -1)));
   }
 
   private void usePersonNameAdapter() {
-    TypeAdapter<Person> personNameAdapter = new TypeAdapter<Person>() {
-      @Override public Person read(JsonReader in) throws IOException {
-        String name = in.nextString();
-        return new Person(name, -1);
-      }
-      @Override public void write(JsonWriter out, Person value) throws IOException {
-        out.value(value.name);
-      }
-    };
+    TypeAdapter<Person> personNameAdapter =
+        new TypeAdapter<Person>() {
+          @Override
+          public Person read(JsonReader in) throws IOException {
+            String name = in.nextString();
+            return new Person(name, -1);
+          }
+
+          @Override
+          public void write(JsonWriter out, Person value) throws IOException {
+            out.value(value.name);
+          }
+        };
     miniGson = new GsonBuilder().registerTypeAdapter(Person.class, personNameAdapter).create();
     truckAdapter = miniGson.getAdapter(Truck.class);
   }
@@ -143,20 +153,20 @@ public final class StreamingTypeAdaptersTest {
   @Test
   public void testSerialize1dArray() {
     TypeAdapter<double[]> arrayAdapter = miniGson.getAdapter(new TypeToken<double[]>() {});
-    assertThat(arrayAdapter.toJson(new double[]{ 1.0, 2.0, 3.0 })).isEqualTo("[1.0,2.0,3.0]");
+    assertThat(arrayAdapter.toJson(new double[] {1.0, 2.0, 3.0})).isEqualTo("[1.0,2.0,3.0]");
   }
 
   @Test
   public void testDeserialize1dArray() throws IOException {
     TypeAdapter<double[]> arrayAdapter = miniGson.getAdapter(new TypeToken<double[]>() {});
     double[] array = arrayAdapter.fromJson("[1.0,2.0,3.0]");
-    assertThat(array).isEqualTo(new double[]{1.0, 2.0, 3.0});
+    assertThat(array).isEqualTo(new double[] {1.0, 2.0, 3.0});
   }
 
   @Test
   public void testSerialize2dArray() {
     TypeAdapter<double[][]> arrayAdapter = miniGson.getAdapter(new TypeToken<double[][]>() {});
-    double[][] array = { {1.0, 2.0 }, { 3.0 } };
+    double[][] array = {{1.0, 2.0}, {3.0}};
     assertThat(arrayAdapter.toJson(array)).isEqualTo("[[1.0,2.0],[3.0]]");
   }
 
@@ -164,23 +174,26 @@ public final class StreamingTypeAdaptersTest {
   public void testDeserialize2dArray() throws IOException {
     TypeAdapter<double[][]> arrayAdapter = miniGson.getAdapter(new TypeToken<double[][]>() {});
     double[][] array = arrayAdapter.fromJson("[[1.0,2.0],[3.0]]");
-    double[][] expected = { {1.0, 2.0 }, { 3.0 } };
+    double[][] expected = {{1.0, 2.0}, {3.0}};
     assertThat(array).isEqualTo(expected);
   }
 
   @Test
   public void testNullSafe() {
-    TypeAdapter<Person> typeAdapter = new TypeAdapter<Person>() {
-      @Override public Person read(JsonReader in) throws IOException {
-        List<String> values = Splitter.on(',').splitToList(in.nextString());
-        return new Person(values.get(0), Integer.parseInt(values.get(1)));
-      }
-      @Override public void write(JsonWriter out, Person person) throws IOException {
-        out.value(person.name + "," + person.age);
-      }
-    };
-    Gson gson = new GsonBuilder().registerTypeAdapter(
-        Person.class, typeAdapter).create();
+    TypeAdapter<Person> typeAdapter =
+        new TypeAdapter<Person>() {
+          @Override
+          public Person read(JsonReader in) throws IOException {
+            List<String> values = Splitter.on(',').splitToList(in.nextString());
+            return new Person(values.get(0), Integer.parseInt(values.get(1)));
+          }
+
+          @Override
+          public void write(JsonWriter out, Person person) throws IOException {
+            out.value(person.name + "," + person.age);
+          }
+        };
+    Gson gson = new GsonBuilder().registerTypeAdapter(Person.class, typeAdapter).create();
     Truck truck = new Truck();
     truck.horsePower = 1.0D;
     truck.passengers = new ArrayList<>();
@@ -189,14 +202,19 @@ public final class StreamingTypeAdaptersTest {
     try {
       gson.toJson(truck, Truck.class);
       fail();
-    } catch (NullPointerException expected) {}
+    } catch (NullPointerException expected) {
+    }
     String json = "{horsePower:1.0,passengers:[null,'jesse,30']}";
     try {
       gson.fromJson(json, Truck.class);
       fail();
     } catch (JsonSyntaxException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("java.lang.IllegalStateException: Expected a string but was NULL at line 1 column 33 path $.passengers[0]"
-          + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#adapter-not-null-safe");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "java.lang.IllegalStateException: Expected a string but was NULL at line 1 column 33"
+                  + " path $.passengers[0]\n"
+                  + "See https://github.com/google/gson/blob/main/Troubleshooting.md#adapter-not-null-safe");
     }
     gson = new GsonBuilder().registerTypeAdapter(Person.class, typeAdapter.nullSafe()).create();
     assertThat(gson.toJson(truck, Truck.class))
@@ -214,9 +232,10 @@ public final class StreamingTypeAdaptersTest {
     root.left = new Node("left");
     root.right = new Node("right");
     assertThat(nodeAdapter.toJson(root).replace('"', '\''))
-        .isEqualTo("{'label':'root',"
-            + "'left':{'label':'left','left':null,'right':null},"
-            + "'right':{'label':'right','left':null,'right':null}}");
+        .isEqualTo(
+            "{'label':'root',"
+                + "'left':{'label':'left','left':null,'right':null},"
+                + "'right':{'label':'right','left':null,'right':null}}");
   }
 
   @Test
@@ -243,17 +262,19 @@ public final class StreamingTypeAdaptersTest {
   static class Person {
     int age;
     String name;
+
     Person(String name, int age) {
       this.name = name;
       this.age = age;
     }
 
-    @Override public boolean equals(Object o) {
-      return o instanceof Person
-          && ((Person) o).name.equals(name)
-          && ((Person) o).age == age;
+    @Override
+    public boolean equals(Object o) {
+      return o instanceof Person && ((Person) o).name.equals(name) && ((Person) o).age == age;
     }
-    @Override public int hashCode() {
+
+    @Override
+    public int hashCode() {
       return name.hashCode() ^ age;
     }
   }
@@ -262,6 +283,7 @@ public final class StreamingTypeAdaptersTest {
     String label;
     Node left;
     Node right;
+
     Node(String label) {
       this.label = label;
     }

--- a/gson/src/test/java/com/google/gson/functional/StringTest.java
+++ b/gson/src/test/java/com/google/gson/functional/StringTest.java
@@ -136,7 +136,8 @@ public class StringTest {
   }
 
   /**
-   * Created in response to http://groups.google.com/group/google-gson/browse_thread/thread/2431d4a3d0d6cb23
+   * Created in response to
+   * http://groups.google.com/group/google-gson/browse_thread/thread/2431d4a3d0d6cb23
    */
   @Test
   public void testAssignmentCharSerialization() {
@@ -146,7 +147,8 @@ public class StringTest {
   }
 
   /**
-   * Created in response to http://groups.google.com/group/google-gson/browse_thread/thread/2431d4a3d0d6cb23
+   * Created in response to
+   * http://groups.google.com/group/google-gson/browse_thread/thread/2431d4a3d0d6cb23
    */
   @Test
   public void testAssignmentCharDeserialization() {

--- a/gson/src/test/java/com/google/gson/functional/ToNumberPolicyFunctionalTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ToNumberPolicyFunctionalTest.java
@@ -44,10 +44,11 @@ public class ToNumberPolicyFunctionalTest {
 
   @Test
   public void testAsDoubles() {
-    Gson gson = new GsonBuilder()
-        .setObjectToNumberStrategy(ToNumberPolicy.DOUBLE)
-        .setNumberToNumberStrategy(ToNumberPolicy.DOUBLE)
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .setObjectToNumberStrategy(ToNumberPolicy.DOUBLE)
+            .setNumberToNumberStrategy(ToNumberPolicy.DOUBLE)
+            .create();
     assertThat(gson.fromJson("null", Object.class)).isEqualTo(null);
     assertThat(gson.fromJson("10", Object.class)).isEqualTo(10.0);
     assertThat(gson.fromJson("null", Number.class)).isEqualTo(null);
@@ -56,10 +57,11 @@ public class ToNumberPolicyFunctionalTest {
 
   @Test
   public void testAsLazilyParsedNumbers() {
-    Gson gson = new GsonBuilder()
-        .setObjectToNumberStrategy(ToNumberPolicy.LAZILY_PARSED_NUMBER)
-        .setNumberToNumberStrategy(ToNumberPolicy.LAZILY_PARSED_NUMBER)
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .setObjectToNumberStrategy(ToNumberPolicy.LAZILY_PARSED_NUMBER)
+            .setNumberToNumberStrategy(ToNumberPolicy.LAZILY_PARSED_NUMBER)
+            .create();
     assertThat(gson.fromJson("null", Object.class)).isEqualTo(null);
     assertThat(gson.fromJson("10", Object.class)).isEqualTo(new LazilyParsedNumber("10"));
     assertThat(gson.fromJson("null", Number.class)).isEqualTo(null);
@@ -68,10 +70,11 @@ public class ToNumberPolicyFunctionalTest {
 
   @Test
   public void testAsLongsOrDoubles() {
-    Gson gson = new GsonBuilder()
-        .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
-        .setNumberToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+            .setNumberToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+            .create();
     assertThat(gson.fromJson("null", Object.class)).isEqualTo(null);
     assertThat(gson.fromJson("10", Object.class)).isEqualTo(10L);
     assertThat(gson.fromJson("10.0", Object.class)).isEqualTo(10.0);
@@ -82,47 +85,50 @@ public class ToNumberPolicyFunctionalTest {
 
   @Test
   public void testAsBigDecimals() {
-    Gson gson = new GsonBuilder()
-        .setObjectToNumberStrategy(ToNumberPolicy.BIG_DECIMAL)
-        .setNumberToNumberStrategy(ToNumberPolicy.BIG_DECIMAL)
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .setObjectToNumberStrategy(ToNumberPolicy.BIG_DECIMAL)
+            .setNumberToNumberStrategy(ToNumberPolicy.BIG_DECIMAL)
+            .create();
     assertThat(gson.fromJson("null", Object.class)).isEqualTo(null);
     assertThat(gson.fromJson("10", Object.class)).isEqualTo(new BigDecimal("10"));
     assertThat(gson.fromJson("10.0", Object.class)).isEqualTo(new BigDecimal("10.0"));
     assertThat(gson.fromJson("null", Number.class)).isEqualTo(null);
     assertThat(gson.fromJson("10", Number.class)).isEqualTo(new BigDecimal("10"));
     assertThat(gson.fromJson("10.0", Number.class)).isEqualTo(new BigDecimal("10.0"));
-    assertThat(gson.fromJson("3.141592653589793238462643383279", BigDecimal.class)).isEqualTo(new BigDecimal("3.141592653589793238462643383279"));
+    assertThat(gson.fromJson("3.141592653589793238462643383279", BigDecimal.class))
+        .isEqualTo(new BigDecimal("3.141592653589793238462643383279"));
     assertThat(gson.fromJson("1e400", BigDecimal.class)).isEqualTo(new BigDecimal("1e400"));
   }
 
   @Test
   public void testAsListOfLongsOrDoubles() {
-    Gson gson = new GsonBuilder()
-        .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
-        .setNumberToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
-        .create();
-    Type objectCollectionType = new TypeToken<Collection<Object>>() { }.getType();
+    Gson gson =
+        new GsonBuilder()
+            .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+            .setNumberToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+            .create();
+    Type objectCollectionType = new TypeToken<Collection<Object>>() {}.getType();
     Collection<Object> objects = gson.fromJson("[null,10,10.0]", objectCollectionType);
     assertThat(objects).containsExactly(null, 10L, 10.0).inOrder();
-    Type numberCollectionType = new TypeToken<Collection<Number>>() { }.getType();
+    Type numberCollectionType = new TypeToken<Collection<Number>>() {}.getType();
     Collection<Object> numbers = gson.fromJson("[null,10,10.0]", numberCollectionType);
     assertThat(numbers).containsExactly(null, 10L, 10.0).inOrder();
   }
 
   @Test
   public void testCustomStrategiesCannotAffectConcreteDeclaredNumbers() {
-    ToNumberStrategy fail = new ToNumberStrategy() {
-      @Override
-      public Byte readNumber(JsonReader in) {
-        throw new UnsupportedOperationException();
-      }
-    };
-    Gson gson = new GsonBuilder()
-        .setObjectToNumberStrategy(fail)
-        .setNumberToNumberStrategy(fail)
-        .create();
-    List<Object> numbers = gson.fromJson("[null, 10, 20, 30]", new TypeToken<List<Byte>>() {}.getType());
+    ToNumberStrategy fail =
+        new ToNumberStrategy() {
+          @Override
+          public Byte readNumber(JsonReader in) {
+            throw new UnsupportedOperationException();
+          }
+        };
+    Gson gson =
+        new GsonBuilder().setObjectToNumberStrategy(fail).setNumberToNumberStrategy(fail).create();
+    List<Object> numbers =
+        gson.fromJson("[null, 10, 20, 30]", new TypeToken<List<Byte>>() {}.getType());
     assertThat(numbers).containsExactly(null, (byte) 10, (byte) 20, (byte) 30).inOrder();
     try {
       gson.fromJson("[null, 10, 20, 30]", new TypeToken<List<Object>>() {}.getType());

--- a/gson/src/test/java/com/google/gson/functional/TreeTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/TreeTypeAdaptersTest.java
@@ -36,29 +36,28 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
-/**
- * Collection of functional tests for DOM tree based type adapters.
- */
+/** Collection of functional tests for DOM tree based type adapters. */
 public class TreeTypeAdaptersTest {
   private static final Id<Student> STUDENT1_ID = new Id<>("5", Student.class);
   private static final Id<Student> STUDENT2_ID = new Id<>("6", Student.class);
   private static final Student STUDENT1 = new Student(STUDENT1_ID, "first");
   private static final Student STUDENT2 = new Student(STUDENT2_ID, "second");
   private static final Type TYPE_COURSE_HISTORY =
-    new TypeToken<Course<HistoryCourse>>(){}.getType();
-  private static final Id<Course<HistoryCourse>> COURSE_ID =
-      new Id<>("10", TYPE_COURSE_HISTORY);
+      new TypeToken<Course<HistoryCourse>>() {}.getType();
+  private static final Id<Course<HistoryCourse>> COURSE_ID = new Id<>("10", TYPE_COURSE_HISTORY);
 
   private Gson gson;
   private Course<HistoryCourse> course;
 
   @Before
   public void setUp() {
-    gson = new GsonBuilder()
-        .registerTypeAdapter(Id.class, new IdTreeTypeAdapter())
-        .create();
-    course = new Course<>(COURSE_ID, 4,
-        new Assignment<HistoryCourse>(null, null), Arrays.asList(STUDENT1, STUDENT2));
+    gson = new GsonBuilder().registerTypeAdapter(Id.class, new IdTreeTypeAdapter()).create();
+    course =
+        new Course<>(
+            COURSE_ID,
+            4,
+            new Assignment<HistoryCourse>(null, null),
+            Arrays.asList(STUDENT1, STUDENT2));
   }
 
   @Test
@@ -71,8 +70,9 @@ public class TreeTypeAdaptersTest {
 
   @Test
   public void testDeserializeId() {
-    String json = "{courseId:1,students:[{id:1,name:'first'},{id:6,name:'second'}],"
-      + "numAssignments:4,assignment:{}}";
+    String json =
+        "{courseId:1,students:[{id:1,name:'first'},{id:6,name:'second'}],"
+            + "numAssignments:4,assignment:{}}";
     Course<HistoryCourse> target = gson.fromJson(json, TYPE_COURSE_HISTORY);
     assertThat(target.getStudents().get(0).id.getValue()).isEqualTo("1");
     assertThat(target.getStudents().get(1).id.getValue()).isEqualTo("6");
@@ -82,6 +82,7 @@ public class TreeTypeAdaptersTest {
   @SuppressWarnings("UnusedTypeParameter")
   private static final class Id<R> {
     final String value;
+
     @SuppressWarnings("unused")
     final Type typeOfId;
 
@@ -89,13 +90,14 @@ public class TreeTypeAdaptersTest {
       this.value = value;
       this.typeOfId = typeOfId;
     }
+
     public String getValue() {
       return value;
     }
   }
 
-  private static final class IdTreeTypeAdapter implements JsonSerializer<Id<?>>,
-      JsonDeserializer<Id<?>> {
+  private static final class IdTreeTypeAdapter
+      implements JsonSerializer<Id<?>>, JsonDeserializer<Id<?>> {
 
     @Override
     public Id<?> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
@@ -124,6 +126,7 @@ public class TreeTypeAdaptersTest {
     private Student() {
       this(null, null);
     }
+
     public Student(Id<Student> id, String name) {
       this.id = id;
       this.name = name;
@@ -141,16 +144,21 @@ public class TreeTypeAdaptersTest {
       this(null, 0, null, new ArrayList<Student>());
     }
 
-    public Course(Id<Course<T>> courseId, int numAssignments,
-        Assignment<T> assignment, List<Student> players) {
+    public Course(
+        Id<Course<T>> courseId,
+        int numAssignments,
+        Assignment<T> assignment,
+        List<Student> players) {
       this.courseId = courseId;
       this.numAssignments = numAssignments;
       this.assignment = assignment;
       this.students = players;
     }
+
     public Id<Course<T>> getId() {
       return courseId;
     }
+
     List<Student> getStudents() {
       return students;
     }
@@ -164,6 +172,7 @@ public class TreeTypeAdaptersTest {
     private Assignment() {
       this(null, null);
     }
+
     public Assignment(Id<Assignment<T>> id, T data) {
       this.id = id;
       this.data = data;

--- a/gson/src/test/java/com/google/gson/functional/TypeAdapterPrecedenceTest.java
+++ b/gson/src/test/java/com/google/gson/functional/TypeAdapterPrecedenceTest.java
@@ -36,95 +36,104 @@ import org.junit.Test;
 public final class TypeAdapterPrecedenceTest {
   @Test
   public void testNonstreamingFollowedByNonstreaming() {
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(Foo.class, newSerializer("serializer 1"))
-        .registerTypeAdapter(Foo.class, newSerializer("serializer 2"))
-        .registerTypeAdapter(Foo.class, newDeserializer("deserializer 1"))
-        .registerTypeAdapter(Foo.class, newDeserializer("deserializer 2"))
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(Foo.class, newSerializer("serializer 1"))
+            .registerTypeAdapter(Foo.class, newSerializer("serializer 2"))
+            .registerTypeAdapter(Foo.class, newDeserializer("deserializer 1"))
+            .registerTypeAdapter(Foo.class, newDeserializer("deserializer 2"))
+            .create();
     assertThat(gson.toJson(new Foo("foo"))).isEqualTo("\"foo via serializer 2\"");
     assertThat(gson.fromJson("foo", Foo.class).name).isEqualTo("foo via deserializer 2");
   }
 
   @Test
   public void testStreamingFollowedByStreaming() {
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(Foo.class, newTypeAdapter("type adapter 1"))
-        .registerTypeAdapter(Foo.class, newTypeAdapter("type adapter 2"))
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(Foo.class, newTypeAdapter("type adapter 1"))
+            .registerTypeAdapter(Foo.class, newTypeAdapter("type adapter 2"))
+            .create();
     assertThat(gson.toJson(new Foo("foo"))).isEqualTo("\"foo via type adapter 2\"");
     assertThat(gson.fromJson("foo", Foo.class).name).isEqualTo("foo via type adapter 2");
   }
 
   @Test
   public void testSerializeNonstreamingTypeAdapterFollowedByStreamingTypeAdapter() {
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(Foo.class, newSerializer("serializer"))
-        .registerTypeAdapter(Foo.class, newDeserializer("deserializer"))
-        .registerTypeAdapter(Foo.class, newTypeAdapter("type adapter"))
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(Foo.class, newSerializer("serializer"))
+            .registerTypeAdapter(Foo.class, newDeserializer("deserializer"))
+            .registerTypeAdapter(Foo.class, newTypeAdapter("type adapter"))
+            .create();
     assertThat(gson.toJson(new Foo("foo"))).isEqualTo("\"foo via type adapter\"");
     assertThat(gson.fromJson("foo", Foo.class).name).isEqualTo("foo via type adapter");
   }
 
   @Test
   public void testStreamingFollowedByNonstreaming() {
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(Foo.class, newTypeAdapter("type adapter"))
-        .registerTypeAdapter(Foo.class, newSerializer("serializer"))
-        .registerTypeAdapter(Foo.class, newDeserializer("deserializer"))
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(Foo.class, newTypeAdapter("type adapter"))
+            .registerTypeAdapter(Foo.class, newSerializer("serializer"))
+            .registerTypeAdapter(Foo.class, newDeserializer("deserializer"))
+            .create();
     assertThat(gson.toJson(new Foo("foo"))).isEqualTo("\"foo via serializer\"");
     assertThat(gson.fromJson("foo", Foo.class).name).isEqualTo("foo via deserializer");
   }
 
   @Test
   public void testStreamingHierarchicalFollowedByNonstreaming() {
-    Gson gson = new GsonBuilder()
-        .registerTypeHierarchyAdapter(Foo.class, newTypeAdapter("type adapter"))
-        .registerTypeAdapter(Foo.class, newSerializer("serializer"))
-        .registerTypeAdapter(Foo.class, newDeserializer("deserializer"))
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeHierarchyAdapter(Foo.class, newTypeAdapter("type adapter"))
+            .registerTypeAdapter(Foo.class, newSerializer("serializer"))
+            .registerTypeAdapter(Foo.class, newDeserializer("deserializer"))
+            .create();
     assertThat(gson.toJson(new Foo("foo"))).isEqualTo("\"foo via serializer\"");
     assertThat(gson.fromJson("foo", Foo.class).name).isEqualTo("foo via deserializer");
   }
 
   @Test
   public void testStreamingFollowedByNonstreamingHierarchical() {
-    Gson gson = new GsonBuilder()
-        .registerTypeAdapter(Foo.class, newTypeAdapter("type adapter"))
-        .registerTypeHierarchyAdapter(Foo.class, newSerializer("serializer"))
-        .registerTypeHierarchyAdapter(Foo.class, newDeserializer("deserializer"))
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(Foo.class, newTypeAdapter("type adapter"))
+            .registerTypeHierarchyAdapter(Foo.class, newSerializer("serializer"))
+            .registerTypeHierarchyAdapter(Foo.class, newDeserializer("deserializer"))
+            .create();
     assertThat(gson.toJson(new Foo("foo"))).isEqualTo("\"foo via type adapter\"");
     assertThat(gson.fromJson("foo", Foo.class).name).isEqualTo("foo via type adapter");
   }
 
   @Test
   public void testStreamingHierarchicalFollowedByNonstreamingHierarchical() {
-    Gson gson = new GsonBuilder()
-        .registerTypeHierarchyAdapter(Foo.class, newSerializer("serializer"))
-        .registerTypeHierarchyAdapter(Foo.class, newDeserializer("deserializer"))
-        .registerTypeHierarchyAdapter(Foo.class, newTypeAdapter("type adapter"))
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeHierarchyAdapter(Foo.class, newSerializer("serializer"))
+            .registerTypeHierarchyAdapter(Foo.class, newDeserializer("deserializer"))
+            .registerTypeHierarchyAdapter(Foo.class, newTypeAdapter("type adapter"))
+            .create();
     assertThat(gson.toJson(new Foo("foo"))).isEqualTo("\"foo via type adapter\"");
     assertThat(gson.fromJson("foo", Foo.class).name).isEqualTo("foo via type adapter");
   }
 
   @Test
   public void testNonstreamingHierarchicalFollowedByNonstreaming() {
-    Gson gson = new GsonBuilder()
-        .registerTypeHierarchyAdapter(Foo.class, newSerializer("hierarchical"))
-        .registerTypeHierarchyAdapter(Foo.class, newDeserializer("hierarchical"))
-        .registerTypeAdapter(Foo.class, newSerializer("non hierarchical"))
-        .registerTypeAdapter(Foo.class, newDeserializer("non hierarchical"))
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeHierarchyAdapter(Foo.class, newSerializer("hierarchical"))
+            .registerTypeHierarchyAdapter(Foo.class, newDeserializer("hierarchical"))
+            .registerTypeAdapter(Foo.class, newSerializer("non hierarchical"))
+            .registerTypeAdapter(Foo.class, newDeserializer("non hierarchical"))
+            .create();
     assertThat(gson.toJson(new Foo("foo"))).isEqualTo("\"foo via non hierarchical\"");
     assertThat(gson.fromJson("foo", Foo.class).name).isEqualTo("foo via non hierarchical");
   }
 
   private static class Foo {
     final String name;
+
     private Foo(String name) {
       this.name = name;
     }
@@ -150,10 +159,13 @@ public final class TypeAdapterPrecedenceTest {
 
   private TypeAdapter<Foo> newTypeAdapter(final String name) {
     return new TypeAdapter<Foo>() {
-      @Override public Foo read(JsonReader in) throws IOException {
+      @Override
+      public Foo read(JsonReader in) throws IOException {
         return new Foo(in.nextString() + " via " + name);
       }
-      @Override public void write(JsonWriter out, Foo value) throws IOException {
+
+      @Override
+      public void write(JsonWriter out, Foo value) throws IOException {
         out.value(value.name + " via " + name);
       }
     };

--- a/gson/src/test/java/com/google/gson/functional/TypeAdapterRuntimeTypeWrapperTest.java
+++ b/gson/src/test/java/com/google/gson/functional/TypeAdapterRuntimeTypeWrapperTest.java
@@ -34,16 +34,18 @@ import java.lang.reflect.Type;
 import org.junit.Test;
 
 public class TypeAdapterRuntimeTypeWrapperTest {
-  private static class Base {
-  }
+  private static class Base {}
+
   private static class Subclass extends Base {
     @SuppressWarnings("unused")
     String f = "test";
   }
+
   private static class Container {
     @SuppressWarnings("unused")
     Base b = new Subclass();
   }
+
   private static class Deserializer implements JsonDeserializer<Base> {
     @Override
     public Base deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
@@ -52,128 +54,144 @@ public class TypeAdapterRuntimeTypeWrapperTest {
   }
 
   /**
-   * When custom {@link JsonSerializer} is registered for Base should
-   * prefer that over reflective adapter for Subclass for serialization.
+   * When custom {@link JsonSerializer} is registered for Base should prefer that over reflective
+   * adapter for Subclass for serialization.
    */
   @Test
   public void testJsonSerializer() {
-    Gson gson = new GsonBuilder()
-      .registerTypeAdapter(Base.class, new JsonSerializer<Base>() {
-        @Override
-        public JsonElement serialize(Base src, Type typeOfSrc, JsonSerializationContext context) {
-          return new JsonPrimitive("serializer");
-        }
-      })
-      .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                Base.class,
+                new JsonSerializer<Base>() {
+                  @Override
+                  public JsonElement serialize(
+                      Base src, Type typeOfSrc, JsonSerializationContext context) {
+                    return new JsonPrimitive("serializer");
+                  }
+                })
+            .create();
 
     String json = gson.toJson(new Container());
     assertThat(json).isEqualTo("{\"b\":\"serializer\"}");
   }
 
   /**
-   * When only {@link JsonDeserializer} is registered for Base, then on
-   * serialization should prefer reflective adapter for Subclass since
-   * Base would use reflective adapter as delegate.
+   * When only {@link JsonDeserializer} is registered for Base, then on serialization should prefer
+   * reflective adapter for Subclass since Base would use reflective adapter as delegate.
    */
   @Test
   public void testJsonDeserializer_ReflectiveSerializerDelegate() {
-    Gson gson = new GsonBuilder()
-      .registerTypeAdapter(Base.class, new Deserializer())
-      .create();
+    Gson gson = new GsonBuilder().registerTypeAdapter(Base.class, new Deserializer()).create();
 
     String json = gson.toJson(new Container());
     assertThat(json).isEqualTo("{\"b\":{\"f\":\"test\"}}");
   }
 
   /**
-   * When {@link JsonDeserializer} with custom adapter as delegate is
-   * registered for Base, then on serialization should prefer custom adapter
-   * delegate for Base over reflective adapter for Subclass.
+   * When {@link JsonDeserializer} with custom adapter as delegate is registered for Base, then on
+   * serialization should prefer custom adapter delegate for Base over reflective adapter for
+   * Subclass.
    */
   @Test
   public void testJsonDeserializer_CustomSerializerDelegate() {
-    Gson gson = new GsonBuilder()
-      // Register custom delegate
-      .registerTypeAdapter(Base.class, new TypeAdapter<Base>() {
-        @Override
-        public Base read(JsonReader in) throws IOException {
-          throw new UnsupportedOperationException();
-        }
-        @Override
-        public void write(JsonWriter out, Base value) throws IOException {
-          out.value("custom delegate");
-        }
-      })
-      .registerTypeAdapter(Base.class, new Deserializer())
-      .create();
+    Gson gson =
+        new GsonBuilder()
+            // Register custom delegate
+            .registerTypeAdapter(
+                Base.class,
+                new TypeAdapter<Base>() {
+                  @Override
+                  public Base read(JsonReader in) throws IOException {
+                    throw new UnsupportedOperationException();
+                  }
+
+                  @Override
+                  public void write(JsonWriter out, Base value) throws IOException {
+                    out.value("custom delegate");
+                  }
+                })
+            .registerTypeAdapter(Base.class, new Deserializer())
+            .create();
 
     String json = gson.toJson(new Container());
     assertThat(json).isEqualTo("{\"b\":\"custom delegate\"}");
   }
 
   /**
-   * When two (or more) {@link JsonDeserializer}s are registered for Base
-   * which eventually fall back to reflective adapter as delegate, then on
-   * serialization should prefer reflective adapter for Subclass.
+   * When two (or more) {@link JsonDeserializer}s are registered for Base which eventually fall back
+   * to reflective adapter as delegate, then on serialization should prefer reflective adapter for
+   * Subclass.
    */
   @Test
   public void testJsonDeserializer_ReflectiveTreeSerializerDelegate() {
-    Gson gson = new GsonBuilder()
-      // Register delegate which itself falls back to reflective serialization
-      .registerTypeAdapter(Base.class, new Deserializer())
-      .registerTypeAdapter(Base.class, new Deserializer())
-      .create();
+    Gson gson =
+        new GsonBuilder()
+            // Register delegate which itself falls back to reflective serialization
+            .registerTypeAdapter(Base.class, new Deserializer())
+            .registerTypeAdapter(Base.class, new Deserializer())
+            .create();
 
     String json = gson.toJson(new Container());
     assertThat(json).isEqualTo("{\"b\":{\"f\":\"test\"}}");
   }
 
   /**
-   * When {@link JsonDeserializer} with {@link JsonSerializer} as delegate
-   * is registered for Base, then on serialization should prefer
-   * {@code JsonSerializer} over reflective adapter for Subclass.
+   * When {@link JsonDeserializer} with {@link JsonSerializer} as delegate is registered for Base,
+   * then on serialization should prefer {@code JsonSerializer} over reflective adapter for
+   * Subclass.
    */
   @Test
   public void testJsonDeserializer_JsonSerializerDelegate() {
-    Gson gson = new GsonBuilder()
-      // Register JsonSerializer as delegate
-      .registerTypeAdapter(Base.class, new JsonSerializer<Base>() {
-        @Override
-        public JsonElement serialize(Base src, Type typeOfSrc, JsonSerializationContext context) {
-          return new JsonPrimitive("custom delegate");
-        }
-      })
-      .registerTypeAdapter(Base.class, new Deserializer())
-      .create();
+    Gson gson =
+        new GsonBuilder()
+            // Register JsonSerializer as delegate
+            .registerTypeAdapter(
+                Base.class,
+                new JsonSerializer<Base>() {
+                  @Override
+                  public JsonElement serialize(
+                      Base src, Type typeOfSrc, JsonSerializationContext context) {
+                    return new JsonPrimitive("custom delegate");
+                  }
+                })
+            .registerTypeAdapter(Base.class, new Deserializer())
+            .create();
 
     String json = gson.toJson(new Container());
     assertThat(json).isEqualTo("{\"b\":\"custom delegate\"}");
   }
 
   /**
-   * When a {@link JsonDeserializer} is registered for Subclass, and a custom
-   * {@link JsonSerializer} is registered for Base, then Gson should prefer
-   * the reflective adapter for Subclass for backward compatibility (see
-   * https://github.com/google/gson/pull/1787#issuecomment-1222175189) even
-   * though normally TypeAdapterRuntimeTypeWrapper should prefer the custom
-   * serializer for Base.
+   * When a {@link JsonDeserializer} is registered for Subclass, and a custom {@link JsonSerializer}
+   * is registered for Base, then Gson should prefer the reflective adapter for Subclass for
+   * backward compatibility (see https://github.com/google/gson/pull/1787#issuecomment-1222175189)
+   * even though normally TypeAdapterRuntimeTypeWrapper should prefer the custom serializer for
+   * Base.
    */
   @Test
   public void testJsonDeserializer_SubclassBackwardCompatibility() {
-    Gson gson = new GsonBuilder()
-      .registerTypeAdapter(Subclass.class, new JsonDeserializer<Subclass>() {
-        @Override
-        public Subclass deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
-          throw new AssertionError("not needed for this test");
-        }
-      })
-      .registerTypeAdapter(Base.class, new JsonSerializer<Base>() {
-        @Override
-        public JsonElement serialize(Base src, Type typeOfSrc, JsonSerializationContext context) {
-          return new JsonPrimitive("base");
-        }
-      })
-      .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(
+                Subclass.class,
+                new JsonDeserializer<Subclass>() {
+                  @Override
+                  public Subclass deserialize(
+                      JsonElement json, Type typeOfT, JsonDeserializationContext context) {
+                    throw new AssertionError("not needed for this test");
+                  }
+                })
+            .registerTypeAdapter(
+                Base.class,
+                new JsonSerializer<Base>() {
+                  @Override
+                  public JsonElement serialize(
+                      Base src, Type typeOfSrc, JsonSerializationContext context) {
+                    return new JsonPrimitive("base");
+                  }
+                })
+            .create();
 
     String json = gson.toJson(new Container());
     assertThat(json).isEqualTo("{\"b\":{\"f\":\"test\"}}");
@@ -194,10 +212,9 @@ public class TypeAdapterRuntimeTypeWrapperTest {
   }
 
   /**
-   * Tests behavior when the type of a field refers to a type whose adapter is
-   * currently in the process of being created. For these cases {@link Gson}
-   * uses a future adapter for the type. That adapter later uses the actual
-   * adapter as delegate.
+   * Tests behavior when the type of a field refers to a type whose adapter is currently in the
+   * process of being created. For these cases {@link Gson} uses a future adapter for the type. That
+   * adapter later uses the actual adapter as delegate.
    */
   @Test
   public void testGsonFutureAdapter() {

--- a/gson/src/test/java/com/google/gson/functional/TypeHierarchyAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/functional/TypeHierarchyAdapterTest.java
@@ -31,9 +31,7 @@ import com.google.gson.JsonSerializer;
 import java.lang.reflect.Type;
 import org.junit.Test;
 
-/**
- * Test that the hierarchy adapter works when subtypes are used.
- */
+/** Test that the hierarchy adapter works when subtypes are used. */
 public final class TypeHierarchyAdapterTest {
 
   @Test
@@ -41,70 +39,71 @@ public final class TypeHierarchyAdapterTest {
     Manager andy = new Manager();
     andy.userid = "andy";
     andy.startDate = 2005;
-    andy.minions = new Employee[] {
-        new Employee("inder", 2007),
-        new Employee("joel", 2006),
-        new Employee("jesse", 2006),
-    };
+    andy.minions =
+        new Employee[] {
+          new Employee("inder", 2007), new Employee("joel", 2006), new Employee("jesse", 2006),
+        };
 
     CEO eric = new CEO();
     eric.userid = "eric";
     eric.startDate = 2001;
     eric.assistant = new Employee("jerome", 2006);
 
-    eric.minions = new Employee[] {
-        new Employee("larry", 1998),
-        new Employee("sergey", 1998),
-        andy,
-    };
+    eric.minions =
+        new Employee[] {
+          new Employee("larry", 1998), new Employee("sergey", 1998), andy,
+        };
 
-    Gson gson = new GsonBuilder()
-        .registerTypeHierarchyAdapter(Employee.class, new EmployeeAdapter())
-        .setPrettyPrinting()
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeHierarchyAdapter(Employee.class, new EmployeeAdapter())
+            .setPrettyPrinting()
+            .create();
 
     Company company = new Company();
     company.ceo = eric;
 
     String json = gson.toJson(company, Company.class);
-    assertThat(json).isEqualTo("{\n" +
-        "  \"ceo\": {\n" +
-        "    \"userid\": \"eric\",\n" +
-        "    \"startDate\": 2001,\n" +
-        "    \"minions\": [\n" +
-        "      {\n" +
-        "        \"userid\": \"larry\",\n" +
-        "        \"startDate\": 1998\n" +
-        "      },\n" +
-        "      {\n" +
-        "        \"userid\": \"sergey\",\n" +
-        "        \"startDate\": 1998\n" +
-        "      },\n" +
-        "      {\n" +
-        "        \"userid\": \"andy\",\n" +
-        "        \"startDate\": 2005,\n" +
-        "        \"minions\": [\n" +
-        "          {\n" +
-        "            \"userid\": \"inder\",\n" +
-        "            \"startDate\": 2007\n" +
-        "          },\n" +
-        "          {\n" +
-        "            \"userid\": \"joel\",\n" +
-        "            \"startDate\": 2006\n" +
-        "          },\n" +
-        "          {\n" +
-        "            \"userid\": \"jesse\",\n" +
-        "            \"startDate\": 2006\n" +
-        "          }\n" +
-        "        ]\n" +
-        "      }\n" +
-        "    ],\n" +
-        "    \"assistant\": {\n" +
-        "      \"userid\": \"jerome\",\n" +
-        "      \"startDate\": 2006\n" +
-        "    }\n" +
-        "  }\n" +
-        "}");
+    assertThat(json)
+        .isEqualTo(
+            "{\n"
+                + "  \"ceo\": {\n"
+                + "    \"userid\": \"eric\",\n"
+                + "    \"startDate\": 2001,\n"
+                + "    \"minions\": [\n"
+                + "      {\n"
+                + "        \"userid\": \"larry\",\n"
+                + "        \"startDate\": 1998\n"
+                + "      },\n"
+                + "      {\n"
+                + "        \"userid\": \"sergey\",\n"
+                + "        \"startDate\": 1998\n"
+                + "      },\n"
+                + "      {\n"
+                + "        \"userid\": \"andy\",\n"
+                + "        \"startDate\": 2005,\n"
+                + "        \"minions\": [\n"
+                + "          {\n"
+                + "            \"userid\": \"inder\",\n"
+                + "            \"startDate\": 2007\n"
+                + "          },\n"
+                + "          {\n"
+                + "            \"userid\": \"joel\",\n"
+                + "            \"startDate\": 2006\n"
+                + "          },\n"
+                + "          {\n"
+                + "            \"userid\": \"jesse\",\n"
+                + "            \"startDate\": 2006\n"
+                + "          }\n"
+                + "        ]\n"
+                + "      }\n"
+                + "    ],\n"
+                + "    \"assistant\": {\n"
+                + "      \"userid\": \"jerome\",\n"
+                + "      \"startDate\": 2006\n"
+                + "    }\n"
+                + "  }\n"
+                + "}");
 
     Company copied = gson.fromJson(json, Company.class);
     assertThat(gson.toJson(copied, Company.class)).isEqualTo(json);
@@ -113,16 +112,19 @@ public final class TypeHierarchyAdapterTest {
     assertThat(company.ceo.minions[0].userid).isEqualTo(copied.ceo.minions[0].userid);
     assertThat(company.ceo.minions[1].userid).isEqualTo(copied.ceo.minions[1].userid);
     assertThat(company.ceo.minions[2].userid).isEqualTo(copied.ceo.minions[2].userid);
-    assertThat(((Manager) company.ceo.minions[2]).minions[0].userid).isEqualTo(((Manager) copied.ceo.minions[2]).minions[0].userid);
-    assertThat(((Manager) company.ceo.minions[2]).minions[1].userid).isEqualTo(((Manager) copied.ceo.minions[2]).minions[1].userid);
+    assertThat(((Manager) company.ceo.minions[2]).minions[0].userid)
+        .isEqualTo(((Manager) copied.ceo.minions[2]).minions[0].userid);
+    assertThat(((Manager) company.ceo.minions[2]).minions[1].userid)
+        .isEqualTo(((Manager) copied.ceo.minions[2]).minions[1].userid);
   }
 
   @Test
   public void testRegisterSuperTypeFirst() {
-    Gson gson = new GsonBuilder()
-        .registerTypeHierarchyAdapter(Employee.class, new EmployeeAdapter())
-        .registerTypeHierarchyAdapter(Manager.class, new ManagerAdapter())
-        .create();
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeHierarchyAdapter(Employee.class, new EmployeeAdapter())
+            .registerTypeHierarchyAdapter(Manager.class, new ManagerAdapter())
+            .create();
 
     Manager manager = new Manager();
     manager.userid = "inder";
@@ -136,26 +138,31 @@ public final class TypeHierarchyAdapterTest {
   /** This behaviour changed in Gson 2.1; it used to throw. */
   @Test
   public void testRegisterSubTypeFirstAllowed() {
-    Gson unused = new GsonBuilder()
-        .registerTypeHierarchyAdapter(Manager.class, new ManagerAdapter())
-        .registerTypeHierarchyAdapter(Employee.class, new EmployeeAdapter())
-        .create();
+    Gson unused =
+        new GsonBuilder()
+            .registerTypeHierarchyAdapter(Manager.class, new ManagerAdapter())
+            .registerTypeHierarchyAdapter(Employee.class, new EmployeeAdapter())
+            .create();
   }
 
   static class ManagerAdapter implements JsonSerializer<Manager>, JsonDeserializer<Manager> {
-    @Override public Manager deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
+    @Override
+    public Manager deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
       Manager result = new Manager();
       result.userid = json.getAsString();
       return result;
     }
-    @Override public JsonElement serialize(Manager src, Type typeOfSrc, JsonSerializationContext context) {
+
+    @Override
+    public JsonElement serialize(Manager src, Type typeOfSrc, JsonSerializationContext context) {
       return new JsonPrimitive(src.userid);
     }
   }
 
   static class EmployeeAdapter implements JsonSerializer<Employee>, JsonDeserializer<Employee> {
-    @Override public JsonElement serialize(Employee employee, Type typeOfSrc,
-        JsonSerializationContext context) {
+    @Override
+    public JsonElement serialize(
+        Employee employee, Type typeOfSrc, JsonSerializationContext context) {
       JsonObject result = new JsonObject();
       result.add("userid", context.serialize(employee.userid, String.class));
       result.add("startDate", context.serialize(employee.startDate, long.class));
@@ -168,8 +175,9 @@ public final class TypeHierarchyAdapterTest {
       return result;
     }
 
-    @Override public Employee deserialize(JsonElement json, Type typeOfT,
-        JsonDeserializationContext context) throws JsonParseException {
+    @Override
+    public Employee deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+        throws JsonParseException {
       JsonObject object = json.getAsJsonObject();
       Employee result = null;
 

--- a/gson/src/test/java/com/google/gson/functional/TypeVariableTest.java
+++ b/gson/src/test/java/com/google/gson/functional/TypeVariableTest.java
@@ -28,8 +28,7 @@ import java.util.Map;
 import org.junit.Test;
 
 /**
- * Functional test for Gson serialization and deserialization of
- * classes with type variables.
+ * Functional test for Gson serialization and deserialization of classes with type variables.
  *
  * @author Joel Leitch
  */
@@ -59,7 +58,8 @@ public class TypeVariableTest {
     Type type = new TypeToken<Foo<String, Integer>>() {}.getType();
     String json = gson.toJson(original, type);
     assertThat(json)
-        .isEqualTo("{\"someSField\":\"e\",\"someTField\":5,\"map\":{\"f\":[6,7]},\"redField\":false}");
+        .isEqualTo(
+            "{\"someSField\":\"e\",\"someTField\":5,\"map\":{\"f\":[6,7]},\"redField\":false}");
     assertThat(gson.<Foo<String, Integer>>fromJson(json, type)).isEqualTo(original);
   }
 
@@ -126,9 +126,9 @@ public class TypeVariableTest {
       }
       Foo<S, T> realFoo = (Foo<S, T>) o;
       return redField.equals(realFoo.redField)
-        && someTField.equals(realFoo.someTField)
-        && someSField.equals(realFoo.someSField)
-        && map.equals(realFoo.map);
+          && someTField.equals(realFoo.someTField)
+          && someSField.equals(realFoo.someSField)
+          && map.equals(realFoo.map);
     }
   }
 

--- a/gson/src/test/java/com/google/gson/functional/UncategorizedTest.java
+++ b/gson/src/test/java/com/google/gson/functional/UncategorizedTest.java
@@ -52,12 +52,14 @@ public class UncategorizedTest {
     try {
       gson.fromJson("adfasdf1112,,,\":", BagOfPrimitives.class);
       fail("Bad JSON should throw a ParseException");
-    } catch (JsonParseException expected) { }
+    } catch (JsonParseException expected) {
+    }
 
     try {
       gson.fromJson("{adfasdf1112,,,\":}", BagOfPrimitives.class);
       fail("Bad JSON should throw a ParseException");
-    } catch (JsonParseException expected) { }
+    } catch (JsonParseException expected) {
+    }
   }
 
   @Test
@@ -108,31 +110,43 @@ public class UncategorizedTest {
    */
   @Test
   public void testTrailingWhitespace() throws Exception {
-    List<Integer> integers = gson.fromJson("[1,2,3]  \n\n  ",
-        new TypeToken<List<Integer>>() {}.getType());
+    List<Integer> integers =
+        gson.fromJson("[1,2,3]  \n\n  ", new TypeToken<List<Integer>>() {}.getType());
     assertThat(integers).containsExactly(1, 2, 3).inOrder();
   }
 
-  private enum OperationType { OP1, OP2 }
+  private enum OperationType {
+    OP1,
+    OP2
+  }
+
   private static class Base {
     OperationType opType;
   }
+
   private static class Derived1 extends Base {
-    Derived1() { opType = OperationType.OP1; }
+    Derived1() {
+      opType = OperationType.OP1;
+    }
   }
+
   private static class Derived2 extends Base {
-    Derived2() { opType = OperationType.OP2; }
+    Derived2() {
+      opType = OperationType.OP2;
+    }
   }
+
   private static class BaseTypeAdapter implements JsonDeserializer<Base> {
-    @Override public Base deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+    @Override
+    public Base deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
         throws JsonParseException {
       String opTypeStr = json.getAsJsonObject().get("opType").getAsString();
       OperationType opType = OperationType.valueOf(opTypeStr);
       switch (opType) {
-      case OP1:
-        return new Derived1();
-      case OP2:
-        return new Derived2();
+        case OP1:
+          return new Derived1();
+        case OP2:
+          return new Derived2();
       }
       throw new JsonParseException("unknown type: " + json);
     }

--- a/gson/src/test/java/com/google/gson/functional/VersioningTest.java
+++ b/gson/src/test/java/com/google/gson/functional/VersioningTest.java
@@ -175,12 +175,16 @@ public class VersioningTest {
   }
 
   private static class Version1 {
-    @Until(1.3) int a = A;
-    @Since(1.0) int b = B;
+    @Until(1.3)
+    int a = A;
+
+    @Since(1.0)
+    int b = B;
   }
 
   private static class Version1_1 extends Version1 {
-    @Since(1.1) int c = C;
+    @Since(1.1)
+    int c = C;
   }
 
   @Since(1.2)

--- a/gson/src/test/java/com/google/gson/internal/ConstructorConstructorTest.java
+++ b/gson/src/test/java/com/google/gson/internal/ConstructorConstructorTest.java
@@ -24,45 +24,52 @@ import java.util.Collections;
 import org.junit.Test;
 
 public class ConstructorConstructorTest {
-  private ConstructorConstructor constructorConstructor = new ConstructorConstructor(
-      Collections.emptyMap(), true,
-      Collections.emptyList()
-  );
+  private ConstructorConstructor constructorConstructor =
+      new ConstructorConstructor(Collections.emptyMap(), true, Collections.emptyList());
 
   private abstract static class AbstractClass {
     @SuppressWarnings("unused")
-    public AbstractClass() { }
+    public AbstractClass() {}
   }
-  private interface Interface { }
+
+  private interface Interface {}
 
   /**
-   * Verify that ConstructorConstructor does not try to invoke no-args constructor
-   * of abstract class.
+   * Verify that ConstructorConstructor does not try to invoke no-args constructor of abstract
+   * class.
    */
   @Test
   public void testGet_AbstractClassNoArgConstructor() {
-    ObjectConstructor<AbstractClass> constructor = constructorConstructor.get(TypeToken.get(AbstractClass.class));
+    ObjectConstructor<AbstractClass> constructor =
+        constructorConstructor.get(TypeToken.get(AbstractClass.class));
     try {
       constructor.construct();
       fail("Expected exception");
     } catch (RuntimeException exception) {
-      assertThat(exception).hasMessageThat().isEqualTo("Abstract classes can't be instantiated!"
-          + " Adjust the R8 configuration or register an InstanceCreator or a TypeAdapter for this type."
-          + " Class name: com.google.gson.internal.ConstructorConstructorTest$AbstractClass"
-          + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#r8-abstract-class");
+      assertThat(exception)
+          .hasMessageThat()
+          .isEqualTo(
+              "Abstract classes can't be instantiated! Adjust the R8 configuration or register an"
+                  + " InstanceCreator or a TypeAdapter for this type. Class name:"
+                  + " com.google.gson.internal.ConstructorConstructorTest$AbstractClass\n"
+                  + "See https://github.com/google/gson/blob/main/Troubleshooting.md#r8-abstract-class");
     }
   }
 
   @Test
   public void testGet_Interface() {
-    ObjectConstructor<Interface> constructor = constructorConstructor.get(TypeToken.get(Interface.class));
+    ObjectConstructor<Interface> constructor =
+        constructorConstructor.get(TypeToken.get(Interface.class));
     try {
       constructor.construct();
       fail("Expected exception");
     } catch (RuntimeException exception) {
-      assertThat(exception).hasMessageThat().isEqualTo("Interfaces can't be instantiated!"
-          + " Register an InstanceCreator or a TypeAdapter for this type."
-          + " Interface name: com.google.gson.internal.ConstructorConstructorTest$Interface");
+      assertThat(exception)
+          .hasMessageThat()
+          .isEqualTo(
+              "Interfaces can't be instantiated! Register an InstanceCreator or a TypeAdapter for"
+                  + " this type. Interface name:"
+                  + " com.google.gson.internal.ConstructorConstructorTest$Interface");
     }
   }
 }

--- a/gson/src/test/java/com/google/gson/internal/GsonTypesTest.java
+++ b/gson/src/test/java/com/google/gson/internal/GsonTypesTest.java
@@ -38,18 +38,21 @@ public final class GsonTypesTest {
     type = $Gson$Types.newParameterizedTypeWithOwner(null, A.class, B.class);
     assertThat(getFirstTypeArgument(type)).isEqualTo(B.class);
 
-    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-        // NonStaticInner<A> is not allowed without owner
-        () -> $Gson$Types.newParameterizedTypeWithOwner(null, NonStaticInner.class, A.class));
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            // NonStaticInner<A> is not allowed without owner
+            () -> $Gson$Types.newParameterizedTypeWithOwner(null, NonStaticInner.class, A.class));
     assertThat(e).hasMessageThat().isEqualTo("Must specify owner type for " + NonStaticInner.class);
 
-    type = $Gson$Types.newParameterizedTypeWithOwner(GsonTypesTest.class, NonStaticInner.class, A.class);
+    type =
+        $Gson$Types.newParameterizedTypeWithOwner(
+            GsonTypesTest.class, NonStaticInner.class, A.class);
     assertThat(type.getOwnerType()).isEqualTo(GsonTypesTest.class);
     assertThat(type.getRawType()).isEqualTo(NonStaticInner.class);
     assertThat(type.getActualTypeArguments()).asList().containsExactly(A.class);
 
-    final class D {
-    }
+    final class D {}
 
     // D<A> is allowed since D has no owner type
     type = $Gson$Types.newParameterizedTypeWithOwner(null, D.class, A.class);
@@ -70,19 +73,18 @@ public final class GsonTypesTest {
     assertThat(getFirstTypeArgument(type)).isEqualTo(B.class);
   }
 
-  private static final class A {
-  }
-  private static final class B {
-  }
-  private static final class C {
-  }
+  private static final class A {}
+
+  private static final class B {}
+
+  private static final class C {}
+
   @SuppressWarnings({"ClassCanBeStatic", "UnusedTypeParameter"})
-  private final class NonStaticInner<T> {
-  }
+  private final class NonStaticInner<T> {}
 
   /**
-   * Given a parameterized type A&lt;B,C&gt;, returns B. If the specified type is not
-   * a generic type, returns null.
+   * Given a parameterized type A&lt;B,C&gt;, returns B. If the specified type is not a generic
+   * type, returns null.
    */
   public static Type getFirstTypeArgument(Type type) throws Exception {
     if (!(type instanceof ParameterizedType)) return null;

--- a/gson/src/test/java/com/google/gson/internal/JavaVersionTest.java
+++ b/gson/src/test/java/com/google/gson/internal/JavaVersionTest.java
@@ -25,21 +25,25 @@ import org.junit.Test;
  * @author Inderjeet Singh
  */
 public class JavaVersionTest {
-  // Borrowed some of test strings from https://github.com/prestodb/presto/blob/master/presto-main/src/test/java/com/facebook/presto/server/TestJavaVersion.java
+  // Borrowed some of test strings from
+  // https://github.com/prestodb/presto/blob/master/presto-main/src/test/java/com/facebook/presto/server/TestJavaVersion.java
 
   @Test
   public void testGetMajorJavaVersion() {
-    assertThat(JavaVersion.getMajorJavaVersion() >= 7).isTrue(); // Gson currently requires at least Java 7
+    assertThat(JavaVersion.getMajorJavaVersion() >= 7)
+        .isTrue(); // Gson currently requires at least Java 7
   }
 
   @Test
   public void testJava6() {
-    assertThat(JavaVersion.getMajorJavaVersion("1.6.0")).isEqualTo(6); // http://www.oracle.com/technetwork/java/javase/version-6-141920.html
+    assertThat(JavaVersion.getMajorJavaVersion("1.6.0"))
+        .isEqualTo(6); // http://www.oracle.com/technetwork/java/javase/version-6-141920.html
   }
 
   @Test
   public void testJava7() {
-    assertThat(JavaVersion.getMajorJavaVersion("1.7.0")).isEqualTo(7); // http://www.oracle.com/technetwork/java/javase/jdk7-naming-418744.html
+    assertThat(JavaVersion.getMajorJavaVersion("1.7.0"))
+        .isEqualTo(7); // http://www.oracle.com/technetwork/java/javase/jdk7-naming-418744.html
   }
 
   @Test
@@ -59,7 +63,8 @@ public class JavaVersionTest {
   public void testJava9() {
     // Legacy style
     assertThat(JavaVersion.getMajorJavaVersion("9.0.4")).isEqualTo(9); // Oracle JDK 9
-    assertThat(JavaVersion.getMajorJavaVersion("9-Debian")).isEqualTo(9); // Debian as reported in https://github.com/google/gson/issues/1310
+    assertThat(JavaVersion.getMajorJavaVersion("9-Debian"))
+        .isEqualTo(9); // Debian as reported in https://github.com/google/gson/issues/1310
     // New style
     assertThat(JavaVersion.getMajorJavaVersion("9-ea+19")).isEqualTo(9);
     assertThat(JavaVersion.getMajorJavaVersion("9+100")).isEqualTo(9);

--- a/gson/src/test/java/com/google/gson/internal/LinkedTreeMapTest.java
+++ b/gson/src/test/java/com/google/gson/internal/LinkedTreeMapTest.java
@@ -52,7 +52,7 @@ public final class LinkedTreeMapTest {
     map.put("a", "android");
     map.put("c", "cola");
     map.put("b", "bbq");
-    Iterator<Map.Entry<String,String>> it = map.entrySet().iterator();
+    Iterator<Map.Entry<String, String>> it = map.entrySet().iterator();
     it.next();
     it.next();
     it.next();
@@ -78,7 +78,8 @@ public final class LinkedTreeMapTest {
     try {
       map.put(new Object(), "android");
       fail();
-    } catch (ClassCastException expected) {}
+    } catch (ClassCastException expected) {
+    }
   }
 
   @Test
@@ -121,7 +122,6 @@ public final class LinkedTreeMapTest {
     assertThat(map.containsValue(null)).isTrue();
     assertThat(map.get("a")).isNull();
   }
-
 
   @Test
   public void testEntrySetValueNull_Forbidden() {

--- a/gson/src/test/java/com/google/gson/internal/UnsafeAllocatorInstantiationTest.java
+++ b/gson/src/test/java/com/google/gson/internal/UnsafeAllocatorInstantiationTest.java
@@ -22,46 +22,40 @@ import org.junit.Test;
 
 /**
  * Test unsafe allocator instantiation
+ *
  * @author Ugljesa Jovanovic
  */
 public final class UnsafeAllocatorInstantiationTest {
 
-  public interface Interface {
-  }
+  public interface Interface {}
 
-  public static abstract class AbstractClass {
-  }
+  public abstract static class AbstractClass {}
 
-  public static class ConcreteClass {
-  }
+  public static class ConcreteClass {}
 
-  /**
-   * Ensure that an {@link AssertionError} is thrown when trying
-   * to instantiate an interface
-   */
+  /** Ensure that an {@link AssertionError} is thrown when trying to instantiate an interface */
   @Test
   public void testInterfaceInstantiation() {
-    AssertionError e = assertThrows(AssertionError.class,
-        () -> UnsafeAllocator.INSTANCE.newInstance(Interface.class));
+    AssertionError e =
+        assertThrows(
+            AssertionError.class, () -> UnsafeAllocator.INSTANCE.newInstance(Interface.class));
 
     assertThat(e).hasMessageThat().startsWith("UnsafeAllocator is used for non-instantiable type");
   }
 
   /**
-   * Ensure that an {@link AssertionError} is thrown when trying
-   * to instantiate an abstract class
+   * Ensure that an {@link AssertionError} is thrown when trying to instantiate an abstract class
    */
   @Test
   public void testAbstractClassInstantiation() {
-    AssertionError e = assertThrows(AssertionError.class,
-        () -> UnsafeAllocator.INSTANCE.newInstance(AbstractClass.class));
+    AssertionError e =
+        assertThrows(
+            AssertionError.class, () -> UnsafeAllocator.INSTANCE.newInstance(AbstractClass.class));
 
     assertThat(e).hasMessageThat().startsWith("UnsafeAllocator is used for non-instantiable type");
   }
 
-  /**
-   * Ensure that no exception is thrown when trying to instantiate a concrete class
-   */
+  /** Ensure that no exception is thrown when trying to instantiate a concrete class */
   @Test
   public void testConcreteClassInstantiation() throws Exception {
     ConcreteClass instance = UnsafeAllocator.INSTANCE.newInstance(ConcreteClass.class);

--- a/gson/src/test/java/com/google/gson/internal/bind/DefaultDateTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/DefaultDateTypeAdapterTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.fail;
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
-import com.google.gson.internal.JavaVersion;
 import com.google.gson.internal.bind.DefaultDateTypeAdapter.DateType;
 import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
@@ -67,13 +66,17 @@ public class DefaultDateTypeAdapterTest {
       assertFormatted("1/1/70", DateType.DATE.createAdapterFactory(DateFormat.SHORT));
       assertFormatted("Jan 1, 1970", DateType.DATE.createAdapterFactory(DateFormat.MEDIUM));
       assertFormatted("January 1, 1970", DateType.DATE.createAdapterFactory(DateFormat.LONG));
-      assertFormatted("1/1/70,? 12:00\\hAM",
+      assertFormatted(
+          "1/1/70,? 12:00\\hAM",
           DateType.DATE.createAdapterFactory(DateFormat.SHORT, DateFormat.SHORT));
-      assertFormatted("Jan 1, 1970,? 12:00:00\\hAM",
+      assertFormatted(
+          "Jan 1, 1970,? 12:00:00\\hAM",
           DateType.DATE.createAdapterFactory(DateFormat.MEDIUM, DateFormat.MEDIUM));
-      assertFormatted("January 1, 1970(,| at)? 12:00:00\\hAM UTC",
+      assertFormatted(
+          "January 1, 1970(,| at)? 12:00:00\\hAM UTC",
           DateType.DATE.createAdapterFactory(DateFormat.LONG, DateFormat.LONG));
-      assertFormatted("Thursday, January 1, 1970(,| at)? 12:00:00\\hAM " + utcFull,
+      assertFormatted(
+          "Thursday, January 1, 1970(,| at)? 12:00:00\\hAM " + utcFull,
           DateType.DATE.createAdapterFactory(DateFormat.FULL, DateFormat.FULL));
     } finally {
       TimeZone.setDefault(defaultTimeZone);
@@ -130,13 +133,16 @@ public class DefaultDateTypeAdapterTest {
       assertParsed("1/1/70", DateType.DATE.createAdapterFactory(DateFormat.SHORT));
       assertParsed("Jan 1, 1970", DateType.DATE.createAdapterFactory(DateFormat.MEDIUM));
       assertParsed("January 1, 1970", DateType.DATE.createAdapterFactory(DateFormat.LONG));
-      assertParsed("1/1/70 0:00 AM",
-          DateType.DATE.createAdapterFactory(DateFormat.SHORT, DateFormat.SHORT));
-      assertParsed("Jan 1, 1970 0:00:00 AM",
+      assertParsed(
+          "1/1/70 0:00 AM", DateType.DATE.createAdapterFactory(DateFormat.SHORT, DateFormat.SHORT));
+      assertParsed(
+          "Jan 1, 1970 0:00:00 AM",
           DateType.DATE.createAdapterFactory(DateFormat.MEDIUM, DateFormat.MEDIUM));
-      assertParsed("January 1, 1970 0:00:00 AM UTC",
+      assertParsed(
+          "January 1, 1970 0:00:00 AM UTC",
           DateType.DATE.createAdapterFactory(DateFormat.LONG, DateFormat.LONG));
-      assertParsed("Thursday, January 1, 1970 0:00:00 AM UTC",
+      assertParsed(
+          "Thursday, January 1, 1970 0:00:00 AM UTC",
           DateType.DATE.createAdapterFactory(DateFormat.FULL, DateFormat.FULL));
     } finally {
       TimeZone.setDefault(defaultTimeZone);
@@ -196,7 +202,8 @@ public class DefaultDateTypeAdapterTest {
     try {
       DateType.DATE.createAdapterFactory("I am a bad Date pattern....");
       fail("Invalid date pattern should fail.");
-    } catch (IllegalArgumentException expected) { }
+    } catch (IllegalArgumentException expected) {
+    }
   }
 
   @Test
@@ -212,7 +219,8 @@ public class DefaultDateTypeAdapterTest {
       TypeAdapter<Date> adapter = dateAdapter(DateType.DATE.createDefaultsAdapterFactory());
       adapter.fromJson("{}");
       fail("Unexpected token should fail.");
-    } catch (IllegalStateException expected) { }
+    } catch (IllegalStateException expected) {
+    }
   }
 
   private static TypeAdapter<Date> dateAdapter(TypeAdapterFactory adapterFactory) {
@@ -228,10 +236,13 @@ public class DefaultDateTypeAdapterTest {
   }
 
   @SuppressWarnings("UndefinedEquals")
-  private static void assertParsed(String date, TypeAdapterFactory adapterFactory) throws IOException {
+  private static void assertParsed(String date, TypeAdapterFactory adapterFactory)
+      throws IOException {
     TypeAdapter<Date> adapter = dateAdapter(adapterFactory);
     assertWithMessage(date).that(adapter.fromJson(toLiteral(date))).isEqualTo(new Date(0));
-    assertWithMessage("ISO 8601").that(adapter.fromJson(toLiteral("1970-01-01T00:00:00Z"))).isEqualTo(new Date(0));
+    assertWithMessage("ISO 8601")
+        .that(adapter.fromJson(toLiteral("1970-01-01T00:00:00Z")))
+        .isEqualTo(new Date(0));
   }
 
   private static String toLiteral(String s) {

--- a/gson/src/test/java/com/google/gson/internal/bind/Java17ReflectiveTypeAdapterFactoryTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/Java17ReflectiveTypeAdapterFactoryTest.java
@@ -33,7 +33,8 @@ import org.junit.Test;
 
 public class Java17ReflectiveTypeAdapterFactoryTest {
 
-  // The class jdk.net.UnixDomainPrincipal is one of the few Record types that are included in the JDK.
+  // The class jdk.net.UnixDomainPrincipal is one of the few Record types that are included in the
+  // JDK.
   // We use this to test serialization and deserialization of Record classes, so we do not need to
   // have record support at the language level for these tests. This class was added in JDK 16.
   Class<?> unixDomainPrincipalClass;
@@ -87,7 +88,8 @@ public class Java17ReflectiveTypeAdapterFactoryTest {
     @Override
     public T read(JsonReader in) throws IOException {
       final String name = in.nextString();
-      // This type adapter is only used for Group and User Principal, both of which are implemented by PrincipalImpl.
+      // This type adapter is only used for Group and User Principal, both of which are implemented
+      // by PrincipalImpl.
       @SuppressWarnings("unchecked")
       T principal = (T) new Java17ReflectionHelperTest.PrincipalImpl(name);
       return principal;

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeReaderTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeReaderTest.java
@@ -133,7 +133,12 @@ public class JsonTreeReaderTest {
       reader.peek();
       fail();
     } catch (MalformedJsonException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Custom JsonElement subclass " + CustomSubclass.class.getName() + " is not supported");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Custom JsonElement subclass "
+                  + CustomSubclass.class.getName()
+                  + " is not supported");
     }
   }
 
@@ -144,7 +149,12 @@ public class JsonTreeReaderTest {
    */
   @Test
   public void testOverrides() {
-    List<String> ignoredMethods = Arrays.asList("setLenient(boolean)", "isLenient()", "setStrictness(com.google.gson.Strictness)", "getStrictness()");
+    List<String> ignoredMethods =
+        Arrays.asList(
+            "setLenient(boolean)",
+            "isLenient()",
+            "setStrictness(com.google.gson.Strictness)",
+            "getStrictness()");
     MoreAsserts.assertOverridesMethods(JsonReader.class, JsonTreeReader.class, ignoredMethods);
   }
 }

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
@@ -225,7 +225,8 @@ public final class JsonTreeWriterTest {
     writer.value(Double.NEGATIVE_INFINITY);
     writer.value(Double.POSITIVE_INFINITY);
     writer.endArray();
-    assertThat(writer.get().toString()).isEqualTo("[NaN,-Infinity,Infinity,NaN,-Infinity,Infinity]");
+    assertThat(writer.get().toString())
+        .isEqualTo("[NaN,-Infinity,Infinity,NaN,-Infinity,Infinity]");
   }
 
   @Test
@@ -315,18 +316,24 @@ public final class JsonTreeWriterTest {
 
   /**
    * {@link JsonTreeWriter} effectively replaces the complete writing logic of {@link JsonWriter} to
-   * create a {@link JsonElement} tree instead of writing to a {@link Writer}. Therefore all relevant
-   * methods of {@code JsonWriter} must be overridden.
+   * create a {@link JsonElement} tree instead of writing to a {@link Writer}. Therefore all
+   * relevant methods of {@code JsonWriter} must be overridden.
    */
   @Test
   public void testOverrides() {
-    List<String> ignoredMethods = Arrays.asList(
-        "setLenient(boolean)", "isLenient()",
-        "setStrictness(com.google.gson.Strictness)", "getStrictness()",
-        "setIndent(java.lang.String)",
-        "setHtmlSafe(boolean)", "isHtmlSafe()",
-        "setFormattingStyle(com.google.gson.FormattingStyle)", "getFormattingStyle()",
-        "setSerializeNulls(boolean)", "getSerializeNulls()");
+    List<String> ignoredMethods =
+        Arrays.asList(
+            "setLenient(boolean)",
+            "isLenient()",
+            "setStrictness(com.google.gson.Strictness)",
+            "getStrictness()",
+            "setIndent(java.lang.String)",
+            "setHtmlSafe(boolean)",
+            "isHtmlSafe()",
+            "setFormattingStyle(com.google.gson.FormattingStyle)",
+            "getFormattingStyle()",
+            "setSerializeNulls(boolean)",
+            "getSerializeNulls()");
     MoreAsserts.assertOverridesMethods(JsonWriter.class, JsonTreeWriter.class, ignoredMethods);
   }
 }

--- a/gson/src/test/java/com/google/gson/internal/bind/RecursiveTypesResolveTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/RecursiveTypesResolveTest.java
@@ -25,11 +25,12 @@ import org.junit.Test;
 
 /**
  * Test fixes for infinite recursion on {@link $Gson$Types#resolve(java.lang.reflect.Type, Class,
- * java.lang.reflect.Type)}, described at <a href="https://github.com/google/gson/issues/440">Issue #440</a>
- * and similar issues.
- * <p>
- * These tests originally caused {@link StackOverflowError} because of infinite recursion on attempts to
- * resolve generics on types, with an intermediate types like 'Foo2&lt;? extends ? super ? extends ... ? extends A&gt;'
+ * java.lang.reflect.Type)}, described at <a href="https://github.com/google/gson/issues/440">Issue
+ * #440</a> and similar issues.
+ *
+ * <p>These tests originally caused {@link StackOverflowError} because of infinite recursion on
+ * attempts to resolve generics on types, with an intermediate types like 'Foo2&lt;? extends ? super
+ * ? extends ... ? extends A&gt;'
  */
 public class RecursiveTypesResolveTest {
 
@@ -37,15 +38,13 @@ public class RecursiveTypesResolveTest {
   private static class Foo1<A> {
     public Foo2<? extends A> foo2;
   }
+
   @SuppressWarnings("unused")
   private static class Foo2<B> {
     public Foo1<? super B> foo1;
   }
 
-  /**
-   * Test simplest case of recursion.
-   */
-
+  /** Test simplest case of recursion. */
   @Test
   public void testRecursiveResolveSimple() {
     @SuppressWarnings("rawtypes")
@@ -53,10 +52,7 @@ public class RecursiveTypesResolveTest {
     assertThat(adapter).isNotNull();
   }
 
-  /**
-   * Tests belows check the behaviour of the methods changed for the fix.
-   */
-
+  /** Tests belows check the behaviour of the methods changed for the fix. */
   @Test
   public void testDoubleSupertype() {
     assertThat($Gson$Types.supertypeOf($Gson$Types.supertypeOf(Number.class)))
@@ -81,10 +77,7 @@ public class RecursiveTypesResolveTest {
         .isEqualTo($Gson$Types.subtypeOf(Object.class));
   }
 
-  /**
-   * Tests for recursion while resolving type variables.
-   */
-
+  /** Tests for recursion while resolving type variables. */
   @SuppressWarnings("unused")
   private static class TestType<X> {
     TestType<? super X> superType;

--- a/gson/src/test/java/com/google/gson/internal/bind/util/ISO8601UtilsTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/util/ISO8601UtilsTest.java
@@ -32,109 +32,111 @@ import org.junit.function.ThrowingRunnable;
 
 public class ISO8601UtilsTest {
 
-    private static TimeZone utcTimeZone() {
-        return TimeZone.getTimeZone("UTC");
-    }
+  private static TimeZone utcTimeZone() {
+    return TimeZone.getTimeZone("UTC");
+  }
 
-    private static GregorianCalendar createUtcCalendar() {
-        TimeZone utc = utcTimeZone();
-        GregorianCalendar calendar = new GregorianCalendar(utc);
-        // Calendar was created with current time, must clear it
-        calendar.clear();
-        return calendar;
-    }
+  private static GregorianCalendar createUtcCalendar() {
+    TimeZone utc = utcTimeZone();
+    GregorianCalendar calendar = new GregorianCalendar(utc);
+    // Calendar was created with current time, must clear it
+    calendar.clear();
+    return calendar;
+  }
 
   @Test
   public void testDateFormatString() {
-        GregorianCalendar calendar = new GregorianCalendar(utcTimeZone(), Locale.US);
-        // Calendar was created with current time, must clear it
-        calendar.clear();
-        calendar.set(2018, Calendar.JUNE, 25);
-        Date date = calendar.getTime();
-        String dateStr = ISO8601Utils.format(date);
-        String expectedDate = "2018-06-25";
-        assertThat(dateStr.substring(0, expectedDate.length())).isEqualTo(expectedDate);
-    }
+    GregorianCalendar calendar = new GregorianCalendar(utcTimeZone(), Locale.US);
+    // Calendar was created with current time, must clear it
+    calendar.clear();
+    calendar.set(2018, Calendar.JUNE, 25);
+    Date date = calendar.getTime();
+    String dateStr = ISO8601Utils.format(date);
+    String expectedDate = "2018-06-25";
+    assertThat(dateStr.substring(0, expectedDate.length())).isEqualTo(expectedDate);
+  }
 
   @Test
   @SuppressWarnings("JavaUtilDate")
   public void testDateFormatWithMilliseconds() {
-        long time = 1530209176870L;
-        Date date = new Date(time);
-        String dateStr = ISO8601Utils.format(date, true);
-        String expectedDate = "2018-06-28T18:06:16.870Z";
-        assertThat(dateStr).isEqualTo(expectedDate);
-    }
+    long time = 1530209176870L;
+    Date date = new Date(time);
+    String dateStr = ISO8601Utils.format(date, true);
+    String expectedDate = "2018-06-28T18:06:16.870Z";
+    assertThat(dateStr).isEqualTo(expectedDate);
+  }
 
   @Test
   @SuppressWarnings("JavaUtilDate")
   public void testDateFormatWithTimezone() {
-        long time = 1530209176870L;
-        Date date = new Date(time);
-        String dateStr = ISO8601Utils.format(date, true, TimeZone.getTimeZone("Brazil/East"));
-        String expectedDate = "2018-06-28T15:06:16.870-03:00";
-        assertThat(dateStr).isEqualTo(expectedDate);
-    }
+    long time = 1530209176870L;
+    Date date = new Date(time);
+    String dateStr = ISO8601Utils.format(date, true, TimeZone.getTimeZone("Brazil/East"));
+    String expectedDate = "2018-06-28T15:06:16.870-03:00";
+    assertThat(dateStr).isEqualTo(expectedDate);
+  }
 
   @Test
   @SuppressWarnings("UndefinedEquals")
   public void testDateParseWithDefaultTimezone() throws ParseException {
-        String dateStr = "2018-06-25";
-        Date date = ISO8601Utils.parse(dateStr, new ParsePosition(0));
-        Date expectedDate = new GregorianCalendar(2018, Calendar.JUNE, 25).getTime();
-        assertThat(date).isEqualTo(expectedDate);
-    }
+    String dateStr = "2018-06-25";
+    Date date = ISO8601Utils.parse(dateStr, new ParsePosition(0));
+    Date expectedDate = new GregorianCalendar(2018, Calendar.JUNE, 25).getTime();
+    assertThat(date).isEqualTo(expectedDate);
+  }
 
   @Test
   public void testDateParseInvalidDay() {
-      String dateStr = "2022-12-33";
-      try {
-        ISO8601Utils.parse(dateStr, new ParsePosition(0));
-        fail("Expected parsing to fail");
-      } catch (ParseException expected) {
-      }
+    String dateStr = "2022-12-33";
+    try {
+      ISO8601Utils.parse(dateStr, new ParsePosition(0));
+      fail("Expected parsing to fail");
+    } catch (ParseException expected) {
     }
+  }
 
   @Test
   public void testDateParseInvalidMonth() {
-      String dateStr = "2022-14-30";
-      try {
-        ISO8601Utils.parse(dateStr, new ParsePosition(0));
-        fail("Expected parsing to fail");
-      } catch (ParseException expected) {
-      }
+    String dateStr = "2022-14-30";
+    try {
+      ISO8601Utils.parse(dateStr, new ParsePosition(0));
+      fail("Expected parsing to fail");
+    } catch (ParseException expected) {
     }
+  }
 
   @Test
   @SuppressWarnings("UndefinedEquals")
   public void testDateParseWithTimezone() throws ParseException {
-        String dateStr = "2018-06-25T00:00:00-03:00";
-        Date date = ISO8601Utils.parse(dateStr, new ParsePosition(0));
-        GregorianCalendar calendar = createUtcCalendar();
-        calendar.set(2018, Calendar.JUNE, 25, 3, 0);
-        Date expectedDate = calendar.getTime();
-        assertThat(date).isEqualTo(expectedDate);
-    }
+    String dateStr = "2018-06-25T00:00:00-03:00";
+    Date date = ISO8601Utils.parse(dateStr, new ParsePosition(0));
+    GregorianCalendar calendar = createUtcCalendar();
+    calendar.set(2018, Calendar.JUNE, 25, 3, 0);
+    Date expectedDate = calendar.getTime();
+    assertThat(date).isEqualTo(expectedDate);
+  }
 
   @Test
   @SuppressWarnings("UndefinedEquals")
   public void testDateParseSpecialTimezone() throws ParseException {
-        String dateStr = "2018-06-25T00:02:00-02:58";
-        Date date = ISO8601Utils.parse(dateStr, new ParsePosition(0));
-        GregorianCalendar calendar = createUtcCalendar();
-        calendar.set(2018, Calendar.JUNE, 25, 3, 0);
-        Date expectedDate = calendar.getTime();
-        assertThat(date).isEqualTo(expectedDate);
-    }
+    String dateStr = "2018-06-25T00:02:00-02:58";
+    Date date = ISO8601Utils.parse(dateStr, new ParsePosition(0));
+    GregorianCalendar calendar = createUtcCalendar();
+    calendar.set(2018, Calendar.JUNE, 25, 3, 0);
+    Date expectedDate = calendar.getTime();
+    assertThat(date).isEqualTo(expectedDate);
+  }
 
   @Test
   public void testDateParseInvalidTime() {
-        final String dateStr = "2018-06-25T61:60:62-03:00";
-        assertThrows(ParseException.class, new ThrowingRunnable() {
+    final String dateStr = "2018-06-25T61:60:62-03:00";
+    assertThrows(
+        ParseException.class,
+        new ThrowingRunnable() {
           @Override
           public void run() throws Throwable {
             ISO8601Utils.parse(dateStr, new ParsePosition(0));
           }
         });
-    }
+  }
 }

--- a/gson/src/test/java/com/google/gson/internal/reflect/Java17ReflectionHelperTest.java
+++ b/gson/src/test/java/com/google/gson/internal/reflect/Java17ReflectionHelperTest.java
@@ -33,12 +33,14 @@ public class Java17ReflectionHelperTest {
     // UnixDomainPrincipal is a record
     assertThat(ReflectionHelper.isRecord(unixDomainPrincipalClass)).isTrue();
     // with 2 components
-    assertThat(ReflectionHelper.getRecordComponentNames(unixDomainPrincipalClass)).isEqualTo(new String[] {"user", "group"});
+    assertThat(ReflectionHelper.getRecordComponentNames(unixDomainPrincipalClass))
+        .isEqualTo(new String[] {"user", "group"});
     // Check canonical constructor
     Constructor<?> constructor =
         ReflectionHelper.getCanonicalRecordConstructor(unixDomainPrincipalClass);
     assertThat(constructor).isNotNull();
-    assertThat(constructor.getParameterTypes()).isEqualTo(new Class<?>[] {UserPrincipal.class, GroupPrincipal.class});
+    assertThat(constructor.getParameterTypes())
+        .isEqualTo(new Class<?>[] {UserPrincipal.class, GroupPrincipal.class});
   }
 
   @Test

--- a/gson/src/test/java/com/google/gson/internal/sql/SqlTypesGsonTest.java
+++ b/gson/src/test/java/com/google/gson/internal/sql/SqlTypesGsonTest.java
@@ -21,7 +21,6 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.functional.DefaultTypeAdaptersTest;
-import com.google.gson.internal.JavaVersion;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;

--- a/gson/src/test/java/com/google/gson/metrics/PerformanceTest.java
+++ b/gson/src/test/java/com/google/gson/metrics/PerformanceTest.java
@@ -90,6 +90,7 @@ public class PerformanceTest {
     private ExceptionHolder() {
       this("", "");
     }
+
     public ExceptionHolder(String message, String stackTrace) {
       this.message = message;
       this.stackTrace = stackTrace;
@@ -112,23 +113,19 @@ public class PerformanceTest {
     }
   }
 
-  /**
-   * Created in response to http://code.google.com/p/google-gson/issues/detail?id=96
-   */
+  /** Created in response to http://code.google.com/p/google-gson/issues/detail?id=96 */
   @Test
   @Ignore
   public void testLargeCollectionSerialization() {
     int count = 1400000;
     List<CollectionEntry> list = new ArrayList<>(count);
     for (int i = 0; i < count; ++i) {
-      list.add(new CollectionEntry("name"+i,"value"+i));
+      list.add(new CollectionEntry("name" + i, "value" + i));
     }
     String unused = gson.toJson(list);
   }
 
-  /**
-   * Created in response to http://code.google.com/p/google-gson/issues/detail?id=96
-   */
+  /** Created in response to http://code.google.com/p/google-gson/issues/detail?id=96 */
   @Test
   @Ignore
   public void testLargeCollectionDeserialization() {
@@ -146,14 +143,12 @@ public class PerformanceTest {
     }
     sb.append(']');
     String json = sb.toString();
-    Type collectionType = new TypeToken<ArrayList<CollectionEntry>>(){}.getType();
+    Type collectionType = new TypeToken<ArrayList<CollectionEntry>>() {}.getType();
     List<CollectionEntry> list = gson.fromJson(json, collectionType);
     assertThat(list).hasSize(count);
   }
 
-  /**
-   * Created in response to http://code.google.com/p/google-gson/issues/detail?id=96
-   */
+  /** Created in response to http://code.google.com/p/google-gson/issues/detail?id=96 */
   // Last I tested, Gson was able to serialize upto 14MB byte array
   @Test
   @Ignore
@@ -168,15 +163,13 @@ public class PerformanceTest {
     }
   }
 
-  /**
-   * Created in response to http://code.google.com/p/google-gson/issues/detail?id=96
-   */
+  /** Created in response to http://code.google.com/p/google-gson/issues/detail?id=96 */
   // Last I tested, Gson was able to deserialize a byte array of 11MB
   @Test
   @Ignore
   public void testByteArrayDeserialization() {
     for (int numElements = 10639296; true; numElements += 16384) {
-      StringBuilder sb = new StringBuilder(numElements*2);
+      StringBuilder sb = new StringBuilder(numElements * 2);
       sb.append("[");
       boolean first = true;
       for (int i = 0; i < numElements; ++i) {
@@ -194,14 +187,14 @@ public class PerformanceTest {
     }
   }
 
-// The tests to measure serialization and deserialization performance of Gson
-// Based on the discussion at
-// http://groups.google.com/group/google-gson/browse_thread/thread/7a50b17a390dfaeb
-// Test results: 10/19/2009
-// Serialize classes avg time: 60 ms
-// Deserialized classes avg time: 70 ms
-// Serialize exposed classes avg time: 159 ms
-// Deserialized exposed classes avg time: 173 ms
+  // The tests to measure serialization and deserialization performance of Gson
+  // Based on the discussion at
+  // http://groups.google.com/group/google-gson/browse_thread/thread/7a50b17a390dfaeb
+  // Test results: 10/19/2009
+  // Serialize classes avg time: 60 ms
+  // Deserialized classes avg time: 70 ms
+  // Serialize exposed classes avg time: 159 ms
+  // Deserialized exposed classes avg time: 173 ms
 
   @Test
   @Ignore
@@ -251,7 +244,6 @@ public class PerformanceTest {
     Map<String, Long> unused = gson.fromJson(json, new TypeToken<Map<String, Long>>() {}.getType());
     t2 = System.currentTimeMillis();
     System.out.printf("Large object deserialized in: %d ms\n", (t2 - t1));
-
   }
 
   @Test
@@ -296,7 +288,7 @@ public class PerformanceTest {
 
     Gson gson = new Gson();
     String json = gson.toJson(original);
-    Type longToLong = new TypeToken<Map<Long, Long>>(){}.getType();
+    Type longToLong = new TypeToken<Map<Long, Long>>() {}.getType();
     Map<Long, Long> unused = gson.fromJson(json, longToLong);
   }
 
@@ -323,9 +315,11 @@ public class PerformanceTest {
   private static final class ClassWithList {
     final String field;
     final List<ClassWithField> list = new ArrayList<>(COLLECTION_SIZE);
+
     ClassWithList() {
       this(null);
     }
+
     ClassWithList(String field) {
       this.field = field;
     }
@@ -334,9 +328,11 @@ public class PerformanceTest {
   @SuppressWarnings("unused")
   private static final class ClassWithField {
     final String field;
+
     ClassWithField() {
       this("");
     }
+
     public ClassWithField(String field) {
       this.field = field;
     }
@@ -344,13 +340,13 @@ public class PerformanceTest {
 
   @SuppressWarnings("unused")
   private static final class ClassWithListOfObjects {
-    @Expose
-    final String field;
-    @Expose
-    final List<ClassWithExposedField> list = new ArrayList<>(COLLECTION_SIZE);
+    @Expose final String field;
+    @Expose final List<ClassWithExposedField> list = new ArrayList<>(COLLECTION_SIZE);
+
     ClassWithListOfObjects() {
       this(null);
     }
+
     ClassWithListOfObjects(String field) {
       this.field = field;
     }
@@ -358,11 +354,12 @@ public class PerformanceTest {
 
   @SuppressWarnings("unused")
   private static final class ClassWithExposedField {
-    @Expose
-    final String field;
+    @Expose final String field;
+
     ClassWithExposedField() {
       this("");
     }
+
     ClassWithExposedField(String field) {
       this.field = field;
     }

--- a/gson/src/test/java/com/google/gson/reflect/TypeTokenTest.java
+++ b/gson/src/test/java/com/google/gson/reflect/TypeTokenTest.java
@@ -112,101 +112,177 @@ public final class TypeTokenTest {
     assertThrows(NullPointerException.class, () -> TypeToken.getArray(null));
   }
 
-  static class NestedGeneric<T> {
-  }
+  static class NestedGeneric<T> {}
 
   @Test
   public void testParameterizedFactory() {
     TypeToken<?> expectedListOfString = new TypeToken<List<String>>() {};
-    assertThat(TypeToken.getParameterized(List.class, String.class)).isEqualTo(expectedListOfString);
+    assertThat(TypeToken.getParameterized(List.class, String.class))
+        .isEqualTo(expectedListOfString);
 
     TypeToken<?> expectedMapOfStringToString = new TypeToken<Map<String, String>>() {};
-    assertThat(TypeToken.getParameterized(Map.class, String.class, String.class)).isEqualTo(expectedMapOfStringToString);
+    assertThat(TypeToken.getParameterized(Map.class, String.class, String.class))
+        .isEqualTo(expectedMapOfStringToString);
 
     TypeToken<?> expectedListOfListOfListOfString = new TypeToken<List<List<List<String>>>>() {};
     Type listOfString = TypeToken.getParameterized(List.class, String.class).getType();
     Type listOfListOfString = TypeToken.getParameterized(List.class, listOfString).getType();
-    assertThat(TypeToken.getParameterized(List.class, listOfListOfString)).isEqualTo(expectedListOfListOfListOfString);
+    assertThat(TypeToken.getParameterized(List.class, listOfListOfString))
+        .isEqualTo(expectedListOfListOfListOfString);
 
     TypeToken<?> expectedWithExactArg = new TypeToken<GenericWithBound<Number>>() {};
-    assertThat(TypeToken.getParameterized(GenericWithBound.class, Number.class)).isEqualTo(expectedWithExactArg);
+    assertThat(TypeToken.getParameterized(GenericWithBound.class, Number.class))
+        .isEqualTo(expectedWithExactArg);
 
     TypeToken<?> expectedWithSubclassArg = new TypeToken<GenericWithBound<Integer>>() {};
-    assertThat(TypeToken.getParameterized(GenericWithBound.class, Integer.class)).isEqualTo(expectedWithSubclassArg);
+    assertThat(TypeToken.getParameterized(GenericWithBound.class, Integer.class))
+        .isEqualTo(expectedWithSubclassArg);
 
-    TypeToken<?> expectedSatisfyingTwoBounds = new TypeToken<GenericWithMultiBound<ClassSatisfyingBounds>>() {};
-    assertThat(TypeToken.getParameterized(GenericWithMultiBound.class, ClassSatisfyingBounds.class)).isEqualTo(expectedSatisfyingTwoBounds);
+    TypeToken<?> expectedSatisfyingTwoBounds =
+        new TypeToken<GenericWithMultiBound<ClassSatisfyingBounds>>() {};
+    assertThat(TypeToken.getParameterized(GenericWithMultiBound.class, ClassSatisfyingBounds.class))
+        .isEqualTo(expectedSatisfyingTwoBounds);
 
     TypeToken<?> nestedTypeToken = TypeToken.getParameterized(NestedGeneric.class, Integer.class);
     ParameterizedType nestedParameterizedType = (ParameterizedType) nestedTypeToken.getType();
-    // TODO: This seems to differ from how Java reflection behaves; when using TypeToken<NestedGeneric<Integer>>,
-    // then NestedGeneric<Integer> does have an owner type
+    // TODO: This seems to differ from how Java reflection behaves; when using
+    // TypeToken<NestedGeneric<Integer>>, then NestedGeneric<Integer> does have an owner type
     assertThat(nestedParameterizedType.getOwnerType()).isNull();
     assertThat(nestedParameterizedType.getRawType()).isEqualTo(NestedGeneric.class);
-    assertThat(nestedParameterizedType.getActualTypeArguments()).asList().containsExactly(Integer.class);
+    assertThat(nestedParameterizedType.getActualTypeArguments())
+        .asList()
+        .containsExactly(Integer.class);
 
     class LocalGenericClass<T> {}
     TypeToken<?> expectedLocalType = new TypeToken<LocalGenericClass<Integer>>() {};
-    assertThat(TypeToken.getParameterized(LocalGenericClass.class, Integer.class)).isEqualTo(expectedLocalType);
+    assertThat(TypeToken.getParameterized(LocalGenericClass.class, Integer.class))
+        .isEqualTo(expectedLocalType);
 
-    // For legacy reasons, if requesting parameterized type for non-generic class, create a `TypeToken(Class)`
+    // For legacy reasons, if requesting parameterized type for non-generic class, create a
+    // `TypeToken(Class)`
     assertThat(TypeToken.getParameterized(String.class)).isEqualTo(TypeToken.get(String.class));
   }
 
   @Test
   public void testParameterizedFactory_Invalid() {
     assertThrows(NullPointerException.class, () -> TypeToken.getParameterized(null, new Type[0]));
-    assertThrows(NullPointerException.class, () -> TypeToken.getParameterized(List.class, new Type[] { null }));
+    assertThrows(
+        NullPointerException.class,
+        () -> TypeToken.getParameterized(List.class, new Type[] {null}));
 
     GenericArrayType arrayType = (GenericArrayType) TypeToken.getArray(String.class).getType();
-    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> TypeToken.getParameterized(arrayType, new Type[0]));
-    assertThat(e).hasMessageThat().isEqualTo("rawType must be of type Class, but was java.lang.String[]");
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> TypeToken.getParameterized(arrayType, new Type[0]));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo("rawType must be of type Class, but was java.lang.String[]");
 
-    e = assertThrows(IllegalArgumentException.class, () -> TypeToken.getParameterized(String.class, Number.class));
-    assertThat(e).hasMessageThat().isEqualTo("java.lang.String requires 0 type arguments, but got 1");
+    e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> TypeToken.getParameterized(String.class, Number.class));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo("java.lang.String requires 0 type arguments, but got 1");
 
-    e = assertThrows(IllegalArgumentException.class, () -> TypeToken.getParameterized(List.class, new Type[0]));
+    e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> TypeToken.getParameterized(List.class, new Type[0]));
     assertThat(e).hasMessageThat().isEqualTo("java.util.List requires 1 type arguments, but got 0");
 
-    e = assertThrows(IllegalArgumentException.class, () -> TypeToken.getParameterized(List.class, String.class, String.class));
+    e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> TypeToken.getParameterized(List.class, String.class, String.class));
     assertThat(e).hasMessageThat().isEqualTo("java.util.List requires 1 type arguments, but got 2");
 
     // Primitive types must not be used as type argument
-    e = assertThrows(IllegalArgumentException.class, () -> TypeToken.getParameterized(List.class, int.class));
-    assertThat(e).hasMessageThat().isEqualTo("Type argument int does not satisfy bounds"
-        + " for type variable E declared by " + List.class);
+    e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> TypeToken.getParameterized(List.class, int.class));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "Type argument int does not satisfy bounds"
+                + " for type variable E declared by "
+                + List.class);
 
-    e = assertThrows(IllegalArgumentException.class, () -> TypeToken.getParameterized(GenericWithBound.class, String.class));
-    assertThat(e).hasMessageThat().isEqualTo("Type argument class java.lang.String does not satisfy bounds"
-        + " for type variable T declared by " + GenericWithBound.class);
+    e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> TypeToken.getParameterized(GenericWithBound.class, String.class));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "Type argument class java.lang.String does not satisfy bounds"
+                + " for type variable T declared by "
+                + GenericWithBound.class);
 
-    e = assertThrows(IllegalArgumentException.class, () -> TypeToken.getParameterized(GenericWithBound.class, Object.class));
-    assertThat(e).hasMessageThat().isEqualTo("Type argument class java.lang.Object does not satisfy bounds"
-        + " for type variable T declared by " + GenericWithBound.class);
+    e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> TypeToken.getParameterized(GenericWithBound.class, Object.class));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "Type argument class java.lang.Object does not satisfy bounds"
+                + " for type variable T declared by "
+                + GenericWithBound.class);
 
-    e = assertThrows(IllegalArgumentException.class, () -> TypeToken.getParameterized(GenericWithMultiBound.class, Number.class));
-    assertThat(e).hasMessageThat().isEqualTo("Type argument class java.lang.Number does not satisfy bounds"
-        + " for type variable T declared by " + GenericWithMultiBound.class);
+    e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> TypeToken.getParameterized(GenericWithMultiBound.class, Number.class));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "Type argument class java.lang.Number does not satisfy bounds"
+                + " for type variable T declared by "
+                + GenericWithMultiBound.class);
 
-    e = assertThrows(IllegalArgumentException.class, () -> TypeToken.getParameterized(GenericWithMultiBound.class, CharSequence.class));
-    assertThat(e).hasMessageThat().isEqualTo("Type argument interface java.lang.CharSequence does not satisfy bounds"
-        + " for type variable T declared by " + GenericWithMultiBound.class);
+    e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> TypeToken.getParameterized(GenericWithMultiBound.class, CharSequence.class));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "Type argument interface java.lang.CharSequence does not satisfy bounds"
+                + " for type variable T declared by "
+                + GenericWithMultiBound.class);
 
-    e = assertThrows(IllegalArgumentException.class, () -> TypeToken.getParameterized(GenericWithMultiBound.class, Object.class));
-    assertThat(e).hasMessageThat().isEqualTo("Type argument class java.lang.Object does not satisfy bounds"
-        + " for type variable T declared by " + GenericWithMultiBound.class);
+    e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> TypeToken.getParameterized(GenericWithMultiBound.class, Object.class));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "Type argument class java.lang.Object does not satisfy bounds"
+                + " for type variable T declared by "
+                + GenericWithMultiBound.class);
 
     class Outer {
       class NonStaticInner<T> {}
     }
 
-    e = assertThrows(IllegalArgumentException.class, () -> TypeToken.getParameterized(Outer.NonStaticInner.class, Object.class));
-    assertThat(e).hasMessageThat().isEqualTo("Raw type " + Outer.NonStaticInner.class.getName()
-        + " is not supported because it requires specifying an owner type");
+    e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> TypeToken.getParameterized(Outer.NonStaticInner.class, Object.class));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "Raw type "
+                + Outer.NonStaticInner.class.getName()
+                + " is not supported because it requires specifying an owner type");
   }
 
-  private static class CustomTypeToken extends TypeToken<String> {
-  }
+  private static class CustomTypeToken extends TypeToken<String> {}
 
   @Test
   public void testTypeTokenNonAnonymousSubclass() {
@@ -216,8 +292,8 @@ public final class TypeTokenTest {
   }
 
   /**
-   * User must only create direct subclasses of TypeToken, but not subclasses
-   * of subclasses (...) of TypeToken.
+   * User must only create direct subclasses of TypeToken, but not subclasses of subclasses (...) of
+   * TypeToken.
    */
   @Test
   public void testTypeTokenSubSubClass() {
@@ -225,7 +301,8 @@ public final class TypeTokenTest {
     class SubSubTypeToken1<T> extends SubTypeToken<T> {}
     class SubSubTypeToken2 extends SubTypeToken<Integer> {}
 
-    IllegalStateException e = assertThrows(IllegalStateException.class, () -> new SubTypeToken<Integer>() {});
+    IllegalStateException e =
+        assertThrows(IllegalStateException.class, () -> new SubTypeToken<Integer>() {});
     assertThat(e).hasMessageThat().isEqualTo("Must only create direct subclasses of TypeToken");
 
     e = assertThrows(IllegalStateException.class, () -> new SubSubTypeToken1<Integer>());
@@ -240,13 +317,13 @@ public final class TypeTokenTest {
   }
 
   /**
-   * TypeToken type argument must not contain a type variable because, due to
-   * type erasure, at runtime only the bound of the type variable is available
-   * which is likely not what the user wanted.
+   * TypeToken type argument must not contain a type variable because, due to type erasure, at
+   * runtime only the bound of the type variable is available which is likely not what the user
+   * wanted.
    *
-   * <p>Note that type variables are allowed for the {@code TypeToken} factory
-   * methods calling {@code TypeToken(Type)} because for them the return type is
-   * {@code TypeToken<?>} which does not give a false sense of type-safety.
+   * <p>Note that type variables are allowed for the {@code TypeToken} factory methods calling
+   * {@code TypeToken(Type)} because for them the return type is {@code TypeToken<?>} which does not
+   * give a false sense of type-safety.
    */
   @Test
   public void testTypeTokenTypeVariable() throws Exception {
@@ -255,25 +332,35 @@ public final class TypeTokenTest {
       class Inner {}
 
       void test() {
-        String expectedMessage = "TypeToken type argument must not contain a type variable;"
-            + " captured type variable T declared by " + Enclosing.class
-            + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#typetoken-type-variable";
-        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new TypeToken<T>() {});
+        String expectedMessage =
+            "TypeToken type argument must not contain a type variable;"
+                + " captured type variable T declared by "
+                + Enclosing.class
+                + "\n"
+                + "See https://github.com/google/gson/blob/main/Troubleshooting.md#typetoken-type-variable";
+        IllegalArgumentException e =
+            assertThrows(IllegalArgumentException.class, () -> new TypeToken<T>() {});
         assertThat(e).hasMessageThat().isEqualTo(expectedMessage);
 
         e = assertThrows(IllegalArgumentException.class, () -> new TypeToken<List<List<T>>>() {});
         assertThat(e).hasMessageThat().isEqualTo(expectedMessage);
 
-        e = assertThrows(IllegalArgumentException.class, () -> new TypeToken<List<? extends List<T>>>() {});
+        e =
+            assertThrows(
+                IllegalArgumentException.class, () -> new TypeToken<List<? extends List<T>>>() {});
         assertThat(e).hasMessageThat().isEqualTo(expectedMessage);
 
-        e = assertThrows(IllegalArgumentException.class, () -> new TypeToken<List<? super List<T>>>() {});
+        e =
+            assertThrows(
+                IllegalArgumentException.class, () -> new TypeToken<List<? super List<T>>>() {});
         assertThat(e).hasMessageThat().isEqualTo(expectedMessage);
 
         e = assertThrows(IllegalArgumentException.class, () -> new TypeToken<List<T>[]>() {});
         assertThat(e).hasMessageThat().isEqualTo(expectedMessage);
 
-        e = assertThrows(IllegalArgumentException.class, () -> new TypeToken<Enclosing<T>.Inner>() {});
+        e =
+            assertThrows(
+                IllegalArgumentException.class, () -> new TypeToken<Enclosing<T>.Inner>() {});
         assertThat(e).hasMessageThat().isEqualTo(expectedMessage);
 
         String systemProperty = "gson.allowCapturingTypeVariables";
@@ -299,13 +386,20 @@ public final class TypeTokenTest {
 
       <M> void testMethodTypeVariable() throws Exception {
         Method testMethod = Enclosing.class.getDeclaredMethod("testMethodTypeVariable");
-        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new TypeToken<M>() {});
-        assertThat(e).hasMessageThat().isAnyOf("TypeToken type argument must not contain a type variable;"
-            + " captured type variable M declared by " + testMethod
-            + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#typetoken-type-variable",
-            // Note: When running this test in Eclipse IDE or with certain Java versions it seems to capture `null`
-            // instead of the type variable, see https://github.com/eclipse-jdt/eclipse.jdt.core/issues/975
-            "TypeToken captured `null` as type argument; probably a compiler / runtime bug");
+        IllegalArgumentException e =
+            assertThrows(IllegalArgumentException.class, () -> new TypeToken<M>() {});
+        assertThat(e)
+            .hasMessageThat()
+            .isAnyOf(
+                "TypeToken type argument must not contain a type variable;"
+                    + " captured type variable M declared by "
+                    + testMethod
+                    + "\n"
+                    + "See https://github.com/google/gson/blob/main/Troubleshooting.md#typetoken-type-variable",
+                // Note: When running this test in Eclipse IDE or with certain Java versions it
+                // seems to capture `null` instead of the type variable, see
+                // https://github.com/eclipse-jdt/eclipse.jdt.core/issues/975
+                "TypeToken captured `null` as type argument; probably a compiler / runtime bug");
       }
     }
 
@@ -313,13 +407,19 @@ public final class TypeTokenTest {
     new Enclosing<>().testMethodTypeVariable();
 
     Method testMethod = TypeTokenTest.class.getDeclaredMethod("createTypeTokenTypeVariable");
-    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> createTypeTokenTypeVariable());
-    assertThat(e).hasMessageThat().isEqualTo("TypeToken type argument must not contain a type variable;"
-        + " captured type variable M declared by " + testMethod
-        + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#typetoken-type-variable");
+    IllegalArgumentException e =
+        assertThrows(IllegalArgumentException.class, () -> createTypeTokenTypeVariable());
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "TypeToken type argument must not contain a type variable;"
+                + " captured type variable M declared by "
+                + testMethod
+                + "\n"
+                + "See https://github.com/google/gson/blob/main/Troubleshooting.md#typetoken-type-variable");
 
-    // Using type variable as argument for factory methods should be allowed; this is not a type-safety
-    // problem because the user would have to perform unsafe casts
+    // Using type variable as argument for factory methods should be allowed; this is not a
+    // type-safety problem because the user would have to perform unsafe casts
     TypeVariable<?> typeVar = Enclosing.class.getTypeParameters()[0];
     TypeToken<?> typeToken = TypeToken.get(typeVar);
     assertThat(typeToken.getType()).isEqualTo(typeVar);
@@ -334,18 +434,21 @@ public final class TypeTokenTest {
   @Test
   public void testTypeTokenRaw() {
     IllegalStateException e = assertThrows(IllegalStateException.class, () -> new TypeToken() {});
-    assertThat(e).hasMessageThat().isEqualTo("TypeToken must be created with a type argument: new TypeToken<...>() {};"
-        + " When using code shrinkers (ProGuard, R8, ...) make sure that generic signatures are preserved."
-        + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#type-token-raw");
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "TypeToken must be created with a type argument: new TypeToken<...>() {}; When using"
+                + " code shrinkers (ProGuard, R8, ...) make sure that generic signatures are"
+                + " preserved.\n"
+                + "See https://github.com/google/gson/blob/main/Troubleshooting.md#type-token-raw");
   }
 }
 
 // Have to declare these classes here as top-level classes because otherwise tests for
 // TypeToken.getParameterized fail due to owner type mismatch
-class GenericWithBound<T extends Number> {
-}
-class GenericWithMultiBound<T extends Number & CharSequence> {
-}
+class GenericWithBound<T extends Number> {}
+
+class GenericWithMultiBound<T extends Number & CharSequence> {}
+
 @SuppressWarnings("serial")
-abstract class ClassSatisfyingBounds extends Number implements CharSequence {
-}
+abstract class ClassSatisfyingBounds extends Number implements CharSequence {}

--- a/gson/src/test/java/com/google/gson/regression/OSGiTest.java
+++ b/gson/src/test/java/com/google/gson/regression/OSGiTest.java
@@ -31,45 +31,49 @@ import org.junit.Test;
 public class OSGiTest {
   @Test
   public void testComGoogleGsonAnnotationsPackage() throws Exception {
-        Manifest mf = findManifest("com.google.gson");
-        String importPkg = mf.getMainAttributes().getValue("Import-Package");
-        assertWithMessage("Import-Package statement is there").that(importPkg).isNotNull();
-        assertSubstring("There should be com.google.gson.annotations dependency", importPkg, "com.google.gson.annotations");
-    }
+    Manifest mf = findManifest("com.google.gson");
+    String importPkg = mf.getMainAttributes().getValue("Import-Package");
+    assertWithMessage("Import-Package statement is there").that(importPkg).isNotNull();
+    assertSubstring(
+        "There should be com.google.gson.annotations dependency",
+        importPkg,
+        "com.google.gson.annotations");
+  }
 
   @Test
   public void testSunMiscImportPackage() throws Exception {
-        Manifest mf = findManifest("com.google.gson");
-        String importPkg = mf.getMainAttributes().getValue("Import-Package");
+    Manifest mf = findManifest("com.google.gson");
+    String importPkg = mf.getMainAttributes().getValue("Import-Package");
     assertWithMessage("Import-Package statement is there").that(importPkg).isNotNull();
-        for (String dep : Splitter.on(',').split(importPkg)) {
-            if (dep.contains("sun.misc")) {
-                assertSubstring("sun.misc import is optional", dep, "resolution:=optional");
-                return;
-            }
-        }
-        fail("There should be sun.misc dependency, but was: " + importPkg);
+    for (String dep : Splitter.on(',').split(importPkg)) {
+      if (dep.contains("sun.misc")) {
+        assertSubstring("sun.misc import is optional", dep, "resolution:=optional");
+        return;
+      }
     }
+    fail("There should be sun.misc dependency, but was: " + importPkg);
+  }
 
-    private Manifest findManifest(String pkg) throws IOException {
-        List<URL> urls = new ArrayList<>();
-        for (URL u : Collections.list(getClass().getClassLoader().getResources("META-INF/MANIFEST.MF"))) {
-            InputStream is = u.openStream();
-            Manifest mf = new Manifest(is);
-            is.close();
-            if (pkg.equals(mf.getMainAttributes().getValue("Bundle-SymbolicName"))) {
-                return mf;
-            }
-            urls.add(u);
-        }
-        fail("Cannot find " + pkg + " OSGi bundle manifest among: " + urls);
-        return null;
+  private Manifest findManifest(String pkg) throws IOException {
+    List<URL> urls = new ArrayList<>();
+    for (URL u :
+        Collections.list(getClass().getClassLoader().getResources("META-INF/MANIFEST.MF"))) {
+      InputStream is = u.openStream();
+      Manifest mf = new Manifest(is);
+      is.close();
+      if (pkg.equals(mf.getMainAttributes().getValue("Bundle-SymbolicName"))) {
+        return mf;
+      }
+      urls.add(u);
     }
+    fail("Cannot find " + pkg + " OSGi bundle manifest among: " + urls);
+    return null;
+  }
 
-    private static void assertSubstring(String msg, String wholeText, String subString) {
-        if (wholeText.contains(subString)) {
-            return;
-        }
-        fail(msg + ". Expecting " + subString + " but was: " + wholeText);
+  private static void assertSubstring(String msg, String wholeText, String subString) {
+    if (wholeText.contains(subString)) {
+      return;
     }
+    fail(msg + ". Expecting " + subString + " but was: " + wholeText);
+  }
 }

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderPathTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderPathTest.java
@@ -37,15 +37,13 @@ public class JsonReaderPathTest {
   @Parameterized.Parameters(name = "{0}")
   public static List<Object[]> parameters() {
     return Arrays.asList(
-        new Object[] { Factory.STRING_READER },
-        new Object[] { Factory.OBJECT_READER }
-    );
+        new Object[] {Factory.STRING_READER}, new Object[] {Factory.OBJECT_READER});
   }
 
-  @Parameterized.Parameter
-  public Factory factory;
+  @Parameterized.Parameter public Factory factory;
 
-  @Test public void path() throws IOException {
+  @Test
+  public void path() throws IOException {
     JsonReader reader = factory.create("{\"a\":[2,true,false,null,\"b\",{\"c\":\"d\"},[3]]}");
     assertThat(reader.getPreviousPath()).isEqualTo("$");
     assertThat(reader.getPath()).isEqualTo("$");
@@ -102,7 +100,8 @@ public class JsonReaderPathTest {
     assertThat(reader.getPath()).isEqualTo("$");
   }
 
-  @Test public void objectPath() throws IOException {
+  @Test
+  public void objectPath() throws IOException {
     JsonReader reader = factory.create("{\"a\":1,\"b\":2}");
     assertThat(reader.getPreviousPath()).isEqualTo("$");
     assertThat(reader.getPath()).isEqualTo("$");
@@ -157,7 +156,8 @@ public class JsonReaderPathTest {
     assertThat(reader.getPath()).isEqualTo("$");
   }
 
-  @Test public void arrayPath() throws IOException {
+  @Test
+  public void arrayPath() throws IOException {
     JsonReader reader = factory.create("[1,2]");
     assertThat(reader.getPreviousPath()).isEqualTo("$");
     assertThat(reader.getPath()).isEqualTo("$");
@@ -198,7 +198,8 @@ public class JsonReaderPathTest {
     assertThat(reader.getPath()).isEqualTo("$");
   }
 
-  @Test public void multipleTopLevelValuesInOneDocument() throws IOException {
+  @Test
+  public void multipleTopLevelValuesInOneDocument() throws IOException {
     assumeTrue(factory == Factory.STRING_READER);
 
     JsonReader reader = factory.create("[][]");
@@ -213,7 +214,8 @@ public class JsonReaderPathTest {
     assertThat(reader.getPath()).isEqualTo("$");
   }
 
-  @Test public void skipArrayElements() throws IOException {
+  @Test
+  public void skipArrayElements() throws IOException {
     JsonReader reader = factory.create("[1,2,3]");
     reader.beginArray();
     reader.skipValue();
@@ -222,7 +224,8 @@ public class JsonReaderPathTest {
     assertThat(reader.getPath()).isEqualTo("$[2]");
   }
 
-  @Test public void skipArrayEnd() throws IOException {
+  @Test
+  public void skipArrayEnd() throws IOException {
     JsonReader reader = factory.create("[[],1]");
     reader.beginArray();
     reader.beginArray();
@@ -233,7 +236,8 @@ public class JsonReaderPathTest {
     assertThat(reader.getPath()).isEqualTo("$[1]");
   }
 
-  @Test public void skipObjectNames() throws IOException {
+  @Test
+  public void skipObjectNames() throws IOException {
     JsonReader reader = factory.create("{\"a\":[]}");
     reader.beginObject();
     reader.skipValue();
@@ -245,7 +249,8 @@ public class JsonReaderPathTest {
     assertThat(reader.getPath()).isEqualTo("$.<skipped>[0]");
   }
 
-  @Test public void skipObjectValues() throws IOException {
+  @Test
+  public void skipObjectValues() throws IOException {
     JsonReader reader = factory.create("{\"a\":1,\"b\":2}");
     reader.beginObject();
     assertThat(reader.getPreviousPath()).isEqualTo("$.");
@@ -259,7 +264,8 @@ public class JsonReaderPathTest {
     assertThat(reader.getPath()).isEqualTo("$.b");
   }
 
-  @Test public void skipObjectEnd() throws IOException {
+  @Test
+  public void skipObjectEnd() throws IOException {
     JsonReader reader = factory.create("{\"a\":{},\"b\":2}");
     reader.beginObject();
     String unused = reader.nextName();
@@ -271,7 +277,8 @@ public class JsonReaderPathTest {
     assertThat(reader.getPath()).isEqualTo("$.a");
   }
 
-  @Test public void skipNestedStructures() throws IOException {
+  @Test
+  public void skipNestedStructures() throws IOException {
     JsonReader reader = factory.create("[[1,2,3],4]");
     reader.beginArray();
     reader.skipValue();
@@ -279,7 +286,8 @@ public class JsonReaderPathTest {
     assertThat(reader.getPath()).isEqualTo("$[1]");
   }
 
-  @Test public void skipEndOfDocument() throws IOException {
+  @Test
+  public void skipEndOfDocument() throws IOException {
     JsonReader reader = factory.create("[]");
     reader.beginArray();
     reader.endArray();
@@ -293,7 +301,8 @@ public class JsonReaderPathTest {
     assertThat(reader.getPath()).isEqualTo("$");
   }
 
-  @Test public void arrayOfObjects() throws IOException {
+  @Test
+  public void arrayOfObjects() throws IOException {
     JsonReader reader = factory.create("[{},{},{}]");
     reader.beginArray();
     assertThat(reader.getPreviousPath()).isEqualTo("$[0]");
@@ -321,7 +330,8 @@ public class JsonReaderPathTest {
     assertThat(reader.getPath()).isEqualTo("$");
   }
 
-  @Test public void arrayOfArrays() throws IOException {
+  @Test
+  public void arrayOfArrays() throws IOException {
     JsonReader reader = factory.create("[[],[],[]]");
     reader.beginArray();
     assertThat(reader.getPreviousPath()).isEqualTo("$[0]");
@@ -349,7 +359,8 @@ public class JsonReaderPathTest {
     assertThat(reader.getPath()).isEqualTo("$");
   }
 
-  @Test public void objectOfObjects() throws IOException {
+  @Test
+  public void objectOfObjects() throws IOException {
     JsonReader reader = factory.create("{\"a\":{\"a1\":1,\"a2\":2},\"b\":{\"b1\":1}}");
     reader.beginObject();
     assertThat(reader.getPreviousPath()).isEqualTo("$.");
@@ -397,12 +408,14 @@ public class JsonReaderPathTest {
 
   public enum Factory {
     STRING_READER {
-      @Override public JsonReader create(String data) {
+      @Override
+      public JsonReader create(String data) {
         return new JsonReader(new StringReader(data));
       }
     },
     OBJECT_READER {
-      @Override public JsonReader create(String data) {
+      @Override
+      public JsonReader create(String data) {
         JsonElement element = Streams.parse(new JsonReader(new StringReader(data)));
         return new JsonTreeReader(element);
       }

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -77,7 +77,9 @@ public final class JsonReaderTest {
     reader.setStrictness(Strictness.STRICT);
 
     IOException expected = assertThrows(IOException.class, reader::nextString);
-    assertThat(expected).hasMessageThat().startsWith("Cannot escape a newline character in strict mode");
+    assertThat(expected)
+        .hasMessageThat()
+        .startsWith("Cannot escape a newline character in strict mode");
   }
 
   @Test
@@ -94,26 +96,36 @@ public final class JsonReaderTest {
     reader.setStrictness(Strictness.STRICT);
 
     IOException expected = assertThrows(IOException.class, reader::nextString);
-    assertThat(expected).hasMessageThat().startsWith("Unescaped control characters (\\u0000-\\u001F) are not allowed in strict mode");
+    assertThat(expected)
+        .hasMessageThat()
+        .startsWith(
+            "Unescaped control characters (\\u0000-\\u001F) are not allowed in strict mode");
 
     json = "\"\t\"";
     reader = new JsonReader(reader(json));
     reader.setStrictness(Strictness.STRICT);
 
     expected = assertThrows(IOException.class, reader::nextString);
-    assertThat(expected).hasMessageThat().startsWith("Unescaped control characters (\\u0000-\\u001F) are not allowed in strict mode");
+    assertThat(expected)
+        .hasMessageThat()
+        .startsWith(
+            "Unescaped control characters (\\u0000-\\u001F) are not allowed in strict mode");
 
     json = "\"\u001F\"";
     reader = new JsonReader(reader(json));
     reader.setStrictness(Strictness.STRICT);
 
     expected = assertThrows(IOException.class, reader::nextString);
-    assertThat(expected).hasMessageThat().startsWith("Unescaped control characters (\\u0000-\\u001F) are not allowed in strict mode");
+    assertThat(expected)
+        .hasMessageThat()
+        .startsWith(
+            "Unescaped control characters (\\u0000-\\u001F) are not allowed in strict mode");
   }
 
   @Test
   public void testStrictModeAllowsOtherControlCharacters() throws IOException {
-    // JSON specification only forbids control characters U+0000 - U+001F, other control characters should be allowed
+    // JSON specification only forbids control characters U+0000 - U+001F, other control characters
+    // should be allowed
     String json = "\"\u007F\u009F\"";
     JsonReader reader = new JsonReader(reader(json));
     reader.setStrictness(Strictness.STRICT);
@@ -133,15 +145,21 @@ public final class JsonReaderTest {
     reader.setStrictness(Strictness.STRICT);
 
     IOException expected = assertThrows(IOException.class, reader::nextBoolean);
-    assertThat(expected).hasMessageThat().startsWith("Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed" +
-        " JSON at line 1 column 1 path $");
+    assertThat(expected)
+        .hasMessageThat()
+        .startsWith(
+            "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed"
+                + " JSON at line 1 column 1 path $");
 
     reader = new JsonReader(reader("True"));
     reader.setStrictness(Strictness.STRICT);
 
     expected = assertThrows(IOException.class, reader::nextBoolean);
-    assertThat(expected).hasMessageThat().startsWith("Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed" +
-        " JSON at line 1 column 1 path $");
+    assertThat(expected)
+        .hasMessageThat()
+        .startsWith(
+            "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed"
+                + " JSON at line 1 column 1 path $");
   }
 
   @Test
@@ -150,15 +168,21 @@ public final class JsonReaderTest {
     reader.setStrictness(Strictness.STRICT);
 
     IOException expected = assertThrows(IOException.class, reader::nextBoolean);
-    assertThat(expected).hasMessageThat().startsWith("Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed" +
-        " JSON at line 1 column 1 path $");
+    assertThat(expected)
+        .hasMessageThat()
+        .startsWith(
+            "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed"
+                + " JSON at line 1 column 1 path $");
 
     reader = new JsonReader(reader("FaLse"));
     reader.setStrictness(Strictness.STRICT);
 
     expected = assertThrows(IOException.class, reader::nextBoolean);
-    assertThat(expected).hasMessageThat().startsWith("Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed" +
-        " JSON at line 1 column 1 path $");
+    assertThat(expected)
+        .hasMessageThat()
+        .startsWith(
+            "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed"
+                + " JSON at line 1 column 1 path $");
   }
 
   @Test
@@ -167,15 +191,21 @@ public final class JsonReaderTest {
     reader.setStrictness(Strictness.STRICT);
 
     IOException expected = assertThrows(IOException.class, reader::nextNull);
-    assertThat(expected).hasMessageThat().startsWith("Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed" +
-        " JSON at line 1 column 1 path $");
+    assertThat(expected)
+        .hasMessageThat()
+        .startsWith(
+            "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed"
+                + " JSON at line 1 column 1 path $");
 
     reader = new JsonReader(reader("nulL"));
     reader.setStrictness(Strictness.STRICT);
 
     expected = assertThrows(IOException.class, reader::nextNull);
-    assertThat(expected).hasMessageThat().startsWith("Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed" +
-        " JSON at line 1 column 1 path $");
+    assertThat(expected)
+        .hasMessageThat()
+        .startsWith(
+            "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed"
+                + " JSON at line 1 column 1 path $");
   }
 
   @Test
@@ -199,8 +229,7 @@ public final class JsonReaderTest {
 
   @Test
   public void testReadObject() throws IOException {
-    JsonReader reader = new JsonReader(reader(
-        "{\"a\": \"android\", \"b\": \"banana\"}"));
+    JsonReader reader = new JsonReader(reader("{\"a\": \"android\", \"b\": \"banana\"}"));
     reader.beginObject();
     assertThat(reader.nextName()).isEqualTo("a");
     assertThat(reader.nextString()).isEqualTo("android");
@@ -229,8 +258,8 @@ public final class JsonReaderTest {
 
   @Test
   public void testSkipArray() throws IOException {
-    JsonReader reader = new JsonReader(reader(
-        "{\"a\": [\"one\", \"two\", \"three\"], \"b\": 123}"));
+    JsonReader reader =
+        new JsonReader(reader("{\"a\": [\"one\", \"two\", \"three\"], \"b\": 123}"));
     reader.beginObject();
     assertThat(reader.nextName()).isEqualTo("a");
     reader.skipValue();
@@ -242,8 +271,8 @@ public final class JsonReaderTest {
 
   @Test
   public void testSkipArrayAfterPeek() throws Exception {
-    JsonReader reader = new JsonReader(reader(
-        "{\"a\": [\"one\", \"two\", \"three\"], \"b\": 123}"));
+    JsonReader reader =
+        new JsonReader(reader("{\"a\": [\"one\", \"two\", \"three\"], \"b\": 123}"));
     reader.beginObject();
     assertThat(reader.nextName()).isEqualTo("a");
     assertThat(reader.peek()).isEqualTo(BEGIN_ARRAY);
@@ -256,16 +285,17 @@ public final class JsonReaderTest {
 
   @Test
   public void testSkipTopLevelObject() throws Exception {
-    JsonReader reader = new JsonReader(reader(
-        "{\"a\": [\"one\", \"two\", \"three\"], \"b\": 123}"));
+    JsonReader reader =
+        new JsonReader(reader("{\"a\": [\"one\", \"two\", \"three\"], \"b\": 123}"));
     reader.skipValue();
     assertThat(reader.peek()).isEqualTo(JsonToken.END_DOCUMENT);
   }
 
   @Test
   public void testSkipObject() throws IOException {
-    JsonReader reader = new JsonReader(reader(
-        "{\"a\": { \"c\": [], \"d\": [true, true, {}] }, \"b\": \"banana\"}"));
+    JsonReader reader =
+        new JsonReader(
+            reader("{\"a\": { \"c\": [], \"d\": [true, true, {}] }, \"b\": \"banana\"}"));
     reader.beginObject();
     assertThat(reader.nextName()).isEqualTo("a");
     reader.skipValue();
@@ -277,8 +307,12 @@ public final class JsonReaderTest {
 
   @Test
   public void testSkipObjectAfterPeek() throws Exception {
-    String json = "{" + "  \"one\": { \"num\": 1 }"
-        + ", \"two\": { \"num\": 2 }" + ", \"three\": { \"num\": 3 }" + "}";
+    String json =
+        "{"
+            + "  \"one\": { \"num\": 1 }"
+            + ", \"two\": { \"num\": 2 }"
+            + ", \"three\": { \"num\": 3 }"
+            + "}";
     JsonReader reader = new JsonReader(reader(json));
     reader.beginObject();
     assertThat(reader.nextName()).isEqualTo("one");
@@ -327,8 +361,7 @@ public final class JsonReaderTest {
 
   @Test
   public void testSkipInteger() throws IOException {
-    JsonReader reader = new JsonReader(reader(
-        "{\"a\":123456789,\"b\":-123456789}"));
+    JsonReader reader = new JsonReader(reader("{\"a\":123456789,\"b\":-123456789}"));
     reader.beginObject();
     assertThat(reader.nextName()).isEqualTo("a");
     reader.skipValue();
@@ -340,8 +373,7 @@ public final class JsonReaderTest {
 
   @Test
   public void testSkipDouble() throws IOException {
-    JsonReader reader = new JsonReader(reader(
-        "{\"a\":-123.456e-789,\"b\":123456789.0}"));
+    JsonReader reader = new JsonReader(reader("{\"a\":-123.456e-789,\"b\":123456789.0}"));
     reader.beginObject();
     assertThat(reader.nextName()).isEqualTo("a");
     reader.skipValue();
@@ -384,10 +416,7 @@ public final class JsonReaderTest {
 
   @Test
   public void testHelloWorld() throws IOException {
-    String json = "{\n" +
-        "   \"hello\": true,\n" +
-        "   \"foo\": [\"world\"]\n" +
-        "}";
+    String json = "{\n" + "   \"hello\": true,\n" + "   \"foo\": [\"world\"]\n" + "}";
     JsonReader reader = new JsonReader(reader(json));
     reader.beginObject();
     assertThat(reader.nextName()).isEqualTo("hello");
@@ -402,10 +431,7 @@ public final class JsonReaderTest {
 
   @Test
   public void testInvalidJsonInput() throws IOException {
-    String json = "{\n"
-        + "   \"h\\ello\": true,\n"
-        + "   \"foo\": [\"world\"]\n"
-        + "}";
+    String json = "{\n" + "   \"h\\ello\": true,\n" + "   \"foo\": [\"world\"]\n" + "}";
 
     JsonReader reader = new JsonReader(reader(json));
     reader.beginObject();
@@ -413,8 +439,11 @@ public final class JsonReaderTest {
       reader.nextName();
       fail();
     } catch (MalformedJsonException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Invalid escape sequence at line 2 column 8 path $."
-          + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Invalid escape sequence at line 2 column 8 path $.\n"
+                  + "See https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
     }
   }
 
@@ -444,26 +473,27 @@ public final class JsonReaderTest {
 
   @Test
   public void testCharacterUnescaping() throws IOException {
-    String json = "[\"a\","
-        + "\"a\\\"\","
-        + "\"\\\"\","
-        + "\":\","
-        + "\",\","
-        + "\"\\b\","
-        + "\"\\f\","
-        + "\"\\n\","
-        + "\"\\r\","
-        + "\"\\t\","
-        + "\" \","
-        + "\"\\\\\","
-        + "\"{\","
-        + "\"}\","
-        + "\"[\","
-        + "\"]\","
-        + "\"\\u0000\","
-        + "\"\\u0019\","
-        + "\"\\u20AC\""
-        + "]";
+    String json =
+        "[\"a\","
+            + "\"a\\\"\","
+            + "\"\\\"\","
+            + "\":\","
+            + "\",\","
+            + "\"\\b\","
+            + "\"\\f\","
+            + "\"\\n\","
+            + "\"\\r\","
+            + "\"\\t\","
+            + "\" \","
+            + "\"\\\\\","
+            + "\"{\","
+            + "\"}\","
+            + "\"[\","
+            + "\"]\","
+            + "\"\\u0000\","
+            + "\"\\u0019\","
+            + "\"\\u20AC\""
+            + "]";
     JsonReader reader = new JsonReader(reader(json));
     reader.beginArray();
     assertThat(reader.nextString()).isEqualTo("a");
@@ -523,7 +553,9 @@ public final class JsonReaderTest {
     reader.setStrictness(Strictness.STRICT);
 
     IOException expected = assertThrows(IOException.class, reader::nextString);
-    assertThat(expected).hasMessageThat().startsWith("Invalid escaped character \"'\" in strict mode");
+    assertThat(expected)
+        .hasMessageThat()
+        .startsWith("Invalid escaped character \"'\" in strict mode");
   }
 
   @Test
@@ -542,8 +574,11 @@ public final class JsonReaderTest {
       reader.nextString();
       fail();
     } catch (MalformedJsonException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Malformed Unicode escape \\u000g at line 1 column 5 path $[0]"
-          + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Malformed Unicode escape \\u000g at line 1 column 5 path $[0]\n"
+                  + "See https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
     }
   }
 
@@ -556,8 +591,11 @@ public final class JsonReaderTest {
       reader.nextString();
       fail();
     } catch (MalformedJsonException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Unterminated escape sequence at line 1 column 5 path $[0]"
-          + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Unterminated escape sequence at line 1 column 5 path $[0]\n"
+                  + "See https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
     }
   }
 
@@ -570,8 +608,11 @@ public final class JsonReaderTest {
       reader.nextString();
       fail();
     } catch (MalformedJsonException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Unterminated escape sequence at line 1 column 4 path $[0]"
-          + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Unterminated escape sequence at line 1 column 4 path $[0]\n"
+                  + "See https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
     }
   }
 
@@ -586,24 +627,25 @@ public final class JsonReaderTest {
 
   @Test
   public void testDoubles() throws IOException {
-    String json = "[-0.0,"
-        + "1.0,"
-        + "1.7976931348623157E308,"
-        + "4.9E-324,"
-        + "0.0,"
-        + "0.00,"
-        + "-0.5,"
-        + "2.2250738585072014E-308,"
-        + "3.141592653589793,"
-        + "2.718281828459045,"
-        + "0,"
-        + "0.01,"
-        + "0e0,"
-        + "1e+0,"
-        + "1e-0,"
-        + "1e0000," // leading 0 is allowed for exponent
-        + "1e00001,"
-        + "1e+1]";
+    String json =
+        "[-0.0,"
+            + "1.0,"
+            + "1.7976931348623157E308,"
+            + "4.9E-324,"
+            + "0.0,"
+            + "0.00,"
+            + "-0.5,"
+            + "2.2250738585072014E-308,"
+            + "3.141592653589793,"
+            + "2.718281828459045,"
+            + "0,"
+            + "0.01,"
+            + "0e0,"
+            + "1e+0,"
+            + "1e-0,"
+            + "1e0000," // leading 0 is allowed for exponent
+            + "1e00001,"
+            + "1e+1]";
     JsonReader reader = new JsonReader(reader(json));
     reader.beginArray();
     assertThat(reader.nextDouble()).isEqualTo(-0.0);
@@ -650,8 +692,11 @@ public final class JsonReaderTest {
       reader.nextDouble();
       fail();
     } catch (MalformedJsonException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("JSON forbids NaN and infinities: NaN at line 1 column 7 path $[0]"
-          + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "JSON forbids NaN and infinities: NaN at line 1 column 7 path $[0]\n"
+                  + "See https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
     }
   }
 
@@ -694,11 +739,8 @@ public final class JsonReaderTest {
 
   @Test
   public void testLongs() throws IOException {
-    String json = "[0,0,0,"
-        + "1,1,1,"
-        + "-1,-1,-1,"
-        + "-9223372036854775808,"
-        + "9223372036854775807]";
+    String json =
+        "[0,0,0," + "1,1,1," + "-1,-1,-1," + "-9223372036854775808," + "9223372036854775807]";
     JsonReader reader = new JsonReader(reader(json));
     reader.beginArray();
     assertThat(reader.nextLong()).isEqualTo(0L);
@@ -727,7 +769,9 @@ public final class JsonReaderTest {
   }
 
   @Test
-  @Ignore("JsonReader advances after exception for invalid number was thrown; to be decided if that is acceptable")
+  @Ignore(
+      "JsonReader advances after exception for invalid number was thrown; to be decided if that is"
+          + " acceptable")
   public void testNumberWithOctalPrefix() throws IOException {
     String json = "[01]";
     JsonReader reader = new JsonReader(reader(json));
@@ -843,7 +887,9 @@ public final class JsonReaderTest {
       strictReader.nextDouble();
       fail("Should have failed reading " + s + " as double");
     } catch (MalformedJsonException e) {
-      assertThat(e).hasMessageThat().startsWith("Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON");
+      assertThat(e)
+          .hasMessageThat()
+          .startsWith("Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON");
     }
   }
 
@@ -905,9 +951,7 @@ public final class JsonReaderTest {
     }
   }
 
-  /**
-   * Issue 1053, negative zero.
-   */
+  /** Issue 1053, negative zero. */
   @Test
   public void testNegativeZero() throws Exception {
     JsonReader reader = new JsonReader(reader("[-0]"));
@@ -918,8 +962,8 @@ public final class JsonReaderTest {
   }
 
   /**
-   * This test fails because there's no double for 9223372036854775808, and our
-   * long parsing uses Double.parseDouble() for fractional values.
+   * This test fails because there's no double for 9223372036854775808, and our long parsing uses
+   * Double.parseDouble() for fractional values.
    */
   @Test
   @Ignore
@@ -936,8 +980,8 @@ public final class JsonReaderTest {
   }
 
   /**
-   * This test fails because there's no double for -9223372036854775809, and our
-   * long parsing uses Double.parseDouble() for fractional values.
+   * This test fails because there's no double for -9223372036854775809, and our long parsing uses
+   * Double.parseDouble() for fractional values.
    */
   @Test
   @Ignore
@@ -957,8 +1001,8 @@ public final class JsonReaderTest {
   }
 
   /**
-   * This test fails because there's no double for 9223372036854775806, and
-   * our long parsing uses Double.parseDouble() for fractional values.
+   * This test fails because there's no double for 9223372036854775806, and our long parsing uses
+   * Double.parseDouble() for fractional values.
    */
   @Test
   @Ignore
@@ -1018,8 +1062,11 @@ public final class JsonReaderTest {
       reader.nextString();
       fail();
     } catch (MalformedJsonException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected value at line 1 column 6 path $.a"
-          + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Expected value at line 1 column 6 path $.a\n"
+                  + "See https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
     }
   }
 
@@ -1091,7 +1138,8 @@ public final class JsonReaderTest {
       reader.beginArray();
       fail();
     } catch (IllegalStateException expected) {
-      assertUnexpectedStructureError(expected, "BEGIN_ARRAY", "BOOLEAN", "line 1 column 10 path $.a");
+      assertUnexpectedStructureError(
+          expected, "BEGIN_ARRAY", "BOOLEAN", "line 1 column 10 path $.a");
     }
     try {
       reader.endArray();
@@ -1103,20 +1151,23 @@ public final class JsonReaderTest {
       reader.beginObject();
       fail();
     } catch (IllegalStateException expected) {
-      assertUnexpectedStructureError(expected, "BEGIN_OBJECT", "BOOLEAN", "line 1 column 10 path $.a");
+      assertUnexpectedStructureError(
+          expected, "BEGIN_OBJECT", "BOOLEAN", "line 1 column 10 path $.a");
     }
     try {
       reader.endObject();
       fail();
     } catch (IllegalStateException expected) {
-      assertUnexpectedStructureError(expected, "END_OBJECT", "BOOLEAN", "line 1 column 10 path $.a");
+      assertUnexpectedStructureError(
+          expected, "END_OBJECT", "BOOLEAN", "line 1 column 10 path $.a");
     }
     assertThat(reader.nextBoolean()).isTrue();
     try {
       reader.nextString();
       fail();
     } catch (IllegalStateException expected) {
-      assertUnexpectedStructureError(expected, "a string", "END_OBJECT", "line 1 column 11 path $.a");
+      assertUnexpectedStructureError(
+          expected, "a string", "END_OBJECT", "line 1 column 11 path $.a");
     }
     try {
       reader.nextName();
@@ -1128,13 +1179,15 @@ public final class JsonReaderTest {
       reader.beginArray();
       fail();
     } catch (IllegalStateException expected) {
-      assertUnexpectedStructureError(expected, "BEGIN_ARRAY", "END_OBJECT", "line 1 column 11 path $.a");
+      assertUnexpectedStructureError(
+          expected, "BEGIN_ARRAY", "END_OBJECT", "line 1 column 11 path $.a");
     }
     try {
       reader.endArray();
       fail();
     } catch (IllegalStateException expected) {
-      assertUnexpectedStructureError(expected, "END_ARRAY", "END_OBJECT", "line 1 column 11 path $.a");
+      assertUnexpectedStructureError(
+          expected, "END_ARRAY", "END_OBJECT", "line 1 column 11 path $.a");
     }
     reader.endObject();
     assertThat(reader.peek()).isEqualTo(JsonToken.END_DOCUMENT);
@@ -1770,8 +1823,11 @@ public final class JsonReaderTest {
       reader.nextString();
       fail();
     } catch (MalformedJsonException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Unexpected value at line 1 column 3 path $"
-          + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Unexpected value at line 1 column 3 path $\n"
+                  + "See https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
     }
   }
 
@@ -1796,39 +1852,38 @@ public final class JsonReaderTest {
 
   @Test
   public void testFailWithPosition() throws IOException {
-    testFailWithPosition("Expected value at line 6 column 5 path $[1]",
-        "[\n\n\n\n\n\"a\",}]");
+    testFailWithPosition("Expected value at line 6 column 5 path $[1]", "[\n\n\n\n\n\"a\",}]");
   }
 
   @Test
   public void testFailWithPositionGreaterThanBufferSize() throws IOException {
     String spaces = repeat(' ', 8192);
-    testFailWithPosition("Expected value at line 6 column 5 path $[1]",
-        "[\n\n" + spaces + "\n\n\n\"a\",}]");
+    testFailWithPosition(
+        "Expected value at line 6 column 5 path $[1]", "[\n\n" + spaces + "\n\n\n\"a\",}]");
   }
 
   @Test
   public void testFailWithPositionOverSlashSlashEndOfLineComment() throws IOException {
-    testFailWithPosition("Expected value at line 5 column 6 path $[1]",
-        "\n// foo\n\n//bar\r\n[\"a\",}");
+    testFailWithPosition(
+        "Expected value at line 5 column 6 path $[1]", "\n// foo\n\n//bar\r\n[\"a\",}");
   }
 
   @Test
   public void testFailWithPositionOverHashEndOfLineComment() throws IOException {
-    testFailWithPosition("Expected value at line 5 column 6 path $[1]",
-        "\n# foo\n\n#bar\r\n[\"a\",}");
+    testFailWithPosition(
+        "Expected value at line 5 column 6 path $[1]", "\n# foo\n\n#bar\r\n[\"a\",}");
   }
 
   @Test
   public void testFailWithPositionOverCStyleComment() throws IOException {
-    testFailWithPosition("Expected value at line 6 column 12 path $[1]",
-        "\n\n/* foo\n*\n*\r\nbar */[\"a\",}");
+    testFailWithPosition(
+        "Expected value at line 6 column 12 path $[1]", "\n\n/* foo\n*\n*\r\nbar */[\"a\",}");
   }
 
   @Test
   public void testFailWithPositionOverQuotedString() throws IOException {
-    testFailWithPosition("Expected value at line 5 column 3 path $[1]",
-        "[\"foo\nbar\r\nbaz\n\",\n  }");
+    testFailWithPosition(
+        "Expected value at line 5 column 3 path $[1]", "[\"foo\nbar\r\nbaz\n\",\n  }");
   }
 
   @Test
@@ -1843,8 +1898,7 @@ public final class JsonReaderTest {
 
   @Test
   public void testFailWithPositionIsOffsetByBom() throws IOException {
-    testFailWithPosition("Expected value at line 1 column 6 path $[1]",
-        "\ufeff[\"a\",}]");
+    testFailWithPosition("Expected value at line 1 column 6 path $[1]", "\ufeff[\"a\",}]");
   }
 
   private void testFailWithPosition(String message, String json) throws IOException {
@@ -1857,7 +1911,12 @@ public final class JsonReaderTest {
       JsonToken unused2 = reader1.peek();
       fail();
     } catch (MalformedJsonException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo(message + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              message
+                  + "\n"
+                  + "See https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
     }
 
     // Also validate that it works when skipping.
@@ -1869,7 +1928,12 @@ public final class JsonReaderTest {
       JsonToken unused3 = reader2.peek();
       fail();
     } catch (MalformedJsonException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo(message + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              message
+                  + "\n"
+                  + "See https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
     }
   }
 
@@ -1887,9 +1951,11 @@ public final class JsonReaderTest {
       JsonToken unused5 = reader.peek();
       fail();
     } catch (MalformedJsonException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo(
-          "Expected value at line 1 column 14 path $[1].a[2]"
-          + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Expected value at line 1 column 14 path $[1].a[2]\n"
+                  + "See https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
     }
   }
 
@@ -1929,13 +1995,17 @@ public final class JsonReaderTest {
   @Test
   public void testDeeplyNestedArrays() throws IOException {
     // this is nested 40 levels deep; Gson is tuned for nesting is 30 levels deep or fewer
-    JsonReader reader = new JsonReader(reader(
-        "[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]"));
+    JsonReader reader =
+        new JsonReader(
+            reader(
+                "[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]"));
     for (int i = 0; i < 40; i++) {
       reader.beginArray();
     }
-    assertThat(reader.getPath()).isEqualTo("$[0][0][0][0][0][0][0][0][0][0][0][0][0][0][0]"
-        + "[0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0]");
+    assertThat(reader.getPath())
+        .isEqualTo(
+            "$[0][0][0][0][0][0][0][0][0][0][0][0][0][0][0]"
+                + "[0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0]");
     for (int i = 0; i < 40; i++) {
       reader.endArray();
     }
@@ -1956,8 +2026,10 @@ public final class JsonReaderTest {
       reader.beginObject();
       assertThat(reader.nextName()).isEqualTo("a");
     }
-    assertThat(reader.getPath()).isEqualTo("$.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a"
-        + ".a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a");
+    assertThat(reader.getPath())
+        .isEqualTo(
+            "$.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a"
+                + ".a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a");
     assertThat(reader.nextBoolean()).isTrue();
     for (int i = 0; i < 40; i++) {
       reader.endObject();
@@ -1974,8 +2046,11 @@ public final class JsonReaderTest {
       reader.peek();
       fail();
     } catch (MalformedJsonException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected value at line 1 column 1 path $"
-          + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Expected value at line 1 column 1 path $\n"
+                  + "See https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
     }
   }
 
@@ -1987,8 +2062,11 @@ public final class JsonReaderTest {
       reader.peek();
       fail();
     } catch (MalformedJsonException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected value at line 1 column 10 path $"
-          + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Expected value at line 1 column 10 path $\n"
+                  + "See https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
     }
   }
 
@@ -2000,8 +2078,11 @@ public final class JsonReaderTest {
       reader.peek();
       fail();
     } catch (MalformedJsonException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected value at line 1 column 1 path $"
-          + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Expected value at line 1 column 1 path $\n"
+                  + "See https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
     }
   }
 
@@ -2016,8 +2097,11 @@ public final class JsonReaderTest {
       reader.peek();
       fail();
     } catch (MalformedJsonException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Unterminated object at line 1 column 16 path $.a"
-          + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Unterminated object at line 1 column 16 path $.a\n"
+                  + "See https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
     }
   }
 
@@ -2145,8 +2229,11 @@ public final class JsonReaderTest {
       reader.peek();
       fail();
     } catch (MalformedJsonException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected name at line 1 column 11 path $.a"
-          + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Expected name at line 1 column 11 path $.a\n"
+                  + "See https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
     }
   }
 
@@ -2161,8 +2248,11 @@ public final class JsonReaderTest {
       reader.peek();
       fail();
     } catch (MalformedJsonException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected name at line 1 column 11 path $.a"
-          + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Expected name at line 1 column 11 path $.a\n"
+                  + "See https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
     }
   }
 
@@ -2186,9 +2276,12 @@ public final class JsonReaderTest {
     assertDocument("{\"name\":,", BEGIN_OBJECT, NAME, MalformedJsonException.class);
     assertDocument("{\"name\"=}", BEGIN_OBJECT, NAME, MalformedJsonException.class);
     assertDocument("{\"name\"=>}", BEGIN_OBJECT, NAME, MalformedJsonException.class);
-    assertDocument("{\"name\"=>\"string\":", BEGIN_OBJECT, NAME, STRING, MalformedJsonException.class);
-    assertDocument("{\"name\"=>\"string\"=", BEGIN_OBJECT, NAME, STRING, MalformedJsonException.class);
-    assertDocument("{\"name\"=>\"string\"=>", BEGIN_OBJECT, NAME, STRING, MalformedJsonException.class);
+    assertDocument(
+        "{\"name\"=>\"string\":", BEGIN_OBJECT, NAME, STRING, MalformedJsonException.class);
+    assertDocument(
+        "{\"name\"=>\"string\"=", BEGIN_OBJECT, NAME, STRING, MalformedJsonException.class);
+    assertDocument(
+        "{\"name\"=>\"string\"=>", BEGIN_OBJECT, NAME, STRING, MalformedJsonException.class);
     assertDocument("{\"name\"=>\"string\",", BEGIN_OBJECT, NAME, STRING, EOFException.class);
     assertDocument("{\"name\"=>\"string\",\"name\"", BEGIN_OBJECT, NAME, STRING, NAME);
     assertDocument("[}", BEGIN_ARRAY, MalformedJsonException.class);
@@ -2216,8 +2309,8 @@ public final class JsonReaderTest {
   }
 
   /**
-   * This test behave slightly differently in Gson 2.2 and earlier. It fails
-   * during peek rather than during nextString().
+   * This test behaves slightly differently in Gson 2.2 and earlier. It fails during peek rather
+   * than during nextString().
    */
   @Test
   public void testUnterminatedStringFailure() throws IOException {
@@ -2229,14 +2322,15 @@ public final class JsonReaderTest {
       reader.nextString();
       fail();
     } catch (MalformedJsonException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Unterminated string at line 1 column 9 path $[0]"
-          + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo(
+              "Unterminated string at line 1 column 9 path $[0]\n"
+                  + "See https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
     }
   }
 
-  /**
-   * Regression test for an issue with buffer filling and consumeNonExecutePrefix.
-   */
+  /** Regression test for an issue with buffer filling and consumeNonExecutePrefix. */
   @Test
   public void testReadAcrossBuffers() throws IOException {
     StringBuilder sb = new StringBuilder("#");
@@ -2251,14 +2345,33 @@ public final class JsonReaderTest {
   }
 
   private static void assertStrictError(MalformedJsonException exception, String expectedLocation) {
-    assertThat(exception).hasMessageThat().isEqualTo("Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON at " + expectedLocation
-        + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
+    assertThat(exception)
+        .hasMessageThat()
+        .isEqualTo(
+            "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON at "
+                + expectedLocation
+                + "\n"
+                + "See https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
   }
 
-  private static void assertUnexpectedStructureError(IllegalStateException exception, String expectedToken, String actualToken, String expectedLocation) {
-    String troubleshootingId = actualToken.equals("NULL") ? "adapter-not-null-safe" : "unexpected-json-structure";
-    assertThat(exception).hasMessageThat().isEqualTo("Expected " + expectedToken + " but was " + actualToken + " at " + expectedLocation
-        + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#" + troubleshootingId);
+  private static void assertUnexpectedStructureError(
+      IllegalStateException exception,
+      String expectedToken,
+      String actualToken,
+      String expectedLocation) {
+    String troubleshootingId =
+        actualToken.equals("NULL") ? "adapter-not-null-safe" : "unexpected-json-structure";
+    assertThat(exception)
+        .hasMessageThat()
+        .isEqualTo(
+            "Expected "
+                + expectedToken
+                + " but was "
+                + actualToken
+                + " at "
+                + expectedLocation
+                + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#"
+                + troubleshootingId);
   }
 
   private void assertDocument(String document, Object... expectations) throws IOException {
@@ -2283,7 +2396,8 @@ public final class JsonReaderTest {
         assertThat(reader.nextInt()).isEqualTo(123);
       } else if (expectation == NULL) {
         reader.nextNull();
-      } else if (expectation instanceof Class && Exception.class.isAssignableFrom((Class<?>) expectation)) {
+      } else if (expectation instanceof Class
+          && Exception.class.isAssignableFrom((Class<?>) expectation)) {
         try {
           reader.peek();
           fail();
@@ -2296,9 +2410,7 @@ public final class JsonReaderTest {
     }
   }
 
-  /**
-   * Returns a reader that returns one character at a time.
-   */
+  /** Returns a reader that returns one character at a time. */
   private Reader reader(final String s) {
     /* if (true) */ return new StringReader(s);
     /* return new Reader() {

--- a/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
@@ -114,7 +114,8 @@ public final class JsonWriterTest {
   public void testNameAsTopLevelValue() throws IOException {
     StringWriter stringWriter = new StringWriter();
     JsonWriter jsonWriter = new JsonWriter(stringWriter);
-    IllegalStateException e = assertThrows(IllegalStateException.class, () -> jsonWriter.name("hello"));
+    IllegalStateException e =
+        assertThrows(IllegalStateException.class, () -> jsonWriter.name("hello"));
     assertThat(e).hasMessageThat().isEqualTo("Please begin an object before writing a name.");
 
     jsonWriter.value(12);
@@ -130,7 +131,8 @@ public final class JsonWriterTest {
     JsonWriter jsonWriter = new JsonWriter(stringWriter);
 
     jsonWriter.beginArray();
-    IllegalStateException e = assertThrows(IllegalStateException.class, () -> jsonWriter.name("hello"));
+    IllegalStateException e =
+        assertThrows(IllegalStateException.class, () -> jsonWriter.name("hello"));
     assertThat(e).hasMessageThat().isEqualTo("Please begin an object before writing a name.");
 
     jsonWriter.value(12);
@@ -190,7 +192,8 @@ public final class JsonWriterTest {
     JsonWriter jsonWriter = new JsonWriter(stringWriter);
     jsonWriter.beginArray().endArray();
 
-    IllegalStateException expected = assertThrows(IllegalStateException.class, jsonWriter::beginArray);
+    IllegalStateException expected =
+        assertThrows(IllegalStateException.class, jsonWriter::beginArray);
     assertThat(expected).hasMessageThat().isEqualTo("JSON must have only one top-level value.");
   }
 
@@ -201,7 +204,8 @@ public final class JsonWriterTest {
     jsonWriter.setStrictness(Strictness.STRICT);
     jsonWriter.beginArray().endArray();
 
-    IllegalStateException expected = assertThrows(IllegalStateException.class, jsonWriter::beginArray);
+    IllegalStateException expected =
+        assertThrows(IllegalStateException.class, jsonWriter::beginArray);
     assertThat(expected).hasMessageThat().isEqualTo("JSON must have only one top-level value.");
   }
 
@@ -288,14 +292,23 @@ public final class JsonWriterTest {
     JsonWriter jsonWriter = new JsonWriter(stringWriter);
     jsonWriter.beginArray();
 
-    IllegalArgumentException expected = assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(Float.NaN));
+    IllegalArgumentException expected =
+        assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(Float.NaN));
     assertThat(expected).hasMessageThat().isEqualTo("Numeric values must be finite, but was NaN");
 
-    expected = assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(Float.NEGATIVE_INFINITY));
-    assertThat(expected).hasMessageThat().isEqualTo("Numeric values must be finite, but was -Infinity");
+    expected =
+        assertThrows(
+            IllegalArgumentException.class, () -> jsonWriter.value(Float.NEGATIVE_INFINITY));
+    assertThat(expected)
+        .hasMessageThat()
+        .isEqualTo("Numeric values must be finite, but was -Infinity");
 
-    expected = assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(Float.POSITIVE_INFINITY));
-    assertThat(expected).hasMessageThat().isEqualTo("Numeric values must be finite, but was Infinity");
+    expected =
+        assertThrows(
+            IllegalArgumentException.class, () -> jsonWriter.value(Float.POSITIVE_INFINITY));
+    assertThat(expected)
+        .hasMessageThat()
+        .isEqualTo("Numeric values must be finite, but was Infinity");
   }
 
   @Test
@@ -305,14 +318,23 @@ public final class JsonWriterTest {
     jsonWriter.setStrictness(Strictness.STRICT);
     jsonWriter.beginArray();
 
-    IllegalArgumentException expected = assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(Float.NaN));
+    IllegalArgumentException expected =
+        assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(Float.NaN));
     assertThat(expected).hasMessageThat().isEqualTo("Numeric values must be finite, but was NaN");
 
-    expected = assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(Float.NEGATIVE_INFINITY));
-    assertThat(expected).hasMessageThat().isEqualTo("Numeric values must be finite, but was -Infinity");
+    expected =
+        assertThrows(
+            IllegalArgumentException.class, () -> jsonWriter.value(Float.NEGATIVE_INFINITY));
+    assertThat(expected)
+        .hasMessageThat()
+        .isEqualTo("Numeric values must be finite, but was -Infinity");
 
-    expected = assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(Float.POSITIVE_INFINITY));
-    assertThat(expected).hasMessageThat().isEqualTo("Numeric values must be finite, but was Infinity");
+    expected =
+        assertThrows(
+            IllegalArgumentException.class, () -> jsonWriter.value(Float.POSITIVE_INFINITY));
+    assertThat(expected)
+        .hasMessageThat()
+        .isEqualTo("Numeric values must be finite, but was Infinity");
   }
 
   @Test
@@ -321,14 +343,23 @@ public final class JsonWriterTest {
     JsonWriter jsonWriter = new JsonWriter(stringWriter);
     jsonWriter.beginArray();
 
-    IllegalArgumentException expected = assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(Double.NaN));
+    IllegalArgumentException expected =
+        assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(Double.NaN));
     assertThat(expected).hasMessageThat().isEqualTo("Numeric values must be finite, but was NaN");
 
-    expected = assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(Double.NEGATIVE_INFINITY));
-    assertThat(expected).hasMessageThat().isEqualTo("Numeric values must be finite, but was -Infinity");
+    expected =
+        assertThrows(
+            IllegalArgumentException.class, () -> jsonWriter.value(Double.NEGATIVE_INFINITY));
+    assertThat(expected)
+        .hasMessageThat()
+        .isEqualTo("Numeric values must be finite, but was -Infinity");
 
-    expected = assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(Double.POSITIVE_INFINITY));
-    assertThat(expected).hasMessageThat().isEqualTo("Numeric values must be finite, but was Infinity");
+    expected =
+        assertThrows(
+            IllegalArgumentException.class, () -> jsonWriter.value(Double.POSITIVE_INFINITY));
+    assertThat(expected)
+        .hasMessageThat()
+        .isEqualTo("Numeric values must be finite, but was Infinity");
   }
 
   @Test
@@ -338,14 +369,23 @@ public final class JsonWriterTest {
     jsonWriter.setStrictness(Strictness.STRICT);
     jsonWriter.beginArray();
 
-    IllegalArgumentException expected = assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(Double.NaN));
+    IllegalArgumentException expected =
+        assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(Double.NaN));
     assertThat(expected).hasMessageThat().isEqualTo("Numeric values must be finite, but was NaN");
 
-    expected = assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(Double.NEGATIVE_INFINITY));
-    assertThat(expected).hasMessageThat().isEqualTo("Numeric values must be finite, but was -Infinity");
+    expected =
+        assertThrows(
+            IllegalArgumentException.class, () -> jsonWriter.value(Double.NEGATIVE_INFINITY));
+    assertThat(expected)
+        .hasMessageThat()
+        .isEqualTo("Numeric values must be finite, but was -Infinity");
 
-    expected = assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(Double.POSITIVE_INFINITY));
-    assertThat(expected).hasMessageThat().isEqualTo("Numeric values must be finite, but was Infinity");
+    expected =
+        assertThrows(
+            IllegalArgumentException.class, () -> jsonWriter.value(Double.POSITIVE_INFINITY));
+    assertThat(expected)
+        .hasMessageThat()
+        .isEqualTo("Numeric values must be finite, but was Infinity");
   }
 
   @Test
@@ -354,17 +394,34 @@ public final class JsonWriterTest {
     JsonWriter jsonWriter = new JsonWriter(stringWriter);
     jsonWriter.beginArray();
 
-    IllegalArgumentException expected = assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(Double.valueOf(Double.NaN)));
+    IllegalArgumentException expected =
+        assertThrows(
+            IllegalArgumentException.class, () -> jsonWriter.value(Double.valueOf(Double.NaN)));
     assertThat(expected).hasMessageThat().isEqualTo("Numeric values must be finite, but was NaN");
 
-    expected = assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(Double.valueOf(Double.NEGATIVE_INFINITY)));
-    assertThat(expected).hasMessageThat().isEqualTo("Numeric values must be finite, but was -Infinity");
+    expected =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> jsonWriter.value(Double.valueOf(Double.NEGATIVE_INFINITY)));
+    assertThat(expected)
+        .hasMessageThat()
+        .isEqualTo("Numeric values must be finite, but was -Infinity");
 
-    expected = assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(Double.valueOf(Double.POSITIVE_INFINITY)));
-    assertThat(expected).hasMessageThat().isEqualTo("Numeric values must be finite, but was Infinity");
+    expected =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> jsonWriter.value(Double.valueOf(Double.POSITIVE_INFINITY)));
+    assertThat(expected)
+        .hasMessageThat()
+        .isEqualTo("Numeric values must be finite, but was Infinity");
 
-    expected = assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(new LazilyParsedNumber("Infinity")));
-    assertThat(expected).hasMessageThat().isEqualTo("Numeric values must be finite, but was Infinity");
+    expected =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> jsonWriter.value(new LazilyParsedNumber("Infinity")));
+    assertThat(expected)
+        .hasMessageThat()
+        .isEqualTo("Numeric values must be finite, but was Infinity");
   }
 
   @Test
@@ -374,17 +431,34 @@ public final class JsonWriterTest {
     jsonWriter.setStrictness(Strictness.STRICT);
     jsonWriter.beginArray();
 
-    IllegalArgumentException expected = assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(Double.valueOf(Double.NaN)));
+    IllegalArgumentException expected =
+        assertThrows(
+            IllegalArgumentException.class, () -> jsonWriter.value(Double.valueOf(Double.NaN)));
     assertThat(expected).hasMessageThat().isEqualTo("Numeric values must be finite, but was NaN");
 
-    expected = assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(Double.valueOf(Double.NEGATIVE_INFINITY)));
-    assertThat(expected).hasMessageThat().isEqualTo("Numeric values must be finite, but was -Infinity");
+    expected =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> jsonWriter.value(Double.valueOf(Double.NEGATIVE_INFINITY)));
+    assertThat(expected)
+        .hasMessageThat()
+        .isEqualTo("Numeric values must be finite, but was -Infinity");
 
-    expected = assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(Double.valueOf(Double.POSITIVE_INFINITY)));
-    assertThat(expected).hasMessageThat().isEqualTo("Numeric values must be finite, but was Infinity");
+    expected =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> jsonWriter.value(Double.valueOf(Double.POSITIVE_INFINITY)));
+    assertThat(expected)
+        .hasMessageThat()
+        .isEqualTo("Numeric values must be finite, but was Infinity");
 
-    expected = assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(new LazilyParsedNumber("Infinity")));
-    assertThat(expected).hasMessageThat().isEqualTo("Numeric values must be finite, but was Infinity");
+    expected =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> jsonWriter.value(new LazilyParsedNumber("Infinity")));
+    assertThat(expected)
+        .hasMessageThat()
+        .isEqualTo("Numeric values must be finite, but was Infinity");
   }
 
   @Test
@@ -444,16 +518,18 @@ public final class JsonWriterTest {
     jsonWriter.value((float) Math.E);
     jsonWriter.endArray();
     jsonWriter.close();
-    assertThat(stringWriter.toString()).isEqualTo("[-0.0,"
-        + "1.0,"
-        + "3.4028235E38,"
-        + "1.4E-45,"
-        + "0.0,"
-        + "-0.5,"
-        + "2.2250739E-38,"
-        + "3.723379,"
-        + "3.1415927,"
-        + "2.7182817]");
+    assertThat(stringWriter.toString())
+        .isEqualTo(
+            "[-0.0,"
+                + "1.0,"
+                + "3.4028235E38,"
+                + "1.4E-45,"
+                + "0.0,"
+                + "-0.5,"
+                + "2.2250739E-38,"
+                + "3.723379,"
+                + "3.1415927,"
+                + "2.7182817]");
   }
 
   @Test
@@ -472,15 +548,17 @@ public final class JsonWriterTest {
     jsonWriter.value(Math.E);
     jsonWriter.endArray();
     jsonWriter.close();
-    assertThat(stringWriter.toString()).isEqualTo("[-0.0,"
-        + "1.0,"
-        + "1.7976931348623157E308,"
-        + "4.9E-324,"
-        + "0.0,"
-        + "-0.5,"
-        + "2.2250738585072014E-308,"
-        + "3.141592653589793,"
-        + "2.718281828459045]");
+    assertThat(stringWriter.toString())
+        .isEqualTo(
+            "[-0.0,"
+                + "1.0,"
+                + "1.7976931348623157E308,"
+                + "4.9E-324,"
+                + "0.0,"
+                + "-0.5,"
+                + "2.2250738585072014E-308,"
+                + "3.141592653589793,"
+                + "2.718281828459045]");
   }
 
   @Test
@@ -495,11 +573,8 @@ public final class JsonWriterTest {
     jsonWriter.value(Long.MAX_VALUE);
     jsonWriter.endArray();
     jsonWriter.close();
-    assertThat(stringWriter.toString()).isEqualTo("[0,"
-        + "1,"
-        + "-1,"
-        + "-9223372036854775808,"
-        + "9223372036854775807]");
+    assertThat(stringWriter.toString())
+        .isEqualTo("[0," + "1," + "-1," + "-9223372036854775808," + "9223372036854775807]");
   }
 
   @Test
@@ -513,36 +588,36 @@ public final class JsonWriterTest {
     jsonWriter.value(new BigDecimal("3.141592653589793238462643383"));
     jsonWriter.endArray();
     jsonWriter.close();
-    assertThat(stringWriter.toString()).isEqualTo("[0,"
-        + "9223372036854775808,"
-        + "-9223372036854775809,"
-        + "3.141592653589793238462643383]");
+    assertThat(stringWriter.toString())
+        .isEqualTo(
+            "[0,"
+                + "9223372036854775808,"
+                + "-9223372036854775809,"
+                + "3.141592653589793238462643383]");
   }
 
-  /**
-   * Tests writing {@code Number} instances which are not one of the standard JDK ones.
-   */
+  /** Tests writing {@code Number} instances which are not one of the standard JDK ones. */
   @Test
   public void testNumbersCustomClass() throws IOException {
     String[] validNumbers = {
-        "-0.0",
-        "1.0",
-        "1.7976931348623157E308",
-        "4.9E-324",
-        "0.0",
-        "0.00",
-        "-0.5",
-        "2.2250738585072014E-308",
-        "3.141592653589793",
-        "2.718281828459045",
-        "0",
-        "0.01",
-        "0e0",
-        "1e+0",
-        "1e-0",
-        "1e0000", // leading 0 is allowed for exponent
-        "1e00001",
-        "1e+1",
+      "-0.0",
+      "1.0",
+      "1.7976931348623157E308",
+      "4.9E-324",
+      "0.0",
+      "0.00",
+      "-0.5",
+      "2.2250738585072014E-308",
+      "3.141592653589793",
+      "2.718281828459045",
+      "0",
+      "0.01",
+      "0e0",
+      "1e+0",
+      "1e-0",
+      "1e0000", // leading 0 is allowed for exponent
+      "1e00001",
+      "1e+1",
     };
 
     for (String validNumber : validNumbers) {
@@ -559,30 +634,30 @@ public final class JsonWriterTest {
   @Test
   public void testMalformedNumbers() throws IOException {
     String[] malformedNumbers = {
-        "some text",
-        "",
-        ".",
-        "00",
-        "01",
-        "-00",
-        "-",
-        "--1",
-        "+1", // plus sign is not allowed for integer part
-        "+",
-        "1,0",
-        "1,000",
-        "0.", // decimal digit is required
-        ".1", // integer part is required
-        "e1",
-        ".e1",
-        ".1e1",
-        "1e-",
-        "1e+",
-        "1e--1",
-        "1e+-1",
-        "1e1e1",
-        "1+e1",
-        "1e1.0",
+      "some text",
+      "",
+      ".",
+      "00",
+      "01",
+      "-00",
+      "-",
+      "--1",
+      "+1", // plus sign is not allowed for integer part
+      "+",
+      "1,0",
+      "1,000",
+      "0.", // decimal digit is required
+      ".1", // integer part is required
+      "e1",
+      ".e1",
+      ".1e1",
+      "1e-",
+      "1e+",
+      "1e--1",
+      "1e+-1",
+      "1e1e1",
+      "1+e1",
+      "1e1.0",
     };
 
     for (String malformedNumber : malformedNumbers) {
@@ -591,7 +666,12 @@ public final class JsonWriterTest {
         jsonWriter.value(new LazilyParsedNumber(malformedNumber));
         fail("Should have failed writing malformed number: " + malformedNumber);
       } catch (IllegalArgumentException e) {
-        assertThat(e).hasMessageThat().isEqualTo("String created by class com.google.gson.internal.LazilyParsedNumber is not a valid JSON number: " + malformedNumber);
+        assertThat(e)
+            .hasMessageThat()
+            .isEqualTo(
+                "String created by class com.google.gson.internal.LazilyParsedNumber is not a valid"
+                    + " JSON number: "
+                    + malformedNumber);
       }
     }
   }
@@ -653,24 +733,26 @@ public final class JsonWriterTest {
     jsonWriter.value("\0");
     jsonWriter.value("\u0019");
     jsonWriter.endArray();
-    assertThat(stringWriter.toString()).isEqualTo("[\"a\","
-        + "\"a\\\"\","
-        + "\"\\\"\","
-        + "\":\","
-        + "\",\","
-        + "\"\\b\","
-        + "\"\\f\","
-        + "\"\\n\","
-        + "\"\\r\","
-        + "\"\\t\","
-        + "\" \","
-        + "\"\\\\\","
-        + "\"{\","
-        + "\"}\","
-        + "\"[\","
-        + "\"]\","
-        + "\"\\u0000\","
-        + "\"\\u0019\"]");
+    assertThat(stringWriter.toString())
+        .isEqualTo(
+            "[\"a\","
+                + "\"a\\\"\","
+                + "\"\\\"\","
+                + "\":\","
+                + "\",\","
+                + "\"\\b\","
+                + "\"\\f\","
+                + "\"\\n\","
+                + "\"\\r\","
+                + "\"\\t\","
+                + "\" \","
+                + "\"\\\\\","
+                + "\"{\","
+                + "\"}\","
+                + "\"[\","
+                + "\"]\","
+                + "\"\\u0000\","
+                + "\"\\u0019\"]");
   }
 
   @Test
@@ -680,8 +762,8 @@ public final class JsonWriterTest {
     jsonWriter.beginArray();
     jsonWriter.value("\u2028 \u2029");
     jsonWriter.endArray();
-    // JSON specification does not require that they are escaped, but Gson escapes them for compatibility with JavaScript
-    // where they are considered line breaks
+    // JSON specification does not require that they are escaped, but Gson escapes them for
+    // compatibility with JavaScript where they are considered line breaks
     assertThat(stringWriter.toString()).isEqualTo("[\"\\u2028 \\u2029\"]");
   }
 
@@ -717,8 +799,8 @@ public final class JsonWriterTest {
     jsonWriter.name("d").value(true);
     jsonWriter.endObject();
     jsonWriter.endArray();
-    assertThat(stringWriter.toString()).isEqualTo("[{\"a\":5,\"b\":false},"
-        + "{\"c\":6,\"d\":true}]");
+    assertThat(stringWriter.toString())
+        .isEqualTo("[{\"a\":5,\"b\":false}," + "{\"c\":6,\"d\":true}]");
   }
 
   @Test
@@ -737,8 +819,7 @@ public final class JsonWriterTest {
     jsonWriter.value(true);
     jsonWriter.endArray();
     jsonWriter.endObject();
-    assertThat(stringWriter.toString()).isEqualTo("{\"a\":[5,false],"
-        + "\"b\":[6,true]}");
+    assertThat(stringWriter.toString()).isEqualTo("{\"a\":[5,false]," + "\"b\":[6,true]}");
   }
 
   @Test
@@ -767,9 +848,11 @@ public final class JsonWriterTest {
       jsonWriter.endObject();
     }
     jsonWriter.endObject();
-    assertThat(stringWriter.toString()).isEqualTo("{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":"
-        + "{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{"
-        + "}}}}}}}}}}}}}}}}}}}}}");
+    assertThat(stringWriter.toString())
+        .isEqualTo(
+            "{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":"
+                + "{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{"
+                + "}}}}}}}}}}}}}}}}}}}}}");
   }
 
   @Test
@@ -805,20 +888,21 @@ public final class JsonWriterTest {
     jsonWriter.endObject();
     jsonWriter.endObject();
 
-    String expected = "{\n"
-        + "   \"a\": true,\n"
-        + "   \"b\": false,\n"
-        + "   \"c\": 5.0,\n"
-        + "   \"e\": null,\n"
-        + "   \"f\": [\n"
-        + "      6.0,\n"
-        + "      7.0\n"
-        + "   ],\n"
-        + "   \"g\": {\n"
-        + "      \"h\": 8.0,\n"
-        + "      \"i\": 9.0\n"
-        + "   }\n"
-        + "}";
+    String expected =
+        "{\n"
+            + "   \"a\": true,\n"
+            + "   \"b\": false,\n"
+            + "   \"c\": 5.0,\n"
+            + "   \"e\": null,\n"
+            + "   \"f\": [\n"
+            + "      6.0,\n"
+            + "      7.0\n"
+            + "   ],\n"
+            + "   \"g\": {\n"
+            + "      \"h\": 8.0,\n"
+            + "      \"i\": 9.0\n"
+            + "   }\n"
+            + "}";
     assertThat(stringWriter.toString()).isEqualTo(expected);
   }
 
@@ -843,20 +927,21 @@ public final class JsonWriterTest {
     jsonWriter.endArray();
     jsonWriter.endArray();
 
-    String expected = "[\n"
-        + "   true,\n"
-        + "   false,\n"
-        + "   5.0,\n"
-        + "   null,\n"
-        + "   {\n"
-        + "      \"a\": 6.0,\n"
-        + "      \"b\": 7.0\n"
-        + "   },\n"
-        + "   [\n"
-        + "      8.0,\n"
-        + "      9.0\n"
-        + "   ]\n"
-        + "]";
+    String expected =
+        "[\n"
+            + "   true,\n"
+            + "   false,\n"
+            + "   5.0,\n"
+            + "   null,\n"
+            + "   {\n"
+            + "      \"a\": 6.0,\n"
+            + "      \"b\": 7.0\n"
+            + "   },\n"
+            + "   [\n"
+            + "      8.0,\n"
+            + "      9.0\n"
+            + "   ]\n"
+            + "]";
     assertThat(stringWriter.toString()).isEqualTo(expected);
   }
 
@@ -949,7 +1034,8 @@ public final class JsonWriterTest {
     JsonWriter jsonWriter = new JsonWriter(stringWriter);
     // Default should be FormattingStyle.COMPACT
     assertThat(jsonWriter.getFormattingStyle()).isSameInstanceAs(FormattingStyle.COMPACT);
-    jsonWriter.setFormattingStyle(FormattingStyle.PRETTY.withIndent(" \t ").withNewline(lineSeparator));
+    jsonWriter.setFormattingStyle(
+        FormattingStyle.PRETTY.withIndent(" \t ").withNewline(lineSeparator));
 
     jsonWriter.beginArray();
     jsonWriter.value(true);
@@ -958,12 +1044,8 @@ public final class JsonWriterTest {
     jsonWriter.nullValue();
     jsonWriter.endArray();
 
-    String expected = "[\r\n"
-        + " \t true,\r\n"
-        + " \t \"text\",\r\n"
-        + " \t 5.0,\r\n"
-        + " \t null\r\n"
-        + "]";
+    String expected =
+        "[\r\n" + " \t true,\r\n" + " \t \"text\",\r\n" + " \t 5.0,\r\n" + " \t null\r\n" + "]";
     assertThat(stringWriter.toString()).isEqualTo(expected);
 
     assertThat(jsonWriter.getFormattingStyle().getNewline()).isEqualTo(lineSeparator);
@@ -985,12 +1067,7 @@ public final class JsonWriterTest {
     jsonWriter.endArray();
     jsonWriter.endObject();
 
-    String expected = "{\n"
-        + "  \"a\": [\n"
-        + "    1,\n"
-        + "    2\n"
-        + "  ]\n"
-        + "}";
+    String expected = "{\n" + "  \"a\": [\n" + "    1,\n" + "    2\n" + "  ]\n" + "}";
     assertThat(stringWriter.toString()).isEqualTo(expected);
   }
 }

--- a/metrics/src/main/java/com/google/gson/metrics/BagOfPrimitives.java
+++ b/metrics/src/main/java/com/google/gson/metrics/BagOfPrimitives.java
@@ -46,10 +46,18 @@ public class BagOfPrimitives {
 
   public String getExpectedJson() {
     return "{"
-        + "\"longValue\":" + longValue + ","
-        + "\"intValue\":" + intValue + ","
-        + "\"booleanValue\":" + booleanValue + ","
-        + "\"stringValue\":\"" + stringValue + "\""
+        + "\"longValue\":"
+        + longValue
+        + ","
+        + "\"intValue\":"
+        + intValue
+        + ","
+        + "\"booleanValue\":"
+        + booleanValue
+        + ","
+        + "\"stringValue\":\""
+        + stringValue
+        + "\""
         + "}";
   }
 
@@ -81,7 +89,8 @@ public class BagOfPrimitives {
 
   @Override
   public String toString() {
-    return String.format("(longValue=%d,intValue=%d,booleanValue=%b,stringValue=%s)",
+    return String.format(
+        "(longValue=%d,intValue=%d,booleanValue=%b,stringValue=%s)",
         longValue, intValue, booleanValue, stringValue);
   }
 }

--- a/metrics/src/main/java/com/google/gson/metrics/BagOfPrimitivesDeserializationBenchmark.java
+++ b/metrics/src/main/java/com/google/gson/metrics/BagOfPrimitivesDeserializationBenchmark.java
@@ -37,7 +37,7 @@ public class BagOfPrimitivesDeserializationBenchmark {
   public static void main(String[] args) {
     NonUploadingCaliperRunner.run(BagOfPrimitivesDeserializationBenchmark.class, args);
   }
-  
+
   @BeforeExperiment
   void setUp() throws Exception {
     this.gson = new Gson();
@@ -45,20 +45,16 @@ public class BagOfPrimitivesDeserializationBenchmark {
     this.json = gson.toJson(bag);
   }
 
-  /** 
-   * Benchmark to measure Gson performance for deserializing an object
-   */
+  /** Benchmark to measure Gson performance for deserializing an object */
   public void timeBagOfPrimitivesDefault(int reps) {
-    for (int i=0; i<reps; ++i) {
+    for (int i = 0; i < reps; ++i) {
       gson.fromJson(json, BagOfPrimitives.class);
     }
   }
 
-  /**
-   * Benchmark to measure deserializing objects by hand
-   */
+  /** Benchmark to measure deserializing objects by hand */
   public void timeBagOfPrimitivesStreaming(int reps) throws IOException {
-    for (int i=0; i<reps; ++i) {
+    for (int i = 0; i < reps; ++i) {
       StringReader reader = new StringReader(json);
       JsonReader jr = new JsonReader(reader);
       jr.beginObject();
@@ -91,7 +87,7 @@ public class BagOfPrimitivesDeserializationBenchmark {
    * and {@link #timeBagOfPrimitivesDefault(int)} .
    */
   public void timeBagOfPrimitivesReflectionStreaming(int reps) throws Exception {
-    for (int i=0; i<reps; ++i) {
+    for (int i = 0; i < reps; ++i) {
       StringReader reader = new StringReader(json);
       JsonReader jr = new JsonReader(reader);
       jr.beginObject();

--- a/metrics/src/main/java/com/google/gson/metrics/CollectionsDeserializationBenchmark.java
+++ b/metrics/src/main/java/com/google/gson/metrics/CollectionsDeserializationBenchmark.java
@@ -33,7 +33,8 @@ import java.util.List;
  */
 public class CollectionsDeserializationBenchmark {
 
-  private static final TypeToken<List<BagOfPrimitives>> LIST_TYPE_TOKEN = new TypeToken<List<BagOfPrimitives>>(){};
+  private static final TypeToken<List<BagOfPrimitives>> LIST_TYPE_TOKEN =
+      new TypeToken<List<BagOfPrimitives>>() {};
   private static final Type LIST_TYPE = LIST_TYPE_TOKEN.getType();
   private Gson gson;
   private String json;
@@ -52,18 +53,14 @@ public class CollectionsDeserializationBenchmark {
     this.json = gson.toJson(bags, LIST_TYPE);
   }
 
-  /**
-   * Benchmark to measure Gson performance for deserializing an object
-   */
+  /** Benchmark to measure Gson performance for deserializing an object */
   public void timeCollectionsDefault(int reps) {
     for (int i = 0; i < reps; ++i) {
       gson.fromJson(json, LIST_TYPE_TOKEN);
     }
   }
 
-  /**
-   * Benchmark to measure deserializing objects by hand
-   */
+  /** Benchmark to measure deserializing objects by hand */
   @SuppressWarnings("ModifiedButNotUsed")
   public void timeCollectionsStreaming(int reps) throws IOException {
     for (int i = 0; i < reps; ++i) {

--- a/metrics/src/main/java/com/google/gson/metrics/NonUploadingCaliperRunner.java
+++ b/metrics/src/main/java/com/google/gson/metrics/NonUploadingCaliperRunner.java
@@ -21,7 +21,7 @@ import com.google.caliper.runner.CaliperMain;
 class NonUploadingCaliperRunner {
   private static String[] concat(String first, String... others) {
     if (others.length == 0) {
-      return new String[] { first };
+      return new String[] {first};
     } else {
       String[] result = new String[others.length + 1];
       result[0] = first;
@@ -31,7 +31,8 @@ class NonUploadingCaliperRunner {
   }
 
   public static void run(Class<?> c, String[] args) {
-    // Disable result upload; Caliper uploads results to webapp by default, see https://github.com/google/caliper/issues/356
+    // Disable result upload; Caliper uploads results to webapp by default, see
+    // https://github.com/google/caliper/issues/356
     CaliperMain.main(c, concat("-Cresults.upload.options.url=", args));
   }
 }

--- a/metrics/src/main/java/com/google/gson/metrics/ParseBenchmark.java
+++ b/metrics/src/main/java/com/google/gson/metrics/ParseBenchmark.java
@@ -50,9 +50,8 @@ import java.util.zip.ZipFile;
 /**
  * Measure Gson and Jackson parsing and binding performance.
  *
- * <p>This benchmark requires that ParseBenchmarkData.zip is on the classpath.
- * That file contains Twitter feed data, which is representative of what
- * applications will be parsing.
+ * <p>This benchmark requires that ParseBenchmarkData.zip is on the classpath. That file contains
+ * Twitter feed data, which is representative of what applications will be parsing.
  */
 public final class ParseBenchmark {
   @Param Document document;
@@ -65,6 +64,7 @@ public final class ParseBenchmark {
 
     @SuppressWarnings("ImmutableEnumChecker")
     private final TypeToken<?> gsonType;
+
     @SuppressWarnings("ImmutableEnumChecker")
     private final TypeReference<?> jacksonType;
 
@@ -76,35 +76,42 @@ public final class ParseBenchmark {
 
   private enum Api {
     JACKSON_STREAM {
-      @Override Parser newParser() {
+      @Override
+      Parser newParser() {
         return new JacksonStreamParser();
       }
     },
     JACKSON_BIND {
-      @Override Parser newParser() {
+      @Override
+      Parser newParser() {
         return new JacksonBindParser();
       }
     },
     GSON_STREAM {
-      @Override Parser newParser() {
+      @Override
+      Parser newParser() {
         return new GsonStreamParser();
       }
     },
     GSON_SKIP {
-      @Override Parser newParser() {
+      @Override
+      Parser newParser() {
         return new GsonSkipParser();
       }
     },
     GSON_DOM {
-      @Override Parser newParser() {
+      @Override
+      Parser newParser() {
         return new GsonDomParser();
       }
     },
     GSON_BIND {
-      @Override Parser newParser() {
+      @Override
+      Parser newParser() {
         return new GsonBindParser();
       }
     };
+
     abstract Parser newParser();
   }
 
@@ -139,7 +146,8 @@ public final class ParseBenchmark {
     ZipFile zipFile = new ZipFile(getResourceFile("/ParseBenchmarkData.zip"));
     try {
       ZipEntry zipEntry = zipFile.getEntry(fileName);
-      Reader reader = new InputStreamReader(zipFile.getInputStream(zipEntry), StandardCharsets.UTF_8);
+      Reader reader =
+          new InputStreamReader(zipFile.getInputStream(zipEntry), StandardCharsets.UTF_8);
       char[] buffer = new char[8192];
       StringWriter writer = new StringWriter();
       int count;
@@ -165,8 +173,8 @@ public final class ParseBenchmark {
   private static class GsonStreamParser implements Parser {
     @Override
     public void parse(char[] data, Document document) throws Exception {
-      com.google.gson.stream.JsonReader jsonReader
-          = new com.google.gson.stream.JsonReader(new CharArrayReader(data));
+      com.google.gson.stream.JsonReader jsonReader =
+          new com.google.gson.stream.JsonReader(new CharArrayReader(data));
       readToken(jsonReader);
       jsonReader.close();
     }
@@ -174,37 +182,37 @@ public final class ParseBenchmark {
     private void readToken(com.google.gson.stream.JsonReader reader) throws IOException {
       while (true) {
         switch (reader.peek()) {
-        case BEGIN_ARRAY:
-          reader.beginArray();
-          break;
-        case END_ARRAY:
-          reader.endArray();
-          break;
-        case BEGIN_OBJECT:
-          reader.beginObject();
-          break;
-        case END_OBJECT:
-          reader.endObject();
-          break;
-        case NAME:
-          reader.nextName();
-          break;
-        case BOOLEAN:
-          reader.nextBoolean();
-          break;
-        case NULL:
-          reader.nextNull();
-          break;
-        case NUMBER:
-          reader.nextLong();
-          break;
-        case STRING:
-          reader.nextString();
-          break;
-        case END_DOCUMENT:
-          return;
-        default:
-          throw new IllegalArgumentException("Unexpected token" + reader.peek());
+          case BEGIN_ARRAY:
+            reader.beginArray();
+            break;
+          case END_ARRAY:
+            reader.endArray();
+            break;
+          case BEGIN_OBJECT:
+            reader.beginObject();
+            break;
+          case END_OBJECT:
+            reader.endObject();
+            break;
+          case NAME:
+            reader.nextName();
+            break;
+          case BOOLEAN:
+            reader.nextBoolean();
+            break;
+          case NULL:
+            reader.nextNull();
+            break;
+          case NUMBER:
+            reader.nextLong();
+            break;
+          case STRING:
+            reader.nextString();
+            break;
+          case END_DOCUMENT:
+            return;
+          default:
+            throw new IllegalArgumentException("Unexpected token" + reader.peek());
         }
       }
     }
@@ -213,8 +221,8 @@ public final class ParseBenchmark {
   private static class GsonSkipParser implements Parser {
     @Override
     public void parse(char[] data, Document document) throws Exception {
-      com.google.gson.stream.JsonReader jsonReader
-          = new com.google.gson.stream.JsonReader(new CharArrayReader(data));
+      com.google.gson.stream.JsonReader jsonReader =
+          new com.google.gson.stream.JsonReader(new CharArrayReader(data));
       jsonReader.skipValue();
       jsonReader.close();
     }
@@ -223,39 +231,43 @@ public final class ParseBenchmark {
   private static class JacksonStreamParser implements Parser {
     @Override
     public void parse(char[] data, Document document) throws Exception {
-      JsonFactory jsonFactory = new JsonFactoryBuilder().configure(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES, false).build();
-      com.fasterxml.jackson.core.JsonParser jp = jsonFactory.createParser(new CharArrayReader(data));
+      JsonFactory jsonFactory =
+          new JsonFactoryBuilder()
+              .configure(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES, false)
+              .build();
+      com.fasterxml.jackson.core.JsonParser jp =
+          jsonFactory.createParser(new CharArrayReader(data));
       int depth = 0;
       do {
         JsonToken token = jp.nextToken();
         switch (token) {
-        case START_OBJECT:
-        case START_ARRAY:
-          depth++;
-          break;
-        case END_OBJECT:
-        case END_ARRAY:
-          depth--;
-          break;
-        case FIELD_NAME:
-          jp.getCurrentName();
-          break;
-        case VALUE_STRING:
-          jp.getText();
-          break;
-        case VALUE_NUMBER_INT:
-        case VALUE_NUMBER_FLOAT:
-          jp.getLongValue();
-          break;
-        case VALUE_TRUE:
-        case VALUE_FALSE:
-          jp.getBooleanValue();
-          break;
-        case VALUE_NULL:
-          // Do nothing; nextToken() will advance in stream
-          break;
-        default:
-          throw new IllegalArgumentException("Unexpected token " + token);
+          case START_OBJECT:
+          case START_ARRAY:
+            depth++;
+            break;
+          case END_OBJECT:
+          case END_ARRAY:
+            depth--;
+            break;
+          case FIELD_NAME:
+            jp.getCurrentName();
+            break;
+          case VALUE_STRING:
+            jp.getText();
+            break;
+          case VALUE_NUMBER_INT:
+          case VALUE_NUMBER_FLOAT:
+            jp.getLongValue();
+            break;
+          case VALUE_TRUE:
+          case VALUE_FALSE:
+            jp.getBooleanValue();
+            break;
+          case VALUE_NULL:
+            // Do nothing; nextToken() will advance in stream
+            break;
+          default:
+            throw new IllegalArgumentException("Unexpected token " + token);
         }
       } while (depth > 0);
       jp.close();
@@ -270,9 +282,8 @@ public final class ParseBenchmark {
   }
 
   private static class GsonBindParser implements Parser {
-    private static final Gson gson = new GsonBuilder()
-        .setDateFormat("EEE MMM dd HH:mm:ss Z yyyy")
-        .create();
+    private static final Gson gson =
+        new GsonBuilder().setDateFormat("EEE MMM dd HH:mm:ss Z yyyy").create();
 
     @Override
     public void parse(char[] data, Document document) throws Exception {
@@ -284,10 +295,11 @@ public final class ParseBenchmark {
     private static final ObjectMapper mapper;
 
     static {
-      mapper = JsonMapper.builder()
-        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-        .configure(MapperFeature.AUTO_DETECT_FIELDS, true)
-        .build();
+      mapper =
+          JsonMapper.builder()
+              .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+              .configure(MapperFeature.AUTO_DETECT_FIELDS, true)
+              .build();
       mapper.setDateFormat(new SimpleDateFormat("EEE MMM dd HH:mm:ss Z yyyy", Locale.ENGLISH));
     }
 
@@ -341,7 +353,11 @@ public final class ParseBenchmark {
     @JsonProperty boolean profile_use_background_image;
     @JsonProperty int listed_count;
     @JsonProperty String lang;
-    @JsonProperty("protected") @SerializedName("protected") boolean isProtected;
+
+    @JsonProperty("protected")
+    @SerializedName("protected")
+    boolean isProtected;
+
     @JsonProperty int followers_count;
     @JsonProperty String profile_text_color;
     @JsonProperty String profile_background_color;
@@ -363,17 +379,27 @@ public final class ParseBenchmark {
     @JsonProperty String id;
     @JsonProperty String title;
     @JsonProperty String description;
-    @JsonProperty("alternate") @SerializedName("alternate") List<Link> alternates;
+
+    @JsonProperty("alternate")
+    @SerializedName("alternate")
+    List<Link> alternates;
+
     @JsonProperty long updated;
     @JsonProperty List<Item> items;
 
-    @Override public String toString() {
-      StringBuilder result = new StringBuilder()
-          .append(id)
-          .append("\n").append(title)
-          .append("\n").append(description)
-          .append("\n").append(alternates)
-          .append("\n").append(updated);
+    @Override
+    public String toString() {
+      StringBuilder result =
+          new StringBuilder()
+              .append(id)
+              .append("\n")
+              .append(title)
+              .append("\n")
+              .append(description)
+              .append("\n")
+              .append(alternates)
+              .append("\n")
+              .append(updated);
       int i = 1;
       for (Item item : items) {
         result.append(i++).append(": ").append(item).append("\n\n");
@@ -385,7 +411,8 @@ public final class ParseBenchmark {
   static class Link {
     @JsonProperty String href;
 
-    @Override public String toString() {
+    @Override
+    public String toString() {
       return href;
     }
   }
@@ -395,27 +422,40 @@ public final class ParseBenchmark {
     @JsonProperty String title;
     @JsonProperty long published;
     @JsonProperty long updated;
-    @JsonProperty("alternate") @SerializedName("alternate") List<Link> alternates;
+
+    @JsonProperty("alternate")
+    @SerializedName("alternate")
+    List<Link> alternates;
+
     @JsonProperty Content content;
     @JsonProperty String author;
     @JsonProperty List<ReaderUser> likingUsers;
 
-    @Override public String toString() {
+    @Override
+    public String toString() {
       return title
-          + "\nauthor: " + author
-          + "\npublished: " + published
-          + "\nupdated: " + updated
-          + "\n" + content
-          + "\nliking users: " + likingUsers
-          + "\nalternates: " + alternates
-          + "\ncategories: " + categories;
+          + "\nauthor: "
+          + author
+          + "\npublished: "
+          + published
+          + "\nupdated: "
+          + updated
+          + "\n"
+          + content
+          + "\nliking users: "
+          + likingUsers
+          + "\nalternates: "
+          + alternates
+          + "\ncategories: "
+          + categories;
     }
   }
 
   static class Content {
     @JsonProperty String content;
 
-    @Override public String toString() {
+    @Override
+    public String toString() {
       return content;
     }
   }
@@ -423,7 +463,8 @@ public final class ParseBenchmark {
   static class ReaderUser {
     @JsonProperty String userId;
 
-    @Override public String toString() {
+    @Override
+    public String toString() {
       return userId;
     }
   }

--- a/metrics/src/main/java/com/google/gson/metrics/SerializationBenchmark.java
+++ b/metrics/src/main/java/com/google/gson/metrics/SerializationBenchmark.java
@@ -31,13 +31,12 @@ public class SerializationBenchmark {
 
   private Gson gson;
   private BagOfPrimitives bag;
-  @Param
-  private boolean pretty;
+  @Param private boolean pretty;
 
   public static void main(String[] args) {
     NonUploadingCaliperRunner.run(SerializationBenchmark.class, args);
   }
-  
+
   @BeforeExperiment
   void setUp() throws Exception {
     this.gson = pretty ? new GsonBuilder().setPrettyPrinting().create() : new Gson();
@@ -45,7 +44,7 @@ public class SerializationBenchmark {
   }
 
   public void timeObjectSerialization(int reps) {
-    for (int i=0; i<reps; ++i) {
+    for (int i = 0; i < reps; ++i) {
       gson.toJson(bag);
     }
   }

--- a/proto/src/main/java/com/google/gson/protobuf/ProtoTypeAdapter.java
+++ b/proto/src/main/java/com/google/gson/protobuf/ProtoTypeAdapter.java
@@ -52,11 +52,12 @@ import java.util.concurrent.ConcurrentMap;
 /**
  * GSON type adapter for protocol buffers that knows how to serialize enums either by using their
  * values or their names, and also supports custom proto field names.
- * <p>
- * You can specify which case representation is used for the proto fields when writing/reading the
- * JSON payload by calling {@link Builder#setFieldNameSerializationFormat(CaseFormat, CaseFormat)}.
- * <p>
- * An example of default serialization/deserialization using custom proto field names is shown
+ *
+ * <p>You can specify which case representation is used for the proto fields when writing/reading
+ * the JSON payload by calling {@link Builder#setFieldNameSerializationFormat(CaseFormat,
+ * CaseFormat)}.
+ *
+ * <p>An example of default serialization/deserialization using custom proto field names is shown
  * below:
  *
  * <pre>
@@ -70,11 +71,8 @@ import java.util.concurrent.ConcurrentMap;
  * @author Emmanuel Cron
  * @author Stanley Wang
  */
-public class ProtoTypeAdapter
-    implements JsonSerializer<Message>, JsonDeserializer<Message> {
-  /**
-   * Determines how enum <u>values</u> should be serialized.
-   */
+public class ProtoTypeAdapter implements JsonSerializer<Message>, JsonDeserializer<Message> {
+  /** Determines how enum <u>values</u> should be serialized. */
   public enum EnumSerialization {
     /**
      * Serializes and deserializes enum values using their <b>number</b>. When this is used, custom
@@ -85,9 +83,7 @@ public class ProtoTypeAdapter
     NAME;
   }
 
-  /**
-   * Builder for {@link ProtoTypeAdapter}s.
-   */
+  /** Builder for {@link ProtoTypeAdapter}s. */
   public static class Builder {
     private final Set<Extension<FieldOptions, String>> serializedNameExtensions;
     private final Set<Extension<EnumValueOptions, String>> serializedEnumValueExtensions;
@@ -95,7 +91,9 @@ public class ProtoTypeAdapter
     private CaseFormat protoFormat;
     private CaseFormat jsonFormat;
 
-    private Builder(EnumSerialization enumSerialization, CaseFormat fromFieldNameFormat,
+    private Builder(
+        EnumSerialization enumSerialization,
+        CaseFormat fromFieldNameFormat,
         CaseFormat toFieldNameFormat) {
       this.serializedNameExtensions = new HashSet<>();
       this.serializedEnumValueExtensions = new HashSet<>();
@@ -113,8 +111,8 @@ public class ProtoTypeAdapter
      * Sets the field names serialization format. The first parameter defines how to read the format
      * of the proto field names you are converting to JSON. The second parameter defines which
      * format to use when serializing them.
-     * <p>
-     * For example, if you use the following parameters: {@link CaseFormat#LOWER_UNDERSCORE},
+     *
+     * <p>For example, if you use the following parameters: {@link CaseFormat#LOWER_UNDERSCORE},
      * {@link CaseFormat#LOWER_CAMEL}, the following conversion will occur:
      *
      * <pre>{@code
@@ -125,8 +123,8 @@ public class ProtoTypeAdapter
      * }</pre>
      */
     @CanIgnoreReturnValue
-    public Builder setFieldNameSerializationFormat(CaseFormat fromFieldNameFormat,
-        CaseFormat toFieldNameFormat) {
+    public Builder setFieldNameSerializationFormat(
+        CaseFormat fromFieldNameFormat, CaseFormat toFieldNameFormat) {
       this.protoFormat = fromFieldNameFormat;
       this.jsonFormat = toFieldNameFormat;
       return this;
@@ -141,8 +139,8 @@ public class ProtoTypeAdapter
      * string client_app_id = 1 [(serialized_name) = "appId"];
      * </pre>
      *
-     * ...the adapter will serialize the field using '{@code appId}' instead of the default '
-     * {@code clientAppId}'. This lets you customize the name serialization of any proto field.
+     * ...the adapter will serialize the field using '{@code appId}' instead of the default ' {@code
+     * clientAppId}'. This lets you customize the name serialization of any proto field.
      */
     @CanIgnoreReturnValue
     public Builder addSerializedNameExtension(
@@ -153,8 +151,8 @@ public class ProtoTypeAdapter
 
     /**
      * Adds an enum value proto annotation that, when set, overrides the default <b>enum</b> value
-     * serialization/deserialization of this adapter. For example, if you add the '
-     * {@code serialized_value}' annotation and you define an enum in your proto like the one below:
+     * serialization/deserialization of this adapter. For example, if you add the ' {@code
+     * serialized_value}' annotation and you define an enum in your proto like the one below:
      *
      * <pre>
      * enum MyEnum {
@@ -166,9 +164,9 @@ public class ProtoTypeAdapter
      *
      * ...the adapter will serialize the value {@code CLIENT_APP_ID} as "{@code APP_ID}" and the
      * value {@code TWO} as "{@code 2}". This works for both serialization and deserialization.
-     * <p>
-     * Note that you need to set the enum serialization of this adapter to
-     * {@link EnumSerialization#NAME}, otherwise these annotations will be ignored.
+     *
+     * <p>Note that you need to set the enum serialization of this adapter to {@link
+     * EnumSerialization#NAME}, otherwise these annotations will be ignored.
      */
     @CanIgnoreReturnValue
     public Builder addSerializedEnumValueExtension(
@@ -178,15 +176,19 @@ public class ProtoTypeAdapter
     }
 
     public ProtoTypeAdapter build() {
-      return new ProtoTypeAdapter(enumSerialization, protoFormat, jsonFormat,
-          serializedNameExtensions, serializedEnumValueExtensions);
+      return new ProtoTypeAdapter(
+          enumSerialization,
+          protoFormat,
+          jsonFormat,
+          serializedNameExtensions,
+          serializedEnumValueExtensions);
     }
   }
 
   /**
-   * Creates a new {@link ProtoTypeAdapter} builder, defaulting enum serialization to
-   * {@link EnumSerialization#NAME} and converting field serialization from
-   * {@link CaseFormat#LOWER_UNDERSCORE} to {@link CaseFormat#LOWER_CAMEL}.
+   * Creates a new {@link ProtoTypeAdapter} builder, defaulting enum serialization to {@link
+   * EnumSerialization#NAME} and converting field serialization from {@link
+   * CaseFormat#LOWER_UNDERSCORE} to {@link CaseFormat#LOWER_CAMEL}.
    */
   public static Builder newBuilder() {
     return new Builder(EnumSerialization.NAME, CaseFormat.LOWER_UNDERSCORE, CaseFormat.LOWER_CAMEL);
@@ -204,7 +206,8 @@ public class ProtoTypeAdapter
   private final Set<Extension<FieldOptions, String>> serializedNameExtensions;
   private final Set<Extension<EnumValueOptions, String>> serializedEnumValueExtensions;
 
-  private ProtoTypeAdapter(EnumSerialization enumSerialization,
+  private ProtoTypeAdapter(
+      EnumSerialization enumSerialization,
       CaseFormat protoFormat,
       CaseFormat jsonFormat,
       Set<Extension<FieldOptions, String>> serializedNameExtensions,
@@ -217,8 +220,7 @@ public class ProtoTypeAdapter
   }
 
   @Override
-  public JsonElement serialize(Message src, Type typeOfSrc,
-      JsonSerializationContext context) {
+  public JsonElement serialize(Message src, Type typeOfSrc, JsonSerializationContext context) {
     JsonObject ret = new JsonObject();
     final Map<FieldDescriptor, Object> fields = src.getAllFields();
 
@@ -250,8 +252,8 @@ public class ProtoTypeAdapter
   }
 
   @Override
-  public Message deserialize(JsonElement json, Type typeOfT,
-      JsonDeserializationContext context) throws JsonParseException {
+  public Message deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
     try {
       JsonObject jsonObject = json.getAsJsonObject();
       @SuppressWarnings("unchecked")
@@ -356,8 +358,8 @@ public class ProtoTypeAdapter
   }
 
   /**
-   * Returns the enum value to use for serialization, depending on the value of
-   * {@link EnumSerialization} that was given to this adapter.
+   * Returns the enum value to use for serialization, depending on the value of {@link
+   * EnumSerialization} that was given to this adapter.
    */
   private Object getEnumValue(EnumValueDescriptor enumDesc) {
     if (enumSerialization == EnumSerialization.NAME) {
@@ -375,8 +377,8 @@ public class ProtoTypeAdapter
    *
    * @throws IllegalArgumentException if a matching name/number was not found
    */
-  private EnumValueDescriptor findValueByNameAndExtension(EnumDescriptor desc,
-      JsonElement jsonElement) {
+  private EnumValueDescriptor findValueByNameAndExtension(
+      EnumDescriptor desc, JsonElement jsonElement) {
     if (enumSerialization == EnumSerialization.NAME) {
       // With enum name
       for (EnumValueDescriptor enumDesc : desc.getValues()) {
@@ -398,8 +400,9 @@ public class ProtoTypeAdapter
     }
   }
 
-  private static Method getCachedMethod(Class<?> clazz, String methodName,
-      Class<?>... methodParamTypes) throws NoSuchMethodException {
+  private static Method getCachedMethod(
+      Class<?> clazz, String methodName, Class<?>... methodParamTypes)
+      throws NoSuchMethodException {
     ConcurrentMap<Class<?>, Method> mapOfMethods = mapOfMapOfMethods.get(methodName);
     if (mapOfMethods == null) {
       mapOfMethods = new MapMaker().makeMap();
@@ -416,5 +419,4 @@ public class ProtoTypeAdapter
     }
     return method;
   }
-
 }

--- a/proto/src/test/java/com/google/gson/protobuf/functional/ProtosWithAnnotationsTest.java
+++ b/proto/src/test/java/com/google/gson/protobuf/functional/ProtosWithAnnotationsTest.java
@@ -44,117 +44,127 @@ public class ProtosWithAnnotationsTest {
 
   @Before
   public void setUp() throws Exception {
-    ProtoTypeAdapter.Builder protoTypeAdapter = ProtoTypeAdapter.newBuilder()
-        .setEnumSerialization(EnumSerialization.NAME)
-        .addSerializedNameExtension(Annotations.serializedName)
-        .addSerializedEnumValueExtension(Annotations.serializedValue);
-    gson = new GsonBuilder()
-        .registerTypeHierarchyAdapter(GeneratedMessageV3.class, protoTypeAdapter.build())
-        .create();
-    gsonWithEnumNumbers = new GsonBuilder()
-        .registerTypeHierarchyAdapter(GeneratedMessageV3.class, protoTypeAdapter
-            .setEnumSerialization(EnumSerialization.NUMBER)
-            .build())
-        .create();
-    gsonWithLowerHyphen = new GsonBuilder()
-        .registerTypeHierarchyAdapter(GeneratedMessageV3.class, protoTypeAdapter
-            .setFieldNameSerializationFormat(CaseFormat.LOWER_UNDERSCORE, CaseFormat.LOWER_HYPHEN)
-            .build())
-        .create();
+    ProtoTypeAdapter.Builder protoTypeAdapter =
+        ProtoTypeAdapter.newBuilder()
+            .setEnumSerialization(EnumSerialization.NAME)
+            .addSerializedNameExtension(Annotations.serializedName)
+            .addSerializedEnumValueExtension(Annotations.serializedValue);
+    gson =
+        new GsonBuilder()
+            .registerTypeHierarchyAdapter(GeneratedMessageV3.class, protoTypeAdapter.build())
+            .create();
+    gsonWithEnumNumbers =
+        new GsonBuilder()
+            .registerTypeHierarchyAdapter(
+                GeneratedMessageV3.class,
+                protoTypeAdapter.setEnumSerialization(EnumSerialization.NUMBER).build())
+            .create();
+    gsonWithLowerHyphen =
+        new GsonBuilder()
+            .registerTypeHierarchyAdapter(
+                GeneratedMessageV3.class,
+                protoTypeAdapter
+                    .setFieldNameSerializationFormat(
+                        CaseFormat.LOWER_UNDERSCORE, CaseFormat.LOWER_HYPHEN)
+                    .build())
+            .create();
   }
 
   @Test
   public void testProtoWithAnnotations_deserialize() {
-    String json = String.format("{  %n"
-        + "   \"id\":\"41e5e7fd6065d101b97018a465ffff01\",%n"
-        + "   \"expiration_date\":{  %n"
-        + "      \"month\":\"12\",%n"
-        + "      \"year\":\"2017\",%n"
-        + "      \"timeStamp\":\"9864653135687\",%n"
-        + "      \"countryCode5f55\":\"en_US\"%n"
-        + "   },%n"
-        // Don't define innerMessage1
-        + "   \"innerMessage2\":{  %n"
-        // Set a number as a string; it should work
-        + "      \"nIdCt\":\"98798465\",%n"
-        + "      \"content\":\"text/plain\",%n"
-        + "      \"$binary_data$\":[  %n"
-        + "         {  %n"
-        + "            \"data\":\"OFIN8e9fhwoeh8((⁹8efywoih\",%n"
-        // Don't define width
-        + "            \"height\":665%n"
-        + "         },%n"
-        + "         {  %n"
-        // Define as an int; it should work
-        + "            \"data\":65,%n"
-        + "            \"width\":-56684%n"
-        // Don't define height
-        + "         }%n"
-        + "      ]%n"
-        + "   },%n"
-        // Define a bunch of non recognizable data
-        + "   \"non_existing\":\"foobar\",%n"
-        + "   \"stillNot\":{  %n"
-        + "      \"bunch\":\"of_useless data\"%n"
-        + "   }%n"
-        + "}");
+    String json =
+        String.format(
+            "{  %n"
+                + "   \"id\":\"41e5e7fd6065d101b97018a465ffff01\",%n"
+                + "   \"expiration_date\":{  %n"
+                + "      \"month\":\"12\",%n"
+                + "      \"year\":\"2017\",%n"
+                + "      \"timeStamp\":\"9864653135687\",%n"
+                + "      \"countryCode5f55\":\"en_US\"%n"
+                + "   },%n"
+                // Don't define innerMessage1
+                + "   \"innerMessage2\":{  %n"
+                // Set a number as a string; it should work
+                + "      \"nIdCt\":\"98798465\",%n"
+                + "      \"content\":\"text/plain\",%n"
+                + "      \"$binary_data$\":[  %n"
+                + "         {  %n"
+                + "            \"data\":\"OFIN8e9fhwoeh8((⁹8efywoih\",%n"
+                // Don't define width
+                + "            \"height\":665%n"
+                + "         },%n"
+                + "         {  %n"
+                // Define as an int; it should work
+                + "            \"data\":65,%n"
+                + "            \"width\":-56684%n"
+                // Don't define height
+                + "         }%n"
+                + "      ]%n"
+                + "   },%n"
+                // Define a bunch of non recognizable data
+                + "   \"non_existing\":\"foobar\",%n"
+                + "   \"stillNot\":{  %n"
+                + "      \"bunch\":\"of_useless data\"%n"
+                + "   }%n"
+                + "}");
     ProtoWithAnnotations proto = gson.fromJson(json, ProtoWithAnnotations.class);
     assertThat(proto.getId()).isEqualTo("41e5e7fd6065d101b97018a465ffff01");
-    assertThat(proto.getOuterMessage()).isEqualTo(OuterMessage.newBuilder()
-        .setMonth(12)
-        .setYear(2017)
-        .setLongTimestamp(9864653135687L)
-        .setCountryCode5F55("en_US")
-        .build());
+    assertThat(proto.getOuterMessage())
+        .isEqualTo(
+            OuterMessage.newBuilder()
+                .setMonth(12)
+                .setYear(2017)
+                .setLongTimestamp(9864653135687L)
+                .setCountryCode5F55("en_US")
+                .build());
     assertThat(proto.hasInnerMessage1()).isFalse();
-    assertThat(proto.getInnerMessage2()).isEqualTo(InnerMessage.newBuilder()
-        .setNIdCt(98798465)
-        .setContent(InnerMessage.Type.TEXT)
-        .addData(InnerMessage.Data.newBuilder()
-            .setData("OFIN8e9fhwoeh8((⁹8efywoih")
-            .setHeight(665))
-        .addData(InnerMessage.Data.newBuilder()
-            .setData("65")
-            .setWidth(-56684))
-        .build());
+    assertThat(proto.getInnerMessage2())
+        .isEqualTo(
+            InnerMessage.newBuilder()
+                .setNIdCt(98798465)
+                .setContent(InnerMessage.Type.TEXT)
+                .addData(
+                    InnerMessage.Data.newBuilder()
+                        .setData("OFIN8e9fhwoeh8((⁹8efywoih")
+                        .setHeight(665))
+                .addData(InnerMessage.Data.newBuilder().setData("65").setWidth(-56684))
+                .build());
 
     String rebuilt = gson.toJson(proto);
-    assertThat(rebuilt).isEqualTo("{"
-        + "\"id\":\"41e5e7fd6065d101b97018a465ffff01\","
-        + "\"expiration_date\":{"
-        + "\"month\":12,"
-        + "\"year\":2017,"
-        + "\"timeStamp\":9864653135687,"
-        + "\"countryCode5f55\":\"en_US\""
-        + "},"
-        + "\"innerMessage2\":{"
-        + "\"nIdCt\":98798465,"
-        + "\"content\":\"text/plain\","
-        + "\"$binary_data$\":["
-        + "{"
-        + "\"data\":\"OFIN8e9fhwoeh8((⁹8efywoih\","
-        + "\"height\":665"
-        + "},"
-        + "{"
-        + "\"data\":\"65\","
-        + "\"width\":-56684"
-        + "}]}}");
+    assertThat(rebuilt)
+        .isEqualTo(
+            "{"
+                + "\"id\":\"41e5e7fd6065d101b97018a465ffff01\","
+                + "\"expiration_date\":{"
+                + "\"month\":12,"
+                + "\"year\":2017,"
+                + "\"timeStamp\":9864653135687,"
+                + "\"countryCode5f55\":\"en_US\""
+                + "},"
+                + "\"innerMessage2\":{"
+                + "\"nIdCt\":98798465,"
+                + "\"content\":\"text/plain\","
+                + "\"$binary_data$\":["
+                + "{"
+                + "\"data\":\"OFIN8e9fhwoeh8((⁹8efywoih\","
+                + "\"height\":665"
+                + "},"
+                + "{"
+                + "\"data\":\"65\","
+                + "\"width\":-56684"
+                + "}]}}");
   }
 
   @Test
   public void testProtoWithAnnotations_deserializeUnknownEnumValue() {
-    String json = String.format("{  %n"
-        + "   \"content\":\"UNKNOWN\"%n"
-        + "}");
+    String json = String.format("{  %n" + "   \"content\":\"UNKNOWN\"%n" + "}");
     InnerMessage proto = gson.fromJson(json, InnerMessage.class);
     assertThat(proto.getContent()).isEqualTo(InnerMessage.Type.UNKNOWN);
   }
 
   @Test
   public void testProtoWithAnnotations_deserializeUnrecognizedEnumValue() {
-    String json = String.format("{  %n"
-        + "   \"content\":\"UNRECOGNIZED\"%n"
-        + "}");
+    String json = String.format("{  %n" + "   \"content\":\"UNRECOGNIZED\"%n" + "}");
     try {
       gson.fromJson(json, InnerMessage.class);
       assertWithMessage("Should have thrown").fail();
@@ -165,17 +175,13 @@ public class ProtosWithAnnotationsTest {
 
   @Test
   public void testProtoWithAnnotations_deserializeWithEnumNumbers() {
-    String json = String.format("{  %n"
-        + "   \"content\":\"0\"%n"
-        + "}");
+    String json = String.format("{  %n" + "   \"content\":\"0\"%n" + "}");
     InnerMessage proto = gsonWithEnumNumbers.fromJson(json, InnerMessage.class);
     assertThat(proto.getContent()).isEqualTo(InnerMessage.Type.UNKNOWN);
     String rebuilt = gsonWithEnumNumbers.toJson(proto);
     assertThat(rebuilt).isEqualTo("{\"content\":0}");
 
-    json = String.format("{  %n"
-        + "   \"content\":\"2\"%n"
-        + "}");
+    json = String.format("{  %n" + "   \"content\":\"2\"%n" + "}");
     proto = gsonWithEnumNumbers.fromJson(json, InnerMessage.class);
     assertThat(proto.getContent()).isEqualTo(InnerMessage.Type.IMAGE);
     rebuilt = gsonWithEnumNumbers.toJson(proto);
@@ -184,44 +190,45 @@ public class ProtosWithAnnotationsTest {
 
   @Test
   public void testProtoWithAnnotations_serialize() {
-    ProtoWithAnnotations proto = ProtoWithAnnotations.newBuilder()
-        .setId("09f3j20839h032y0329hf30932h0nffn")
-        .setOuterMessage(OuterMessage.newBuilder()
-            .setMonth(14)
-            .setYear(6650)
-            .setLongTimestamp(468406876880768L))
-        .setInnerMessage1(InnerMessage.newBuilder()
-            .setNIdCt(12)
-            .setContent(InnerMessage.Type.IMAGE)
-            .addData(InnerMessage.Data.newBuilder()
-                .setData("data$$")
-                .setWidth(200))
-            .addData(InnerMessage.Data.newBuilder()
-                .setHeight(56)))
-        .build();
+    ProtoWithAnnotations proto =
+        ProtoWithAnnotations.newBuilder()
+            .setId("09f3j20839h032y0329hf30932h0nffn")
+            .setOuterMessage(
+                OuterMessage.newBuilder()
+                    .setMonth(14)
+                    .setYear(6650)
+                    .setLongTimestamp(468406876880768L))
+            .setInnerMessage1(
+                InnerMessage.newBuilder()
+                    .setNIdCt(12)
+                    .setContent(InnerMessage.Type.IMAGE)
+                    .addData(InnerMessage.Data.newBuilder().setData("data$$").setWidth(200))
+                    .addData(InnerMessage.Data.newBuilder().setHeight(56)))
+            .build();
 
     String json = gsonWithLowerHyphen.toJson(proto);
-    assertThat(json).isEqualTo(
-        "{\"id\":\"09f3j20839h032y0329hf30932h0nffn\","
-        + "\"expiration_date\":{"
-            + "\"month\":14,"
-            + "\"year\":6650,"
-            + "\"timeStamp\":468406876880768"
-        + "},"
-        // This field should be using hyphens
-        + "\"inner-message-1\":{"
-            + "\"n--id-ct\":12,"
-            + "\"content\":2,"
-            + "\"$binary_data$\":["
-              + "{"
-                  + "\"data\":\"data$$\","
-                  + "\"width\":200"
-              + "},"
-              + "{"
-                  + "\"height\":56"
-              + "}]"
-            + "}"
-        + "}");
+    assertThat(json)
+        .isEqualTo(
+            "{\"id\":\"09f3j20839h032y0329hf30932h0nffn\","
+                + "\"expiration_date\":{"
+                + "\"month\":14,"
+                + "\"year\":6650,"
+                + "\"timeStamp\":468406876880768"
+                + "},"
+                // This field should be using hyphens
+                + "\"inner-message-1\":{"
+                + "\"n--id-ct\":12,"
+                + "\"content\":2,"
+                + "\"$binary_data$\":["
+                + "{"
+                + "\"data\":\"data$$\","
+                + "\"width\":200"
+                + "},"
+                + "{"
+                + "\"height\":56"
+                + "}]"
+                + "}"
+                + "}");
 
     ProtoWithAnnotations rebuilt = gsonWithLowerHyphen.fromJson(json, ProtoWithAnnotations.class);
     assertThat(rebuilt).isEqualTo(proto);

--- a/proto/src/test/java/com/google/gson/protobuf/functional/ProtosWithComplexAndRepeatedFieldsTest.java
+++ b/proto/src/test/java/com/google/gson/protobuf/functional/ProtosWithComplexAndRepeatedFieldsTest.java
@@ -44,7 +44,8 @@ public class ProtosWithComplexAndRepeatedFieldsTest {
   public void setUp() throws Exception {
     gson =
         new GsonBuilder()
-            .registerTypeHierarchyAdapter(GeneratedMessageV3.class,
+            .registerTypeHierarchyAdapter(
+                GeneratedMessageV3.class,
                 ProtoTypeAdapter.newBuilder()
                     .setEnumSerialization(EnumSerialization.NUMBER)
                     .build())
@@ -52,7 +53,8 @@ public class ProtosWithComplexAndRepeatedFieldsTest {
     upperCamelGson =
         new GsonBuilder()
             .registerTypeHierarchyAdapter(
-                GeneratedMessageV3.class, ProtoTypeAdapter.newBuilder()
+                GeneratedMessageV3.class,
+                ProtoTypeAdapter.newBuilder()
                     .setFieldNameSerializationFormat(
                         CaseFormat.LOWER_UNDERSCORE, CaseFormat.UPPER_CAMEL)
                     .build())
@@ -61,12 +63,13 @@ public class ProtosWithComplexAndRepeatedFieldsTest {
 
   @Test
   public void testSerializeRepeatedFields() {
-    ProtoWithRepeatedFields proto = ProtoWithRepeatedFields.newBuilder()
-      .addNumbers(2)
-      .addNumbers(3)
-      .addSimples(SimpleProto.newBuilder().setMsg("foo").build())
-      .addSimples(SimpleProto.newBuilder().setCount(3).build())
-      .build();
+    ProtoWithRepeatedFields proto =
+        ProtoWithRepeatedFields.newBuilder()
+            .addNumbers(2)
+            .addNumbers(3)
+            .addSimples(SimpleProto.newBuilder().setMsg("foo").build())
+            .addSimples(SimpleProto.newBuilder().setCount(3).build())
+            .build();
     String json = gson.toJson(proto);
     assertTrue(json.contains("[2,3]"));
     assertTrue(json.contains("foo"));
@@ -76,8 +79,7 @@ public class ProtosWithComplexAndRepeatedFieldsTest {
   @Test
   public void testDeserializeRepeatedFieldsProto() {
     String json = "{numbers:[4,6],simples:[{msg:'bar'},{count:7}]}";
-    ProtoWithRepeatedFields proto =
-      gson.fromJson(json, ProtoWithRepeatedFields.class);
+    ProtoWithRepeatedFields proto = gson.fromJson(json, ProtoWithRepeatedFields.class);
     assertEquals(4, proto.getNumbers(0));
     assertEquals(6, proto.getNumbers(1));
     assertEquals("bar", proto.getSimples(0).getMsg());
@@ -87,10 +89,10 @@ public class ProtosWithComplexAndRepeatedFieldsTest {
   @Test
   public void testSerializeDifferentCaseFormat() {
     final ProtoWithDifferentCaseFormat proto =
-      ProtoWithDifferentCaseFormat.newBuilder()
-        .setAnotherField("foo")
-        .addNameThatTestsCaseFormat("bar")
-        .build();
+        ProtoWithDifferentCaseFormat.newBuilder()
+            .setAnotherField("foo")
+            .addNameThatTestsCaseFormat("bar")
+            .build();
     final JsonObject json = upperCamelGson.toJsonTree(proto).getAsJsonObject();
     assertEquals("foo", json.get("AnotherField").getAsString());
     assertEquals("bar", json.get("NameThatTestsCaseFormat").getAsJsonArray().get(0).getAsString());
@@ -100,7 +102,7 @@ public class ProtosWithComplexAndRepeatedFieldsTest {
   public void testDeserializeDifferentCaseFormat() {
     final String json = "{NameThatTestsCaseFormat:['bar'],AnotherField:'foo'}";
     ProtoWithDifferentCaseFormat proto =
-      upperCamelGson.fromJson(json, ProtoWithDifferentCaseFormat.class);
+        upperCamelGson.fromJson(json, ProtoWithDifferentCaseFormat.class);
     assertEquals("foo", proto.getAnotherField());
     assertEquals("bar", proto.getNameThatTestsCaseFormat(0));
   }

--- a/proto/src/test/java/com/google/gson/protobuf/functional/ProtosWithPrimitiveTypesTest.java
+++ b/proto/src/test/java/com/google/gson/protobuf/functional/ProtosWithPrimitiveTypesTest.java
@@ -24,7 +24,6 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.protobuf.ProtoTypeAdapter;
 import com.google.gson.protobuf.ProtoTypeAdapter.EnumSerialization;
 import com.google.gson.protobuf.generated.Bag.SimpleProto;
-import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.GeneratedMessageV3;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,11 +33,14 @@ public class ProtosWithPrimitiveTypesTest {
 
   @Before
   public void setUp() throws Exception {
-    gson = new GsonBuilder().registerTypeHierarchyAdapter(
-      GeneratedMessageV3.class, ProtoTypeAdapter.newBuilder()
-          .setEnumSerialization(EnumSerialization.NUMBER)
-          .build())
-      .create();
+    gson =
+        new GsonBuilder()
+            .registerTypeHierarchyAdapter(
+                GeneratedMessageV3.class,
+                ProtoTypeAdapter.newBuilder()
+                    .setEnumSerialization(EnumSerialization.NUMBER)
+                    .build())
+            .create();
   }
 
   @Test
@@ -57,10 +59,7 @@ public class ProtosWithPrimitiveTypesTest {
 
   @Test
   public void testSerializeProto() {
-    SimpleProto proto = SimpleProto.newBuilder()
-      .setCount(3)
-      .setMsg("foo")
-      .build();
+    SimpleProto proto = SimpleProto.newBuilder().setCount(3).setMsg("foo").build();
     String json = gson.toJson(proto);
     assertTrue(json.contains("\"msg\":\"foo\""));
     assertTrue(json.contains("\"count\":3"));
@@ -79,5 +78,4 @@ public class ProtosWithPrimitiveTypesTest {
     assertEquals("foo", proto.getMsg());
     assertEquals(0, proto.getCount());
   }
-
 }

--- a/shrinker-test/src/main/java/com/example/ClassWithExposeAnnotation.java
+++ b/shrinker-test/src/main/java/com/example/ClassWithExposeAnnotation.java
@@ -2,12 +2,9 @@ package com.example;
 
 import com.google.gson.annotations.Expose;
 
-/**
- * Uses {@link Expose} annotation.
- */
+/** Uses {@link Expose} annotation. */
 public class ClassWithExposeAnnotation {
-  @Expose
-  int i;
+  @Expose int i;
 
   int i2;
 }

--- a/shrinker-test/src/main/java/com/example/ClassWithHasArgsConstructor.java
+++ b/shrinker-test/src/main/java/com/example/ClassWithHasArgsConstructor.java
@@ -2,10 +2,7 @@ package com.example;
 
 import com.google.gson.annotations.SerializedName;
 
-/**
- * Class without no-args constructor, but with field annotated with
- * {@link SerializedName}.
- */
+/** Class without no-args constructor, but with field annotated with {@link SerializedName}. */
 public class ClassWithHasArgsConstructor {
   @SerializedName("myField")
   public int i;

--- a/shrinker-test/src/main/java/com/example/ClassWithJsonAdapterAnnotation.java
+++ b/shrinker-test/src/main/java/com/example/ClassWithJsonAdapterAnnotation.java
@@ -18,9 +18,7 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.lang.reflect.Type;
 
-/**
- * Uses {@link JsonAdapter} annotation on fields.
- */
+/** Uses {@link JsonAdapter} annotation on fields. */
 public class ClassWithJsonAdapterAnnotation {
   // For this field don't use @SerializedName and ignore it for deserialization
   // Has custom ProGuard rule to keep the field name
@@ -43,8 +41,7 @@ public class ClassWithJsonAdapterAnnotation {
   @JsonAdapter(Deserializer.class)
   DummyClass f4;
 
-  public ClassWithJsonAdapterAnnotation() {
-  }
+  public ClassWithJsonAdapterAnnotation() {}
 
   // Note: R8 seems to make this constructor the no-args constructor and initialize fields
   // by default; currently this is not visible in the deserialization test because the JSON data
@@ -60,7 +57,15 @@ public class ClassWithJsonAdapterAnnotation {
 
   @Override
   public String toString() {
-    return "ClassWithJsonAdapterAnnotation[f1=" + f1 + ", f2=" + f2 + ", f3=" + f3 + ", f4=" + f4 + "]";
+    return "ClassWithJsonAdapterAnnotation[f1="
+        + f1
+        + ", f2="
+        + f2
+        + ", f3="
+        + f3
+        + ", f4="
+        + f4
+        + "]";
   }
 
   static class Adapter extends TypeAdapter<DummyClass> {
@@ -78,18 +83,21 @@ public class ClassWithJsonAdapterAnnotation {
   static class Factory implements TypeAdapterFactory {
     @Override
     public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
-      @SuppressWarnings("unchecked") // the code below is not type-safe, but does not matter for this test
-      TypeAdapter<T> r = (TypeAdapter<T>) new TypeAdapter<DummyClass>() {
-        @Override
-        public DummyClass read(JsonReader in) throws IOException {
-          return new DummyClass("factory-" + in.nextInt());
-        }
+      // the code below is not type-safe, but does not matter for this test
+      @SuppressWarnings("unchecked")
+      TypeAdapter<T> r =
+          (TypeAdapter<T>)
+              new TypeAdapter<DummyClass>() {
+                @Override
+                public DummyClass read(JsonReader in) throws IOException {
+                  return new DummyClass("factory-" + in.nextInt());
+                }
 
-        @Override
-        public void write(JsonWriter out, DummyClass value) throws IOException {
-          out.value("factory-" + value.s);
-        }
-      };
+                @Override
+                public void write(JsonWriter out, DummyClass value) throws IOException {
+                  out.value("factory-" + value.s);
+                }
+              };
 
       return r;
     }
@@ -104,7 +112,9 @@ public class ClassWithJsonAdapterAnnotation {
 
   static class Deserializer implements JsonDeserializer<DummyClass> {
     @Override
-    public DummyClass deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+    public DummyClass deserialize(
+        JsonElement json, Type typeOfT, JsonDeserializationContext context)
+        throws JsonParseException {
       return new DummyClass("deserializer-" + json.getAsInt());
     }
   }

--- a/shrinker-test/src/main/java/com/example/ClassWithNoArgsConstructor.java
+++ b/shrinker-test/src/main/java/com/example/ClassWithNoArgsConstructor.java
@@ -2,10 +2,7 @@ package com.example;
 
 import com.google.gson.annotations.SerializedName;
 
-/**
- * Class with no-args constructor and with field annotated with
- * {@link SerializedName}.
- */
+/** Class with no-args constructor and with field annotated with {@link SerializedName}. */
 public class ClassWithNoArgsConstructor {
   @SerializedName("myField")
   public int i;

--- a/shrinker-test/src/main/java/com/example/ClassWithUnreferencedHasArgsConstructor.java
+++ b/shrinker-test/src/main/java/com/example/ClassWithUnreferencedHasArgsConstructor.java
@@ -3,10 +3,9 @@ package com.example;
 import com.google.gson.annotations.SerializedName;
 
 /**
- * Class without no-args constructor, but with field annotated with
- * {@link SerializedName}. The constructor should not actually be used in the
- * code, but this shouldn't lead to R8 concluding that values of the type are
- * not constructible and therefore must be null.
+ * Class without no-args constructor, but with field annotated with {@link SerializedName}. The
+ * constructor should not be used in the code, but this shouldn't lead to R8 concluding that values
+ * of the type are not constructible and therefore must be null.
  */
 public class ClassWithUnreferencedHasArgsConstructor {
   @SerializedName("myField")

--- a/shrinker-test/src/main/java/com/example/ClassWithUnreferencedNoArgsConstructor.java
+++ b/shrinker-test/src/main/java/com/example/ClassWithUnreferencedNoArgsConstructor.java
@@ -3,10 +3,9 @@ package com.example;
 import com.google.gson.annotations.SerializedName;
 
 /**
- * Class with no-args constructor and with field annotated with
- * {@link SerializedName}. The constructor should not actually be used in the
- * code, but this shouldn't lead to R8 concluding that values of the type are
- * not constructible and therefore must be null.
+ * Class with no-args constructor and with field annotated with {@link SerializedName}. The
+ * constructor should not be used in the code, but this shouldn't lead to R8 concluding that values
+ * of the type are not constructible and therefore must be null.
  */
 public class ClassWithUnreferencedNoArgsConstructor {
   @SerializedName("myField")

--- a/shrinker-test/src/main/java/com/example/ClassWithVersionAnnotations.java
+++ b/shrinker-test/src/main/java/com/example/ClassWithVersionAnnotations.java
@@ -3,9 +3,7 @@ package com.example;
 import com.google.gson.annotations.Since;
 import com.google.gson.annotations.Until;
 
-/**
- * Uses {@link Since} and {@link Until} annotations.
- */
+/** Uses {@link Since} and {@link Until} annotations. */
 public class ClassWithVersionAnnotations {
   @Since(1)
   int i1;

--- a/shrinker-test/src/main/java/com/example/Main.java
+++ b/shrinker-test/src/main/java/com/example/Main.java
@@ -18,16 +18,20 @@ public class Main {
   /**
    * Main entrypoint, called by {@code ShrinkingIT.test()}.
    *
-   * <p>To be safe let all tests put their output to the consumer and let integration test verify it;
-   * don't perform any relevant assertions in this code because code shrinkers could affect it.
+   * <p>To be safe let all tests put their output to the consumer and let integration test verify
+   * it; don't perform any relevant assertions in this code because code shrinkers could affect it.
    *
    * @param outputConsumer consumes the test output: {@code name, content} pairs
    */
   public static void runTests(BiConsumer<String, String> outputConsumer) {
     // Create the TypeToken instances on demand because creation of them can fail when
     // generic signatures were erased
-    testTypeTokenWriteRead(outputConsumer, "anonymous", () -> new TypeToken<List<ClassWithAdapter>>() {});
-    testTypeTokenWriteRead(outputConsumer, "manual", () -> TypeToken.getParameterized(List.class, ClassWithAdapter.class));
+    testTypeTokenWriteRead(
+        outputConsumer, "anonymous", () -> new TypeToken<List<ClassWithAdapter>>() {});
+    testTypeTokenWriteRead(
+        outputConsumer,
+        "manual",
+        () -> TypeToken.getParameterized(List.class, ClassWithAdapter.class));
 
     testNamedFields(outputConsumer);
     testSerializedName(outputConsumer);
@@ -49,28 +53,37 @@ public class Main {
     testGenericClasses(outputConsumer);
   }
 
-  private static void testTypeTokenWriteRead(BiConsumer<String, String> outputConsumer, String description, Supplier<TypeToken<?>> typeTokenSupplier) {
+  private static void testTypeTokenWriteRead(
+      BiConsumer<String, String> outputConsumer,
+      String description,
+      Supplier<TypeToken<?>> typeTokenSupplier) {
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
-    TestExecutor.run(outputConsumer, "Write: TypeToken " + description,
-        () -> gson.toJson(Arrays.asList(new ClassWithAdapter(1)), typeTokenSupplier.get().getType()));
-    TestExecutor.run(outputConsumer, "Read: TypeToken " + description, () -> {
-      Object deserialized = gson.fromJson("[{\"custom\": 3}]", typeTokenSupplier.get());
-      return deserialized.toString();
-    });
+    TestExecutor.run(
+        outputConsumer,
+        "Write: TypeToken " + description,
+        () ->
+            gson.toJson(Arrays.asList(new ClassWithAdapter(1)), typeTokenSupplier.get().getType()));
+    TestExecutor.run(
+        outputConsumer,
+        "Read: TypeToken " + description,
+        () -> {
+          Object deserialized = gson.fromJson("[{\"custom\": 3}]", typeTokenSupplier.get());
+          return deserialized.toString();
+        });
   }
 
   /**
-   * Calls {@link Gson#toJson}, but (hopefully) in a way which prevents code shrinkers
-   * from understanding that reflection is used for {@code obj}.
+   * Calls {@link Gson#toJson}, but (hopefully) in a way which prevents code shrinkers from
+   * understanding that reflection is used for {@code obj}.
    */
   private static String toJson(Gson gson, Object obj) {
     return gson.toJson(same(obj));
   }
 
   /**
-   * Calls {@link Gson#fromJson}, but (hopefully) in a way which prevents code shrinkers
-   * from understanding that reflection is used for {@code c}.
+   * Calls {@link Gson#fromJson}, but (hopefully) in a way which prevents code shrinkers from
+   * understanding that reflection is used for {@code c}.
    */
   private static <T> T fromJson(Gson gson, String json, Class<T> c) {
     return gson.fromJson(json, same(c));
@@ -78,46 +91,74 @@ public class Main {
 
   private static void testNamedFields(BiConsumer<String, String> outputConsumer) {
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
-    TestExecutor.run(outputConsumer, "Write: Named fields", () -> toJson(gson, new ClassWithNamedFields(2)));
-    TestExecutor.run(outputConsumer, "Read: Named fields", () -> {
-      ClassWithNamedFields deserialized = fromJson(gson, "{\"myField\": 3}", ClassWithNamedFields.class);
-      return Integer.toString(deserialized.myField);
-    });
+    TestExecutor.run(
+        outputConsumer, "Write: Named fields", () -> toJson(gson, new ClassWithNamedFields(2)));
+    TestExecutor.run(
+        outputConsumer,
+        "Read: Named fields",
+        () -> {
+          ClassWithNamedFields deserialized =
+              fromJson(gson, "{\"myField\": 3}", ClassWithNamedFields.class);
+          return Integer.toString(deserialized.myField);
+        });
   }
 
   private static void testSerializedName(BiConsumer<String, String> outputConsumer) {
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
-    TestExecutor.run(outputConsumer, "Write: SerializedName", () -> toJson(gson, new ClassWithSerializedName(2)));
-    TestExecutor.run(outputConsumer, "Read: SerializedName", () -> {
-      ClassWithSerializedName deserialized = fromJson(gson, "{\"myField\": 3}", ClassWithSerializedName.class);
-      return Integer.toString(deserialized.i);
-    });
+    TestExecutor.run(
+        outputConsumer,
+        "Write: SerializedName",
+        () -> toJson(gson, new ClassWithSerializedName(2)));
+    TestExecutor.run(
+        outputConsumer,
+        "Read: SerializedName",
+        () -> {
+          ClassWithSerializedName deserialized =
+              fromJson(gson, "{\"myField\": 3}", ClassWithSerializedName.class);
+          return Integer.toString(deserialized.i);
+        });
   }
 
   private static void testConstructorNoArgs(BiConsumer<String, String> outputConsumer) {
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
-    TestExecutor.run(outputConsumer, "Write: No args constructor", () -> toJson(
-        gson, new ClassWithNoArgsConstructor()));
-    TestExecutor.run(outputConsumer, "Read: No args constructor; initial constructor value", () -> {
-      ClassWithNoArgsConstructor deserialized = fromJson(gson, "{}", ClassWithNoArgsConstructor.class);
-      return Integer.toString(deserialized.i);
-    });
-    TestExecutor.run(outputConsumer, "Read: No args constructor; custom value", () -> {
-      ClassWithNoArgsConstructor deserialized = fromJson(gson, "{\"myField\": 3}", ClassWithNoArgsConstructor.class);
-      return Integer.toString(deserialized.i);
-    });
+    TestExecutor.run(
+        outputConsumer,
+        "Write: No args constructor",
+        () -> toJson(gson, new ClassWithNoArgsConstructor()));
+    TestExecutor.run(
+        outputConsumer,
+        "Read: No args constructor; initial constructor value",
+        () -> {
+          ClassWithNoArgsConstructor deserialized =
+              fromJson(gson, "{}", ClassWithNoArgsConstructor.class);
+          return Integer.toString(deserialized.i);
+        });
+    TestExecutor.run(
+        outputConsumer,
+        "Read: No args constructor; custom value",
+        () -> {
+          ClassWithNoArgsConstructor deserialized =
+              fromJson(gson, "{\"myField\": 3}", ClassWithNoArgsConstructor.class);
+          return Integer.toString(deserialized.i);
+        });
   }
 
   private static void testConstructorHasArgs(BiConsumer<String, String> outputConsumer) {
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
-    TestExecutor.run(outputConsumer, "Write: Constructor with args", () -> toJson(
-        gson, new ClassWithHasArgsConstructor(2)));
-    // This most likely relies on JDK Unsafe (unless the shrinker rewrites the constructor in some way)
-    TestExecutor.run(outputConsumer, "Read: Constructor with args", () -> {
-      ClassWithHasArgsConstructor deserialized = fromJson(
-          gson, "{\"myField\": 3}", ClassWithHasArgsConstructor.class);
-      return Integer.toString(deserialized.i);
-    });
+    TestExecutor.run(
+        outputConsumer,
+        "Write: Constructor with args",
+        () -> toJson(gson, new ClassWithHasArgsConstructor(2)));
+    // This most likely relies on JDK Unsafe (unless the shrinker rewrites the constructor in some
+    // way)
+    TestExecutor.run(
+        outputConsumer,
+        "Read: Constructor with args",
+        () -> {
+          ClassWithHasArgsConstructor deserialized =
+              fromJson(gson, "{\"myField\": 3}", ClassWithHasArgsConstructor.class);
+          return Integer.toString(deserialized.i);
+        });
   }
 
   private static void testUnreferencedConstructorNoArgs(BiConsumer<String, String> outputConsumer) {
@@ -125,80 +166,126 @@ public class Main {
     // No write because we're not referencing this class's constructor.
 
     // This runs the no-args constructor.
-    TestExecutor.run(outputConsumer, "Read: Unreferenced no args constructor; initial constructor value", () -> {
-      ClassWithUnreferencedNoArgsConstructor deserialized = fromJson(
-          gson, "{}", ClassWithUnreferencedNoArgsConstructor.class);
-      return Integer.toString(deserialized.i);
-    });
-    TestExecutor.run(outputConsumer, "Read: Unreferenced no args constructor; custom value", () -> {
-      ClassWithUnreferencedNoArgsConstructor deserialized = fromJson(
-          gson, "{\"myField\": 3}", ClassWithUnreferencedNoArgsConstructor.class);
-      return Integer.toString(deserialized.i);
-    });
+    TestExecutor.run(
+        outputConsumer,
+        "Read: Unreferenced no args constructor; initial constructor value",
+        () -> {
+          ClassWithUnreferencedNoArgsConstructor deserialized =
+              fromJson(gson, "{}", ClassWithUnreferencedNoArgsConstructor.class);
+          return Integer.toString(deserialized.i);
+        });
+    TestExecutor.run(
+        outputConsumer,
+        "Read: Unreferenced no args constructor; custom value",
+        () -> {
+          ClassWithUnreferencedNoArgsConstructor deserialized =
+              fromJson(gson, "{\"myField\": 3}", ClassWithUnreferencedNoArgsConstructor.class);
+          return Integer.toString(deserialized.i);
+        });
   }
 
-  private static void testUnreferencedConstructorHasArgs(BiConsumer<String, String> outputConsumer) {
+  private static void testUnreferencedConstructorHasArgs(
+      BiConsumer<String, String> outputConsumer) {
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
     // No write because we're not referencing this class's constructor.
 
-    // This most likely relies on JDK Unsafe (unless the shrinker rewrites the constructor in some way)
-    TestExecutor.run(outputConsumer, "Read: Unreferenced constructor with args", () -> {
-      ClassWithUnreferencedHasArgsConstructor deserialized = fromJson(
-          gson, "{\"myField\": 3}", ClassWithUnreferencedHasArgsConstructor.class);
-      return Integer.toString(deserialized.i);
-    });
+    // This most likely relies on JDK Unsafe (unless the shrinker rewrites the constructor in some
+    // way)
+    TestExecutor.run(
+        outputConsumer,
+        "Read: Unreferenced constructor with args",
+        () -> {
+          ClassWithUnreferencedHasArgsConstructor deserialized =
+              fromJson(gson, "{\"myField\": 3}", ClassWithUnreferencedHasArgsConstructor.class);
+          return Integer.toString(deserialized.i);
+        });
   }
 
   private static void testNoJdkUnsafe(BiConsumer<String, String> outputConsumer) {
     Gson gson = new GsonBuilder().disableJdkUnsafe().create();
-    TestExecutor.run(outputConsumer, "Read: No JDK Unsafe; initial constructor value", () -> {
-      ClassWithNoArgsConstructor deserialized = fromJson(
-          gson, "{}", ClassWithNoArgsConstructor.class);
-      return Integer.toString(deserialized.i);
-    });
-    TestExecutor.run(outputConsumer, "Read: No JDK Unsafe; custom value", () -> {
-      ClassWithNoArgsConstructor deserialized = fromJson(
-          gson, "{\"myField\": 3}", ClassWithNoArgsConstructor.class);
-      return Integer.toString(deserialized.i);
-    });
+    TestExecutor.run(
+        outputConsumer,
+        "Read: No JDK Unsafe; initial constructor value",
+        () -> {
+          ClassWithNoArgsConstructor deserialized =
+              fromJson(gson, "{}", ClassWithNoArgsConstructor.class);
+          return Integer.toString(deserialized.i);
+        });
+    TestExecutor.run(
+        outputConsumer,
+        "Read: No JDK Unsafe; custom value",
+        () -> {
+          ClassWithNoArgsConstructor deserialized =
+              fromJson(gson, "{\"myField\": 3}", ClassWithNoArgsConstructor.class);
+          return Integer.toString(deserialized.i);
+        });
   }
 
   private static void testEnum(BiConsumer<String, String> outputConsumer) {
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
     TestExecutor.run(outputConsumer, "Write: Enum", () -> toJson(gson, EnumClass.FIRST));
-    TestExecutor.run(outputConsumer, "Read: Enum", () -> fromJson(gson, "\"SECOND\"", EnumClass.class).toString());
+    TestExecutor.run(
+        outputConsumer,
+        "Read: Enum",
+        () -> fromJson(gson, "\"SECOND\"", EnumClass.class).toString());
   }
 
   private static void testEnumSerializedName(BiConsumer<String, String> outputConsumer) {
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
-    TestExecutor.run(outputConsumer, "Write: Enum SerializedName",
+    TestExecutor.run(
+        outputConsumer,
+        "Write: Enum SerializedName",
         () -> toJson(gson, EnumClassWithSerializedName.FIRST));
-    TestExecutor.run(outputConsumer, "Read: Enum SerializedName",
+    TestExecutor.run(
+        outputConsumer,
+        "Read: Enum SerializedName",
         () -> fromJson(gson, "\"two\"", EnumClassWithSerializedName.class).toString());
   }
 
   private static void testExposeAnnotation(BiConsumer<String, String> outputConsumer) {
     Gson gson = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
-    TestExecutor.run(outputConsumer, "Write: @Expose", () -> toJson(gson, new ClassWithExposeAnnotation()));
+    TestExecutor.run(
+        outputConsumer, "Write: @Expose", () -> toJson(gson, new ClassWithExposeAnnotation()));
   }
 
   private static void testVersionAnnotations(BiConsumer<String, String> outputConsumer) {
     Gson gson = new GsonBuilder().setVersion(1).create();
-    TestExecutor.run(outputConsumer, "Write: Version annotations", () -> toJson(gson, new ClassWithVersionAnnotations()));
+    TestExecutor.run(
+        outputConsumer,
+        "Write: Version annotations",
+        () -> toJson(gson, new ClassWithVersionAnnotations()));
   }
 
   private static void testJsonAdapterAnnotation(BiConsumer<String, String> outputConsumer) {
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
-    TestExecutor.run(outputConsumer, "Write: JsonAdapter on fields", () -> toJson(gson, new ClassWithJsonAdapterAnnotation(1, 2, 3, 4)));
+    TestExecutor.run(
+        outputConsumer,
+        "Write: JsonAdapter on fields",
+        () -> toJson(gson, new ClassWithJsonAdapterAnnotation(1, 2, 3, 4)));
 
     String json = "{\"f1\": 1, \"f2\": 2, \"f3\": {\"s\": \"3\"}, \"f4\": 4}";
-    TestExecutor.run(outputConsumer, "Read: JsonAdapter on fields", () -> fromJson(gson, json, ClassWithJsonAdapterAnnotation.class).toString());
+    TestExecutor.run(
+        outputConsumer,
+        "Read: JsonAdapter on fields",
+        () -> fromJson(gson, json, ClassWithJsonAdapterAnnotation.class).toString());
   }
 
   private static void testGenericClasses(BiConsumer<String, String> outputConsumer) {
     Gson gson = new Gson();
-    TestExecutor.run(outputConsumer, "Read: Generic TypeToken", () -> gson.fromJson("{\"t\": 1}", new TypeToken<GenericClass<DummyClass>>() {}).toString());
-    TestExecutor.run(outputConsumer, "Read: Using Generic", () -> fromJson(gson, "{\"g\": {\"t\": 1}}", UsingGenericClass.class).toString());
-    TestExecutor.run(outputConsumer, "Read: Using Generic TypeToken", () -> gson.fromJson("{\"g\": {\"t\": 1}}", new TypeToken<GenericUsingGenericClass<DummyClass>>() {}).toString());
+    TestExecutor.run(
+        outputConsumer,
+        "Read: Generic TypeToken",
+        () -> gson.fromJson("{\"t\": 1}", new TypeToken<GenericClass<DummyClass>>() {}).toString());
+    TestExecutor.run(
+        outputConsumer,
+        "Read: Using Generic",
+        () -> fromJson(gson, "{\"g\": {\"t\": 1}}", UsingGenericClass.class).toString());
+    TestExecutor.run(
+        outputConsumer,
+        "Read: Using Generic TypeToken",
+        () ->
+            gson.fromJson(
+                    "{\"g\": {\"t\": 1}}", new TypeToken<GenericUsingGenericClass<DummyClass>>() {})
+                .toString());
   }
 }

--- a/shrinker-test/src/main/java/com/example/NoSerializedNameMain.java
+++ b/shrinker-test/src/main/java/com/example/NoSerializedNameMain.java
@@ -15,7 +15,8 @@ public class NoSerializedNameMain {
     public String s;
   }
 
-  // R8 test rule in r8.pro for this class still removes no-args constructor, but doesn't make class abstract
+  // R8 test rule in r8.pro for this class still removes no-args constructor, but doesn't make class
+  // abstract
   static class TestClassNotAbstract {
     public String s;
   }
@@ -29,31 +30,28 @@ public class NoSerializedNameMain {
     }
   }
 
-  /**
-   * Main entrypoint, called by {@code ShrinkingIT.testNoSerializedName_NoArgsConstructor()}.
-   */
+  /** Main entrypoint, called by {@code ShrinkingIT.testNoSerializedName_NoArgsConstructor()}. */
   public static String runTestNoArgsConstructor() {
-    TestClassNoArgsConstructor deserialized = new Gson().fromJson(
-        "{\"s\":\"value\"}", same(TestClassNoArgsConstructor.class));
+    TestClassNoArgsConstructor deserialized =
+        new Gson().fromJson("{\"s\":\"value\"}", same(TestClassNoArgsConstructor.class));
     return deserialized.s;
   }
 
   /**
-   * Main entrypoint, called by {@code ShrinkingIT.testNoSerializedName_NoArgsConstructorNoJdkUnsafe()}.
+   * Main entrypoint, called by {@code
+   * ShrinkingIT.testNoSerializedName_NoArgsConstructorNoJdkUnsafe()}.
    */
   public static String runTestNoJdkUnsafe() {
     Gson gson = new GsonBuilder().disableJdkUnsafe().create();
-    TestClassNotAbstract deserialized = gson.fromJson(
-        "{\"s\": \"value\"}", same(TestClassNotAbstract.class));
+    TestClassNotAbstract deserialized =
+        gson.fromJson("{\"s\": \"value\"}", same(TestClassNotAbstract.class));
     return deserialized.s;
   }
 
-  /**
-   * Main entrypoint, called by {@code ShrinkingIT.testNoSerializedName_HasArgsConstructor()}.
-   */
+  /** Main entrypoint, called by {@code ShrinkingIT.testNoSerializedName_HasArgsConstructor()}. */
   public static String runTestHasArgsConstructor() {
-    TestClassHasArgsConstructor deserialized = new Gson().fromJson(
-        "{\"s\":\"value\"}", same(TestClassHasArgsConstructor.class));
+    TestClassHasArgsConstructor deserialized =
+        new Gson().fromJson("{\"s\":\"value\"}", same(TestClassHasArgsConstructor.class));
     return deserialized.s;
   }
 }

--- a/shrinker-test/src/main/java/com/example/TestExecutor.java
+++ b/shrinker-test/src/main/java/com/example/TestExecutor.java
@@ -6,11 +6,11 @@ import java.util.function.Supplier;
 
 public class TestExecutor {
   /**
-   * Helper method for running individual tests. In case of an exception wraps it and
-   * includes the {@code name} of the test to make debugging issues with the obfuscated
-   * JARs a bit easier.
+   * Helper method for running individual tests. In case of an exception wraps it and includes the
+   * {@code name} of the test to make debugging issues with the obfuscated JARs a bit easier.
    */
-  public static void run(BiConsumer<String, String> outputConsumer, String name, Supplier<String> resultSupplier) {
+  public static void run(
+      BiConsumer<String, String> outputConsumer, String name, Supplier<String> resultSupplier) {
     String result;
     try {
       result = resultSupplier.get();
@@ -21,8 +21,8 @@ public class TestExecutor {
   }
 
   /**
-   * Returns {@code t}, but in a way which (hopefully) prevents code shrinkers from
-   * simplifying this.
+   * Returns {@code t}, but in a way which (hopefully) prevents code shrinkers from simplifying
+   * this.
    */
   public static <T> T same(T t) {
     // This is essentially `return t`, but contains some redundant code to try

--- a/shrinker-test/src/main/java/com/example/UnusedClass.java
+++ b/shrinker-test/src/main/java/com/example/UnusedClass.java
@@ -3,14 +3,13 @@ package com.example;
 import com.google.gson.annotations.SerializedName;
 
 /**
- * Class with no-args constructor and field annotated with {@code @SerializedName},
- * but which is not actually used anywhere in the code.
+ * Class with no-args constructor and field annotated with {@code @SerializedName}, but which is not
+ * actually used anywhere in the code.
  *
  * <p>The default ProGuard rules should not keep this class.
  */
 public class UnusedClass {
-  public UnusedClass() {
-  }
+  public UnusedClass() {}
 
   @SerializedName("i")
   public int i;

--- a/shrinker-test/src/test/java/com/google/gson/it/ShrinkingIT.java
+++ b/shrinker-test/src/test/java/com/google/gson/it/ShrinkingIT.java
@@ -39,9 +39,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
-/**
- * Integration test verifying behavior of shrunken and obfuscated JARs.
- */
+/** Integration test verifying behavior of shrunken and obfuscated JARs. */
 @RunWith(Parameterized.class)
 public class ShrinkingIT {
   // These JAR files are prepared by the Maven build
@@ -53,8 +51,7 @@ public class ShrinkingIT {
     return Arrays.asList(PROGUARD_RESULT_PATH, R8_RESULT_PATH);
   }
 
-  @Parameter
-  public Path jarToTest;
+  @Parameter public Path jarToTest;
 
   @Before
   public void verifyJarExists() {
@@ -75,7 +72,8 @@ public class ShrinkingIT {
 
     // Load the shrunken and obfuscated JARs with a separate class loader, then load
     // the main test class from it and let the test action invoke its test methods
-    try (URLClassLoader loader = new URLClassLoader(new URL[] {jarToTest.toUri().toURL()}, classLoader)) {
+    try (URLClassLoader loader =
+        new URLClassLoader(new URL[] {jarToTest.toUri().toURL()}, classLoader)) {
       Class<?> c = loader.loadClass(className);
       testAction.run(c);
     }
@@ -85,203 +83,235 @@ public class ShrinkingIT {
   public void test() throws Exception {
     StringBuilder output = new StringBuilder();
 
-    runTest("com.example.Main", c -> {
-      Method m = c.getMethod("runTests", BiConsumer.class);
-      m.invoke(null, (BiConsumer<String, String>) (name, content) -> output.append(name + "\n" + content + "\n===\n"));
-    });
+    runTest(
+        "com.example.Main",
+        c -> {
+          Method m = c.getMethod("runTests", BiConsumer.class);
+          m.invoke(
+              null,
+              (BiConsumer<String, String>)
+                  (name, content) -> output.append(name + "\n" + content + "\n===\n"));
+        });
 
-    assertThat(output.toString()).isEqualTo(String.join("\n",
-        "Write: TypeToken anonymous",
-        "[",
-        "  {",
-        "    \"custom\": 1",
-        "  }",
-        "]",
-        "===",
-        "Read: TypeToken anonymous",
-        "[ClassWithAdapter[3]]",
-        "===",
-        "Write: TypeToken manual",
-        "[",
-        "  {",
-        "    \"custom\": 1",
-        "  }",
-        "]",
-        "===",
-        "Read: TypeToken manual",
-        "[ClassWithAdapter[3]]",
-        "===",
-        "Write: Named fields",
-        "{",
-        "  \"myField\": 2,",
-        "  \"notAccessedField\": -1",
-        "}",
-        "===",
-        "Read: Named fields",
-        "3",
-        "===",
-        "Write: SerializedName",
-        "{",
-        "  \"myField\": 2,",
-        "  \"notAccessed\": -1",
-        "}",
-        "===",
-        "Read: SerializedName",
-        "3",
-        "===",
-        "Write: No args constructor",
-        "{",
-        "  \"myField\": -3",
-        "}",
-        "===",
-        "Read: No args constructor; initial constructor value",
-        "-3",
-        "===",
-        "Read: No args constructor; custom value",
-        "3",
-        "===",
-        "Write: Constructor with args",
-        "{",
-        "  \"myField\": 2",
-        "}",
-        "===",
-        "Read: Constructor with args",
-        "3",
-        "===",
-        "Read: Unreferenced no args constructor; initial constructor value",
-        "-3",
-        "===",
-        "Read: Unreferenced no args constructor; custom value",
-        "3",
-        "===",
-        "Read: Unreferenced constructor with args",
-        "3",
-        "===",
-        "Read: No JDK Unsafe; initial constructor value",
-        "-3",
-        "===",
-        "Read: No JDK Unsafe; custom value",
-        "3",
-        "===",
-        "Write: Enum",
-        "\"FIRST\"",
-        "===",
-        "Read: Enum",
-        "SECOND",
-        "===",
-        "Write: Enum SerializedName",
-        "\"one\"",
-        "===",
-        "Read: Enum SerializedName",
-        "SECOND",
-        "===",
-        "Write: @Expose",
-        "{\"i\":0}",
-        "===",
-        "Write: Version annotations",
-        "{\"i1\":0,\"i4\":0}",
-        "===",
-        "Write: JsonAdapter on fields",
-        "{",
-        "  \"f\": \"adapter-null\",",
-        "  \"f1\": \"adapter-1\",",
-        "  \"f2\": \"factory-2\",",
-        "  \"f3\": \"serializer-3\",",
-        // For f4 only a JsonDeserializer is registered, so serialization falls back to reflection
-        "  \"f4\": {",
-        "    \"s\": \"4\"",
-        "  }",
-        "}",
-        "===",
-        "Read: JsonAdapter on fields",
-        // For f3 only a JsonSerializer is registered, so for deserialization value is read as is using reflection
-        "ClassWithJsonAdapterAnnotation[f1=adapter-1, f2=factory-2, f3=3, f4=deserializer-4]",
-        "===",
-        "Read: Generic TypeToken",
-        "{t=read-1}",
-        "===",
-        "Read: Using Generic",
-        "{g={t=read-1}}",
-        "===",
-        "Read: Using Generic TypeToken",
-        "{g={t=read-1}}",
-        "===",
-        ""
-      ));
+    assertThat(output.toString())
+        .isEqualTo(
+            String.join(
+                "\n",
+                "Write: TypeToken anonymous",
+                "[",
+                "  {",
+                "    \"custom\": 1",
+                "  }",
+                "]",
+                "===",
+                "Read: TypeToken anonymous",
+                "[ClassWithAdapter[3]]",
+                "===",
+                "Write: TypeToken manual",
+                "[",
+                "  {",
+                "    \"custom\": 1",
+                "  }",
+                "]",
+                "===",
+                "Read: TypeToken manual",
+                "[ClassWithAdapter[3]]",
+                "===",
+                "Write: Named fields",
+                "{",
+                "  \"myField\": 2,",
+                "  \"notAccessedField\": -1",
+                "}",
+                "===",
+                "Read: Named fields",
+                "3",
+                "===",
+                "Write: SerializedName",
+                "{",
+                "  \"myField\": 2,",
+                "  \"notAccessed\": -1",
+                "}",
+                "===",
+                "Read: SerializedName",
+                "3",
+                "===",
+                "Write: No args constructor",
+                "{",
+                "  \"myField\": -3",
+                "}",
+                "===",
+                "Read: No args constructor; initial constructor value",
+                "-3",
+                "===",
+                "Read: No args constructor; custom value",
+                "3",
+                "===",
+                "Write: Constructor with args",
+                "{",
+                "  \"myField\": 2",
+                "}",
+                "===",
+                "Read: Constructor with args",
+                "3",
+                "===",
+                "Read: Unreferenced no args constructor; initial constructor value",
+                "-3",
+                "===",
+                "Read: Unreferenced no args constructor; custom value",
+                "3",
+                "===",
+                "Read: Unreferenced constructor with args",
+                "3",
+                "===",
+                "Read: No JDK Unsafe; initial constructor value",
+                "-3",
+                "===",
+                "Read: No JDK Unsafe; custom value",
+                "3",
+                "===",
+                "Write: Enum",
+                "\"FIRST\"",
+                "===",
+                "Read: Enum",
+                "SECOND",
+                "===",
+                "Write: Enum SerializedName",
+                "\"one\"",
+                "===",
+                "Read: Enum SerializedName",
+                "SECOND",
+                "===",
+                "Write: @Expose",
+                "{\"i\":0}",
+                "===",
+                "Write: Version annotations",
+                "{\"i1\":0,\"i4\":0}",
+                "===",
+                "Write: JsonAdapter on fields",
+                "{",
+                "  \"f\": \"adapter-null\",",
+                "  \"f1\": \"adapter-1\",",
+                "  \"f2\": \"factory-2\",",
+                "  \"f3\": \"serializer-3\",",
+                // For f4 only a JsonDeserializer is registered, so serialization falls back to
+                // reflection
+                "  \"f4\": {",
+                "    \"s\": \"4\"",
+                "  }",
+                "}",
+                "===",
+                "Read: JsonAdapter on fields",
+                // For f3 only a JsonSerializer is registered, so for deserialization value is read
+                // as is using reflection
+                "ClassWithJsonAdapterAnnotation[f1=adapter-1, f2=factory-2, f3=3,"
+                    + " f4=deserializer-4]",
+                "===",
+                "Read: Generic TypeToken",
+                "{t=read-1}",
+                "===",
+                "Read: Using Generic",
+                "{g={t=read-1}}",
+                "===",
+                "Read: Using Generic TypeToken",
+                "{g={t=read-1}}",
+                "===",
+                ""));
   }
 
   @Test
   public void testNoSerializedName_NoArgsConstructor() throws Exception {
-    runTest("com.example.NoSerializedNameMain", c -> {
-      Method m = c.getMethod("runTestNoArgsConstructor");
+    runTest(
+        "com.example.NoSerializedNameMain",
+        c -> {
+          Method m = c.getMethod("runTestNoArgsConstructor");
 
-      if (jarToTest.equals(PROGUARD_RESULT_PATH)) {
-        Object result = m.invoke(null);
-        assertThat(result).isEqualTo("value");
-      } else {
-        // R8 performs more aggressive optimizations
-        Exception e = assertThrows(InvocationTargetException.class, () -> m.invoke(null));
-        assertThat(e).hasCauseThat().hasMessageThat().isEqualTo(
-            "Abstract classes can't be instantiated! Adjust the R8 configuration or register an InstanceCreator"
-            + " or a TypeAdapter for this type. Class name: com.example.NoSerializedNameMain$TestClassNoArgsConstructor"
-            + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#r8-abstract-class"
-        );
-      }
-    });
+          if (jarToTest.equals(PROGUARD_RESULT_PATH)) {
+            Object result = m.invoke(null);
+            assertThat(result).isEqualTo("value");
+          } else {
+            // R8 performs more aggressive optimizations
+            Exception e = assertThrows(InvocationTargetException.class, () -> m.invoke(null));
+            assertThat(e)
+                .hasCauseThat()
+                .hasMessageThat()
+                .isEqualTo(
+                    "Abstract classes can't be instantiated! Adjust the R8 configuration or"
+                        + " register an InstanceCreator or a TypeAdapter for this type. Class name:"
+                        + " com.example.NoSerializedNameMain$TestClassNoArgsConstructor\n"
+                        + "See https://github.com/google/gson/blob/main/Troubleshooting.md#r8-abstract-class");
+          }
+        });
   }
 
   @Test
   public void testNoSerializedName_NoArgsConstructorNoJdkUnsafe() throws Exception {
-    runTest("com.example.NoSerializedNameMain", c -> {
-      Method m = c.getMethod("runTestNoJdkUnsafe");
+    runTest(
+        "com.example.NoSerializedNameMain",
+        c -> {
+          Method m = c.getMethod("runTestNoJdkUnsafe");
 
-      if (jarToTest.equals(PROGUARD_RESULT_PATH)) {
-        Object result = m.invoke(null);
-        assertThat(result).isEqualTo("value");
-      } else {
-        // R8 performs more aggressive optimizations
-        Exception e = assertThrows(InvocationTargetException.class, () -> m.invoke(null));
-        assertThat(e).hasCauseThat().hasMessageThat().isEqualTo(
-            "Unable to create instance of class com.example.NoSerializedNameMain$TestClassNotAbstract;"
-            + " usage of JDK Unsafe is disabled. Registering an InstanceCreator or a TypeAdapter for this type,"
-            + " adding a no-args constructor, or enabling usage of JDK Unsafe may fix this problem. Or adjust"
-            + " your R8 configuration to keep the no-args constructor of the class."
-        );
-      }
-    });
+          if (jarToTest.equals(PROGUARD_RESULT_PATH)) {
+            Object result = m.invoke(null);
+            assertThat(result).isEqualTo("value");
+          } else {
+            // R8 performs more aggressive optimizations
+            Exception e = assertThrows(InvocationTargetException.class, () -> m.invoke(null));
+            assertThat(e)
+                .hasCauseThat()
+                .hasMessageThat()
+                .isEqualTo(
+                    "Unable to create instance of class"
+                        + " com.example.NoSerializedNameMain$TestClassNotAbstract; usage of JDK"
+                        + " Unsafe is disabled. Registering an InstanceCreator or a TypeAdapter for"
+                        + " this type, adding a no-args constructor, or enabling usage of JDK"
+                        + " Unsafe may fix this problem. Or adjust your R8 configuration to keep"
+                        + " the no-args constructor of the class.");
+          }
+        });
   }
 
   @Test
   public void testNoSerializedName_HasArgsConstructor() throws Exception {
-    runTest("com.example.NoSerializedNameMain", c -> {
-      Method m = c.getMethod("runTestHasArgsConstructor");
+    runTest(
+        "com.example.NoSerializedNameMain",
+        c -> {
+          Method m = c.getMethod("runTestHasArgsConstructor");
 
-      if (jarToTest.equals(PROGUARD_RESULT_PATH)) {
-        Object result = m.invoke(null);
-        assertThat(result).isEqualTo("value");
-      } else {
-        // R8 performs more aggressive optimizations
-        Exception e = assertThrows(InvocationTargetException.class, () -> m.invoke(null));
-        assertThat(e).hasCauseThat().hasMessageThat().isEqualTo(
-            "Abstract classes can't be instantiated! Adjust the R8 configuration or register an InstanceCreator"
-            + " or a TypeAdapter for this type. Class name: com.example.NoSerializedNameMain$TestClassHasArgsConstructor"
-            + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#r8-abstract-class"
-        );
-      }
-    });
+          if (jarToTest.equals(PROGUARD_RESULT_PATH)) {
+            Object result = m.invoke(null);
+            assertThat(result).isEqualTo("value");
+          } else {
+            // R8 performs more aggressive optimizations
+            Exception e = assertThrows(InvocationTargetException.class, () -> m.invoke(null));
+            assertThat(e)
+                .hasCauseThat()
+                .hasMessageThat()
+                .isEqualTo(
+                    "Abstract classes can't be instantiated! Adjust the R8 configuration or"
+                        + " register an InstanceCreator or a TypeAdapter for this type. Class name:"
+                        + " com.example.NoSerializedNameMain$TestClassHasArgsConstructor\n"
+                        + "See https://github.com/google/gson/blob/main/Troubleshooting.md#r8-abstract-class");
+          }
+        });
   }
 
   @Test
   public void testUnusedClassRemoved() throws Exception {
-    // For some reason this test only works for R8 but not for ProGuard; ProGuard keeps the unused class
+    // For some reason this test only works for R8 but not for ProGuard; ProGuard keeps the unused
+    // class
     assumeTrue(jarToTest.equals(R8_RESULT_PATH));
 
     String className = UnusedClass.class.getName();
-    ClassNotFoundException e = assertThrows(ClassNotFoundException.class, () -> {
-      runTest(className, c -> {
-        fail("Class should have been removed during shrinking: " + c);
-      });
-    });
+    ClassNotFoundException e =
+        assertThrows(
+            ClassNotFoundException.class,
+            () -> {
+              runTest(
+                  className,
+                  c -> {
+                    fail("Class should have been removed during shrinking: " + c);
+                  });
+            });
     assertThat(e).hasMessageThat().contains(className);
   }
 }


### PR DESCRIPTION
### Purpose
Reformat the Gson codebase to follow the Google Java Style Guide

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
