### PR TITLE
Support building with JDK 21.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,12 +10,7 @@ jobs:
     name: "Build on JDK ${{ matrix.java }}"
     strategy:
       matrix:
-        java: [ 11, 17 ]
-        # Custom JDK 21 configuration
-        include:
-          - java: 21
-            # Disable Enforcer check which (intentionally) prevents using JDK 21 for building
-            extra-mvn-args: -Denforcer.fail=false
+        java: [ 11, 17, 21 ]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-api-compatibility.yml
+++ b/.github/workflows/check-api-compatibility.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           cd gson-old-japicmp
           # Set dummy version
-          mvn --batch-mode --no-transfer-progress org.codehaus.mojo:versions-maven-plugin:2.11.0:set -DnewVersion=JAPICMP-OLD
+          mvn --batch-mode --no-transfer-progress org.codehaus.mojo:versions-maven-plugin:2.11.0:set -DnewVersion=JAPICMP_OLD
           # Install artifacts with dummy version in local repository; used later by Maven plugin for comparison
           mvn --batch-mode --no-transfer-progress install -DskipTests
 

--- a/pom.xml
+++ b/pom.xml
@@ -127,9 +127,7 @@
                 <!-- Enforce that correct JDK version is used to avoid cryptic build errors -->
                 <requireJavaVersion>
                   <!-- Other plugins of this build require at least JDK 11 -->
-                  <!-- Fail fast when building with JDK > 17 because it causes build failures,
-                    see https://github.com/google/gson/issues/2501 -->
-                  <version>[11,18)</version>
+                  <version>[11,21]</version>
                 </requireJavaVersion>
               </rules>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -475,7 +475,7 @@
                 <groupId>${project.groupId}</groupId>
                 <artifactId>${project.artifactId}</artifactId>
                 <!-- This is set by the GitHub workflow -->
-                <version>JAPICMP-OLD</version>
+                <version>JAPICMP_OLD</version>
               </dependency>
             </oldVersion>
             <newVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
                 <!-- Enforce that correct JDK version is used to avoid cryptic build errors -->
                 <requireJavaVersion>
                   <!-- Other plugins of this build require at least JDK 11 -->
-                  <version>[11,21]</version>
+                  <version>[11,22)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
I think the main reason we weren't doing this before is that the ProGuard plugin didn't support it. Apparently it does now.
