### PR TITLE
Remove a Spotless exclusion for `target` files.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,8 +173,6 @@
                 so formatting will fail if build is executed with JDK 11 -->
               <exclude>src/test/java/com/google/gson/functional/Java17RecordTest.java</exclude>
               <exclude>src/test/java/com/google/gson/native_test/Java17RecordReflectionTest.java</exclude>
-              <!-- Exclude protobuf generated code. -->
-              <exclude>target/generated-test-sources/protobuf/**/*.java</exclude>
             </excludes>
             <googleJavaFormat>
               <style>GOOGLE</style>


### PR DESCRIPTION
This was needed because of a Spotless bug which has now been fixed.
