### PR TITLE
Enforce that JDK <= 17 is used for building

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Gson uses Maven to build the project:
 mvn clean verify
 ```
 
-JDK 11 or newer is required for building, JDK 17 is recommended.
+JDK 11 or newer is required for building, JDK 17 is recommended. Newer JDKs are currently not supported for building (but are supported when _using_ Gson).
 
 ### Contributing
 

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,9 @@
                 <!-- Enforce that correct JDK version is used to avoid cryptic build errors -->
                 <requireJavaVersion>
                   <!-- Other plugins of this build require at least JDK 11 -->
-                  <version>[11,)</version>
+                  <!-- Fail fast when building with JDK > 17 because it causes build failures,
+                    see https://github.com/google/gson/issues/2501 -->
+                  <version>[11,18)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
### Purpose
Enforce that JDK <= 17 is used for building, but add JDK 21 CI build

### Description
Using JDK 21 currently causes multiple issues, some of which are not easy to fix at the moment (such as target version 7 not being supported anymore), see
- #2501
- #2530

So it might be better to fail fast for now with a somewhat understandable error message, than having them encounter confusing build errors or test failures. The error message they will see with these changes is:
> [ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.4.1:enforce (enforce-versions) on project gson-parent:
> [ERROR] Rule 1: org.apache.maven.enforcer.rules.version.RequireJavaVersion failed with message:
> [ERROR] Detected JDK version 21 (JAVA_HOME=...\openjdk-21_windows-x64_bin\jdk-21) is not in the allowed range [11,18).

The better solution would of course be to allow building with JDK 21, but this might not be easily possible at the moment.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [ ] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
