### PR TITLE
Document that other JVM languages are not fully supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ There are a few open-source projects that can convert Java objects to JSON. Howe
 > [!NOTE]\
 > Gson is currently in maintenance mode; existing bugs will be fixed, but large new features will likely not be added. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.
 
+> [!IMPORTANT]\
+> Gson's main focus is on Java. Using it with other JVM languages such as Kotlin or Scala might work fine in many cases, but language-specific features such as Kotlin's non-`null` types or constructors with default arguments are not supported. This can lead to confusing and incorrect behavior.\
+> When using languages other than Java, prefer a JSON library with explicit support for that language.
+
 ### Goals
   * Provide simple `toJson()` and `fromJson()` methods to convert Java objects to JSON and vice-versa
   * Allow pre-existing unmodifiable objects to be converted to and from JSON


### PR DESCRIPTION
### Purpose
Document that other JVM languages are not fully supported

### Description
Gson's main focus is on Java. Because Gson uses reflection it works in many cases also for other JVM languages such as Kotlin or Scala, but because it does not explicitly consider these languages, language-specific features which do not exist in Java don't work properly. See for example issues with https://github.com/google/gson/labels/kotlin label.

Therefore this pull request adds a warning to prevent new users from investing a lot of time to use Gson with these languages just to notice in the end that it is not properly working or error-prone.
If at some point in the future Gson properly supports other JVM languages, the warning can be removed again. But (at least to me) it seems a bit unlikely that this will ever happen, because:
- Gson is in maintenance mode
- Additional code and dependencies (or a separate module) is needed to account for these language-specific features
- It could cause confusion if new API is added to Gson which is only relevant for other JVM languages but not Java (and the other way around)
- There are already mature other JSON libraries for these languages, so Gson would then just compete with them

Actually this limitation mostly (or only) applies to reflection-based serialization and deserialization. Using only custom `TypeAdapter`s, `JsonElement` (and subclasses) or `JsonReader` and `JsonWriter` will probably work fine. However, explaining this might be a bit verbose, and most likely using reflection-based serialization is the most common use case. And even if users initially only use the non-reflective features, they might in the future use them and would then either have to migrate or mix multiple JSON libraries which often does not work that well.

Feedback regarding the wording and where to document this (e.g. not in the README but instead somewhere else) is appreciated. I did not want to explicitly list the other JSON libraries because there are multiple and to not endorse specific ones when there are other ones which might be better suited for the specific use case of the user, or if new libraries emerge in the future.
