### PR TITLE
Update to proto 4.26.1.

### DIFF
--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -32,7 +32,7 @@
     <!-- This is duplicated here because that is recommended by `artifact:check-buildplan` -->
     <project.build.outputTimestamp>2023-01-01T00:00:00Z</project.build.outputTimestamp>
 
-    <protobufVersion>3.25.3</protobufVersion>
+    <protobufVersion>4.26.1</protobufVersion>
   </properties>
 
   <licenses>

--- a/proto/src/test/java/com/google/gson/protobuf/functional/ProtosWithAnnotationsTest.java
+++ b/proto/src/test/java/com/google/gson/protobuf/functional/ProtosWithAnnotationsTest.java
@@ -28,7 +28,7 @@ import com.google.gson.protobuf.generated.Annotations;
 import com.google.gson.protobuf.generated.Bag.OuterMessage;
 import com.google.gson.protobuf.generated.Bag.ProtoWithAnnotations;
 import com.google.gson.protobuf.generated.Bag.ProtoWithAnnotations.InnerMessage;
-import com.google.protobuf.GeneratedMessageV3;
+import com.google.protobuf.GeneratedMessage;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -51,18 +51,18 @@ public class ProtosWithAnnotationsTest {
             .addSerializedEnumValueExtension(Annotations.serializedValue);
     gson =
         new GsonBuilder()
-            .registerTypeHierarchyAdapter(GeneratedMessageV3.class, protoTypeAdapter.build())
+            .registerTypeHierarchyAdapter(GeneratedMessage.class, protoTypeAdapter.build())
             .create();
     gsonWithEnumNumbers =
         new GsonBuilder()
             .registerTypeHierarchyAdapter(
-                GeneratedMessageV3.class,
+                GeneratedMessage.class,
                 protoTypeAdapter.setEnumSerialization(EnumSerialization.NUMBER).build())
             .create();
     gsonWithLowerHyphen =
         new GsonBuilder()
             .registerTypeHierarchyAdapter(
-                GeneratedMessageV3.class,
+                GeneratedMessage.class,
                 protoTypeAdapter
                     .setFieldNameSerializationFormat(
                         CaseFormat.LOWER_UNDERSCORE, CaseFormat.LOWER_HYPHEN)

--- a/proto/src/test/java/com/google/gson/protobuf/functional/ProtosWithComplexAndRepeatedFieldsTest.java
+++ b/proto/src/test/java/com/google/gson/protobuf/functional/ProtosWithComplexAndRepeatedFieldsTest.java
@@ -27,7 +27,7 @@ import com.google.gson.protobuf.ProtoTypeAdapter.EnumSerialization;
 import com.google.gson.protobuf.generated.Bag.ProtoWithDifferentCaseFormat;
 import com.google.gson.protobuf.generated.Bag.ProtoWithRepeatedFields;
 import com.google.gson.protobuf.generated.Bag.SimpleProto;
-import com.google.protobuf.GeneratedMessageV3;
+import com.google.protobuf.GeneratedMessage;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -45,7 +45,7 @@ public class ProtosWithComplexAndRepeatedFieldsTest {
     gson =
         new GsonBuilder()
             .registerTypeHierarchyAdapter(
-                GeneratedMessageV3.class,
+                GeneratedMessage.class,
                 ProtoTypeAdapter.newBuilder()
                     .setEnumSerialization(EnumSerialization.NUMBER)
                     .build())
@@ -53,7 +53,7 @@ public class ProtosWithComplexAndRepeatedFieldsTest {
     upperCamelGson =
         new GsonBuilder()
             .registerTypeHierarchyAdapter(
-                GeneratedMessageV3.class,
+                GeneratedMessage.class,
                 ProtoTypeAdapter.newBuilder()
                     .setFieldNameSerializationFormat(
                         CaseFormat.LOWER_UNDERSCORE, CaseFormat.UPPER_CAMEL)

--- a/proto/src/test/java/com/google/gson/protobuf/functional/ProtosWithPrimitiveTypesTest.java
+++ b/proto/src/test/java/com/google/gson/protobuf/functional/ProtosWithPrimitiveTypesTest.java
@@ -24,7 +24,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.protobuf.ProtoTypeAdapter;
 import com.google.gson.protobuf.ProtoTypeAdapter.EnumSerialization;
 import com.google.gson.protobuf.generated.Bag.SimpleProto;
-import com.google.protobuf.GeneratedMessageV3;
+import com.google.protobuf.GeneratedMessage;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -36,7 +36,7 @@ public class ProtosWithPrimitiveTypesTest {
     gson =
         new GsonBuilder()
             .registerTypeHierarchyAdapter(
-                GeneratedMessageV3.class,
+                GeneratedMessage.class,
                 ProtoTypeAdapter.newBuilder()
                     .setEnumSerialization(EnumSerialization.NUMBER)
                     .build())


### PR DESCRIPTION
Use `GeneratedMessage` rather than `GeneratedMessageV3` in proto tests. [Proto v26.0](https://github.com/protocolbuffers/protobuf/releases/tag/v26.0) made a number of incompatible API changes, including changing the base class for generated proto message code.