### PR TITLE
Improve location information for `JsonDeserializer` exceptions

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/TreeTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TreeTypeAdapter.java
@@ -92,7 +92,15 @@ public final class TreeTypeAdapter<T> extends SerializationDelegatingTypeAdapter
     if (nullSafe && value.isJsonNull()) {
       return null;
     }
-    return deserializer.deserialize(value, typeToken.getType(), context);
+
+    try {
+      return deserializer.deserialize(value, typeToken.getType(), context);
+    } catch (Exception e) {
+      // Wrap and include path of `value`; otherwise exception would only include path relative
+      // to `value`, making troubleshooting difficult
+      String valuePath = in.getPreviousPath();
+      throw new JsonParseException("Deserialization failed at path " + valuePath, e);
+    }
   }
 
   @Override


### PR DESCRIPTION
<!--
    Thank you for your contribution!
    Please see the contributing guide: https://github.com/google/.github/blob/master/CONTRIBUTING.md

    Keep in mind that Gson is in maintenance mode. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.
-->

### Purpose
Resolves #1135

### Description
When `JsonDeserializer.deserialize` throws an exception, wrap it and include the path of the `JsonElement` to make troubleshooting easier.

Risks of this approach:
- Troubleshooting might still be difficult / confusing because it is not obvious that the path reported by the wrapped exception is relative
- User code might expect the exception to be propagated without any wrapping
- If users use a lot `JsonDeserializer`s and a deeply nested one throws an exception, it would create a large exception chain, which is difficult to read and could be a performance issue

:warning: So I am not completely sure if this is worth it. Feel free to reject this pull request (or suggest another solution).

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [x] If necessary, new unit tests have been added  
  - [x] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [x] No JUnit 3 features are used (such as extending class `TestCase`)
  - [x] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
