### PR TITLE
Fix DateFormat time zone is not restored and add Test.

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/DefaultDateTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/DefaultDateTypeAdapter.java
@@ -187,10 +187,13 @@ public final class DefaultDateTypeAdapter<T extends Date> extends TypeAdapter<T>
     // Needs to be synchronized since JDK DateFormat classes are not thread-safe
     synchronized (dateFormats) {
       for (DateFormat dateFormat : dateFormats) {
+        TimeZone originalTimeZone = dateFormat.getTimeZone();
         try {
           return dateFormat.parse(s);
         } catch (ParseException ignored) {
           // OK: try the next format
+        } finally {
+          dateFormat.setTimeZone(originalTimeZone);
         }
       }
     }

--- a/gson/src/main/java/com/google/gson/internal/sql/SqlDateTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/sql/SqlDateTypeAdapter.java
@@ -60,17 +60,18 @@ final class SqlDateTypeAdapter extends TypeAdapter<java.sql.Date> {
       return null;
     }
     String s = in.nextString();
+    TimeZone originalTimeZone = format.getTimeZone(); // Save the original time zone
     try {
       Date utilDate;
       synchronized (this) {
-        TimeZone originalTimeZone = format.getTimeZone(); // Save the original time zone
         utilDate = format.parse(s);
-        format.setTimeZone(originalTimeZone); // Restore the original time zone after parsing
       }
       return new java.sql.Date(utilDate.getTime());
     } catch (ParseException e) {
       throw new JsonSyntaxException(
           "Failed parsing '" + s + "' as SQL Date; at path " + in.getPreviousPath(), e);
+    } finally {
+      format.setTimeZone(originalTimeZone); // Restore the original time zone after parsing
     }
   }
 

--- a/gson/src/main/java/com/google/gson/internal/sql/SqlDateTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/sql/SqlDateTypeAdapter.java
@@ -60,18 +60,17 @@ final class SqlDateTypeAdapter extends TypeAdapter<java.sql.Date> {
       return null;
     }
     String s = in.nextString();
-    TimeZone originalTimeZone = format.getTimeZone(); // Save the original time zone
-    try {
-      Date utilDate;
-      synchronized (this) {
-        utilDate = format.parse(s);
+    synchronized (this) {
+      TimeZone originalTimeZone = format.getTimeZone(); // Save the original time zone
+      try {
+        Date utilDate = format.parse(s);
+        return new java.sql.Date(utilDate.getTime());
+      } catch (ParseException e) {
+        throw new JsonSyntaxException(
+            "Failed parsing '" + s + "' as SQL Date; at path " + in.getPreviousPath(), e);
+      } finally {
+        format.setTimeZone(originalTimeZone); // Restore the original time zone after parsing
       }
-      return new java.sql.Date(utilDate.getTime());
-    } catch (ParseException e) {
-      throw new JsonSyntaxException(
-          "Failed parsing '" + s + "' as SQL Date; at path " + in.getPreviousPath(), e);
-    } finally {
-      format.setTimeZone(originalTimeZone); // Restore the original time zone after parsing
     }
   }
 

--- a/gson/src/main/java/com/google/gson/internal/sql/SqlDateTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/sql/SqlDateTypeAdapter.java
@@ -29,6 +29,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
 /**
  * Adapter for java.sql.Date. Although this class appears stateless, it is not. DateFormat captures
@@ -62,7 +63,9 @@ final class SqlDateTypeAdapter extends TypeAdapter<java.sql.Date> {
     try {
       Date utilDate;
       synchronized (this) {
+        TimeZone originalTimeZone = format.getTimeZone(); // Save the original time zone
         utilDate = format.parse(s);
+        format.setTimeZone(originalTimeZone); // Restore the original time zone after parsing
       }
       return new java.sql.Date(utilDate.getTime());
     } catch (ParseException e) {

--- a/gson/src/main/java/com/google/gson/internal/sql/SqlTimeTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/sql/SqlTimeTypeAdapter.java
@@ -30,6 +30,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
 /**
  * Adapter for java.sql.Time. Although this class appears stateless, it is not. DateFormat captures
@@ -62,7 +63,9 @@ final class SqlTimeTypeAdapter extends TypeAdapter<Time> {
     String s = in.nextString();
     try {
       synchronized (this) {
+        TimeZone originalTimeZone = format.getTimeZone(); // Save the original time zone
         Date date = format.parse(s);
+        format.setTimeZone(originalTimeZone); // Restore the original time zone
         return new Time(date.getTime());
       }
     } catch (ParseException e) {

--- a/gson/src/main/java/com/google/gson/internal/sql/SqlTimeTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/sql/SqlTimeTypeAdapter.java
@@ -61,16 +61,17 @@ final class SqlTimeTypeAdapter extends TypeAdapter<Time> {
       return null;
     }
     String s = in.nextString();
+    TimeZone originalTimeZone = format.getTimeZone(); // Save the original time zone
     try {
       synchronized (this) {
-        TimeZone originalTimeZone = format.getTimeZone(); // Save the original time zone
         Date date = format.parse(s);
-        format.setTimeZone(originalTimeZone); // Restore the original time zone
         return new Time(date.getTime());
       }
     } catch (ParseException e) {
       throw new JsonSyntaxException(
           "Failed parsing '" + s + "' as SQL Time; at path " + in.getPreviousPath(), e);
+    } finally {
+      format.setTimeZone(originalTimeZone); // Restore the original time zone
     }
   }
 

--- a/gson/src/main/java/com/google/gson/internal/sql/SqlTimeTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/sql/SqlTimeTypeAdapter.java
@@ -61,17 +61,17 @@ final class SqlTimeTypeAdapter extends TypeAdapter<Time> {
       return null;
     }
     String s = in.nextString();
-    TimeZone originalTimeZone = format.getTimeZone(); // Save the original time zone
-    try {
-      synchronized (this) {
+    synchronized (this) {
+      TimeZone originalTimeZone = format.getTimeZone(); // Save the original time zone
+      try {
         Date date = format.parse(s);
         return new Time(date.getTime());
+      } catch (ParseException e) {
+        throw new JsonSyntaxException(
+            "Failed parsing '" + s + "' as SQL Time; at path " + in.getPreviousPath(), e);
+      } finally {
+        format.setTimeZone(originalTimeZone); // Restore the original time zone
       }
-    } catch (ParseException e) {
-      throw new JsonSyntaxException(
-          "Failed parsing '" + s + "' as SQL Time; at path " + in.getPreviousPath(), e);
-    } finally {
-      format.setTimeZone(originalTimeZone); // Restore the original time zone
     }
   }
 

--- a/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java
@@ -17,6 +17,7 @@
 package com.google.gson.functional;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import com.google.common.base.Splitter;
@@ -39,8 +40,10 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.TimeZone;
 import org.junit.Test;
 
 /** Functional tests for the {@link JsonAdapter} annotation on classes. */
@@ -792,6 +795,27 @@ public final class JsonAdapterAnnotationOnClassesTest {
   public void testAdapterCreatedByJdkUnsafe() {
     String json = new Gson().toJson(new CreatedByJdkUnsafe());
     assertThat(json).isEqualTo("false");
+  }
+
+  @Test
+  public void testGsonDateFormat() {
+    // Set the default timezone to UTC
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd HH:mm z").create();
+    Date originalDate = new Date(0);
+
+    // Serialize the date object
+    String json = gson.toJson(originalDate);
+    assertEquals("\"1970-01-01 00:00 UTC\"", json);
+
+    // Deserialize a date string with the PST timezone
+    Date deserializedDate = gson.fromJson("\"1970-01-01 00:00 PST\"", Date.class);
+
+    // Serialize the deserialized date object again
+    String jsonAfterDeserialization = gson.toJson(deserializedDate);
+    // The expectation is that the date, after deserialization, when serialized again should still
+    // be in the UTC timezone
+    assertEquals("\"1970-01-01 08:00 UTC\"", jsonAfterDeserialization);
   }
 
   @JsonAdapter(CreatedByJdkUnsafe.Serializer.class)

--- a/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java
@@ -17,7 +17,6 @@
 package com.google.gson.functional;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import com.google.common.base.Splitter;
@@ -40,10 +39,8 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
-import java.util.TimeZone;
 import org.junit.Test;
 
 /** Functional tests for the {@link JsonAdapter} annotation on classes. */
@@ -796,6 +793,7 @@ public final class JsonAdapterAnnotationOnClassesTest {
     String json = new Gson().toJson(new CreatedByJdkUnsafe());
     assertThat(json).isEqualTo("false");
   }
+
   @JsonAdapter(CreatedByJdkUnsafe.Serializer.class)
   private static class CreatedByJdkUnsafe {
     static class Serializer implements JsonSerializer<CreatedByJdkUnsafe> {

--- a/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java
@@ -796,28 +796,6 @@ public final class JsonAdapterAnnotationOnClassesTest {
     String json = new Gson().toJson(new CreatedByJdkUnsafe());
     assertThat(json).isEqualTo("false");
   }
-
-  @Test
-  public void testGsonDateFormat() {
-    // Set the default timezone to UTC
-    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
-    Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd HH:mm z").create();
-    Date originalDate = new Date(0);
-
-    // Serialize the date object
-    String json = gson.toJson(originalDate);
-    assertEquals("\"1970-01-01 00:00 UTC\"", json);
-
-    // Deserialize a date string with the PST timezone
-    Date deserializedDate = gson.fromJson("\"1970-01-01 00:00 PST\"", Date.class);
-
-    // Serialize the deserialized date object again
-    String jsonAfterDeserialization = gson.toJson(deserializedDate);
-    // The expectation is that the date, after deserialization, when serialized again should still
-    // be in the UTC timezone
-    assertEquals("\"1970-01-01 08:00 UTC\"", jsonAfterDeserialization);
-  }
-
   @JsonAdapter(CreatedByJdkUnsafe.Serializer.class)
   private static class CreatedByJdkUnsafe {
     static class Serializer implements JsonSerializer<CreatedByJdkUnsafe> {

--- a/gson/src/test/java/com/google/gson/internal/bind/DefaultDateTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/DefaultDateTypeAdapterTest.java
@@ -240,12 +240,14 @@ public class DefaultDateTypeAdapterTest {
 
       // Deserialize a date string with the PST timezone
       Date deserializedDate = gson.fromJson("\"1970-01-01 00:00 PST\"", Date.class);
+      // Assert that the deserialized date is correct
+      assertThat(deserializedDate).isEqualTo(new Date(28800000));
 
       // Serialize the deserialized date object again
-      String jsonAfterDeserialization = gson.toJson(deserializedDate);
+      String jsonAfterDeserialization = gson.toJson(originalDate);
       // The expectation is that the date, after deserialization, when serialized again should still
       // be in the UTC timezone
-      assertEquals("\"1970-01-01 08:00 UTC\"", jsonAfterDeserialization);
+      assertThat(jsonAfterDeserialization).isEqualTo("\"1970-01-01 00:00 UTC\"");
     } finally {
       TimeZone.setDefault(originalTimeZone);
     }

--- a/gson/src/test/java/com/google/gson/internal/bind/DefaultDateTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/DefaultDateTypeAdapterTest.java
@@ -18,7 +18,6 @@ package com.google.gson.internal.bind;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
-import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.fail;
 
 import com.google.gson.Gson;
@@ -236,7 +235,7 @@ public class DefaultDateTypeAdapterTest {
 
       // Serialize the date object
       String json = gson.toJson(originalDate);
-      assertEquals("\"1970-01-01 00:00 UTC\"", json);
+      assertThat(json).isEqualTo("\"1970-01-01 00:00 UTC\"");
 
       // Deserialize a date string with the PST timezone
       Date deserializedDate = gson.fromJson("\"1970-01-01 00:00 PST\"", Date.class);
@@ -247,9 +246,7 @@ public class DefaultDateTypeAdapterTest {
       String jsonAfterDeserialization = gson.toJson(deserializedDate);
       // The expectation is that the date, after deserialization, when serialized again should still
       // be in the UTC timezone
-      Date expectedDate = new Date(28800000); // This represents the original date in UTC
-      String expectedJson = gson.toJson(expectedDate);
-      assertThat(jsonAfterDeserialization).isEqualTo(expectedJson);
+      assertThat(jsonAfterDeserialization).isEqualTo("\"1970-01-01 08:00 UTC\"");
     } finally {
       TimeZone.setDefault(originalTimeZone);
     }

--- a/gson/src/test/java/com/google/gson/internal/bind/DefaultDateTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/DefaultDateTypeAdapterTest.java
@@ -227,23 +227,28 @@ public class DefaultDateTypeAdapterTest {
 
   @Test
   public void testGsonDateFormat() {
+    TimeZone originalTimeZone = TimeZone.getDefault();
     // Set the default timezone to UTC
     TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
-    Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd HH:mm z").create();
-    Date originalDate = new Date(0);
+    try {
+      Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd HH:mm z").create();
+      Date originalDate = new Date(0);
 
-    // Serialize the date object
-    String json = gson.toJson(originalDate);
-    assertEquals("\"1970-01-01 00:00 UTC\"", json);
+      // Serialize the date object
+      String json = gson.toJson(originalDate);
+      assertEquals("\"1970-01-01 00:00 UTC\"", json);
 
-    // Deserialize a date string with the PST timezone
-    Date deserializedDate = gson.fromJson("\"1970-01-01 00:00 PST\"", Date.class);
+      // Deserialize a date string with the PST timezone
+      Date deserializedDate = gson.fromJson("\"1970-01-01 00:00 PST\"", Date.class);
 
-    // Serialize the deserialized date object again
-    String jsonAfterDeserialization = gson.toJson(deserializedDate);
-    // The expectation is that the date, after deserialization, when serialized again should still
-    // be in the UTC timezone
-    assertEquals("\"1970-01-01 08:00 UTC\"", jsonAfterDeserialization);
+      // Serialize the deserialized date object again
+      String jsonAfterDeserialization = gson.toJson(deserializedDate);
+      // The expectation is that the date, after deserialization, when serialized again should still
+      // be in the UTC timezone
+      assertEquals("\"1970-01-01 08:00 UTC\"", jsonAfterDeserialization);
+    }finally {
+      TimeZone.setDefault(originalTimeZone);
+    }
   }
 
   private static TypeAdapter<Date> dateAdapter(TypeAdapterFactory adapterFactory) {

--- a/gson/src/test/java/com/google/gson/internal/bind/DefaultDateTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/DefaultDateTypeAdapterTest.java
@@ -240,14 +240,16 @@ public class DefaultDateTypeAdapterTest {
 
       // Deserialize a date string with the PST timezone
       Date deserializedDate = gson.fromJson("\"1970-01-01 00:00 PST\"", Date.class);
-      // Assert that the deserialized date is correct
-      assertThat(deserializedDate).isEqualTo(new Date(28800000));
+      // Assert that the deserialized date's time is correct
+      assertThat(deserializedDate.getTime()).isEqualTo(new Date(28800000).getTime());
 
       // Serialize the deserialized date object again
-      String jsonAfterDeserialization = gson.toJson(originalDate);
+      String jsonAfterDeserialization = gson.toJson(deserializedDate);
       // The expectation is that the date, after deserialization, when serialized again should still
       // be in the UTC timezone
-      assertThat(jsonAfterDeserialization).isEqualTo("\"1970-01-01 00:00 UTC\"");
+      Date expectedDate = new Date(28800000); // This represents the original date in UTC
+      String expectedJson = gson.toJson(expectedDate);
+      assertThat(jsonAfterDeserialization).isEqualTo(expectedJson);
     } finally {
       TimeZone.setDefault(originalTimeZone);
     }

--- a/gson/src/test/java/com/google/gson/internal/bind/DefaultDateTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/DefaultDateTypeAdapterTest.java
@@ -18,9 +18,11 @@ package com.google.gson.internal.bind;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
 import com.google.gson.internal.bind.DefaultDateTypeAdapter.DateType;
@@ -221,6 +223,27 @@ public class DefaultDateTypeAdapterTest {
       fail("Unexpected token should fail.");
     } catch (IllegalStateException expected) {
     }
+  }
+
+  @Test
+  public void testGsonDateFormat() {
+    // Set the default timezone to UTC
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd HH:mm z").create();
+    Date originalDate = new Date(0);
+
+    // Serialize the date object
+    String json = gson.toJson(originalDate);
+    assertEquals("\"1970-01-01 00:00 UTC\"", json);
+
+    // Deserialize a date string with the PST timezone
+    Date deserializedDate = gson.fromJson("\"1970-01-01 00:00 PST\"", Date.class);
+
+    // Serialize the deserialized date object again
+    String jsonAfterDeserialization = gson.toJson(deserializedDate);
+    // The expectation is that the date, after deserialization, when serialized again should still
+    // be in the UTC timezone
+    assertEquals("\"1970-01-01 08:00 UTC\"", jsonAfterDeserialization);
   }
 
   private static TypeAdapter<Date> dateAdapter(TypeAdapterFactory adapterFactory) {

--- a/gson/src/test/java/com/google/gson/internal/bind/DefaultDateTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/DefaultDateTypeAdapterTest.java
@@ -18,7 +18,7 @@ package com.google.gson.internal.bind;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
-import static org.junit.Assert.assertEquals;
+import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.fail;
 
 import com.google.gson.Gson;
@@ -246,7 +246,7 @@ public class DefaultDateTypeAdapterTest {
       // The expectation is that the date, after deserialization, when serialized again should still
       // be in the UTC timezone
       assertEquals("\"1970-01-01 08:00 UTC\"", jsonAfterDeserialization);
-    }finally {
+    } finally {
       TimeZone.setDefault(originalTimeZone);
     }
   }


### PR DESCRIPTION

### Purpose
Fix DateFormat time zone is not restored after parsing. Fixes #2547
### Description
Before attempting to parse the date string, save the current timezone for each DateFormat object. Use a finally block to ensure that the original timezone is restored for each DateFormat object.



### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [x] If necessary, new public API validates arguments, for example rejects `null`
- [x] New public API has Javadoc
    - [x] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [x] If necessary, new unit tests have been added  
  - [x] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [x] No JUnit 3 features are used (such as extending class `TestCase`)
  - [x] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
