### PR TITLE
Fix `GsonBuilder.setDateFormat` ignoring partial DEFAULT; deprecate `setDateFormat(int)`

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -232,7 +232,7 @@ public final class Gson {
    *       through {@link GsonBuilder#registerTypeAdapter(Type, Object)}.
    *   <li>The default Date format is same as {@link java.text.DateFormat#DEFAULT}. This format
    *       ignores the millisecond portion of the date during serialization. You can change this by
-   *       invoking {@link GsonBuilder#setDateFormat(int)} or {@link
+   *       invoking {@link GsonBuilder#setDateFormat(int, int)} or {@link
    *       GsonBuilder#setDateFormat(String)}.
    *   <li>By default, Gson ignores the {@link com.google.gson.annotations.Expose} annotation. You
    *       can enable Gson to serialize/deserialize only those fields marked with this annotation

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -583,16 +583,16 @@ public final class GsonBuilder {
 
   /**
    * Configures Gson to serialize {@code Date} objects according to the pattern provided. You can
-   * call this method or {@link #setDateFormat(int)} multiple times, but only the last invocation
-   * will be used to decide the serialization format.
+   * call this method or {@link #setDateFormat(int, int)} multiple times, but only the last
+   * invocation will be used to decide the serialization format.
    *
    * <p>The date format will be used to serialize and deserialize {@link java.util.Date} and in case
    * the {@code java.sql} module is present, also {@link java.sql.Timestamp} and {@link
    * java.sql.Date}.
    *
    * <p>Note that this pattern must abide by the convention provided by {@code SimpleDateFormat}
-   * class. See the documentation in {@link java.text.SimpleDateFormat} for more information on
-   * valid date and time patterns.
+   * class. See the documentation in {@link SimpleDateFormat} for more information on valid date and
+   * time patterns.
    *
    * @param pattern the pattern that dates will be serialized/deserialized to/from; can be {@code
    *     null} to reset the pattern
@@ -632,12 +632,17 @@ public final class GsonBuilder {
    * DateFormat} class, such as {@link DateFormat#MEDIUM}. See the documentation of the {@link
    * DateFormat} class for more information on the valid style constants.
    *
+   * @deprecated Counterintuitively, despite this method taking only a 'date style' Gson will use a
+   *     format which includes both date and time, with the 'time style' being the last value set by
+   *     {@link #setDateFormat(int, int)}. Therefore prefer using {@link #setDateFormat(int, int)}
+   *     and explicitly provide the desired 'time style'.
    * @param dateStyle the predefined date style that date objects will be serialized/deserialized
    *     to/from
    * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
    * @throws IllegalArgumentException if the style is invalid
    * @since 1.2
    */
+  @Deprecated
   @CanIgnoreReturnValue
   public GsonBuilder setDateFormat(int dateStyle) {
     this.dateStyle = checkDateFormatStyle(dateStyle);
@@ -916,7 +921,7 @@ public final class GsonBuilder {
             SqlTypesSupport.TIMESTAMP_DATE_TYPE.createAdapterFactory(datePattern);
         sqlDateAdapterFactory = SqlTypesSupport.DATE_DATE_TYPE.createAdapterFactory(datePattern);
       }
-    } else if (dateStyle != DateFormat.DEFAULT && timeStyle != DateFormat.DEFAULT) {
+    } else if (dateStyle != DateFormat.DEFAULT || timeStyle != DateFormat.DEFAULT) {
       dateAdapterFactory =
           DefaultDateTypeAdapter.DateType.DATE.createAdapterFactory(dateStyle, timeStyle);
 

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -66,7 +66,7 @@ import java.util.Objects;
  *     .registerTypeAdapter(Id.class, new IdTypeAdapter())
  *     .enableComplexMapKeySerialization()
  *     .serializeNulls()
- *     .setDateFormat(DateFormat.LONG)
+ *     .setDateFormat(DateFormat.LONG, DateFormat.LONG)
  *     .setFieldNamingPolicy(FieldNamingPolicy.UPPER_CAMEL_CASE)
  *     .setPrettyPrinting()
  *     .setVersion(1.0)

--- a/gson/src/main/java/com/google/gson/internal/PreJava9DateFormatProvider.java
+++ b/gson/src/main/java/com/google/gson/internal/PreJava9DateFormatProvider.java
@@ -21,15 +21,6 @@ import java.util.Locale;
 
 /** Provides DateFormats for US locale with patterns which were the default ones before Java 9. */
 public class PreJava9DateFormatProvider {
-
-  /**
-   * Returns the same DateFormat as {@code DateFormat.getDateInstance(style, Locale.US)} in Java 8
-   * or below.
-   */
-  public static DateFormat getUSDateFormat(int style) {
-    return new SimpleDateFormat(getDateFormatPattern(style), Locale.US);
-  }
-
   /**
    * Returns the same DateFormat as {@code DateFormat.getDateTimeInstance(dateStyle, timeStyle,
    * Locale.US)} in Java 8 or below.
@@ -38,21 +29,6 @@ public class PreJava9DateFormatProvider {
     String pattern =
         getDatePartOfDateTimePattern(dateStyle) + " " + getTimePartOfDateTimePattern(timeStyle);
     return new SimpleDateFormat(pattern, Locale.US);
-  }
-
-  private static String getDateFormatPattern(int style) {
-    switch (style) {
-      case DateFormat.SHORT:
-        return "M/d/yy";
-      case DateFormat.MEDIUM:
-        return "MMM d, y";
-      case DateFormat.LONG:
-        return "MMMM d, y";
-      case DateFormat.FULL:
-        return "EEEE, MMMM d, y";
-      default:
-        throw new IllegalArgumentException("Unknown DateFormat style: " + style);
-    }
   }
 
   private static String getDatePartOfDateTimePattern(int dateStyle) {

--- a/gson/src/main/java/com/google/gson/internal/bind/DefaultDateTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/DefaultDateTypeAdapter.java
@@ -104,17 +104,8 @@ public final class DefaultDateTypeAdapter<T extends Date> extends TypeAdapter<T>
       return createFactory(new DefaultDateTypeAdapter<>(this, datePattern));
     }
 
-    public final TypeAdapterFactory createAdapterFactory(int style) {
-      return createFactory(new DefaultDateTypeAdapter<>(this, style));
-    }
-
     public final TypeAdapterFactory createAdapterFactory(int dateStyle, int timeStyle) {
       return createFactory(new DefaultDateTypeAdapter<>(this, dateStyle, timeStyle));
-    }
-
-    public final TypeAdapterFactory createDefaultsAdapterFactory() {
-      return createFactory(
-          new DefaultDateTypeAdapter<>(this, DateFormat.DEFAULT, DateFormat.DEFAULT));
     }
   }
 
@@ -131,17 +122,6 @@ public final class DefaultDateTypeAdapter<T extends Date> extends TypeAdapter<T>
     dateFormats.add(new SimpleDateFormat(datePattern, Locale.US));
     if (!Locale.getDefault().equals(Locale.US)) {
       dateFormats.add(new SimpleDateFormat(datePattern));
-    }
-  }
-
-  private DefaultDateTypeAdapter(DateType<T> dateType, int style) {
-    this.dateType = Objects.requireNonNull(dateType);
-    dateFormats.add(DateFormat.getDateInstance(style, Locale.US));
-    if (!Locale.getDefault().equals(Locale.US)) {
-      dateFormats.add(DateFormat.getDateInstance(style));
-    }
-    if (JavaVersion.isJava9OrLater()) {
-      dateFormats.add(PreJava9DateFormatProvider.getUSDateFormat(style));
     }
   }
 

--- a/gson/src/test/java/com/google/gson/GsonBuilderTest.java
+++ b/gson/src/test/java/com/google/gson/GsonBuilderTest.java
@@ -358,6 +358,7 @@ public class GsonBuilderTest {
     assertThat(emptyFormatted).isEqualTo(originalFormatted);
   }
 
+  @SuppressWarnings("deprecation") // for GsonBuilder.setDateFormat(int)
   @Test
   public void testSetDateFormatValidStyle() {
     GsonBuilder builder = new GsonBuilder();
@@ -370,6 +371,7 @@ public class GsonBuilderTest {
     }
   }
 
+  @SuppressWarnings("deprecation") // for GsonBuilder.setDateFormat(int)
   @Test
   public void testSetDateFormatInvalidStyle() {
     GsonBuilder builder = new GsonBuilder();

--- a/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
@@ -16,6 +16,7 @@
 package com.google.gson.functional;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.Assert.fail;
 
 import com.google.gson.Gson;
@@ -492,22 +493,84 @@ public class DefaultTypeAdaptersTest {
     assertThat(cal.get(Calendar.SECOND)).isEqualTo(23);
   }
 
+  /** Uses {@link GsonBuilder#setDateFormat(int, int)} */
   @Test
   public void testDateSerializationWithStyle() {
-    int style = DateFormat.SHORT;
     Date date = new Date(0);
-    String expectedFormatted = DateFormat.getDateTimeInstance(style, style, Locale.US).format(date);
+    int[] styles = {DateFormat.FULL, DateFormat.LONG, DateFormat.MEDIUM, DateFormat.SHORT};
 
-    Gson gson = new GsonBuilder().setDateFormat(style, style).create();
-    String json = gson.toJson(date);
-    assertThat(json).isEqualTo("\"" + expectedFormatted + "\"");
-    // Verify that custom style is not equal to default style
-    assertThat(json).isNotEqualTo(new Gson().toJson(date));
+    for (int dateStyle : styles) {
+      for (int timeStyle : styles) {
+        String expectedFormatted =
+            DateFormat.getDateTimeInstance(dateStyle, timeStyle, Locale.US).format(date);
+
+        Gson gson = new GsonBuilder().setDateFormat(dateStyle, timeStyle).create();
+        String json = gson.toJson(date);
+        assertWithMessage("dateStyle=" + dateStyle + ", timeStyle=" + timeStyle)
+            .that(json)
+            .isEqualTo("\"" + expectedFormatted + "\"");
+
+        assertWithMessage("dateStyle=" + dateStyle + ", timeStyle=" + timeStyle)
+            .that(gson.fromJson(json, Date.class).getTime())
+            .isEqualTo(date.getTime());
+      }
+    }
+
+    // `new Gson()` should use dateStyle=DEFAULT, timeStyle=DEFAULT
+    String expectedFormatted =
+        DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.DEFAULT, Locale.US)
+            .format(date);
+    assertThat(new Gson().toJson(date)).isEqualTo("\"" + expectedFormatted + "\"");
   }
 
+  /** Uses {@link GsonBuilder#setDateFormat(int)} */
+  @SuppressWarnings("deprecation") // for GsonBuilder.setDateFormat(int)
+  @Test
+  public void testDateSerializationWithDateStyle() {
+    Date date = new Date(0);
+    int[] styles = {DateFormat.FULL, DateFormat.LONG, DateFormat.MEDIUM, DateFormat.SHORT};
+
+    for (int dateStyle : styles) {
+      String expectedFormatted =
+          DateFormat.getDateTimeInstance(dateStyle, DateFormat.DEFAULT, Locale.US).format(date);
+
+      Gson gson = new GsonBuilder().setDateFormat(dateStyle).create();
+      String json = gson.toJson(date);
+      assertWithMessage("dateStyle=" + dateStyle)
+          .that(json)
+          .isEqualTo("\"" + expectedFormatted + "\"");
+
+      assertWithMessage("dateStyle=" + dateStyle)
+          .that(gson.fromJson(json, Date.class).getTime())
+          .isEqualTo(date.getTime());
+    }
+  }
+
+  /**
+   * Using {@link GsonBuilder#setDateFormat(int, int)} should overwrite previous patterns set with
+   * {@link GsonBuilder#setDateFormat(String)}
+   */
+  @Test
+  public void testDateStyleOverwritesPattern() {
+    String pattern = "yyyy-MM-dd";
+    Date date = new Date(0);
+    GsonBuilder gsonBuilder = new GsonBuilder().setDateFormat(pattern);
+    String patternJson = gsonBuilder.create().toJson(date);
+
+    int style = DateFormat.SHORT;
+    String styleJson = gsonBuilder.setDateFormat(style, style).create().toJson(date);
+    String expectedFormatted = DateFormat.getDateTimeInstance(style, style, Locale.US).format(date);
+    assertThat(styleJson).isEqualTo("\"" + expectedFormatted + "\"");
+
+    // Should not be equal to pattern JSON output
+    assertThat(styleJson).isNotEqualTo(patternJson);
+  }
+
+  @SuppressWarnings("deprecation") // for GsonBuilder.setDateFormat(int)
   @Test
   public void testDateSerializationWithPattern() {
     String pattern = "yyyy-MM-dd";
+    // This also verifies that a custom pattern overwrites a custom style
     Gson gson = new GsonBuilder().setDateFormat(DateFormat.FULL).setDateFormat(pattern).create();
     Date now = new Date(1315806903103L);
     String json = gson.toJson(now);
@@ -518,6 +581,7 @@ public class DefaultTypeAdaptersTest {
   @Test
   public void testDateDeserializationWithPattern() {
     String pattern = "yyyy-MM-dd";
+    // This also verifies that a custom pattern overwrites a custom style
     Gson gson = new GsonBuilder().setDateFormat(DateFormat.FULL).setDateFormat(pattern).create();
     Date now = new Date(1315806903103L);
     String json = gson.toJson(now);

--- a/gson/src/test/java/com/google/gson/internal/bind/DefaultDateTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/DefaultDateTypeAdapterTest.java
@@ -18,7 +18,7 @@ package com.google.gson.internal.bind;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
@@ -62,10 +62,7 @@ public class DefaultDateTypeAdapterTest {
       // Note: \h means "horizontal space", because some JDK versions use Narrow No Break Space
       // (U+202F) before the AM or PM indication.
       String utcFull = "(Coordinated Universal Time|UTC)";
-      assertFormatted("Jan 1, 1970,? 12:00:00\\hAM", DateType.DATE.createDefaultsAdapterFactory());
-      assertFormatted("1/1/70", DateType.DATE.createAdapterFactory(DateFormat.SHORT));
-      assertFormatted("Jan 1, 1970", DateType.DATE.createAdapterFactory(DateFormat.MEDIUM));
-      assertFormatted("January 1, 1970", DateType.DATE.createAdapterFactory(DateFormat.LONG));
+      assertFormatted("Jan 1, 1970,? 12:00:00\\hAM", DefaultDateTypeAdapter.DEFAULT_STYLE_FACTORY);
       assertFormatted(
           "1/1/70,? 12:00\\hAM",
           DateType.DATE.createAdapterFactory(DateFormat.SHORT, DateFormat.SHORT));
@@ -94,16 +91,7 @@ public class DefaultDateTypeAdapterTest {
       Date date = new Date(0);
       assertParsed(
           DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.MEDIUM).format(date),
-          DateType.DATE.createDefaultsAdapterFactory());
-      assertParsed(
-          DateFormat.getDateInstance(DateFormat.SHORT).format(date),
-          DateType.DATE.createAdapterFactory(DateFormat.SHORT));
-      assertParsed(
-          DateFormat.getDateInstance(DateFormat.MEDIUM).format(date),
-          DateType.DATE.createAdapterFactory(DateFormat.MEDIUM));
-      assertParsed(
-          DateFormat.getDateInstance(DateFormat.LONG).format(date),
-          DateType.DATE.createAdapterFactory(DateFormat.LONG));
+          DefaultDateTypeAdapter.DEFAULT_STYLE_FACTORY);
       assertParsed(
           DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT).format(date),
           DateType.DATE.createAdapterFactory(DateFormat.SHORT, DateFormat.SHORT));
@@ -129,10 +117,7 @@ public class DefaultDateTypeAdapterTest {
     Locale defaultLocale = Locale.getDefault();
     Locale.setDefault(Locale.US);
     try {
-      assertParsed("Jan 1, 1970 0:00:00 AM", DateType.DATE.createDefaultsAdapterFactory());
-      assertParsed("1/1/70", DateType.DATE.createAdapterFactory(DateFormat.SHORT));
-      assertParsed("Jan 1, 1970", DateType.DATE.createAdapterFactory(DateFormat.MEDIUM));
-      assertParsed("January 1, 1970", DateType.DATE.createAdapterFactory(DateFormat.LONG));
+      assertParsed("Jan 1, 1970 0:00:00 AM", DefaultDateTypeAdapter.DEFAULT_STYLE_FACTORY);
       assertParsed(
           "1/1/70 0:00 AM", DateType.DATE.createAdapterFactory(DateFormat.SHORT, DateFormat.SHORT));
       assertParsed(
@@ -157,8 +142,8 @@ public class DefaultDateTypeAdapterTest {
     Locale defaultLocale = Locale.getDefault();
     Locale.setDefault(Locale.US);
     try {
-      assertFormatted("Dec 31, 1969,? 4:00:00\\hPM", DateType.DATE.createDefaultsAdapterFactory());
-      assertParsed("Dec 31, 1969 4:00:00 PM", DateType.DATE.createDefaultsAdapterFactory());
+      assertFormatted("Dec 31, 1969,? 4:00:00\\hPM", DefaultDateTypeAdapter.DEFAULT_STYLE_FACTORY);
+      assertParsed("Dec 31, 1969 4:00:00 PM", DefaultDateTypeAdapter.DEFAULT_STYLE_FACTORY);
     } finally {
       TimeZone.setDefault(defaultTimeZone);
       Locale.setDefault(defaultLocale);
@@ -167,23 +152,12 @@ public class DefaultDateTypeAdapterTest {
 
   @Test
   public void testDateDeserializationISO8601() throws Exception {
-    TypeAdapterFactory adapterFactory = DateType.DATE.createDefaultsAdapterFactory();
+    TypeAdapterFactory adapterFactory = DefaultDateTypeAdapter.DEFAULT_STYLE_FACTORY;
     assertParsed("1970-01-01T00:00:00.000Z", adapterFactory);
     assertParsed("1970-01-01T00:00Z", adapterFactory);
     assertParsed("1970-01-01T00:00:00+00:00", adapterFactory);
     assertParsed("1970-01-01T01:00:00+01:00", adapterFactory);
     assertParsed("1970-01-01T01:00:00+01", adapterFactory);
-  }
-
-  @Test
-  public void testDateSerialization() {
-    int dateStyle = DateFormat.LONG;
-    TypeAdapter<Date> dateTypeAdapter = dateAdapter(DateType.DATE.createAdapterFactory(dateStyle));
-    DateFormat formatter = DateFormat.getDateInstance(dateStyle, Locale.US);
-    Date currentDate = new Date();
-
-    String dateString = dateTypeAdapter.toJson(currentDate);
-    assertThat(dateString).isEqualTo(toLiteral(formatter.format(currentDate)));
   }
 
   @Test
@@ -199,28 +173,24 @@ public class DefaultDateTypeAdapterTest {
 
   @Test
   public void testInvalidDatePattern() {
-    try {
-      DateType.DATE.createAdapterFactory("I am a bad Date pattern....");
-      fail("Invalid date pattern should fail.");
-    } catch (IllegalArgumentException expected) {
-    }
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> DateType.DATE.createAdapterFactory("I am a bad Date pattern...."));
   }
 
   @Test
   public void testNullValue() throws Exception {
-    TypeAdapter<Date> adapter = dateAdapter(DateType.DATE.createDefaultsAdapterFactory());
+    TypeAdapter<Date> adapter = dateAdapter(DefaultDateTypeAdapter.DEFAULT_STYLE_FACTORY);
     assertThat(adapter.fromJson("null")).isNull();
     assertThat(adapter.toJson(null)).isEqualTo("null");
   }
 
   @Test
   public void testUnexpectedToken() throws Exception {
-    try {
-      TypeAdapter<Date> adapter = dateAdapter(DateType.DATE.createDefaultsAdapterFactory());
-      adapter.fromJson("{}");
-      fail("Unexpected token should fail.");
-    } catch (IllegalStateException expected) {
-    }
+    TypeAdapter<Date> adapter = dateAdapter(DefaultDateTypeAdapter.DEFAULT_STYLE_FACTORY);
+    IllegalStateException e =
+        assertThrows(IllegalStateException.class, () -> adapter.fromJson("{}"));
+    assertThat(e).hasMessageThat().startsWith("Expected a string but was BEGIN_OBJECT");
   }
 
   private static TypeAdapter<Date> dateAdapter(TypeAdapterFactory adapterFactory) {


### PR DESCRIPTION
### Purpose
Resolves #1529

### Description
The main issue was this line:
https://github.com/google/gson/blob/3b1b361be1202a73b4fe4808c4553e735857e825/gson/src/main/java/com/google/gson/GsonBuilder.java#L919

When one style was non-DEFAULT but the other was DEFAULT (e.g. `dateStyle=SHORT, timeStyle=DEFAULT`), then `GsonBuilder` would ignore the styles and use DEFAULT, DEFAULT. That is incorrect because it leads to a different date pattern.
This affected both `setDateFormat(int)` and `setDateFormat(int, int)` of `GsonBuilder`.

However, `setDateFormat(int)` is a bit counterintuitive: Since it only takes a 'date style' you would expect it to use `DateFormat.getDateInstance`. However, that is not actually the case, it uses `DateFormat.getDateTimeInstance` with the 'time style' being the value which has been set previously with `GsonBuilder.setDateFormat(int, int)`. See also https://github.com/google/gson/issues/1529#issuecomment-1821922091 for more details.

Arguably this could have been fixed by changing `setDateFormat(int)` to use `DateFormat.getDateInstance`, as one would expect. But since we don't encourage users to use the locale specific formatted dates anymore (see e.g. https://github.com/google/gson/pull/2546#pullrequestreview-1738676651) I thought it would be easier to just deprecate the method, especially since it was not working properly anyway due to #1529 (which is fixed by this PR now though).

This pull request also removes internal code which handled the 'date style'-only case, but which was never actually called from the main code but only from tests.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [x] If necessary, new unit tests have been added  
  - [x] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [x] No JUnit 3 features are used (such as extending class `TestCase`)
  - [x] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
