### PR TITLE
Add more Javadoc cross-links between methods

### DIFF
--- a/gson/src/main/java/com/google/gson/FormattingStyle.java
+++ b/gson/src/main/java/com/google/gson/FormattingStyle.java
@@ -90,6 +90,7 @@ public class FormattingStyle {
    *
    * @param newline the string value that will be used as newline.
    * @return a newly created {@link FormattingStyle}
+   * @see #getNewline()
    */
   public FormattingStyle withNewline(String newline) {
     return new FormattingStyle(newline, this.indent, this.spaceAfterSeparators);
@@ -98,10 +99,11 @@ public class FormattingStyle {
   /**
    * Creates a {@link FormattingStyle} with the specified indent string.
    *
-   * <p>Only combinations of spaces and tabs allowed in indent.
+   * <p>Only combinations of spaces and tabs are allowed in indent.
    *
    * @param indent the string value that will be used as indent.
    * @return a newly created {@link FormattingStyle}
+   * @see #getIndent()
    */
   public FormattingStyle withIndent(String indent) {
     return new FormattingStyle(this.newline, indent, this.spaceAfterSeparators);
@@ -117,6 +119,7 @@ public class FormattingStyle {
    *
    * @param spaceAfterSeparators whether to output a space after {@code ','} and {@code ':'}.
    * @return a newly created {@link FormattingStyle}
+   * @see #usesSpaceAfterSeparators()
    */
   public FormattingStyle withSpaceAfterSeparators(boolean spaceAfterSeparators) {
     return new FormattingStyle(this.newline, this.indent, spaceAfterSeparators);
@@ -126,6 +129,7 @@ public class FormattingStyle {
    * Returns the string value that will be used as a newline.
    *
    * @return the newline value.
+   * @see #withNewline(String)
    */
   public String getNewline() {
     return this.newline;
@@ -135,12 +139,17 @@ public class FormattingStyle {
    * Returns the string value that will be used as indent.
    *
    * @return the indent value.
+   * @see #withIndent(String)
    */
   public String getIndent() {
     return this.indent;
   }
 
-  /** Returns whether a space will be used after {@code ','} and {@code ':'}. */
+  /**
+   * Returns whether a space will be used after {@code ','} and {@code ':'}.
+   *
+   * @see #withSpaceAfterSeparators(boolean)
+   */
   public boolean usesSpaceAfterSeparators() {
     return this.spaceAfterSeparators;
   }

--- a/gson/src/main/java/com/google/gson/Strictness.java
+++ b/gson/src/main/java/com/google/gson/Strictness.java
@@ -12,6 +12,7 @@ import com.google.gson.stream.JsonWriter;
  * the {@link JsonReader} and you can look at {@link JsonWriter#setStrictness(Strictness)} to see
  * how the strictness affects the {@link JsonWriter}.
  *
+ * @see GsonBuilder#setStrictness(Strictness)
  * @see JsonReader#setStrictness(Strictness)
  * @see JsonWriter#setStrictness(Strictness)
  * @since 2.11.0

--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -261,6 +261,7 @@ public class JsonWriter implements Closeable, Flushable {
    * level of indentation, or the newline style, to accommodate various OS styles.
    *
    * @param formattingStyle the formatting style to use, must not be {@code null}.
+   * @see #getFormattingStyle()
    * @since 2.11.0
    */
   public final void setFormattingStyle(FormattingStyle formattingStyle) {
@@ -286,6 +287,7 @@ public class JsonWriter implements Closeable, Flushable {
    * Returns the pretty printing style used by this writer.
    *
    * @return the {@code FormattingStyle} that will be used.
+   * @see #setFormattingStyle(FormattingStyle)
    * @since 2.11.0
    */
   public final FormattingStyle getFormattingStyle() {
@@ -360,6 +362,8 @@ public class JsonWriter implements Closeable, Flushable {
    * This escapes the HTML characters {@code <}, {@code >}, {@code &}, {@code =} and {@code '}
    * before writing them to the stream. Without this setting, your XML/HTML encoder should replace
    * these characters with the corresponding escape sequences.
+   *
+   * @see #isHtmlSafe()
    */
   public final void setHtmlSafe(boolean htmlSafe) {
     this.htmlSafe = htmlSafe;
@@ -367,6 +371,8 @@ public class JsonWriter implements Closeable, Flushable {
 
   /**
    * Returns true if this writer writes JSON that's safe for inclusion in HTML and XML documents.
+   *
+   * @see #setHtmlSafe(boolean)
    */
   public final boolean isHtmlSafe() {
     return htmlSafe;
@@ -375,6 +381,8 @@ public class JsonWriter implements Closeable, Flushable {
   /**
    * Sets whether object members are serialized when their value is null. This has no impact on
    * array elements. The default is true.
+   *
+   * @see #getSerializeNulls()
    */
   public final void setSerializeNulls(boolean serializeNulls) {
     this.serializeNulls = serializeNulls;
@@ -383,6 +391,8 @@ public class JsonWriter implements Closeable, Flushable {
   /**
    * Returns true if object members are serialized when their value is null. This has no impact on
    * array elements. The default is true.
+   *
+   * @see #setSerializeNulls(boolean)
    */
   public final boolean getSerializeNulls() {
     return serializeNulls;


### PR DESCRIPTION
### Purpose
Add more Javadoc cross-links between methods, mainly between getters and setters

### Description
This hopefully makes it easier to find the corresponding getter / setter. Though on the other hand it also makes the documentation more verbose, so please let me know if you don't think this is needed.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
