### PR TITLE
Add CI build using JDK 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,12 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17 ]
+        # Custom JDK 21 configuration
+        include:
+          - java: 21
+            # Disable Enforcer check which (intentionally) prevents using JDK 21 for building
+            # Exclude 'shrinker-test' module because R8 does not support JDK 21 yet
+            extra-mvn-args: -Denforcer.fail=false --projects '!:shrinker-test'
     runs-on: ubuntu-latest
 
     steps:
@@ -23,7 +29,7 @@ jobs:
           cache: 'maven'
       - name: Build with Maven
         # This also runs javadoc:jar to detect any issues with the Javadoc generated during release
-        run: mvn --batch-mode --no-transfer-progress verify javadoc:jar
+        run: mvn --batch-mode --no-transfer-progress verify javadoc:jar ${{ matrix.extra-mvn-args || '' }}
 
   native-image-test:
     name: "GraalVM Native Image test"

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Gson uses Maven to build the project:
 mvn clean verify
 ```
 
-JDK 11 or newer is required for building, JDK 17 is recommended.
+JDK 11 or newer is required for building, JDK 17 is recommended. Newer JDKs are currently not supported for building (but are supported when _using_ Gson).
 
 ### Contributing
 

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -191,6 +191,19 @@
             </goals>
           </execution>
         </executions>
+        <!-- Upgrades ProGuard to version newer than the one included by plugin by default -->
+        <dependencies>
+          <dependency>
+            <groupId>com.guardsquare</groupId>
+            <artifactId>proguard-base</artifactId>
+            <version>7.4.0</version>
+          </dependency>
+          <dependency>
+            <groupId>com.guardsquare</groupId>
+            <artifactId>proguard-core</artifactId>
+            <version>9.1.0</version>
+          </dependency>
+        </dependencies>
         <configuration>
           <obfuscate>true</obfuscate>
           <injar>test-classes-obfuscated-injar</injar>

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -196,7 +196,7 @@
           <dependency>
             <groupId>com.guardsquare</groupId>
             <artifactId>proguard-base</artifactId>
-            <version>7.4.0</version>
+            <version>7.4.1</version>
           </dependency>
           <dependency>
             <groupId>com.guardsquare</groupId>

--- a/gson/src/test/java/com/google/gson/functional/ReflectionAccessTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ReflectionAccessTest.java
@@ -18,6 +18,7 @@ package com.google.gson.functional;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -52,6 +53,9 @@ public class ReflectionAccessTest {
   @SuppressWarnings("removal") // java.lang.SecurityManager deprecation in Java 17
   @Test
   public void testRestrictiveSecurityManager() throws Exception {
+    // Skip for newer Java versions where `System.setSecurityManager` is unsupported
+    assumeTrue(Runtime.version().feature() <= 17);
+
     // Must use separate class loader, otherwise permission is not checked, see
     // Class.getDeclaredFields()
     Class<?> clazz = loadClassWithDifferentClassLoader(ClassWithPrivateMembers.class);

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,9 @@
                 <!-- Enforce that correct JDK version is used to avoid cryptic build errors -->
                 <requireJavaVersion>
                   <!-- Other plugins of this build require at least JDK 11 -->
-                  <version>[11,)</version>
+                  <!-- Fail fast when building with JDK > 17 because it causes build failures,
+                    see https://github.com/google/gson/issues/2501 -->
+                  <version>[11,18)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -463,6 +463,32 @@
       </build>
     </profile>
 
+    <!-- Slightly adjust build to support building with JDK >= 21
+      However, by default this will intentionally be blocked by the Maven Enforcer Plugin defined above
+      and must be explicitly circumvented to avoid building non-release Gson artifacts by accident -->
+    <profile>
+      <id>jdk21+</id>
+      <activation>
+        <jdk>[21,)</jdk>
+      </activation>
+      <properties>
+        <!-- JDK 21 does not support Java 7 as release, must use at least Java 8 -->
+        <maven.compiler.release>8</maven.compiler.release>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <!-- Don't fail on warning because javac reports lint warnings for generated code of 'proto' module -->
+              <failOnWarning>false</failOnWarning>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <!-- Profile defining additional plugins to be executed for release -->
     <profile>
       <id>release</id>

--- a/pom.xml
+++ b/pom.xml
@@ -475,18 +475,6 @@
         <!-- JDK 21 does not support Java 7 as release, must use at least Java 8 -->
         <maven.compiler.release>8</maven.compiler.release>
       </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <!-- Don't fail on warning because javac reports lint warnings for generated code of 'proto' module -->
-              <failOnWarning>false</failOnWarning>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
 
     <!-- Profile defining additional plugins to be executed for release -->

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -31,6 +31,8 @@
     <!-- Make the build reproducible, see root `pom.xml` -->
     <!-- This is duplicated here because that is recommended by `artifact:check-buildplan` -->
     <project.build.outputTimestamp>2023-01-01T00:00:00Z</project.build.outputTimestamp>
+
+    <protobufVersion>3.25.1</protobufVersion>
   </properties>
 
   <licenses>
@@ -50,7 +52,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>4.0.0-rc-2</version>
+      <version>${protobufVersion}</version>
     </dependency>
 
     <dependency>
@@ -89,7 +91,7 @@
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>0.6.1</version>
         <configuration>
-          <protocArtifact>com.google.protobuf:protoc:3.17.3:exe:${os.detected.classifier}</protocArtifact>
+          <protocArtifact>com.google.protobuf:protoc:${protobufVersion}:exe:${os.detected.classifier}</protocArtifact>
         </configuration>
         <executions>
           <execution>

--- a/shrinker-test/pom.xml
+++ b/shrinker-test/pom.xml
@@ -109,7 +109,7 @@
           <dependency>
             <groupId>com.guardsquare</groupId>
             <artifactId>proguard-base</artifactId>
-            <version>7.4.0</version>
+            <version>7.4.1</version>
           </dependency>
           <dependency>
             <groupId>com.guardsquare</groupId>

--- a/shrinker-test/pom.xml
+++ b/shrinker-test/pom.xml
@@ -104,6 +104,19 @@
             </goals>
           </execution>
         </executions>
+        <!-- Upgrades ProGuard to version newer than the one included by plugin by default -->
+        <dependencies>
+          <dependency>
+            <groupId>com.guardsquare</groupId>
+            <artifactId>proguard-base</artifactId>
+            <version>7.4.0</version>
+          </dependency>
+          <dependency>
+            <groupId>com.guardsquare</groupId>
+            <artifactId>proguard-core</artifactId>
+            <version>9.1.0</version>
+          </dependency>
+        </dependencies>
         <configuration>
           <obfuscate>true</obfuscate>
           <proguardInclude>${project.basedir}/proguard.pro</proguardInclude>
@@ -205,6 +218,7 @@
               but it appears that can be ignored -->
             <groupId>com.android.tools</groupId>
             <artifactId>r8</artifactId>
+            <!-- TODO: When updating to a version which supports JDK 21, remove 'shrinker-test' exclusion from build.yml workflow -->
             <version>8.1.56</version>
           </dependency>
         </dependencies>


### PR DESCRIPTION
<!--
    Thank you for your contribution!
    Please see the contributing guide: https://github.com/google/.github/blob/master/CONTRIBUTING.md

    Keep in mind that Gson is in maintenance mode. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.
-->

### Purpose
Add CI build using JDK 21

### Description
Depends on #2551

This is mainly to make sure that besides the known JDK 21 build incompatibilities Gson can be built and run using JDK 21. However, the restriction that JDK 21 must not be used for building enforced by #2551 still remains, the GitHub workflow just disables this restriction, and performs some adjustments to the build to work around these issues.

Since a JDK 21 build still does not work out of the box and differs from the desired configuration for building a release (e.g. release Java version is increased to Java 8), I think it does not make sense to allow or encourage users to use JDK 21 for building yet.

I have split this into a separate PR from #2551 because otherwise it would be a bit weird to have the commit message say on one hand that builds must use JDK <= 17, but also say that CI now builds with JDK 21 as well.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [ ] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
