### PR TITLE
Added FormattedDouble Class

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/FormattedDouble.java
+++ b/gson/src/main/java/com/google/gson/internal/FormattedDouble.java
@@ -1,0 +1,66 @@
+public class FormattedDouble extends Number {
+    private static final long serialVersionUID = 1L;
+
+    // ThreadLocal because DecimalFormat is not thread-safe
+    private static final ThreadLocal<DecimalFormat> format =
+            // Specify DecimalFormatSymbols to make code independent from default Locale
+            ThreadLocal.withInitial(() -> new DecimalFormat("0.00", DecimalFormatSymbols.getInstance(Locale.ENGLISH)));
+
+    private final Double delegate;
+
+    public FormattedDouble(Double value) {
+        Objects.requireNonNull(value, "Value should not be null");
+        this.delegate = value;
+    }
+
+    @Override
+    public byte byteValue() {
+        return delegate.byteValue();
+    }
+
+    @Override
+    public short shortValue() {
+        return delegate.shortValue();
+    }
+
+    @Override
+    public int intValue() {
+        return delegate.intValue();
+    }
+
+    @Override
+    public long longValue() {
+        return delegate.longValue();
+    }
+
+    @Override
+    public float floatValue() {
+        return delegate.floatValue();
+    }
+
+    @Override
+    public double doubleValue() {
+        return delegate.doubleValue();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        } else if (obj instanceof FormattedDouble) {
+            return ((FormattedDouble) obj).delegate.equals(delegate);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * delegate.hashCode() + format.get().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return format.get().format((double) delegate);
+    }
+}


### PR DESCRIPTION
<!--
    Thank you for your contribution!
    Please see the contributing guide: https://github.com/google/.github/blob/master/CONTRIBUTING.md

    Keep in mind that Gson is in maintenance mode. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.
-->

### Purpose
<!-- Describe the purpose of this pull request, for example which new feature it adds or which bug it fixes -->
<!-- If this pull request closes a GitHub issue, please write "Closes #<issue>", for example "Closes #123" -->


### Description
<!-- If necessary provide more information, for example relevant implementation details or corner cases which are not covered yet -->
<!-- If there are related issues or pull requests, link to them by referencing their number, for example "pull request #123" -->
- Fixes #1769 
- Added FormattedDouble Class that'll help write double numbers using gson



### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [ ] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [ ] `mvn clean verify javadoc:jar` passes without errors
