### PR TITLE
Validate `GsonBuilder.setDateFormat` style arguments & extend tests

### DIFF
--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -593,8 +593,10 @@ public final class GsonBuilder {
    * class. See the documentation in {@link java.text.SimpleDateFormat} for more information on
    * valid date and time patterns.
    *
-   * @param pattern the pattern that dates will be serialized/deserialized to/from
+   * @param pattern the pattern that dates will be serialized/deserialized to/from; can be {@code
+   *     null} to reset the pattern
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
+   * @throws IllegalArgumentException if the pattern is invalid
    * @since 1.2
    */
   @CanIgnoreReturnValue
@@ -611,6 +613,14 @@ public final class GsonBuilder {
     return this;
   }
 
+  private static int checkDateFormatStyle(int style) {
+    // Valid DateFormat styles are: 0, 1, 2, 3 (FULL, LONG, MEDIUM, SHORT)
+    if (style < 0 || style > 3) {
+      throw new IllegalArgumentException("Invalid style: " + style);
+    }
+    return style;
+  }
+
   /**
    * Configures Gson to serialize {@code Date} objects according to the style value provided. You
    * can call this method or {@link #setDateFormat(String)} multiple times, but only the last
@@ -623,11 +633,12 @@ public final class GsonBuilder {
    * @param style the predefined date style that date objects will be serialized/deserialized
    *     to/from
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
+   * @throws IllegalArgumentException if the style is invalid
    * @since 1.2
    */
   @CanIgnoreReturnValue
   public GsonBuilder setDateFormat(int style) {
-    this.dateStyle = style;
+    this.dateStyle = checkDateFormatStyle(style);
     this.datePattern = null;
     return this;
   }
@@ -645,12 +656,13 @@ public final class GsonBuilder {
    *     to/from
    * @param timeStyle the predefined style for the time portion of the date objects
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
+   * @throws IllegalArgumentException if the style values are invalid
    * @since 1.2
    */
   @CanIgnoreReturnValue
   public GsonBuilder setDateFormat(int dateStyle, int timeStyle) {
-    this.dateStyle = dateStyle;
-    this.timeStyle = timeStyle;
+    this.dateStyle = checkDateFormatStyle(dateStyle);
+    this.timeStyle = checkDateFormatStyle(timeStyle);
     this.datePattern = null;
     return this;
   }

--- a/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
@@ -16,7 +16,6 @@
 package com.google.gson.functional;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import com.google.gson.Gson;
@@ -494,6 +493,19 @@ public class DefaultTypeAdaptersTest {
   }
 
   @Test
+  public void testDateSerializationWithStyle() {
+    int style = DateFormat.SHORT;
+    Date date = new Date(0);
+    String expectedFormatted = DateFormat.getDateTimeInstance(style, style, Locale.US).format(date);
+
+    Gson gson = new GsonBuilder().setDateFormat(style, style).create();
+    String json = gson.toJson(date);
+    assertThat(json).isEqualTo("\"" + expectedFormatted + "\"");
+    // Verify that custom style is not equal to default style
+    assertThat(json).isNotEqualTo(new Gson().toJson(date));
+  }
+
+  @Test
   public void testDateSerializationWithPattern() {
     String pattern = "yyyy-MM-dd";
     Gson gson = new GsonBuilder().setDateFormat(DateFormat.FULL).setDateFormat(pattern).create();
@@ -736,24 +748,6 @@ public class DefaultTypeAdaptersTest {
   public void testStringBufferDeserialization() {
     StringBuffer sb = gson.fromJson("'abc'", StringBuffer.class);
     assertThat(sb.toString()).isEqualTo("abc");
-  }
-
-  @Test
-  public void testSetDateFormatWithInvalidPattern() {
-    GsonBuilder builder = new GsonBuilder();
-    String invalidPattern = "This is a invalid Pattern";
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> {
-          builder.setDateFormat(invalidPattern);
-        });
-  }
-
-  @Test
-  public void testSetDateFormatWithValidPattern() {
-    GsonBuilder builder = new GsonBuilder();
-    String validPattern = "yyyy-MM-dd";
-    builder.setDateFormat(validPattern);
   }
 
   private static class MyClassTypeAdapter extends TypeAdapter<Class<?>> {


### PR DESCRIPTION
### Purpose
Validate `GsonBuilder.setDateFormat` style arguments & extend tests

### Description
As side note: `DateFormat` validates these arguments as well, but it is currently not documented, see https://bugs.openjdk.org/browse/JDK-8319628.

Also moves the other tests for `setDateFormat(String)` from `DefaultTypeAdaptersTest` to `GsonBuilderTest` because they just test functionality of `GsonBuilder.setDateFormat` would testing any type adapter functionality.
(Acts a bit as follow-up for #2538.)

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [x] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [x] If necessary, new unit tests have been added  
  - [x] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [x] No JUnit 3 features are used (such as extending class `TestCase`)
  - [x] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
