### PR TITLE
Improved Long-Double Number Policy

### DIFF
--- a/gson/src/main/java/com/google/gson/ToNumberPolicy.java
+++ b/gson/src/main/java/com/google/gson/ToNumberPolicy.java
@@ -68,20 +68,28 @@ public enum ToNumberPolicy implements ToNumberStrategy {
     @Override
     public Number readNumber(JsonReader in) throws IOException, JsonParseException {
       String value = in.nextString();
-      try {
-        return Long.parseLong(value);
-      } catch (NumberFormatException longE) {
+      if (value.contains(".")) {
+        return parseAsDouble(value, in);
+      } else {
         try {
-          Double d = Double.valueOf(value);
-          if ((d.isInfinite() || d.isNaN()) && !in.isLenient()) {
-            throw new MalformedJsonException(
-                "JSON forbids NaN and infinities: " + d + "; at path " + in.getPreviousPath());
-          }
-          return d;
-        } catch (NumberFormatException doubleE) {
-          throw new JsonParseException(
-              "Cannot parse " + value + "; at path " + in.getPreviousPath(), doubleE);
+          return Long.parseLong(value);
+        } catch (NumberFormatException longE) {
+          return parseAsDouble(value, in);
         }
+      }
+    }
+
+    private Number parseAsDouble(String value, JsonReader in) throws IOException {
+      try {
+        Double d = Double.valueOf(value);
+        if ((d.isInfinite() || d.isNaN()) && !in.isLenient()) {
+          throw new MalformedJsonException(
+              "JSON forbids NaN and infinities: " + d + "; at path " + in.getPreviousPath());
+        }
+        return d;
+      } catch (NumberFormatException doubleE) {
+        throw new JsonParseException(
+            "Cannot parse " + value + "; at path " + in.getPreviousPath(), doubleE);
       }
     }
   },

--- a/gson/src/main/java/com/google/gson/ToNumberPolicy.java
+++ b/gson/src/main/java/com/google/gson/ToNumberPolicy.java
@@ -73,7 +73,7 @@ public enum ToNumberPolicy implements ToNumberStrategy {
       } else {
         try {
           return Long.parseLong(value);
-        } catch (NumberFormatException longE) {
+        } catch (NumberFormatException e) {
           return parseAsDouble(value, in);
         }
       }
@@ -87,9 +87,9 @@ public enum ToNumberPolicy implements ToNumberStrategy {
               "JSON forbids NaN and infinities: " + d + "; at path " + in.getPreviousPath());
         }
         return d;
-      } catch (NumberFormatException doubleE) {
+      } catch (NumberFormatException e) {
         throw new JsonParseException(
-            "Cannot parse " + value + "; at path " + in.getPreviousPath(), doubleE);
+            "Cannot parse " + value + "; at path " + in.getPreviousPath(), e);
       }
     }
   },

--- a/gson/src/main/java/com/google/gson/ToNumberPolicy.java
+++ b/gson/src/main/java/com/google/gson/ToNumberPolicy.java
@@ -68,7 +68,7 @@ public enum ToNumberPolicy implements ToNumberStrategy {
     @Override
     public Number readNumber(JsonReader in) throws IOException, JsonParseException {
       String value = in.nextString();
-      if (value.contains(".")) {
+      if (value.indexOf('.') >= 0) {
         return parseAsDouble(value, in);
       } else {
         try {


### PR DESCRIPTION
<!--
    Thank you for your contribution!
    Please see the contributing guide: https://github.com/google/.github/blob/master/CONTRIBUTING.md

    Keep in mind that Gson is in maintenance mode. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.
-->

### Purpose
Fixes a performance issue while using the `ToNumberPolicy.LONG_OR_DOUBLE` with `Double` values

### Description
The Parsing of a Double value was always executing a `Long.parseLong(value)`, which generated a `NumberFormatException`.

Identifying that a Number is a Double or a Long can be easily achieve (in a naive way) looking for the decimal separator.

This simple change avoids the extra `NumberFormatException`

A simple JUnit test, parsing a `Long` or a `Double` 10K times shows the next values:

* Double (old parsing): ~42 ms
* Double (new parsing): ~6 ms
* Long (old parsing): ~7 ms
* Long (new parsing): ~7 ms

As we can see, the parsing for `Long` values stays the same (±1ms), while the parsing for `Double` is dramatically improved.

Reducing the number of exceptions also has a positive side effect in memory consumption.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
