### PR TITLE
Run shrinker-test for JDK 21 CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,7 @@ jobs:
         include:
           - java: 21
             # Disable Enforcer check which (intentionally) prevents using JDK 21 for building
-            # Exclude 'shrinker-test' module because R8 does not support JDK 21 yet
-            extra-mvn-args: -Denforcer.fail=false --projects '!:shrinker-test'
+            extra-mvn-args: -Denforcer.fail=false
     runs-on: ubuntu-latest
 
     steps:

--- a/shrinker-test/pom.xml
+++ b/shrinker-test/pom.xml
@@ -218,7 +218,6 @@
               but it appears that can be ignored -->
             <groupId>com.android.tools</groupId>
             <artifactId>r8</artifactId>
-            <!-- TODO: When updating to a version which supports JDK 21, remove 'shrinker-test' exclusion from build.yml workflow -->
             <version>8.2.33</version>
           </dependency>
         </dependencies>


### PR DESCRIPTION
### Purpose
Follow-up for #2569


### Description
The latest R8 version seems to support JDK 21 now.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [ ] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
