### PR TITLE
Improve formatting of README maintenance note

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Gson can work with arbitrary Java objects including pre-existing objects that yo
 
 There are a few open-source projects that can convert Java objects to JSON. However, most of them require that you place Java annotations in your classes; something that you can not do if you do not have access to the source-code. Most also do not fully support the use of Java Generics. Gson considers both of these as very important design goals.
 
-:information_source: Gson is currently in maintenance mode; existing bugs will be fixed, but large new features will likely not be added. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.
+> [!NOTE]\
+> Gson is currently in maintenance mode; existing bugs will be fixed, but large new features will likely not be added. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.
 
 ### Goals
   * Provide simple `toJson()` and `fromJson()` methods to convert Java objects to JSON and vice-versa


### PR DESCRIPTION
### Purpose
Resolves #2617

### Description
Currently the README uses `:information_source:` (ℹ️) for the maintenance note. It might not be obvious to all users what this icon is supposed to mean, and for some fonts it looks unremarkable, like a regular 'i'.

Therefore, this pull request changes it to use a [GitHub alert section](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts). This is not standard Markdown syntax, but assuming that most users view the README on GitHub, using GitHub-specific syntax is probably fine.
