### PR TITLE
Create grouped Dependabot pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,21 @@ updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
+    groups:
+      # Name is used for branch name and pull request title
+      maven:
+        patterns:
+        # Create a single pull request for all dependencies and plugins
+        - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      # Name is used for branch name and pull request title
+      github-actions:
+        patterns:
+        # Create a single pull request for all actions
+        - "*"


### PR DESCRIPTION
### Purpose
Group Dependabot pull requests instead of creating a separate one for each update, see #2639

I think the syntax should be correct, but I haven't tested it yet. We will probably see within the next month whether this works as desired.