### PR TITLE
Update GraphAdapterBuilderTest.java

### DIFF
--- a/extras/src/test/java/com/google/gson/graph/GraphAdapterBuilderTest.java
+++ b/extras/src/test/java/com/google/gson/graph/GraphAdapterBuilderTest.java
@@ -84,9 +84,41 @@ public final class GraphAdapterBuilderTest {
 
   @Test
   public void testSerializeListOfLists() {
+    /*
+    Self-Referencing Issue:
+
+Elements in listOfLists that reference themselves do not create a meaningful structure. Reevaluate this situation and organize your data structure.
+Data Structure and Elements:
+
+If you choose to continue using the data structure of List<List<?>>, make sure to populate it with meaningful and realistic data.
+JSON Transformation and Assertion:
+
+The JSON transformation and assertion operations will work correctly, but the example used here is not meaningful. Adjust your data to make these operations meaningful.
+Circular References:
+
+The GraphAdapterBuilder is added to handle circular references, but in this scenario, it doesn't seem to have a meaningful purpose. Evaluate whether there is a need to handle circular references in a real-world scenario.
+Below is a modified version using a non-self-referencing structure with more meaningful data:
+          // Example data structure
+        List<List<String>> listOfLists = new ArrayList<>();
+        listOfLists.add(Arrays.asList("A", "B"));
+        listOfLists.add(new ArrayList<>());
+
+        // Creating type information
+        Type listOfListsType = new TypeToken<List<List<String>>>() {}.getType();
+
+        // Using GsonBuilder and GraphAdapterBuilder
+        GsonBuilder gsonBuilder = new GsonBuilder();
+        gsonBuilder.registerTypeAdapterFactory(new GraphAdapterBuilder().create());
+        Gson gson = gsonBuilder.create();
+
+        // JSON transformation
+        String json = gson.toJson(listOfLists, listOfListsType);
+        System.out.println(json);
+    */
     Type listOfListsType = new TypeToken<List<List<?>>>() {}.getType();
     Type listOfAnyType = new TypeToken<List<?>>() {}.getType();
 
+    //
     List<List<?>> listOfLists = new ArrayList<>();
     listOfLists.add(listOfLists);
     listOfLists.add(new ArrayList<>());


### PR DESCRIPTION
<!--
    Thank you for your contribution!
    Please see the contributing guide: https://github.com/google/.github/blob/master/CONTRIBUTING.md

    Keep in mind that Gson is in maintenance mode. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.
-->

### Purpose
<!-- Describe the purpose of this pull request, for example which new feature it adds or which bug it fixes -->
<!-- If this pull request closes a GitHub issue, please write "Closes #<issue>", for example "Closes #123" -->


### Description
<!-- If necessary provide more information, for example relevant implementation details or corner cases which are not covered yet -->
<!-- If there are related issues or pull requests, link to them by referencing their number, for example "pull request #123" -->



### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [ ] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [x] If necessary, new public API validates arguments, for example rejects `null`
- [x] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [ ] `mvn clean verify javadoc:jar` passes without errors
