### PR TITLE
Another approach to fix 2563

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -324,13 +324,15 @@ public final class Gson {
 
     // built-in type adapters that cannot be overridden
     factories.add(TypeAdapters.JSON_ELEMENT_FACTORY);
-    factories.add(ObjectTypeAdapter.getFactory(objectToNumberStrategy));
+    factories.add(ObjectTypeAdapter.getFactory(objectToNumberStrategy, true));
 
     // the excluder must precede all adapters that handle user-defined types
     factories.add(excluder);
 
     // users' type adapters
     factories.addAll(factoriesToBeAdded);
+
+    factories.add(ObjectTypeAdapter.getFactory(objectToNumberStrategy, false));
 
     // type adapters for basic platform types
     factories.add(TypeAdapters.STRING_FACTORY);

--- a/gson/src/main/java/com/google/gson/internal/bind/ObjectTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ObjectTypeAdapter.java
@@ -27,6 +27,8 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -39,7 +41,7 @@ import java.util.Map;
  */
 public final class ObjectTypeAdapter extends TypeAdapter<Object> {
   /** Gson default factory using {@link ToNumberPolicy#DOUBLE}. */
-  private static final TypeAdapterFactory DOUBLE_FACTORY = newFactory(ToNumberPolicy.DOUBLE);
+  private static final TypeAdapterFactory DOUBLE_FACTORY = newFactory(ToNumberPolicy.DOUBLE, true);
 
   private final Gson gson;
   private final ToNumberStrategy toNumberStrategy;
@@ -49,24 +51,37 @@ public final class ObjectTypeAdapter extends TypeAdapter<Object> {
     this.toNumberStrategy = toNumberStrategy;
   }
 
-  private static TypeAdapterFactory newFactory(final ToNumberStrategy toNumberStrategy) {
+  private static TypeAdapterFactory newFactory(
+      final ToNumberStrategy toNumberStrategy, final boolean skipTypeVariable) {
     return new TypeAdapterFactory() {
       @SuppressWarnings("unchecked")
       @Override
       public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
-        if (type.getRawType() == Object.class) {
+        if (type.getRawType() == Object.class
+            && (!skipTypeVariable || !isTypeVariableWithBound(type.getType()))) {
           return (TypeAdapter<T>) new ObjectTypeAdapter(gson, toNumberStrategy);
         }
         return null;
       }
+
+      private boolean isTypeVariableWithBound(Type type) {
+        if (type instanceof TypeVariable<?>) {
+          TypeVariable<?> tv = (TypeVariable<?>) type;
+          Type bound = tv.getBounds()[0];
+          return bound != Object.class && bound instanceof Class<?>;
+        } else {
+          return false;
+        }
+      }
     };
   }
 
-  public static TypeAdapterFactory getFactory(ToNumberStrategy toNumberStrategy) {
+  public static TypeAdapterFactory getFactory(
+      ToNumberStrategy toNumberStrategy, boolean skipTypeVariable) {
     if (toNumberStrategy == ToNumberPolicy.DOUBLE) {
       return DOUBLE_FACTORY;
     } else {
-      return newFactory(toNumberStrategy);
+      return newFactory(toNumberStrategy, skipTypeVariable);
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/google/gson/issues/2563

This is alternative, more conservative approach to https://github.com/google/gson/pull/2571 . It doesn't attempt to process type variables with bounds the issue out of the box, but allows user code to intercept type variables.

The trick is the following. ObjectTypeAdapter instance is split into two. The first instance, which cannot be overriden, does not trigger on the mere condition `type.getRawType() == Object.class`. Specifically, it passes through TypeTokens if TypeToken.getType is a type variable, with a non-Object bound.

There is another instance that maps all remaining TypeTokens with rawType being Object.class, to ObjectTypeAdapter. But this second instance comes only after user defined adapters, so user has a chance to intercept type variables.

You may then fix the issue with the following custom adapter factory:

```java
/**
 * This adapter factory works around the https://github.com/google/gson/issues/2563 gson issue. Unfortunately it must be
 * applied to each affected field using the @JsonAdapter(ResolveGenericBoundFactory.class) declaration, as it is
 * otherwise superseded by the ObjectTypeAdapter.
 * <p>
 * It is also registered with GsonFactory, but is ineffective without annotation.
 */
public class ResolveGenericBoundFactory implements TypeAdapterFactory  {

	@Override
	public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
		if (type.getType() instanceof TypeVariable<?> tv) {
			Type[] bounds = tv.getBounds();
			if (bounds.length == 1 && bounds[0] != Object.class) {
				Type bound = bounds[0];
				return (TypeAdapter<T>) gson.getAdapter(TypeToken.get(bound));
			}
		}
		return null;
	}
	
}
```

There is still a change in behavior. Namely, custom type adapters get type variable tokens to process. This may be unexpected for them, they may fail on such an input. Before the change in behavior, custom type adapters never get the Type of TypeVariable, as this was unconditionally handled by the non-overridable ObjectTypeAdapter.

Even more conservative approach may be to introduce new option to GsonBuilder to trigger this new behavior.

### Purpose
The purpose is to fix https://github.com/google/gson/issues/2563 as described therein.

### Description
See discussion in https://github.com/google/gson/issues/2563. See InferenceFromTypeVariableTest for demo.