### PR TITLE
Add JPMS module test

### DIFF
--- a/.github/workflows/check-android-compatibility.yml
+++ b/.github/workflows/check-android-compatibility.yml
@@ -26,4 +26,5 @@ jobs:
       - name: Check Android compatibility
         run: |
           # Run 'test' phase because plugin normally expects to be executed after tests have been compiled
-          mvn --batch-mode --no-transfer-progress test animal-sniffer:check@check-android-compatibility -DskipTests
+          # Have to skip 'jpms-test' module because it requires that full Gson JAR has been built
+          mvn --batch-mode --no-transfer-progress test animal-sniffer:check@check-android-compatibility -DskipTests --projects '!jpms-test'

--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -31,6 +31,9 @@
     <!-- Make the build reproducible, see root `pom.xml` -->
     <!-- This is duplicated here because that is recommended by `artifact:check-buildplan` -->
     <project.build.outputTimestamp>2024-05-19T18:54:10Z</project.build.outputTimestamp>
+
+    <!-- Overwrite property from parent; this module is currently not deployed -->
+    <gson.isInternalModule>true</gson.isInternalModule>
   </properties>
 
   <licenses>
@@ -63,21 +66,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <configuration>
-            <!-- Currently not deployed -->
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 
   <developers>
     <developer>

--- a/graal-native-image-test/pom.xml
+++ b/graal-native-image-test/pom.xml
@@ -14,7 +14,6 @@
   limitations under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -26,14 +25,13 @@
   <name>Test: GraalVM Native Image</name>
 
   <properties>
-    <!-- Make the build reproducible, see root `pom.xml` -->
-    <!-- This is duplicated here because that is recommended by `artifact:check-buildplan` -->
-    <project.build.outputTimestamp>2024-05-19T18:54:10Z</project.build.outputTimestamp>
-
     <!-- GraalVM is JDK >= 17, however for build with regular JDK these tests
       are also executed with JDK 11, so for them exclude JDK 17 specific tests -->
     <maven.compiler.testRelease>11</maven.compiler.testRelease>
     <excludeTestCompilation>**/Java17*</excludeTestCompilation>
+
+    <!-- Overwrite property from parent -->
+    <gson.isTestModule>true</gson.isTestModule>
   </properties>
 
   <dependencies>
@@ -65,52 +63,11 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>com.github.siom79.japicmp</groupId>
-          <artifactId>japicmp-maven-plugin</artifactId>
-          <configuration>
-            <!-- This module is not supposed to be consumed as library, so no need to check API -->
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>animal-sniffer-maven-plugin</artifactId>
-          <configuration>
-            <!-- This module is not supposed to be consumed as library, so no need to check used classes -->
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <configuration>
             <!-- This module has no 'main' source code; skip creating JAR and avoid warning on console -->
             <skipIfEmpty>true</skipIfEmpty>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-install-plugin</artifactId>
-          <configuration>
-            <!-- This module has no 'main' source code, so no JAR is created which could be installed;
-              see maven-jar-plugin configuration above -->
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <configuration>
-            <!-- Not deployed -->
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-gpg-plugin</artifactId>
-          <configuration>
-            <!-- Not deployed -->
-            <skip>true</skip>
           </configuration>
         </plugin>
       </plugins>

--- a/gson/src/main/java/module-info.java
+++ b/gson/src/main/java/module-info.java
@@ -25,7 +25,7 @@ module com.google.gson {
   exports com.google.gson.reflect;
   exports com.google.gson.stream;
 
-  // Dependency on Error Prone Annotations
+  // Optional dependency on Error Prone Annotations
   requires static com.google.errorprone.annotations;
 
   // Optional dependency on java.sql

--- a/jpms-test/README.md
+++ b/jpms-test/README.md
@@ -1,0 +1,5 @@
+# jpms-test
+
+This Maven module contains tests to verify that Gson's `module-info.class` which is used by the Java Platform Module System (JPMS) works properly and can be used by other projects. The module declaration file `src/test/java/module-info.java` uses Gson's module.
+
+This is a separate Maven module to test Gson's final JAR instead of just the compiled classes.

--- a/jpms-test/pom.xml
+++ b/jpms-test/pom.xml
@@ -28,9 +28,8 @@
     <maven.compiler.release>11</maven.compiler.release>
     <maven.compiler.testRelease>${maven.compiler.release}</maven.compiler.testRelease>
 
-    <!-- Make the build reproducible, see root `pom.xml` -->
-    <!-- This is duplicated here because that is recommended by `artifact:check-buildplan` -->
-    <project.build.outputTimestamp>2024-05-19T18:54:10Z</project.build.outputTimestamp>
+    <!-- Overwrite property from parent -->
+    <gson.isTestModule>true</gson.isTestModule>
   </properties>
 
   <dependencies>
@@ -51,60 +50,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>com.github.siom79.japicmp</groupId>
-          <artifactId>japicmp-maven-plugin</artifactId>
-          <configuration>
-            <!-- This module is not supposed to be consumed as library, so no need to check API -->
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>animal-sniffer-maven-plugin</artifactId>
-          <configuration>
-            <!-- This module is not supposed to be consumed as library, so no need to check used classes -->
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-jar-plugin</artifactId>
-          <configuration>
-            <!-- This module has no 'main' source code; skip creating JAR and avoid warning on console -->
-            <skipIfEmpty>true</skipIfEmpty>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-install-plugin</artifactId>
-          <configuration>
-            <!-- This module has no 'main' source code, so no JAR is created which could be installed;
-              see maven-jar-plugin configuration above -->
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <configuration>
-            <!-- Not deployed -->
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-gpg-plugin</artifactId>
-          <configuration>
-            <!-- Not deployed -->
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 </project>

--- a/jpms-test/pom.xml
+++ b/jpms-test/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2023 Google Inc.
+  Copyright 2024 Google Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
   limitations under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -22,18 +21,16 @@
     <artifactId>gson-parent</artifactId>
     <version>2.11.1-SNAPSHOT</version>
   </parent>
-  <artifactId>graal-native-image-test</artifactId>
-  <name>Test: GraalVM Native Image</name>
+  <artifactId>jpms-test</artifactId>
+  <name>Test: Java Platform Module System (JPMS)</name>
 
   <properties>
+    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.testRelease>${maven.compiler.release}</maven.compiler.testRelease>
+
     <!-- Make the build reproducible, see root `pom.xml` -->
     <!-- This is duplicated here because that is recommended by `artifact:check-buildplan` -->
     <project.build.outputTimestamp>2024-05-19T18:54:10Z</project.build.outputTimestamp>
-
-    <!-- GraalVM is JDK >= 17, however for build with regular JDK these tests
-      are also executed with JDK 11, so for them exclude JDK 17 specific tests -->
-    <maven.compiler.testRelease>11</maven.compiler.testRelease>
-    <excludeTestCompilation>**/Java17*</excludeTestCompilation>
   </properties>
 
   <dependencies>
@@ -43,17 +40,11 @@
       <version>${project.parent.version}</version>
     </dependency>
 
-    <!-- Graal Native Maven Plugin requires using JUnit Platform (JUnit 5), see
-      https://graalvm.github.io/native-build-tools/latest/maven-plugin.html#testing-support
-      This also supports using JUnit Vintage to run JUnit 4 tests, but for simplicity
-      completely use JUnit 5 here and no JUnit 4 at all -->
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>5.10.2</version>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
@@ -115,68 +106,5 @@
         </plugin>
       </plugins>
     </pluginManagement>
-
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <executions>
-          <!-- Adjust standard `default-testCompile` execution -->
-          <execution>
-            <id>default-testCompile</id>
-            <phase>test-compile</phase>
-            <goals>
-              <goal>testCompile</goal>
-            </goals>
-            <configuration>
-              <testExcludes>
-                <exclude>${excludeTestCompilation}</exclude>
-              </testExcludes>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>JDK17</id>
-      <activation>
-        <jdk>[17,)</jdk>
-      </activation>
-      <properties>
-        <maven.compiler.testRelease>17</maven.compiler.testRelease>
-        <excludeTestCompilation />
-      </properties>
-    </profile>
-
-    <profile>
-      <id>native-image-test</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.graalvm.buildtools</groupId>
-            <artifactId>native-maven-plugin</artifactId>
-            <version>0.10.1</version>
-            <extensions>true</extensions>
-            <executions>
-              <execution>
-                <id>test-native</id>
-                <goals>
-                  <goal>test</goal>
-                </goals>
-                <configuration>
-                  <quickBuild>true</quickBuild>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/jpms-test/src/main/java/module-info.java
+++ b/jpms-test/src/main/java/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Dummy module to prevent Maven Compiler Plugin from failing if {@code module-info.java} exists
+ * only in test sources:
+ *
+ * <blockquote>
+ *
+ * Can't compile test sources when main sources are missing a module descriptor
+ *
+ * </blockquote>
+ */
+module com.google.gson.dummy {}

--- a/jpms-test/src/test/java/com/google/gson/jpms_test/ExportedPackagesTest.java
+++ b/jpms-test/src/test/java/com/google/gson/jpms_test/ExportedPackagesTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson.jpms_test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InaccessibleObjectException;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import org.junit.Test;
+
+/**
+ * Verifies that Gson's {@code module-info.class} properly 'exports' all its packages containing
+ * public API.
+ */
+public class ExportedPackagesTest {
+  /** Tests package {@code com.google.gson} */
+  @Test
+  public void testMainPackage() {
+    Gson gson = new Gson();
+    assertThat(gson.toJson(1)).isEqualTo("1");
+  }
+
+  /** Tests package {@code com.google.gson.annotations} */
+  @Test
+  public void testAnnotationsPackage() throws Exception {
+    class Annotated {
+      @SerializedName("custom-name")
+      int i;
+    }
+
+    Field field = Annotated.class.getDeclaredField("i");
+    SerializedName annotation = field.getAnnotation(SerializedName.class);
+    assertThat(annotation.value()).isEqualTo("custom-name");
+  }
+
+  /** Tests package {@code com.google.gson.reflect} */
+  @Test
+  public void testReflectPackage() {
+    var typeToken = TypeToken.get(String.class);
+    assertThat(typeToken.getRawType()).isEqualTo(String.class);
+  }
+
+  /** Tests package {@code com.google.gson.stream} */
+  @Test
+  public void testStreamPackage() throws IOException {
+    JsonReader jsonReader = new JsonReader(new StringReader("2"));
+    assertThat(jsonReader.nextInt()).isEqualTo(2);
+  }
+
+  /** Verifies that Gson packages are only 'exported' but not 'opened' for reflection. */
+  @Test
+  public void testReflectionInternalField() throws Exception {
+    Gson gson = new Gson();
+
+    // Get an arbitrary non-public instance field
+    Field field =
+        Arrays.stream(Gson.class.getDeclaredFields())
+            .filter(
+                f -> !Modifier.isStatic(f.getModifiers()) && !Modifier.isPublic(f.getModifiers()))
+            .findFirst()
+            .get();
+    assertThrows(InaccessibleObjectException.class, () -> field.setAccessible(true));
+    assertThrows(IllegalAccessException.class, () -> field.get(gson));
+  }
+
+  @Test
+  public void testInaccessiblePackage() throws Exception {
+    // Note: In case this class is renamed / removed, can change this to any other internal class
+    Class<?> internalClass = Class.forName("com.google.gson.internal.LinkedTreeMap");
+    assertThat(Modifier.isPublic(internalClass.getModifiers())).isTrue();
+    // Get the public constructor
+    Constructor<?> constructor = internalClass.getConstructor();
+    assertThrows(InaccessibleObjectException.class, () -> constructor.setAccessible(true));
+    assertThrows(IllegalAccessException.class, () -> constructor.newInstance());
+  }
+}

--- a/jpms-test/src/test/java/com/google/gson/jpms_test/ModuleTest.java
+++ b/jpms-test/src/test/java/com/google/gson/jpms_test/ModuleTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson.jpms_test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.gson.Gson;
+import java.lang.module.ModuleDescriptor;
+import java.lang.module.ModuleDescriptor.Exports;
+import java.lang.module.ModuleDescriptor.Requires;
+import java.net.URL;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.Test;
+
+/**
+ * Verifies that this test project is properly set up and has a module descriptor, and checks Gson's
+ * module descriptor.
+ */
+public class ModuleTest {
+  @Test
+  public void testOwnModule() {
+    Module module = getClass().getModule();
+    assertThat(module.getName()).isEqualTo("com.google.gson.jpms_test");
+  }
+
+  @Test
+  public void testGsonModule() {
+    // Verify that this test actually loads the final Gson JAR, and not only compiled classes
+    // Note: This might fail when run from the IDE, but should succeed when run with Maven from
+    // command line
+    URL gsonLocation = Gson.class.getProtectionDomain().getCodeSource().getLocation();
+    assertThat(gsonLocation.getPath()).containsMatch("gson/target/gson-[^/]+\\.jar");
+
+    Module module = Gson.class.getModule();
+    ModuleDescriptor moduleDescriptor = module.getDescriptor();
+
+    assertThat(moduleDescriptor.name()).isEqualTo("com.google.gson");
+    // Permit `Modifier.SYNTHETIC`; current versions of Moditect seem to set that
+    assertThat(moduleDescriptor.modifiers())
+        .containsNoneOf(
+            ModuleDescriptor.Modifier.AUTOMATIC,
+            ModuleDescriptor.Modifier.MANDATED,
+            ModuleDescriptor.Modifier.OPEN);
+    // Should have implicitly included the Maven project version
+    assertThat(moduleDescriptor.rawVersion()).isPresent();
+
+    Set<Requires> moduleRequires = moduleDescriptor.requires();
+    assertThat(getModuleDependencies(moduleRequires))
+        .containsExactly("com.google.errorprone.annotations", "java.sql", "jdk.unsupported");
+    assertThat(getTransitiveModuleDependencies(moduleRequires)).isEmpty();
+    assertThat(getOptionalModuleDependencies(moduleRequires))
+        .containsExactly("com.google.errorprone.annotations", "java.sql", "jdk.unsupported");
+
+    Set<Exports> packageExports = moduleDescriptor.exports();
+    assertThat(packageExports.stream().map(Exports::source))
+        .containsExactly(
+            "com.google.gson",
+            "com.google.gson.annotations",
+            "com.google.gson.reflect",
+            "com.google.gson.stream");
+    // Gson currently does not export packages to specific modules only
+    assertThat(packageExports.stream().filter(Exports::isQualified)).isEmpty();
+
+    // Gson does not allow access to its implementation details using reflection
+    assertThat(moduleDescriptor.opens()).isEmpty();
+    // Gson currently does not use or provide any services
+    assertThat(moduleDescriptor.uses()).isEmpty();
+    assertThat(moduleDescriptor.provides()).isEmpty();
+    // Gson has no main class
+    assertThat(moduleDescriptor.mainClass()).isEmpty();
+  }
+
+  private static Stream<Requires> filterImplicitRequires(Set<Requires> requires) {
+    return requires.stream()
+        .filter(
+            r ->
+                !r.modifiers().contains(Requires.Modifier.MANDATED)
+                    && !r.modifiers().contains(Requires.Modifier.SYNTHETIC));
+  }
+
+  private static Set<String> getModuleDependencies(Set<Requires> requires) {
+    return filterImplicitRequires(requires).map(Requires::name).collect(Collectors.toSet());
+  }
+
+  private static Set<String> getTransitiveModuleDependencies(Set<Requires> requires) {
+    return filterImplicitRequires(requires)
+        .filter(r -> r.modifiers().contains(Requires.Modifier.TRANSITIVE))
+        .map(Requires::name)
+        .collect(Collectors.toSet());
+  }
+
+  private static Set<String> getOptionalModuleDependencies(Set<Requires> requires) {
+    return filterImplicitRequires(requires)
+        .filter(r -> r.modifiers().contains(Requires.Modifier.STATIC))
+        .map(Requires::name)
+        .collect(Collectors.toSet());
+  }
+}

--- a/jpms-test/src/test/java/com/google/gson/jpms_test/ReflectionInaccessibleTest.java
+++ b/jpms-test/src/test/java/com/google/gson/jpms_test/ReflectionInaccessibleTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson.jpms_test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonIOException;
+import org.junit.Test;
+
+/**
+ * Verifies that Gson cannot use reflection for classes in a package if it has not been 'opened' to
+ * the Gson module in the {@code module-info.java} of the project.
+ */
+public class ReflectionInaccessibleTest {
+  private static class MyClass {
+    @SuppressWarnings("unused")
+    int i;
+  }
+
+  @Test
+  public void testDeserialization() {
+    Gson gson = new Gson();
+    var e = assertThrows(JsonIOException.class, () -> gson.fromJson("{\"i\":1}", MyClass.class));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "Failed making field '"
+                + MyClass.class.getName()
+                + "#i' accessible; either increase its visibility or write a custom TypeAdapter for"
+                + " its declaring type.\n"
+                + "See https://github.com/google/gson/blob/main/Troubleshooting.md#reflection-inaccessible-to-module-gson");
+  }
+
+  @Test
+  public void testSerialization() {
+    Gson gson = new Gson();
+
+    MyClass obj = new MyClass();
+    obj.i = 1;
+    var e = assertThrows(JsonIOException.class, () -> gson.toJson(obj));
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "Failed making field '"
+                + MyClass.class.getName()
+                + "#i' accessible; either increase its visibility or write a custom TypeAdapter for"
+                + " its declaring type.\n"
+                + "See https://github.com/google/gson/blob/main/Troubleshooting.md#reflection-inaccessible-to-module-gson");
+  }
+}

--- a/jpms-test/src/test/java/com/google/gson/jpms_test/opened/ReflectionTest.java
+++ b/jpms-test/src/test/java/com/google/gson/jpms_test/opened/ReflectionTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This package is opened for reflection, see `module-info.java`
+package com.google.gson.jpms_test.opened;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.gson.Gson;
+import org.junit.Test;
+
+/**
+ * Verifies that Gson can use reflection for classes in a package if it has been 'opened' to the
+ * Gson module in the {@code module-info.java} of the project.
+ */
+public class ReflectionTest {
+  private static class MyClass {
+    int i;
+  }
+
+  @Test
+  public void testDeserialization() {
+    Gson gson = new Gson();
+    MyClass deserialized = gson.fromJson("{\"i\":1}", MyClass.class);
+    assertThat(deserialized.i).isEqualTo(1);
+  }
+
+  @Test
+  public void testSerialization() {
+    Gson gson = new Gson();
+
+    MyClass obj = new MyClass();
+    obj.i = 1;
+    String serialized = gson.toJson(obj);
+    assertThat(serialized).isEqualTo("{\"i\":1}");
+  }
+}

--- a/jpms-test/src/test/java/module-info.java
+++ b/jpms-test/src/test/java/module-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@SuppressWarnings("requires-automatic") // for automatic module names for 'junit' and 'truth'
+module com.google.gson.jpms_test {
+  requires com.google.gson;
+
+  // Test dependencies
+  requires junit;
+  requires truth; // has no proper module name yet, see https://github.com/google/truth/issues/605
+
+  opens com.google.gson.jpms_test to
+      junit;
+  opens com.google.gson.jpms_test.opened to
+      junit,
+      com.google.gson;
+}

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -28,9 +28,8 @@
   <description>Performance Metrics for Google Gson library</description>
 
   <properties>
-    <!-- Make the build reproducible, see root `pom.xml` -->
-    <!-- This is duplicated here because that is recommended by `artifact:check-buildplan` -->
-    <project.build.outputTimestamp>2024-05-19T18:54:10Z</project.build.outputTimestamp>
+    <!-- Overwrite property from parent -->
+    <gson.isTestModule>true</gson.isTestModule>
   </properties>
 
   <licenses>
@@ -62,37 +61,6 @@
       <version>1.0-beta-3</version>
     </dependency>
   </dependencies>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>com.github.siom79.japicmp</groupId>
-          <artifactId>japicmp-maven-plugin</artifactId>
-          <configuration>
-            <!-- This module is not supposed to be consumed as library, so no need to check API -->
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>animal-sniffer-maven-plugin</artifactId>
-          <configuration>
-            <!-- This module is not supposed to be consumed as library, so no need to check used classes -->
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <configuration>
-            <!-- Not deployed -->
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 
   <developers>
     <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
 
   <modules>
     <module>gson</module>
+    <module>jpms-test</module>
     <module>graal-native-image-test</module>
     <module>shrinker-test</module>
     <module>extras</module>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,12 @@
     <!-- Make the build reproducible, see https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
     <!-- Automatically updated by Maven Release Plugin -->
     <project.build.outputTimestamp>2024-05-19T18:54:10Z</project.build.outputTimestamp>
+
+    <!-- These properties are to be overwritten by the Maven modules -->
+    <!-- Whether this module is an integration test module -->
+    <gson.isTestModule>false</gson.isTestModule>
+    <!-- Whether this module is internal and currently not deployed -->
+    <gson.isInternalModule>${gson.isTestModule}</gson.isInternalModule>
   </properties>
 
   <!-- These attributes specify that the URLs should be inherited by the modules as is, to avoid constructing
@@ -304,6 +310,8 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.6.3</version>
           <configuration>
+            <skip>${gson.isTestModule}</skip>
+
             <!-- Specify newer JDK as target to allow linking to newer Java API, and to generate
               module overview in Javadoc for Gson's module descriptor -->
             <release>11</release>
@@ -341,16 +349,33 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
           <version>3.1.2</version>
+          <configuration>
+            <skip>${gson.isTestModule}</skip>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
           <version>3.3.1</version>
+          <configuration>
+            <skipSource>${gson.isTestModule}</skipSource>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-gpg-plugin</artifactId>
           <version>3.2.4</version>
+          <configuration>
+            <skip>${gson.isTestModule}</skip>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>3.1.2</version>
+          <configuration>
+            <skip>${gson.isInternalModule}</skip>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -445,6 +470,8 @@
           <artifactId>japicmp-maven-plugin</artifactId>
           <version>0.21.1</version>
           <configuration>
+            <skip>${gson.isTestModule}</skip>
+
             <oldVersion>
               <dependency>
                 <groupId>${project.groupId}</groupId>
@@ -486,6 +513,8 @@
                 <goal>check</goal>
               </goals>
               <configuration>
+                <skip>${gson.isTestModule}</skip>
+
                 <signature>
                   <!-- Note: In case Android compatibility impedes Gson development too much in the
                     future, could consider switching to https://github.com/open-toast/gummy-bears

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -15,7 +15,6 @@
   limitations under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.google.code.gson</groupId>
@@ -33,6 +32,9 @@
     <project.build.outputTimestamp>2024-05-19T18:54:10Z</project.build.outputTimestamp>
 
     <protobufVersion>4.26.1</protobufVersion>
+
+    <!-- Overwrite property from parent; this module is currently not deployed -->
+    <gson.isInternalModule>true</gson.isInternalModule>
   </properties>
 
   <licenses>
@@ -102,19 +104,6 @@
         </executions>
       </plugin>
     </plugins>
-
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <configuration>
-            <!-- Not deployed -->
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
   </build>
 
   <developers>

--- a/shrinker-test/pom.xml
+++ b/shrinker-test/pom.xml
@@ -22,8 +22,8 @@
     <artifactId>gson-parent</artifactId>
     <version>2.11.1-SNAPSHOT</version>
   </parent>
-
   <artifactId>shrinker-test</artifactId>
+  <name>Test: Code shrinking (ProGuard / R8)</name>
 
   <properties>
     <!-- Make the build reproducible, see root `pom.xml` -->

--- a/shrinker-test/pom.xml
+++ b/shrinker-test/pom.xml
@@ -26,11 +26,10 @@
   <name>Test: Code shrinking (ProGuard / R8)</name>
 
   <properties>
-    <!-- Make the build reproducible, see root `pom.xml` -->
-    <!-- This is duplicated here because that is recommended by `artifact:check-buildplan` -->
-    <project.build.outputTimestamp>2024-05-19T18:54:10Z</project.build.outputTimestamp>
-
     <maven.compiler.release>8</maven.compiler.release>
+
+    <!-- Overwrite property from parent -->
+    <gson.isTestModule>true</gson.isTestModule>
   </properties>
 
   <pluginRepositories>
@@ -61,35 +60,6 @@
   </dependencies>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>com.github.siom79.japicmp</groupId>
-          <artifactId>japicmp-maven-plugin</artifactId>
-          <configuration>
-            <!-- This module is not supposed to be consumed as library, so no need to check API -->
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>animal-sniffer-maven-plugin</artifactId>
-          <configuration>
-            <!-- This module is not supposed to be consumed as library, so no need to check used classes -->
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <configuration>
-            <!-- Not deployed -->
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-
     <plugins>
       <!-- Process JAR with ProGuard -->
       <plugin>


### PR DESCRIPTION
### Purpose
Adds a Maven module to test Gson's `module-info.class`

### Description
Previously the build would not have detected if `module-info.class` was missing, or incorrectly configured. Therefore this pull request adds a new Maven module to test using the `module-info.class`.

The new integration tests might not work when run from the IDE, but they will work when run with `mvn ...` from the command line.

Please let me know if you think it is too verbose, if the test should cover additional cases, or if there might be a better way to implement this. Any feedback is appreciated.

To simplify disabling certain Maven plugins (e.g. install, gpg and deploy) for the integration test modules I have instead added two properties in the parent project which can disable the plugins. See the second commit.
I have done a short test of the release workflow (but without gpg), and everything still seems to work as desired: The build succeeds and only `gson-parent` and `gson` are deployed.

### Checklist
- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [x] If necessary, new unit tests have been added  
  - [x] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [x] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
