### PR TITLE
Split `testWriteHtmlSafe` into Two Separate Test Cases for Improved Test Granularity

### DIFF
--- a/gson/src/test/java/com/google/gson/MixedStreamTest.java
+++ b/gson/src/test/java/com/google/gson/MixedStreamTest.java
@@ -197,19 +197,25 @@ public final class MixedStreamTest {
   }
 
   @Test
-  public void testWriteHtmlSafe() {
+  public void testWriteHtmlSafeWithEscaping() {
     List<String> contents = Arrays.asList("<", ">", "&", "=", "'");
     Type type = new TypeToken<List<String>>() {}.getType();
 
     StringWriter writer = new StringWriter();
     new Gson().toJson(contents, type, new JsonWriter(writer));
-    assertThat(writer.toString())
-        .isEqualTo("[\"\\u003c\",\"\\u003e\",\"\\u0026\",\"\\u003d\",\"\\u0027\"]");
+    assertThat(writer.toString()).isEqualTo("[\"\\u003c\",\"\\u003e\",\"\\u0026\",\"\\u003d\",\"\\u0027\"]");
+  }
 
-    writer = new StringWriter();
+  @Test
+  public void testWriteHtmlSafeWithoutEscaping() {
+    List<String> contents = Arrays.asList("<", ">", "&", "=", "'");
+    Type type = new TypeToken<List<String>>() {}.getType();
+
+    StringWriter writer = new StringWriter();
     new GsonBuilder().disableHtmlEscaping().create().toJson(contents, type, new JsonWriter(writer));
     assertThat(writer.toString()).isEqualTo("[\"<\",\">\",\"&\",\"=\",\"'\"]");
   }
+
 
   @Test
   public void testWriteLenient() {

--- a/gson/src/test/java/com/google/gson/MixedStreamTest.java
+++ b/gson/src/test/java/com/google/gson/MixedStreamTest.java
@@ -203,7 +203,8 @@ public final class MixedStreamTest {
 
     StringWriter writer = new StringWriter();
     new Gson().toJson(contents, type, new JsonWriter(writer));
-    assertThat(writer.toString()).isEqualTo("[\"\\u003c\",\"\\u003e\",\"\\u0026\",\"\\u003d\",\"\\u0027\"]");
+    assertThat(writer.toString())
+        .isEqualTo("[\"\\u003c\",\"\\u003e\",\"\\u0026\",\"\\u003d\",\"\\u0027\"]");
   }
 
   @Test
@@ -215,7 +216,6 @@ public final class MixedStreamTest {
     new GsonBuilder().disableHtmlEscaping().create().toJson(contents, type, new JsonWriter(writer));
     assertThat(writer.toString()).isEqualTo("[\"<\",\">\",\"&\",\"=\",\"'\"]");
   }
-
 
   @Test
   public void testWriteLenient() {


### PR DESCRIPTION
<!--
    Thank you for your contribution!
    Please see the contributing guide: https://github.com/google/.github/blob/master/CONTRIBUTING.md

    Keep in mind that Gson is in maintenance mode. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.
-->

### Purpose
<!-- Describe the purpose of this pull request, for example which new feature it adds or which bug it fixes -->
<!-- If this pull request closes a GitHub issue, please write "Closes #<issue>", for example "Closes #123" -->
This pull request aims to improve the granularity and clarity of testing in the Gson project by splitting the testWriteHtmlSafe test case into two separate tests. This change allows each test to focus on a single scenario: one with HTML escaping enabled and the other with it disabled. Splitting the test enhances the readability and maintainability of the test suite, ensuring that failures in one scenario do not affect the execution of tests in another scenario. This approach facilitates more precise identification of issues and improves the efficiency of debugging and test execution.

Closes #2651 

### Description
<!-- If necessary provide more information, for example relevant implementation details or corner cases which are not covered yet -->
<!-- If there are related issues or pull requests, link to them by referencing their number, for example "pull request #123" -->

The existing testWriteHtmlSafe combined two scenarios—testing Gson's behavior with HTML escaping both enabled and disabled—into a single test method. This PR proposes splitting this into two distinct test methods:

* `testWriteHtmlSafeWithEscaping`: Tests Gson's default behavior of escaping HTML characters.
* `testWriteHtmlSafeWithoutEscaping`: Tests Gson's behavior when HTML escaping is disabled using `GsonBuilder().disableHtmlEscaping()`.

This separation increases test specificity and ensures that a failure in one part of the test suite does not hinder the execution or identification of issues in another part. The PR includes the addition of these two new test methods to the Gson test suite, providing a clearer, more targeted approach to testing Gson's HTML escaping functionalities.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [x] If necessary, new unit tests have been added  
  - [x] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [x] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
