### PR TITLE
Make Maven build reproducible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           cache: 'maven'
       - name: Build with Maven
         # This also runs javadoc:jar to detect any issues with the Javadoc generated during release
-        run: mvn --batch-mode --update-snapshots --no-transfer-progress verify javadoc:jar
+        run: mvn --batch-mode --no-transfer-progress verify javadoc:jar
 
   native-image-test:
     name: "GraalVM Native Image test"
@@ -42,4 +42,29 @@ jobs:
       - name: Build and run tests
         # Only run tests in `graal-native-image-test` (and implicitly build and run tests in `gson`),
         # everything else is covered already by regular build job above
-        run: mvn test --batch-mode --update-snapshots --no-transfer-progress --activate-profiles native-image-test --projects graal-native-image-test --also-make
+        run: mvn test --batch-mode --no-transfer-progress --activate-profiles native-image-test --projects graal-native-image-test --also-make
+
+  verify-reproducible-build:
+    name: "Verify reproducible build"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: "Set up JDK 17"
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'maven'
+
+      - name: "Verify no plugin issues"
+        run: mvn artifact:check-buildplan --batch-mode --no-transfer-progress
+
+      - name: "Verify reproducible build"
+        # See https://maven.apache.org/guides/mini/guide-reproducible-builds.html#how-to-test-my-maven-build-reproducibility
+        run: |
+          mvn clean install --batch-mode --no-transfer-progress -Dproguard.skip -DskipTests
+          # Run with `-Dbuildinfo.attach=false`; otherwise `artifact:compare` fails because it creates a `.buildinfo` file which
+          # erroneously references the existing `.buildinfo` file (respectively because it is overwriting it, a file with size 0)
+          # See https://issues.apache.org/jira/browse/MARTIFACT-57
+          mvn clean verify artifact:compare --batch-mode --no-transfer-progress -Dproguard.skip -DskipTests -Dbuildinfo.attach=false

--- a/ReleaseProcess.md
+++ b/ReleaseProcess.md
@@ -37,6 +37,72 @@ This section was borrowed heavily from [Doclava release process](https://code.go
 
 See [OSSRH Publish Guide](https://central.sonatype.org/publish/publish-guide/).
 
+## Testing Maven release workflow locally
+
+The following describes how to perform the steps of the release locally to verify that they work as desired.
+
+**Warning:** Be careful with this, these steps might be outdated or incomplete. Doublecheck that you are working on a copy of your local Gson Git repository and make sure you have followed all steps. To be safe you can also temporarily turn off your internet connection to avoid accidentally pushing changes to the real remote Git or Maven repository.\
+As an alternative to the steps described below you can instead [perform a dry run](https://maven.apache.org/maven-release/maven-release-plugin/usage.html#do-a-dry-run), though this might not behave identical to a real release.
+
+1. Make a copy of your local Gson Git repository and only work with that copy
+2. Make sure you are on the `main` branch
+3. Create a temp directory outside the Gson directory\
+   In the following steps this will be called `#gson-remote-temp#`; replace this with the actual absolute file path of the directory, using only forward slashes. For example under Windows `C:\my-dir` becomes `C:/my-dir`.
+4. Create the directory `#gson-remote-temp#/git-repo`
+5. In that directory run
+
+    ```sh
+    git init --bare --initial-branch=main .
+    ```
+
+6. Create the directory `#gson-remote-temp#/maven-repo`
+7. Edit the root `pom.xml` of Gson
+    1. Change the `<developerConnection>` to
+
+       ```txt
+       scm:git:file:///#gson-remote-temp#/git-repo
+       ```
+
+    2. Change the `<url>` of the `<distributionManagement>` to
+
+       ```txt
+       file:///#gson-remote-temp#/maven-repo
+       ```
+
+    3. If you don't want to use GPG, remove the `maven-gpg-plugin` entry from the 'release' profile.\
+       There is also an entry under `<pluginManagement>`; you can remove that as well.
+8. Commit the changes using Git
+9. Change the remote repository of the Git project
+
+    <!-- Uses `txt` instead of `sh` to avoid the `#` being highlighted in some way -->
+    ```txt
+    git remote set-url origin file:///#gson-remote-temp#/git-repo
+    ```
+
+10. Push the changes
+
+    ```sh
+    git push origin main
+    ```
+
+Now you can perform the steps of the release:
+
+1. ```sh
+   mvn release:clean
+   ```
+
+2. ```sh
+   mvn release:prepare
+   ```
+
+3. ```sh
+   mvn release:perform
+   ```
+
+4. Verify that `#gson-remote-temp#/git-repo` and `#gson-remote-temp#/maven-repo` contain all the desired changes
+5. Afterwards delete all Gson files under `${user.home}/.m2/repository/com/google/code/gson` which have been installed in your local Maven repository during the release.\
+   Otherwise Maven might not download the real Gson artifacts with these version numbers, once they are released.
+
 ## Running Benchmarks or Tests on Android
 
 * Download vogar

--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -27,6 +27,12 @@
   <name>Gson Extras</name>
   <description>Google Gson grab bag of utilities, type adapters, etc.</description>
 
+  <properties>
+    <!-- Make the build reproducible, see root `pom.xml` -->
+    <!-- This is duplicated here because that is recommended by `artifact:check-buildplan` -->
+    <project.build.outputTimestamp>2023-01-01T00:00:00Z</project.build.outputTimestamp>
+  </properties>
+
   <licenses>
     <license>
       <name>Apache-2.0</name>

--- a/graal-native-image-test/pom.xml
+++ b/graal-native-image-test/pom.xml
@@ -13,9 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
@@ -27,6 +25,10 @@
   <artifactId>graal-native-image-test</artifactId>
 
   <properties>
+    <!-- Make the build reproducible, see root `pom.xml` -->
+    <!-- This is duplicated here because that is recommended by `artifact:check-buildplan` -->
+    <project.build.outputTimestamp>2023-01-01T00:00:00Z</project.build.outputTimestamp>
+
     <!-- GraalVM is JDK >= 17, however for build with regular JDK these tests
       are also executed with JDK 11, so for them exclude JDK 17 specific tests -->
     <maven.compiler.testRelease>11</maven.compiler.testRelease>

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -34,6 +34,10 @@
   </licenses>
 
   <properties>
+    <!-- Make the build reproducible, see root `pom.xml` -->
+    <!-- This is duplicated here because that is recommended by `artifact:check-buildplan` -->
+    <project.build.outputTimestamp>2023-01-01T00:00:00Z</project.build.outputTimestamp>
+
     <excludeTestCompilation>**/Java17*</excludeTestCompilation>
   </properties>
 

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -27,6 +27,12 @@
   <name>Gson Metrics</name>
   <description>Performance Metrics for Google Gson library</description>
 
+  <properties>
+    <!-- Make the build reproducible, see root `pom.xml` -->
+    <!-- This is duplicated here because that is recommended by `artifact:check-buildplan` -->
+    <project.build.outputTimestamp>2023-01-01T00:00:00Z</project.build.outputTimestamp>
+  </properties>
+
   <licenses>
     <license>
       <name>Apache-2.0</name>

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"
-    child.project.url.inherit.append.path="false">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd" child.project.url.inherit.append.path="false">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.google.code.gson</groupId>
@@ -40,6 +39,10 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>7</maven.compiler.release>
     <maven.compiler.testRelease>11</maven.compiler.testRelease>
+
+    <!-- Make the build reproducible, see https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
+    <!-- Automatically updated by Maven Release Plugin -->
+    <project.build.outputTimestamp>2023-01-01T00:00:00Z</project.build.outputTimestamp>
   </properties>
 
   <!-- These attributes specify that the URLs should be inherited by the modules as is, to avoid constructing
@@ -152,8 +155,8 @@
               <!-- For Markdown files removing trailing whitespace causes issues for hard line breaks,
                 which use two trailing spaces. However, the trailing spaces are difficult to notice anyway;
                 prefer a trailing `\` instead of two spaces. -->
-              <trimTrailingWhitespace/>
-              <endWithNewline/>
+              <trimTrailingWhitespace />
+              <endWithNewline />
               <indent>
                 <spaces>true</spaces>
                 <!-- This seems to mostly (or only?) affect the suggested fix in case code contains tabs -->
@@ -175,9 +178,28 @@
               <reorderImports>true</reorderImports>
               <formatJavadoc>true</formatJavadoc>
             </googleJavaFormat>
-            <formatAnnotations/>     <!-- Puts type annotations immediately before types. -->
+            <formatAnnotations />     <!-- Puts type annotations immediately before types. -->
           </java>
         </configuration>
+      </plugin>
+
+      <!-- Attaches a `.buildinfo` file which contains information for reproducing the build,
+        such as OS, JDK version, ...
+        Since this is a multi-module Maven project, only one aggregated file will be created for
+        the last module, see the note on https://maven.apache.org/plugins/maven-artifact-plugin/usage.html#recording-buildinfo-file -->
+      <!-- The other goals of this plugin are run by the GitHub workflow to verify that
+        the build is reproducible (see `artifact:...` usage in the workflow) -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-artifact-plugin</artifactId>
+        <version>3.5.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>buildinfo</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
 
@@ -350,6 +372,7 @@
             </execution>
           </executions>
         </plugin>
+
         <!-- Plugin for checking source and binary compatibility; used by GitHub workflow -->
         <plugin>
           <groupId>com.github.siom79.japicmp</groupId>
@@ -381,6 +404,7 @@
             </parameter>
           </configuration>
         </plugin>
+
         <!-- Plugin for checking compatibility with Android API -->
         <!-- Note: For now this is not part of a normal Maven build but instead executed only by a
           GitHub workflow because the Animal Sniffer signature files use Java Serialization, so they

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -27,6 +27,12 @@
   <name>Gson Protobuf Support</name>
   <description>Gson support for Protobufs</description>
 
+  <properties>
+    <!-- Make the build reproducible, see root `pom.xml` -->
+    <!-- This is duplicated here because that is recommended by `artifact:check-buildplan` -->
+    <project.build.outputTimestamp>2023-01-01T00:00:00Z</project.build.outputTimestamp>
+  </properties>
+
   <licenses>
     <license>
       <name>Apache-2.0</name>

--- a/shrinker-test/pom.xml
+++ b/shrinker-test/pom.xml
@@ -14,9 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -28,6 +26,10 @@
   <artifactId>shrinker-test</artifactId>
 
   <properties>
+    <!-- Make the build reproducible, see root `pom.xml` -->
+    <!-- This is duplicated here because that is recommended by `artifact:check-buildplan` -->
+    <project.build.outputTimestamp>2023-01-01T00:00:00Z</project.build.outputTimestamp>
+
     <maven.compiler.release>8</maven.compiler.release>
   </properties>
 


### PR DESCRIPTION
### Purpose
Makes the Maven build reproducible

### Description
Makes the Maven build reproducible, see https://maven.apache.org/guides/mini/guide-reproducible-builds.html, and also https://github.com/google/guava/pull/6322. However, it might still be necessary to use the same OS and JDK version to actually be able to reproduce a build.

The changes also format the `pom.xml` files in the way the Maven Release Plugin would.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
