### PR TITLE
Restore hard line breaks in `README.md`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ Despite supporting older Java versions, Gson also provides a JPMS module descrip
 These are the optional Java Platform Module System (JPMS) JDK modules which Gson depends on.
 This only applies when running Java 9 or newer.
 
-- `java.sql` (optional since Gson 2.8.9)
+- `java.sql` (optional since Gson 2.8.9)\
 When this module is present, Gson provides default adapters for some SQL date and time classes.
 
-- `jdk.unsupported`, respectively class `sun.misc.Unsafe` (optional)
+- `jdk.unsupported`, respectively class `sun.misc.Unsafe` (optional)\
 When this module is present, Gson can use the `Unsafe` class to create instances of classes without no-args constructor.
 However, care should be taken when relying on this. `Unsafe` is not available in all environments and its usage has some pitfalls,
 see [`GsonBuilder.disableJdkUnsafe()`](https://javadoc.io/doc/com.google.code.gson/gson/latest/com.google.gson/com/google/gson/GsonBuilder.html#disableJdkUnsafe()).
@@ -87,7 +87,7 @@ JDK 11 or newer is required for building, JDK 17 is recommended.
 
 ### Contributing
 
-See the [contributing guide](https://github.com/google/.github/blob/master/CONTRIBUTING.md).
+See the [contributing guide](https://github.com/google/.github/blob/master/CONTRIBUTING.md).\
 Please perform a quick search to check if there are already existing issues or pull requests related to your contribution.
 
 Keep in mind that Gson is in maintenance mode. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.


### PR DESCRIPTION
They were previously using the terrible convention of two spaces at the end of a line signaling a hard break. The change here uses the alternative syntax of a final backslash, which can actually be seen in the source code.