### PR TITLE
Add Assertions to Validate `testWriterCloseIsIdempotent` Test for JsonWriter's Idempotency

### DIFF
--- a/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
@@ -970,7 +970,9 @@ public final class JsonWriterTest {
     writer.beginArray();
     writer.endArray();
     writer.close();
+    assertThat(stringWriter.toString()).isEqualTo("[]");
     writer.close();
+    assertThat(stringWriter.toString()).isEqualTo("[]");
   }
 
   @Test


### PR DESCRIPTION
<!--
    Thank you for your contribution!
    Please see the contributing guide: https://github.com/google/.github/blob/master/CONTRIBUTING.md

    Keep in mind that Gson is in maintenance mode. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.
-->

### Purpose
<!-- Describe the purpose of this pull request, for example which new feature it adds or which bug it fixes -->
<!-- If this pull request closes a GitHub issue, please write "Closes #<issue>", for example "Closes #123" -->
Closes #2650 

This PR aims to enhance the clarity and completeness of the testWriterCloseIsIdempotent method in the JsonWriter class's unit tests. It introduces explicit assertions to verify the idempotency of the close method by ensuring the output remains unchanged after multiple calls. This change addresses a potential gap in our current testing strategy by providing a more explicit demonstration of the close method's behavior.

### Description
<!-- If necessary provide more information, for example relevant implementation details or corner cases which are not covered yet -->
<!-- If there are related issues or pull requests, link to them by referencing their number, for example "pull request #123" -->
In the existing implementation of the `testWriterCloseIsIdempotent` test, we call the close method on `JsonWriter` twice to check for idempotency but do not assert the outcome explicitly. This PR adds assertions to this test method to explicitly verify that the content of the `StringWriter` remains the same after the second call to close. This provides a clearer and more definitive confirmation of the method's idempotency. The modification aims to improve our test's expressiveness without altering the functionality of the `JsonWriter` class.

#### Changes made:

* Added an assertion before the second close call to verify the StringWriter's content matches the expected output after the first close.
* Added a second assertion after the second close call to ensure the output remains unchanged, confirming the close method's idempotency.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [x] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [x] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
