### PR TITLE
Fix $Gson$Types equals method for TypeVariable when its generic declaration is not a Class

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
+++ b/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
@@ -217,7 +217,7 @@ public final class $Gson$Types {
       }
       TypeVariable<?> va = (TypeVariable<?>) a;
       TypeVariable<?> vb = (TypeVariable<?>) b;
-      return va.getGenericDeclaration() == vb.getGenericDeclaration()
+      return Objects.equals(va.getGenericDeclaration(), vb.getGenericDeclaration())
           && va.getName().equals(vb.getName());
 
     } else {

--- a/gson/src/test/java/com/google/gson/internal/GsonTypesTest.java
+++ b/gson/src/test/java/com/google/gson/internal/GsonTypesTest.java
@@ -19,6 +19,8 @@ package com.google.gson.internal;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.List;
@@ -98,4 +100,37 @@ public final class GsonTypesTest {
     }
     return $Gson$Types.canonicalize(actualTypeArguments[0]);
   }
+
+  @Test
+  public void testEqualsOnMethodTypeVariables() throws Exception {
+    Method m1 = TypeVariableTest.class.getMethod("method");
+    Method m2 = TypeVariableTest.class.getMethod("method");
+
+    Type rt1 = m1.getGenericReturnType();
+    Type rt2 = m2.getGenericReturnType();
+
+    assertThat($Gson$Types.equals(rt1, rt2)).isTrue();
+  }
+
+  @Test
+  public void testEqualsOnConstructorParameterTypeVariables() throws Exception {
+    Constructor<TypeVariableTest> c1 = TypeVariableTest.class.getConstructor(Object.class);
+    Constructor<TypeVariableTest> c2 = TypeVariableTest.class.getConstructor(Object.class);
+
+    Type rt1 = c1.getGenericParameterTypes()[0];
+    Type rt2 = c2.getGenericParameterTypes()[0];
+
+    assertThat($Gson$Types.equals(rt1, rt2)).isTrue();
+  }
+
+  private static final class TypeVariableTest {
+
+    public <T> TypeVariableTest(T parameter) {}
+
+    public <T> T method() {
+      return null;
+    }
+
+  }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
       <dependency>
         <groupId>com.google.truth</groupId>
         <artifactId>truth</artifactId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
### Purpose
When $Gson$Types equals method check two `TypeVariable`, it can return false while `Objects#equals(Object, Object)` returns true.


### Description
```java
public class Main {

    private static class MyClass {

        public <T> T method() { return null; }

    }

    public static void main(String[] args) throws NoSuchMethodException {
        Method m1 = MyClass.class.getMethod("method");
        Method m2 = MyClass.class.getMethod("method");

        Type rt1 = m1.getGenericReturnType();
        Type rt2 = m2.getGenericReturnType();

        TypeToken<?> t1 = TypeToken.get(rt1);
        TypeToken<?> t2 = TypeToken.get(rt2);

        System.out.println(Objects.equals(rt1, rt2)); // true
        System.out.println(Objects.equals(t1, t2));  // false
    }

}
```
The root cause is [here](https://github.com/google/gson/blob/51cce39e0064a755d32f820670770f82519039de/gson/src/main/java/com/google/gson/internal/%24Gson%24Types.java#L220).
For `Class` generic declaration, reference equality is enough because there is one reference of each class.
But for `Method`generic declaration, it is not, `Class#getMethod(String, Class<?>...)` returns a new instance of the `Method` per call.


### Checklist

- [ ] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [ ] `mvn clean verify javadoc:jar` passes without errors
