### PR TITLE
Formatting follow-up

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Ignore commit which reformatted code
+2c94c757a6a9426cc2fe47bc1c63f69e7c73b7b4
+
+# Ignore commit which changed line endings consistently to LF
+c2a0e4634a2100494159add78db2ee06f5eb9be6

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,9 @@
 ### Checklist
 <!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->
 
-- [ ] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)
+- [ ] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
+  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
+  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
 - [ ] If necessary, new public API validates arguments, for example rejects `null`
 - [ ] New public API has Javadoc
     - [ ] Javadoc uses `@since $next-version$`  

--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -127,8 +127,8 @@ For example, let's assume you want to deserialize the following JSON data:
 }
 ```
 
-This will fail with an exception similar to this one: `MalformedJsonException: Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON at line 5 column 4 path $.languages[2]`
-The problem here is the trailing comma (`,`) after `"French"`, trailing commas are not allowed by the JSON specification. The location information "line 5 column 4" points to the `]` in the JSON data (with some slight inaccuracies) because Gson expected another value after `,` instead of the closing `]`. The JSONPath `$.languages[2]` in the exception message also points there: `$.` refers to the root object, `languages` refers to its member of that name and `[2]` refers to the (missing) third value in the JSON array value of that member (numbering starts at 0, so it is `[2]` instead of `[3]`).
+This will fail with an exception similar to this one: `MalformedJsonException: Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON at line 5 column 4 path $.languages[2]`\
+The problem here is the trailing comma (`,`) after `"French"`, trailing commas are not allowed by the JSON specification. The location information "line 5 column 4" points to the `]` in the JSON data (with some slight inaccuracies) because Gson expected another value after `,` instead of the closing `]`. The JSONPath `$.languages[2]` in the exception message also points there: `$.` refers to the root object, `languages` refers to its member of that name and `[2]` refers to the (missing) third value in the JSON array value of that member (numbering starts at 0, so it is `[2]` instead of `[3]`).\
 The proper solution here is to fix the malformed JSON data.
 
 To spot syntax errors in the JSON data easily you can open it in an editor with support for JSON, for example Visual Studio Code. It will highlight within the JSON data the error location and show why the JSON data is considered invalid.
@@ -178,8 +178,8 @@ And you want to deserialize the following JSON data:
 }
 ```
 
-This will fail with an exception similar to this one: `IllegalStateException: Expected a string but was BEGIN_ARRAY at line 2 column 17 path $.languages`
-This means Gson expected a JSON string value but found the beginning of a JSON array (`[`). The location information "line 2 column 17" points to the `[` in the JSON data (with some slight inaccuracies), so does the JSONPath `$.languages` in the exception message. It refers to the `languages` member of the root object (`$.`).
+This will fail with an exception similar to this one: `IllegalStateException: Expected a string but was BEGIN_ARRAY at line 2 column 17 path $.languages`\
+This means Gson expected a JSON string value but found the beginning of a JSON array (`[`). The location information "line 2 column 17" points to the `[` in the JSON data (with some slight inaccuracies), so does the JSONPath `$.languages` in the exception message. It refers to the `languages` member of the root object (`$.`).\
 The solution here is to change in the `WebPage` class the field `String languages` to `List<String> languages`.
 
 ## <a id="adapter-not-null-safe"></a> `IllegalStateException`: "Expected ... but was NULL"
@@ -287,7 +287,7 @@ This will not initialize arbitrary classes, and it will throw a `ClassCastExcept
 
 ## <a id="type-token-raw"></a> `IllegalStateException`: 'TypeToken must be created with a type argument' <br> `RuntimeException`: 'Missing type parameter'
 
-**Symptom:** An `IllegalStateException` with the message 'TypeToken must be created with a type argument' is thrown.
+**Symptom:** An `IllegalStateException` with the message 'TypeToken must be created with a type argument' is thrown.\
 For older Gson versions a `RuntimeException` with message 'Missing type parameter' is thrown.
 
 **Reason:**

--- a/extras/src/test/java/com/google/gson/typeadapters/PostConstructAdapterFactoryTest.java
+++ b/extras/src/test/java/com/google/gson/typeadapters/PostConstructAdapterFactoryTest.java
@@ -52,8 +52,8 @@ public class PostConstructAdapterFactoryTest {
     // Throws NullPointerException without the fix in https://github.com/google/gson/pull/1103
     String json = gson.toJson(sandwiches);
     assertEquals(
-        "{\"sandwiches\":[{\"bread\":\"white\",\"cheese\":\"cheddar\"},{\"bread\":\"whole"
-            + " wheat\",\"cheese\":\"swiss\"}]}",
+        "{\"sandwiches\":[{\"bread\":\"white\",\"cheese\":\"cheddar\"},"
+            + "{\"bread\":\"whole wheat\",\"cheese\":\"swiss\"}]}",
         json);
 
     MultipleSandwiches sandwichesFromJson = gson.fromJson(json, MultipleSandwiches.class);

--- a/graal-native-image-test/src/test/java/com/google/gson/native_test/ReflectionTest.java
+++ b/graal-native-image-test/src/test/java/com/google/gson/native_test/ReflectionTest.java
@@ -90,8 +90,8 @@ class ReflectionTest {
     assertThat(c.i).isEqualTo(1);
 
     c = gson.fromJson("{}", ClassWithoutDefaultConstructor.class);
-    // Class is instantiated with JDK Unsafe, so field keeps its default value instead of assigned
-    // -1
+    // Class is instantiated with JDK Unsafe, therefore field keeps its default value instead of
+    // assigned -1
     assertThat(c.i).isEqualTo(0);
   }
 

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -139,11 +139,11 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <!-- Deny illegal access, this is required for ReflectionAccessTest -->
-          <!-- Requires Java >= 9; Important: In case future Java versions 
-            don't support this flag anymore, don't remove it unless CI also runs with 
-            that Java version. Ideally would use toolchain to specify that this should 
-            run with e.g. Java 11, but Maven toolchain requirements (unlike Gradle ones) 
-            don't seem to be portable (every developer would have to set up toolchain 
+          <!-- Requires Java >= 9; Important: In case future Java versions
+            don't support this flag anymore, don't remove it unless CI also runs with
+            that Java version. Ideally would use toolchain to specify that this should
+            run with e.g. Java 11, but Maven toolchain requirements (unlike Gradle ones)
+            don't seem to be portable (every developer would have to set up toolchain
             configuration locally). -->
           <argLine>--illegal-access=deny</argLine>
         </configuration>
@@ -239,7 +239,7 @@
         </configuration>
       </plugin>
       <!-- Add module-info to JAR, see https://github.com/moditect/moditect#adding-module-descriptors-to-existing-jar-files -->
-      <!-- Uses ModiTect instead of separate maven-compiler-plugin executions 
+      <!-- Uses ModiTect instead of separate maven-compiler-plugin executions
         for better Eclipse IDE support, see https://github.com/eclipse-m2e/m2e-core/issues/393 -->
       <!-- Note: For some reason this has to be executed before javadoc plugin; otherwise `javadoc:jar` goal fails
         to find source files -->

--- a/gson/src/main/java/com/google/gson/JsonArray.java
+++ b/gson/src/main/java/com/google/gson/JsonArray.java
@@ -163,7 +163,8 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
 
   /**
    * Removes the element at the specified position in this array. Shifts any subsequent elements to
-   * the left (subtracts one from their indices). Returns the element removed from the array.
+   * the left (subtracts one from their indices). Returns the element that was removed from the
+   * array.
    *
    * @param index index the index of the element to be removed
    * @return the element previously at the specified position

--- a/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
+++ b/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
@@ -1,16 +1,19 @@
-/**
+/*
  * Copyright (C) 2008 Google Inc.
  *
- * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
- * except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.google.gson.internal;
 
 import static com.google.gson.internal.$Gson$Preconditions.checkArgument;
@@ -156,8 +159,7 @@ public final class $Gson$Types {
     } else {
       String className = type == null ? "null" : type.getClass().getName();
       throw new IllegalArgumentException(
-          "Expected a Class, ParameterizedType, or "
-              + "GenericArrayType, but <"
+          "Expected a Class, ParameterizedType, or GenericArrayType, but <"
               + type
               + "> is of type "
               + className);

--- a/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
+++ b/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
@@ -303,8 +303,7 @@ public final class ConstructorConstructor {
           throw new RuntimeException(
               "Failed to invoke constructor '"
                   + ReflectionHelper.constructorToString(constructor)
-                  + "'"
-                  + " with no args",
+                  + "' with no args",
               e);
         } catch (InvocationTargetException e) {
           // TODO: don't wrap if cause is unchecked?
@@ -312,8 +311,7 @@ public final class ConstructorConstructor {
           throw new RuntimeException(
               "Failed to invoke constructor '"
                   + ReflectionHelper.constructorToString(constructor)
-                  + "'"
-                  + " with no args",
+                  + "' with no args",
               e.getCause());
         } catch (IllegalAccessException e) {
           throw ReflectionHelper.createExceptionForUnexpectedIllegalAccess(e);

--- a/gson/src/main/java/com/google/gson/internal/JavaVersion.java
+++ b/gson/src/main/java/com/google/gson/internal/JavaVersion.java
@@ -37,7 +37,7 @@ public final class JavaVersion {
       version = extractBeginningInt(javaVersion);
     }
     if (version == -1) {
-      return 6; // Choose a minimum supported JDK version as default
+      return 6; // Choose minimum supported JDK version as default
     }
     return version;
   }

--- a/gson/src/main/java/com/google/gson/internal/UnsafeAllocator.java
+++ b/gson/src/main/java/com/google/gson/internal/UnsafeAllocator.java
@@ -121,8 +121,8 @@ public abstract class UnsafeAllocator {
         throw new UnsupportedOperationException(
             "Cannot allocate "
                 + c
-                + ". Usage of JDK sun.misc.Unsafe is enabled, "
-                + "but it could not be used. Make sure your runtime is configured correctly.");
+                + ". Usage of JDK sun.misc.Unsafe is enabled, but it could not be used."
+                + " Make sure your runtime is configured correctly.");
       }
     };
   }

--- a/gson/src/main/java/com/google/gson/internal/bind/JsonAdapterAnnotationTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonAdapterAnnotationTypeAdapterFactory.java
@@ -71,7 +71,7 @@ public final class JsonAdapterAnnotationTypeAdapterFactory implements TypeAdapte
     return rawType.getAnnotation(JsonAdapter.class);
   }
 
-  // this is not safe; requires that user has specified correct adapter class for  @JsonAdapter
+  // this is not safe; requires that user has specified correct adapter class for @JsonAdapter
   @SuppressWarnings("unchecked")
   @Override
   public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> targetType) {

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -228,8 +228,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
           throw new JsonParseException(
               "null is not allowed as value for record component '"
                   + fieldName
-                  + "'"
-                  + " of primitive type; at path "
+                  + "' of primitive type; at path "
                   + reader.getPath());
         }
         target[index] = fieldValue;
@@ -244,8 +243,8 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
             checkAccessible(target, field);
           } else if (isStaticFinalField) {
             // Reflection does not permit setting value of `static final` field, even after calling
-            // `setAccessible` Handle this here to avoid causing IllegalAccessException when calling
-            // `Field.set`
+            // `setAccessible`
+            // Handle this here to avoid causing IllegalAccessException when calling `Field.set`
             String fieldDescription = ReflectionHelper.getAccessibleObjectDescription(field, false);
             throw new JsonIOException("Cannot set value of 'static final' " + fieldDescription);
           }
@@ -279,8 +278,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
             + declaringType.getName()
             + " declares multiple JSON fields named '"
             + duplicateName
-            + "'; conflict is caused"
-            + " by fields "
+            + "'; conflict is caused by fields "
             + ReflectionHelper.fieldToString(field1)
             + " and "
             + ReflectionHelper.fieldToString(field2)
@@ -313,8 +311,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
                   + raw
                   + " (supertype of "
                   + originalRaw
-                  + "). Register a TypeAdapter for this type"
-                  + " or adjust the access filter.");
+                  + "). Register a TypeAdapter for this type or adjust the access filter.");
         }
         blockInaccessible = filterResult == FilterResult.BLOCK_INACCESSIBLE;
       }
@@ -603,8 +600,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
         throw new IllegalStateException(
             "Could not find the index in the constructor '"
                 + ReflectionHelper.constructorToString(constructor)
-                + "'"
-                + " for field with name '"
+                + "' for field with name '"
                 + field.fieldName
                 + "', unable to determine which argument in the constructor the field corresponds"
                 + " to. This is unexpected behavior, as we expect the RecordComponents to have the"
@@ -624,13 +620,12 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
       }
       // Note: InstantiationException should be impossible because record class is not abstract;
       //  IllegalArgumentException should not be possible unless a bad adapter returns objects of
-      // the wrong type
+      //  the wrong type
       catch (InstantiationException | IllegalArgumentException e) {
         throw new RuntimeException(
             "Failed to invoke constructor '"
                 + ReflectionHelper.constructorToString(constructor)
-                + "'"
-                + " with args "
+                + "' with args "
                 + Arrays.toString(accumulator),
             e);
       } catch (InvocationTargetException e) {
@@ -638,8 +633,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
         throw new RuntimeException(
             "Failed to invoke constructor '"
                 + ReflectionHelper.constructorToString(constructor)
-                + "'"
-                + " with args "
+                + "' with args "
                 + Arrays.toString(accumulator),
             e.getCause());
       }

--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapterRuntimeTypeWrapper.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapterRuntimeTypeWrapper.java
@@ -45,8 +45,8 @@ final class TypeAdapterRuntimeTypeWrapper<T> extends TypeAdapter<T> {
     // Order of preference for choosing type adapters
     // First preference: a type adapter registered for the runtime type
     // Second preference: a type adapter registered for the declared type
-    // Third preference: reflective type adapter for the runtime type (if it is a subclass of the
-    // declared type)
+    // Third preference: reflective type adapter for the runtime type
+    //                   (if it is a subclass of the declared type)
     // Fourth preference: reflective type adapter for the declared type
 
     TypeAdapter<T> chosen = delegate;

--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -401,8 +401,8 @@ public final class TypeAdapters {
             out.nullValue();
           } else {
             // For backward compatibility don't call `JsonWriter.value(float)` because that method
-            // has
-            // been newly added and not all custom JsonWriter implementations might override it yet
+            // has been newly added and not all custom JsonWriter implementations might override
+            // it yet
             Number floatNumber = value instanceof Float ? value : value.floatValue();
             out.value(floatNumber);
           }
@@ -952,7 +952,8 @@ public final class TypeAdapters {
     public EnumTypeAdapter(final Class<T> classOfT) {
       try {
         // Uses reflection to find enum constants to work around name mismatches for obfuscated
-        // classes Reflection access might throw SecurityException, therefore run this in privileged
+        // classes
+        // Reflection access might throw SecurityException, therefore run this in privileged
         // context; should be acceptable because this only retrieves enum constants, but does not
         // expose anything else
         Field[] constantFields =

--- a/gson/src/main/java/com/google/gson/internal/bind/util/ISO8601Utils.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/util/ISO8601Utils.java
@@ -160,10 +160,12 @@ public class ISO8601Utils {
 
       // extract day
       int day = parseInt(date, offset, offset += 2);
+
       // default time value
       int hour = 0;
       int minutes = 0;
       int seconds = 0;
+
       // always use 0 otherwise returned date will include millis of current time
       int milliseconds = 0;
 

--- a/gson/src/main/java/com/google/gson/internal/bind/util/ISO8601Utils.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/util/ISO8601Utils.java
@@ -164,8 +164,8 @@ public class ISO8601Utils {
       int hour = 0;
       int minutes = 0;
       int seconds = 0;
-      int milliseconds =
-          0; // always use 0 otherwise returned date will include millis of current time
+      // always use 0 otherwise returned date will include millis of current time
+      int milliseconds = 0;
 
       // if the value has no time component (and no time zone), we are done
       boolean hasT = checkOffset(date, offset, 'T');

--- a/gson/src/main/java/com/google/gson/internal/reflect/ReflectionHelper.java
+++ b/gson/src/main/java/com/google/gson/internal/reflect/ReflectionHelper.java
@@ -159,10 +159,9 @@ public class ReflectionHelper {
     } catch (Exception exception) {
       return "Failed making constructor '"
           + constructorToString(constructor)
-          + "' accessible;"
-          + " either increase its visibility or write a custom InstanceCreator or TypeAdapter for"
+          + "' accessible; either increase its visibility or write a custom InstanceCreator or"
+          + " TypeAdapter for its declaring type: "
           // Include the message since it might contain more detailed information
-          + " its declaring type: "
           + exception.getMessage()
           + getInaccessibleTroubleshootingSuffix(exception);
     }

--- a/gson/src/main/java/com/google/gson/reflect/TypeToken.java
+++ b/gson/src/main/java/com/google/gson/reflect/TypeToken.java
@@ -109,8 +109,8 @@ public class TypeToken<T> {
     else if (superclass == TypeToken.class) {
       throw new IllegalStateException(
           "TypeToken must be created with a type argument: new TypeToken<...>() {}; When using code"
-              + " shrinkers (ProGuard, R8, ...) make sure that generic signatures are preserved.\n"
-              + "See "
+              + " shrinkers (ProGuard, R8, ...) make sure that generic signatures are preserved."
+              + "\nSee "
               + TroubleshootingGuide.createUrl("type-token-raw"));
     }
 
@@ -416,8 +416,7 @@ public class TypeToken<T> {
       throw new IllegalArgumentException(
           "Raw type "
               + rawClass.getName()
-              + " is not supported because"
-              + " it requires specifying an owner type");
+              + " is not supported because it requires specifying an owner type");
     }
 
     for (int i = 0; i < expectedArgsCount; i++) {
@@ -433,8 +432,7 @@ public class TypeToken<T> {
           throw new IllegalArgumentException(
               "Type argument "
                   + typeArgument
-                  + " does not satisfy bounds"
-                  + " for type variable "
+                  + " does not satisfy bounds for type variable "
                   + typeVariable
                   + " declared by "
                   + rawType);

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -1339,8 +1339,8 @@ public class JsonReader implements Closeable {
           // Only update when object end is explicitly skipped, otherwise stack is not updated
           // anyways
           if (count == 0) {
-            pathNames[stackSize - 1] =
-                null; // Free the last path name so that it can be garbage collected
+            // Free the last path name so that it can be garbage collected
+            pathNames[stackSize - 1] = null;
           }
           stackSize--;
           count--;
@@ -1616,7 +1616,7 @@ public class JsonReader implements Closeable {
 
   /**
    * Returns a <a href="https://goessner.net/articles/JsonPath/">JSONPath</a> in <i>dot-notation</i>
-   * to the previous (or current) location in the JSON document:
+   * to the previous (or current) location in the JSON document. That means:
    *
    * <ul>
    *   <li>For JSON arrays the path points to the index of the previous element.<br>
@@ -1634,7 +1634,7 @@ public class JsonReader implements Closeable {
 
   /**
    * Returns a <a href="https://goessner.net/articles/JsonPath/">JSONPath</a> in <i>dot-notation</i>
-   * to the next (or current) location in the JSON document:
+   * to the next (or current) location in the JSON document. That means:
    *
    * <ul>
    *   <li>For JSON arrays the path points to the index of the next element (even if there are no

--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -306,9 +306,9 @@ public class JsonWriter implements Closeable, Flushable {
    * @see #setStrictness(Strictness)
    */
   @Deprecated
-  @SuppressWarnings(
-      "InlineMeSuggester") // Don't specify @InlineMe, so caller with `setLenient(false)` becomes
-  // aware of new Strictness.STRICT
+  // Don't specify @InlineMe, so caller with `setLenient(false)` becomes aware of new
+  // Strictness.STRICT
+  @SuppressWarnings("InlineMeSuggester")
   public final void setLenient(boolean lenient) {
     setStrictness(lenient ? Strictness.LENIENT : Strictness.LEGACY_STRICT);
   }

--- a/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
@@ -648,8 +648,8 @@ public class DefaultTypeAdaptersTest {
       assertThat(expected)
           .hasMessageThat()
           .isEqualTo(
-              "Expected a com.google.gson.JsonObject but was com.google.gson.JsonPrimitive; at path"
-                  + " $");
+              "Expected a com.google.gson.JsonObject but was com.google.gson.JsonPrimitive;"
+                  + " at path $");
     }
   }
 

--- a/gson/src/test/java/com/google/gson/functional/FormattingStyleTest.java
+++ b/gson/src/test/java/com/google/gson/functional/FormattingStyleTest.java
@@ -115,14 +115,12 @@ public class FormattingStyleTest {
     // Sanity check to verify that `buildExpected` works correctly
     assertThat(json)
         .isEqualTo(
-            // spotless:off
-            "{\n"
-            + "  \"a\": [\n"
-            + "    1,\n"
-            + "    2\n"
-            + "  ]\n"
-            + "}");
-            // spotless:on
+            "{\n" //
+                + "  \"a\": [\n" //
+                + "    1,\n" //
+                + "    2\n" //
+                + "  ]\n" //
+                + "}");
   }
 
   @Test

--- a/gson/src/test/java/com/google/gson/functional/FormattingStyleTest.java
+++ b/gson/src/test/java/com/google/gson/functional/FormattingStyleTest.java
@@ -113,7 +113,16 @@ public class FormattingStyleTest {
     String expectedJson = buildExpected("\n", "  ", true);
     assertThat(json).isEqualTo(expectedJson);
     // Sanity check to verify that `buildExpected` works correctly
-    assertThat(json).isEqualTo("{\n" + "  \"a\": [\n" + "    1,\n" + "    2\n" + "  ]\n" + "}");
+    assertThat(json)
+        .isEqualTo(
+            // spotless:off
+            "{\n"
+            + "  \"a\": [\n"
+            + "    1,\n"
+            + "    2\n"
+            + "  ]\n"
+            + "}");
+            // spotless:on
   }
 
   @Test

--- a/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java
@@ -474,9 +474,8 @@ public final class JsonAdapterAnnotationOnClassesTest {
       @Override
       public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
         return new TypeAdapter<T>() {
-          @SuppressWarnings(
-              "SameNameButDifferent") // suppress Error Prone warning; should be clear that
-          // `Factory` refers to enclosing class
+          // suppress Error Prone warning; should be clear that `Factory` refers to enclosing class
+          @SuppressWarnings("SameNameButDifferent")
           private TypeAdapter<T> delegate() {
             return gson.getDelegateAdapter(Factory.this, type);
           }

--- a/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnFieldsTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnFieldsTest.java
@@ -604,8 +604,7 @@ public final class JsonAdapterAnnotationOnFieldsTest {
     assertThat(new Gson().toJson(serialized)).isEqualTo("{\"f\":\"value-custom\"}");
   }
 
-  // suppress Error Prone warning; should be clear that `Factory` refers to nested class to nested
-  // class
+  // suppress Error Prone warning; should be clear that `Factory` refers to nested class
   @SuppressWarnings("SameNameButDifferent")
   private static class WithDelayedDelegatingFactory {
     @JsonAdapter(Factory.class)

--- a/gson/src/test/java/com/google/gson/functional/LeniencyTest.java
+++ b/gson/src/test/java/com/google/gson/functional/LeniencyTest.java
@@ -40,7 +40,11 @@ public class LeniencyTest {
   public void testLenientFromJson() {
     List<String> json =
         gson.fromJson(
-            "" + "[ # One!\n" + "  'Hi' #Element!\n" + "] # Array!",
+            // spotless:off
+            "[ # One!\n"
+            + "  'Hi' #Element!\n"
+            + "] # Array!",
+            // spotless:on
             new TypeToken<List<String>>() {}.getType());
     assertThat(json).isEqualTo(singletonList("Hi"));
   }

--- a/gson/src/test/java/com/google/gson/functional/LeniencyTest.java
+++ b/gson/src/test/java/com/google/gson/functional/LeniencyTest.java
@@ -40,11 +40,9 @@ public class LeniencyTest {
   public void testLenientFromJson() {
     List<String> json =
         gson.fromJson(
-            // spotless:off
-            "[ # One!\n"
-            + "  'Hi' #Element!\n"
-            + "] # Array!",
-            // spotless:on
+            "[ # One!\n" //
+                + "  'Hi' #Element!\n" //
+                + "] # Array!",
             new TypeToken<List<String>>() {}.getType());
     assertThat(json).isEqualTo(singletonList("Hi"));
   }

--- a/gson/src/test/java/com/google/gson/functional/MapTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MapTest.java
@@ -500,7 +500,7 @@ public class MapTest {
 
     String subTypeJson = new Gson().toJson(subType);
     String expected =
-        "{\"bases\":{\"Test\":" + subTypeJson + "}," + "\"subs\":{\"Test\":" + subTypeJson + "}}";
+        "{\"bases\":{\"Test\":" + subTypeJson + "},\"subs\":{\"Test\":" + subTypeJson + "}}";
 
     Gson gsonWithComplexKeys = new GsonBuilder().enableComplexMapKeySerialization().create();
     String json = gsonWithComplexKeys.toJson(element);
@@ -523,7 +523,7 @@ public class MapTest {
     final JsonElement baseTypeJsonElement = tempGson.toJsonTree(subType, TestTypes.Base.class);
     String baseTypeJson = tempGson.toJson(baseTypeJsonElement);
     String expected =
-        "{\"bases\":{\"Test\":" + baseTypeJson + "}," + "\"subs\":{\"Test\":" + subTypeJson + "}}";
+        "{\"bases\":{\"Test\":" + baseTypeJson + "},\"subs\":{\"Test\":" + subTypeJson + "}}";
 
     JsonSerializer<TestTypes.Base> baseTypeAdapter =
         new JsonSerializer<TestTypes.Base>() {

--- a/gson/src/test/java/com/google/gson/functional/PrimitiveTest.java
+++ b/gson/src/test/java/com/google/gson/functional/PrimitiveTest.java
@@ -100,8 +100,8 @@ public class PrimitiveTest {
     assertThat(e)
         .hasMessageThat()
         .isEqualTo(
-            "java.lang.NumberFormatException: Expected an int but was 2147483648 at line 1 column"
-                + " 11 path $");
+            "java.lang.NumberFormatException: Expected an int but was 2147483648"
+                + " at line 1 column 11 path $");
   }
 
   @Test
@@ -143,8 +143,8 @@ public class PrimitiveTest {
     assertThat(e)
         .hasMessageThat()
         .isEqualTo(
-            "java.lang.NumberFormatException: Expected an int but was 2147483648 at line 1 column"
-                + " 11 path $");
+            "java.lang.NumberFormatException: Expected an int but was 2147483648"
+                + " at line 1 column 11 path $");
   }
 
   @Test

--- a/gson/src/test/java/com/google/gson/functional/ReflectionAccessFilterTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ReflectionAccessFilterTest.java
@@ -447,7 +447,7 @@ public class ReflectionAccessFilterTest {
   }
 
   /**
-   * Should not fail when deserializing collection interface (Even though this goes through {@link
+   * Should not fail when deserializing collection interface (even though this goes through {@link
    * ConstructorConstructor} as well)
    */
   @Test
@@ -467,7 +467,7 @@ public class ReflectionAccessFilterTest {
   }
 
   /**
-   * Should not fail when deserializing specific collection implementation (Even though this goes
+   * Should not fail when deserializing specific collection implementation (even though this goes
    * through {@link ConstructorConstructor} as well)
    */
   @Test

--- a/gson/src/test/java/com/google/gson/internal/JavaVersionTest.java
+++ b/gson/src/test/java/com/google/gson/internal/JavaVersionTest.java
@@ -30,20 +30,20 @@ public class JavaVersionTest {
 
   @Test
   public void testGetMajorJavaVersion() {
-    assertThat(JavaVersion.getMajorJavaVersion() >= 7)
-        .isTrue(); // Gson currently requires at least Java 7
+    // Gson currently requires at least Java 7
+    assertThat(JavaVersion.getMajorJavaVersion() >= 7).isTrue();
   }
 
   @Test
   public void testJava6() {
-    assertThat(JavaVersion.getMajorJavaVersion("1.6.0"))
-        .isEqualTo(6); // http://www.oracle.com/technetwork/java/javase/version-6-141920.html
+    // http://www.oracle.com/technetwork/java/javase/version-6-141920.html
+    assertThat(JavaVersion.getMajorJavaVersion("1.6.0")).isEqualTo(6);
   }
 
   @Test
   public void testJava7() {
-    assertThat(JavaVersion.getMajorJavaVersion("1.7.0"))
-        .isEqualTo(7); // http://www.oracle.com/technetwork/java/javase/jdk7-naming-418744.html
+    // http://www.oracle.com/technetwork/java/javase/jdk7-naming-418744.html
+    assertThat(JavaVersion.getMajorJavaVersion("1.7.0")).isEqualTo(7);
   }
 
   @Test
@@ -63,8 +63,9 @@ public class JavaVersionTest {
   public void testJava9() {
     // Legacy style
     assertThat(JavaVersion.getMajorJavaVersion("9.0.4")).isEqualTo(9); // Oracle JDK 9
-    assertThat(JavaVersion.getMajorJavaVersion("9-Debian"))
-        .isEqualTo(9); // Debian as reported in https://github.com/google/gson/issues/1310
+    // Debian as reported in https://github.com/google/gson/issues/1310
+    assertThat(JavaVersion.getMajorJavaVersion("9-Debian")).isEqualTo(9);
+
     // New style
     assertThat(JavaVersion.getMajorJavaVersion("9-ea+19")).isEqualTo(9);
     assertThat(JavaVersion.getMajorJavaVersion("9+100")).isEqualTo(9);

--- a/gson/src/test/java/com/google/gson/internal/bind/RecursiveTypesResolveTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/RecursiveTypesResolveTest.java
@@ -29,8 +29,8 @@ import org.junit.Test;
  * #440</a> and similar issues.
  *
  * <p>These tests originally caused {@link StackOverflowError} because of infinite recursion on
- * attempts to resolve generics on types, with an intermediate types like 'Foo2&lt;? extends ? super
- * ? extends ... ? extends A&gt;'
+ * attempts to resolve generics on types, with intermediate types like {@code Foo2<? extends ? super
+ * ? extends ... ? extends A>}
  */
 public class RecursiveTypesResolveTest {
 
@@ -52,7 +52,7 @@ public class RecursiveTypesResolveTest {
     assertThat(adapter).isNotNull();
   }
 
-  /** Tests belows check the behaviour of the methods changed for the fix. */
+  /** Tests below check the behavior of the methods changed for the fix. */
   @Test
   public void testDoubleSupertype() {
     assertThat($Gson$Types.supertypeOf($Gson$Types.supertypeOf(Number.class)))

--- a/gson/src/test/java/com/google/gson/reflect/TypeTokenTest.java
+++ b/gson/src/test/java/com/google/gson/reflect/TypeTokenTest.java
@@ -207,8 +207,7 @@ public final class TypeTokenTest {
     assertThat(e)
         .hasMessageThat()
         .isEqualTo(
-            "Type argument int does not satisfy bounds"
-                + " for type variable E declared by "
+            "Type argument int does not satisfy bounds for type variable E declared by "
                 + List.class);
 
     e =

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -417,12 +417,10 @@ public final class JsonReaderTest {
   @Test
   public void testHelloWorld() throws IOException {
     String json =
-        // spotless:off
-        "{\n" +
-        "   \"hello\": true,\n" +
-        "   \"foo\": [\"world\"]\n" +
-        "}";
-        // spotless:on
+        "{\n" //
+            + "   \"hello\": true,\n" //
+            + "   \"foo\": [\"world\"]\n" //
+            + "}";
     JsonReader reader = new JsonReader(reader(json));
     reader.beginObject();
     assertThat(reader.nextName()).isEqualTo("hello");
@@ -438,12 +436,10 @@ public final class JsonReaderTest {
   @Test
   public void testInvalidJsonInput() throws IOException {
     String json =
-        // spotless:off
-        "{\n"
-        + "   \"h\\ello\": true,\n"
-        + "   \"foo\": [\"world\"]\n"
-        + "}";
-        // spotless:on
+        "{\n" //
+            + "   \"h\\ello\": true,\n" //
+            + "   \"foo\": [\"world\"]\n" //
+            + "}";
 
     JsonReader reader = new JsonReader(reader(json));
     reader.beginObject();

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -148,8 +148,8 @@ public final class JsonReaderTest {
     assertThat(expected)
         .hasMessageThat()
         .startsWith(
-            "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed"
-                + " JSON at line 1 column 1 path $");
+            "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON"
+                + " at line 1 column 1 path $");
 
     reader = new JsonReader(reader("True"));
     reader.setStrictness(Strictness.STRICT);
@@ -158,8 +158,8 @@ public final class JsonReaderTest {
     assertThat(expected)
         .hasMessageThat()
         .startsWith(
-            "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed"
-                + " JSON at line 1 column 1 path $");
+            "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON"
+                + " at line 1 column 1 path $");
   }
 
   @Test
@@ -171,8 +171,8 @@ public final class JsonReaderTest {
     assertThat(expected)
         .hasMessageThat()
         .startsWith(
-            "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed"
-                + " JSON at line 1 column 1 path $");
+            "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON"
+                + " at line 1 column 1 path $");
 
     reader = new JsonReader(reader("FaLse"));
     reader.setStrictness(Strictness.STRICT);
@@ -181,8 +181,8 @@ public final class JsonReaderTest {
     assertThat(expected)
         .hasMessageThat()
         .startsWith(
-            "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed"
-                + " JSON at line 1 column 1 path $");
+            "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON"
+                + " at line 1 column 1 path $");
   }
 
   @Test
@@ -194,8 +194,8 @@ public final class JsonReaderTest {
     assertThat(expected)
         .hasMessageThat()
         .startsWith(
-            "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed"
-                + " JSON at line 1 column 1 path $");
+            "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON"
+                + " at line 1 column 1 path $");
 
     reader = new JsonReader(reader("nulL"));
     reader.setStrictness(Strictness.STRICT);
@@ -204,8 +204,8 @@ public final class JsonReaderTest {
     assertThat(expected)
         .hasMessageThat()
         .startsWith(
-            "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed"
-                + " JSON at line 1 column 1 path $");
+            "Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON"
+                + " at line 1 column 1 path $");
   }
 
   @Test
@@ -416,7 +416,13 @@ public final class JsonReaderTest {
 
   @Test
   public void testHelloWorld() throws IOException {
-    String json = "{\n" + "   \"hello\": true,\n" + "   \"foo\": [\"world\"]\n" + "}";
+    String json =
+        // spotless:off
+        "{\n" +
+        "   \"hello\": true,\n" +
+        "   \"foo\": [\"world\"]\n" +
+        "}";
+        // spotless:on
     JsonReader reader = new JsonReader(reader(json));
     reader.beginObject();
     assertThat(reader.nextName()).isEqualTo("hello");
@@ -431,7 +437,13 @@ public final class JsonReaderTest {
 
   @Test
   public void testInvalidJsonInput() throws IOException {
-    String json = "{\n" + "   \"h\\ello\": true,\n" + "   \"foo\": [\"world\"]\n" + "}";
+    String json =
+        // spotless:off
+        "{\n"
+        + "   \"h\\ello\": true,\n"
+        + "   \"foo\": [\"world\"]\n"
+        + "}";
+        // spotless:on
 
     JsonReader reader = new JsonReader(reader(json));
     reader.beginObject();

--- a/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
@@ -1045,14 +1045,12 @@ public final class JsonWriterTest {
     jsonWriter.endArray();
 
     String expected =
-        // spotless:off
-        "[\r\n"
-        + " \t true,\r\n"
-        + " \t \"text\",\r\n"
-        + " \t 5.0,\r\n"
-        + " \t null\r\n"
-        + "]";
-        // spotless:on
+        "[\r\n" //
+            + " \t true,\r\n" //
+            + " \t \"text\",\r\n" //
+            + " \t 5.0,\r\n" //
+            + " \t null\r\n" //
+            + "]";
     assertThat(stringWriter.toString()).isEqualTo(expected);
 
     assertThat(jsonWriter.getFormattingStyle().getNewline()).isEqualTo(lineSeparator);
@@ -1075,14 +1073,12 @@ public final class JsonWriterTest {
     jsonWriter.endObject();
 
     String expected =
-        // spotless:off
-       "{\n"
-        + "  \"a\": [\n"
-        + "    1,\n"
-        + "    2\n"
-        + "  ]\n"
-        + "}";
-        // spotless:on
+        "{\n" //
+            + "  \"a\": [\n" //
+            + "    1,\n" //
+            + "    2\n" //
+            + "  ]\n" //
+            + "}";
     assertThat(stringWriter.toString()).isEqualTo(expected);
   }
 }

--- a/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
@@ -1045,7 +1045,14 @@ public final class JsonWriterTest {
     jsonWriter.endArray();
 
     String expected =
-        "[\r\n" + " \t true,\r\n" + " \t \"text\",\r\n" + " \t 5.0,\r\n" + " \t null\r\n" + "]";
+        // spotless:off
+        "[\r\n"
+        + " \t true,\r\n"
+        + " \t \"text\",\r\n"
+        + " \t 5.0,\r\n"
+        + " \t null\r\n"
+        + "]";
+        // spotless:on
     assertThat(stringWriter.toString()).isEqualTo(expected);
 
     assertThat(jsonWriter.getFormattingStyle().getNewline()).isEqualTo(lineSeparator);
@@ -1067,7 +1074,15 @@ public final class JsonWriterTest {
     jsonWriter.endArray();
     jsonWriter.endObject();
 
-    String expected = "{\n" + "  \"a\": [\n" + "    1,\n" + "    2\n" + "  ]\n" + "}";
+    String expected =
+        // spotless:off
+       "{\n"
+        + "  \"a\": [\n"
+        + "    1,\n"
+        + "    2\n"
+        + "  ]\n"
+        + "}";
+        // spotless:on
     assertThat(stringWriter.toString()).isEqualTo(expected);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,6 @@
               <exclude>src/test/java/com/google/gson/functional/Java17RecordTest.java</exclude>
               <exclude>src/test/java/com/google/gson/native_test/Java17RecordReflectionTest.java</exclude>
             </excludes>
-            <toggleOffOn/>
             <googleJavaFormat>
               <style>GOOGLE</style>
               <reflowLongStrings>true</reflowLongStrings>

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
           </execution>
         </executions>
       </plugin>
+
       <!-- Spotless plugin: keeps the code formatted following the google-java-styleguide -->
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
@@ -136,34 +137,45 @@
             </goals>
           </execution>
         </executions>
+        <!-- Note: The configuration here is not specific to the `<execution>` above to allow users to run
+          `mvn spotless:apply` from the command line, using the same configuration -->
         <configuration>
+          <!-- Perform some basic formatting for non-Java code -->
           <formats>
             <format>
               <includes>
                 <include>*.md</include>
+                <include>*.xml</include>
                 <include>.gitignore</include>
               </includes>
+              <!-- For Markdown files removing trailing whitespace causes issues for hard line breaks,
+                which use two trailing spaces. However, the trailing spaces are difficult to notice anyway;
+                prefer a trailing `\` instead of two spaces. -->
               <trimTrailingWhitespace/>
               <endWithNewline/>
               <indent>
                 <spaces>true</spaces>
-                <spacesPerTab>4</spacesPerTab>
+                <!-- This seems to mostly (or only?) affect the suggested fix in case code contains tabs -->
+                <spacesPerTab>2</spacesPerTab>
               </indent>
             </format>
           </formats>
+
           <java>
+            <!-- Exclude classes which need Java 17 for compilation; Google Java Format internally relies on javac,
+              so formatting will fail if build is executed with JDK 11 -->
             <excludes>
               <exclude>src/test/java/com/google/gson/functional/Java17RecordTest.java</exclude>
               <exclude>src/test/java/com/google/gson/native_test/Java17RecordReflectionTest.java</exclude>
             </excludes>
+            <toggleOffOn/>
             <googleJavaFormat>
               <style>GOOGLE</style>
               <reflowLongStrings>true</reflowLongStrings>
+              <reorderImports>true</reorderImports>
               <formatJavadoc>true</formatJavadoc>
             </googleJavaFormat>
-            <importOrder/>
-            <removeUnusedImports/>
-            <formatAnnotations/>     <!-- Puts type annotations immediately before types. -->.
+            <formatAnnotations/>     <!-- Puts type annotations immediately before types. -->
           </java>
         </configuration>
       </plugin>
@@ -209,17 +221,17 @@
             <release>11</release>
             <!-- Exclude `missing` group because some tags have been omitted when they are redundant -->
             <doclint>all,-missing</doclint>
-            <!-- Link against newer Java API Javadoc because most users likely 
+            <!-- Link against newer Java API Javadoc because most users likely
               use a newer Java version than the one used for building this project -->
             <detectJavaApiLink>false</detectJavaApiLink>
             <links>
               <link>https://docs.oracle.com/en/java/javase/11/docs/api/</link>
               <link>https://errorprone.info/api/latest/</link>
             </links>
-            <!-- Disable detection of offline links between Maven modules: 
-              (1) Only `gson` module is published, so for other modules Javadoc links don't 
-              matter much at the moment; (2) The derived URL for the modules is based on 
-              the project URL (= Gson GitHub repo) which is incorrect because it is not 
+            <!-- Disable detection of offline links between Maven modules:
+              (1) Only `gson` module is published, so for other modules Javadoc links don't
+              matter much at the moment; (2) The derived URL for the modules is based on
+              the project URL (= Gson GitHub repo) which is incorrect because it is not
               hosting the Javadoc (3) It might fail due to https://bugs.openjdk.java.net/browse/JDK-8212233 -->
             <detectOfflineLinks>false</detectOfflineLinks>
             <!-- Only show warnings and errors -->

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,7 @@
               <includes>
                 <include>*.md</include>
                 <include>*.xml</include>
+                <include>.github/**/*.yml</include>
                 <include>.gitignore</include>
               </includes>
               <!-- For Markdown files removing trailing whitespace causes issues for hard line breaks,


### PR DESCRIPTION


<!--
    Thank you for your contribution!
    Please see the contributing guide: https://github.com/google/.github/blob/master/CONTRIBUTING.md

    Keep in mind that Gson is in maintenance mode. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.
-->

### Purpose
Follow-up for #2531, #2536 and #2537

### Description
- Adds formatting commits to `.git-blame-ignore-revs` so that they don't distract during Git blame; see also the [GitHub documentation](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view)
- Restores hard line breaks in Troubleshooting.md using `\` instead of trailing spaces
- Changes formatting of some string literals and comments
- Fixes accidental Javadoc and comment issues introduced by manual changes of formatting commit
- Fixes license header in `$Gson$Types.java` erroneously being a Javadoc comment and being reformatted
- Slightly changes `JsonReader` `getPath` and `getPreviousPath` documentation to help Javadoc detect first sentence as summary
- Adjusts pull request template to mention Maven commands for checking and fixing formatting issues

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
