### PR TITLE
Support strict mode for `JsonParser`

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -930,7 +930,9 @@ public final class Gson {
     Strictness oldStrictness = writer.getStrictness();
     if (this.strictness != null) {
       writer.setStrictness(this.strictness);
-    } else if (writer.getStrictness() != Strictness.STRICT) {
+    }
+    // For backward compatibility change to LENIENT if writer has default strictness LEGACY_STRICT
+    else if (writer.getStrictness() == Strictness.LEGACY_STRICT) {
       writer.setStrictness(Strictness.LENIENT);
     }
 
@@ -1013,7 +1015,9 @@ public final class Gson {
 
     if (this.strictness != null) {
       writer.setStrictness(this.strictness);
-    } else if (writer.getStrictness() != Strictness.STRICT) {
+    }
+    // For backward compatibility change to LENIENT if writer has default strictness LEGACY_STRICT
+    else if (writer.getStrictness() == Strictness.LEGACY_STRICT) {
       writer.setStrictness(Strictness.LENIENT);
     }
 
@@ -1347,7 +1351,9 @@ public final class Gson {
 
     if (this.strictness != null) {
       reader.setStrictness(this.strictness);
-    } else if (reader.getStrictness() != Strictness.STRICT) {
+    }
+    // For backward compatibility change to LENIENT if reader has default strictness LEGACY_STRICT
+    else if (reader.getStrictness() == Strictness.LEGACY_STRICT) {
       reader.setStrictness(Strictness.LENIENT);
     }
 

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -930,9 +930,8 @@ public final class Gson {
     Strictness oldStrictness = writer.getStrictness();
     if (this.strictness != null) {
       writer.setStrictness(this.strictness);
-    }
-    // For backward compatibility change to LENIENT if writer has default strictness LEGACY_STRICT
-    else if (writer.getStrictness() == Strictness.LEGACY_STRICT) {
+    } else if (writer.getStrictness() == Strictness.LEGACY_STRICT) {
+      // For backward compatibility change to LENIENT if writer has default strictness LEGACY_STRICT
       writer.setStrictness(Strictness.LENIENT);
     }
 
@@ -1015,9 +1014,8 @@ public final class Gson {
 
     if (this.strictness != null) {
       writer.setStrictness(this.strictness);
-    }
-    // For backward compatibility change to LENIENT if writer has default strictness LEGACY_STRICT
-    else if (writer.getStrictness() == Strictness.LEGACY_STRICT) {
+    } else if (writer.getStrictness() == Strictness.LEGACY_STRICT) {
+      // For backward compatibility change to LENIENT if writer has default strictness LEGACY_STRICT
       writer.setStrictness(Strictness.LENIENT);
     }
 
@@ -1351,9 +1349,8 @@ public final class Gson {
 
     if (this.strictness != null) {
       reader.setStrictness(this.strictness);
-    }
-    // For backward compatibility change to LENIENT if reader has default strictness LEGACY_STRICT
-    else if (reader.getStrictness() == Strictness.LEGACY_STRICT) {
+    } else if (reader.getStrictness() == Strictness.LEGACY_STRICT) {
+      // For backward compatibility change to LENIENT if reader has default strictness LEGACY_STRICT
       reader.setStrictness(Strictness.LENIENT);
     }
 

--- a/gson/src/main/java/com/google/gson/JsonParser.java
+++ b/gson/src/main/java/com/google/gson/JsonParser.java
@@ -87,9 +87,10 @@ public final class JsonParser {
    * methods, no exception is thrown if the JSON data has multiple top-level JSON elements, or if
    * there is trailing data.
    *
-   * <p>The JSON data is parsed in {@linkplain JsonReader#setStrictness(Strictness) lenient mode},
-   * regardless of the strictness setting of the provided reader. The strictness setting of the
-   * reader is restored once this method returns.
+   * <p>If the {@linkplain JsonReader#getStrictness() strictness of the reader} is {@link
+   * Strictness#STRICT}, that strictness will be used for parsing. Otherwise the strictness will be
+   * temporarily changed to {@link Strictness#LENIENT} and will be restored once this method
+   * returns.
    *
    * @throws JsonParseException if there is an IOException or if the specified text is not valid
    *     JSON
@@ -98,7 +99,10 @@ public final class JsonParser {
   public static JsonElement parseReader(JsonReader reader)
       throws JsonIOException, JsonSyntaxException {
     Strictness strictness = reader.getStrictness();
-    reader.setStrictness(Strictness.LENIENT);
+    // For backward compatibility change to LENIENT if reader has default strictness LEGACY_STRICT
+    if (strictness == Strictness.LEGACY_STRICT) {
+      reader.setStrictness(Strictness.LENIENT);
+    }
     try {
       return Streams.parse(reader);
     } catch (StackOverflowError e) {

--- a/gson/src/main/java/com/google/gson/JsonParser.java
+++ b/gson/src/main/java/com/google/gson/JsonParser.java
@@ -99,8 +99,8 @@ public final class JsonParser {
   public static JsonElement parseReader(JsonReader reader)
       throws JsonIOException, JsonSyntaxException {
     Strictness strictness = reader.getStrictness();
-    // For backward compatibility change to LENIENT if reader has default strictness LEGACY_STRICT
     if (strictness == Strictness.LEGACY_STRICT) {
+      // For backward compatibility change to LENIENT if reader has default strictness LEGACY_STRICT
       reader.setStrictness(Strictness.LENIENT);
     }
     try {

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -336,7 +336,7 @@ public class JsonReader implements Closeable {
   /**
    * Returns true if the {@link Strictness} of this reader is equal to {@link Strictness#LENIENT}.
    *
-   * @see #setStrictness(Strictness)
+   * @see #getStrictness()
    */
   public final boolean isLenient() {
     return strictness == Strictness.LENIENT;
@@ -393,6 +393,7 @@ public class JsonReader implements Closeable {
    * </dl>
    *
    * @param strictness the new strictness value of this reader. May not be {@code null}.
+   * @see #getStrictness()
    * @since $next-version$
    */
   public final void setStrictness(Strictness strictness) {

--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -316,7 +316,7 @@ public class JsonWriter implements Closeable, Flushable {
   /**
    * Returns true if the {@link Strictness} of this writer is equal to {@link Strictness#LENIENT}.
    *
-   * @see JsonWriter#setStrictness(Strictness)
+   * @see #getStrictness()
    */
   public boolean isLenient() {
     return strictness == Strictness.LENIENT;
@@ -338,6 +338,7 @@ public class JsonWriter implements Closeable, Flushable {
    * </dl>
    *
    * @param strictness the new strictness of this writer. May not be {@code null}.
+   * @see #getStrictness()
    * @since $next-version$
    */
   public final void setStrictness(Strictness strictness) {

--- a/gson/src/test/java/com/google/gson/JsonParserTest.java
+++ b/gson/src/test/java/com/google/gson/JsonParserTest.java
@@ -174,14 +174,29 @@ public class JsonParserTest {
   }
 
   @Test
+  public void testLegacyStrict() {
+    JsonReader reader = new JsonReader(new StringReader("unquoted"));
+    Strictness strictness = Strictness.LEGACY_STRICT;
+    // LEGACY_STRICT is ignored by JsonParser later; parses in lenient mode instead
+    reader.setStrictness(strictness);
+
+    assertThat(JsonParser.parseReader(reader)).isEqualTo(new JsonPrimitive("unquoted"));
+    // Original strictness was restored
+    assertThat(reader.getStrictness()).isEqualTo(strictness);
+  }
+
+  @Test
   public void testStrict() {
     JsonReader reader = new JsonReader(new StringReader("faLsE"));
     Strictness strictness = Strictness.STRICT;
-    // Strictness is ignored by JsonParser later; always parses in lenient mode
     reader.setStrictness(strictness);
 
-    assertThat(JsonParser.parseReader(reader)).isEqualTo(new JsonPrimitive(false));
-    // Original strictness was restored
+    var e = assertThrows(JsonSyntaxException.class, () -> JsonParser.parseReader(reader));
+    assertThat(e)
+        .hasCauseThat()
+        .hasMessageThat()
+        .startsWith("Use JsonReader.setStrictness(Strictness.LENIENT) to accept malformed JSON");
+    // Original strictness was kept
     assertThat(reader.getStrictness()).isEqualTo(strictness);
   }
 }

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -41,6 +41,12 @@ import org.junit.Test;
 @SuppressWarnings("resource")
 public final class JsonReaderTest {
 
+  @Test
+  public void testDefaultStrictness() {
+    JsonReader reader = new JsonReader(reader("{}"));
+    assertThat(reader.getStrictness()).isEqualTo(Strictness.LEGACY_STRICT);
+  }
+
   @SuppressWarnings("deprecation") // for JsonReader.setLenient
   @Test
   public void testSetLenientTrue() {


### PR DESCRIPTION
### Purpose
Support strict parsing for `JsonParser`

### Description
Since the `Strictness` API (#2323) has not been released yet, we can fix the parsing of `JsonParser` in the same backward compatible way we fixed it for the `Gson` methods:
- If the strictness is `LEGACY_STRICT` (the default) we parse with `LENIENT`
- But if the user has explicitly set `STRICT` (which will only be possible now with the `Strictness` API) we respect this setting and parse in strict mode


This pull request also changes the `getStrictness() == Strictness.LEGACY_STRICT` checks in `Gson` to make the intention clearer that this is for backward compatibility. Behavior-wise they still act like before:
- `LENIENT` -> `LENIENT` (but is not explicitly overwritten anymore now)
- `LEGACY_STRICT` -> `LENIENT`
- `STRICT` -> `STRICT`


### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [x] If necessary, new unit tests have been added  
  - [x] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [x] No JUnit 3 features are used (such as extending class `TestCase`)
  - [x] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
