### PR TITLE
Spotless: Fail for wildcard imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,7 @@
               <exclude>src/test/java/com/google/gson/functional/Java17RecordTest.java</exclude>
               <exclude>src/test/java/com/google/gson/native_test/Java17RecordReflectionTest.java</exclude>
             </excludes>
+
             <googleJavaFormat>
               <style>GOOGLE</style>
               <reflowLongStrings>true</reflowLongStrings>
@@ -179,6 +180,21 @@
               <formatJavadoc>true</formatJavadoc>
             </googleJavaFormat>
             <formatAnnotations />     <!-- Puts type annotations immediately before types. -->
+
+            <!-- Manually detect wildcard imports
+              Neither Spotless nor google-java-format can detect or fix wildcard imports currently
+              (see https://github.com/diffplug/spotless/issues/649
+              and https://github.com/google/google-java-format/issues/956) -->
+            <replaceRegex>
+              <name>Disallow wildcard imports</name>
+              <searchRegex>^(import\s.+)\.\*\s*;\s*$</searchRegex>
+              <!-- Replacing seems to be performed before google-java-format is run, so the replacement
+                must be syntactically valid Java code -->
+              <!-- Instead of just removing the import, add a comment so that users understand why the
+                import was modified, but at the same time make the import invalid to cause a compiler
+                error and force the user to fix it -->
+              <replacement>$1.DISALLOWED.*; // wildcard imports are not allowed</replacement>
+            </replaceRegex>
           </java>
         </configuration>
       </plugin>


### PR DESCRIPTION
### Purpose
Fail for wildcard `import` statements because they violate the Google Java Style Guide


### Description
Neither Spotless nor google-java-format can currently detect or fix wildcard imports. This might be a bit frustrating for new contributors because for example IntelliJ by default uses wildcard imports, and currently the formatting check passes. So the contributor would only learn during the PR review that wildcard imports are not allowed.

This change causes Spotless to add a comment behind the import statement and turn the import invalid so that the user has to fix it:
```diff
-import·java.util.*;
+import·java.util.DISALLOWED.*;·//·wildcard·imports·are·not·allowed
```

This is a slightly hacky approach, so no worries if you don't want to merge this. Or in case you merge this but in the future this causes cryptic google-java-format exceptions because this replacement somehow made the Java source code invalid, or if this does not turn out to be useful, then we can also revert the change again.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [ ] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
