### PR TITLE
Improve `Calendar` unit tests

### DIFF
--- a/gson/src/test/java/com/google/gson/internal/bind/util/ISO8601UtilsTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/util/ISO8601UtilsTest.java
@@ -18,7 +18,6 @@ package com.google.gson.internal.bind.util;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
 
 import java.text.ParseException;
 import java.text.ParsePosition;
@@ -52,7 +51,7 @@ public class ISO8601UtilsTest {
     Date date = calendar.getTime();
     String dateStr = ISO8601Utils.format(date);
     String expectedDate = "2018-06-25";
-    assertThat(dateStr.substring(0, expectedDate.length())).isEqualTo(expectedDate);
+    assertThat(dateStr).startsWith(expectedDate);
   }
 
   @Test
@@ -87,21 +86,13 @@ public class ISO8601UtilsTest {
   @Test
   public void testDateParseInvalidDay() {
     String dateStr = "2022-12-33";
-    try {
-      ISO8601Utils.parse(dateStr, new ParsePosition(0));
-      fail("Expected parsing to fail");
-    } catch (ParseException expected) {
-    }
+    assertThrows(ParseException.class, () -> ISO8601Utils.parse(dateStr, new ParsePosition(0)));
   }
 
   @Test
   public void testDateParseInvalidMonth() {
     String dateStr = "2022-14-30";
-    try {
-      ISO8601Utils.parse(dateStr, new ParsePosition(0));
-      fail("Expected parsing to fail");
-    } catch (ParseException expected) {
-    }
+    assertThrows(ParseException.class, () -> ISO8601Utils.parse(dateStr, new ParsePosition(0)));
   }
 
   @Test


### PR DESCRIPTION
### Purpose
Improve `Calendar` unit tests

### Description
Improves the `Calendar` unit tests and slightly refactors other tests.
This is mainly in response to #1339 to verify that Gson does not contain a bug causing the month to be off by 1.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [x] If necessary, new unit tests have been added  
  - [x] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [x] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
