### PR TITLE
Run japicmp against last release instead of previous commit

### DIFF
--- a/.github/workflows/check-api-compatibility.yml
+++ b/.github/workflows/check-api-compatibility.yml
@@ -9,11 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout old version
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b  # v4.1.4
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-          path: 'gson-old-japicmp'
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b  # v4.1.4
 
       - name: Set up JDK 11
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9  # v4.2.1
@@ -21,17 +17,6 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
           cache: 'maven'
-
-      - name: Build old version
-        run: |
-          cd gson-old-japicmp
-          # Set dummy version
-          mvn --batch-mode --no-transfer-progress org.codehaus.mojo:versions-maven-plugin:2.11.0:set -DnewVersion=JAPICMP-OLD
-          # Install artifacts with dummy version in local repository; used later by Maven plugin for comparison
-          mvn --batch-mode --no-transfer-progress install -DskipTests
-
-      - name: Checkout new version
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b  # v4.1.4
 
       - name: Check API compatibility
         id: check-compatibility

--- a/pom.xml
+++ b/pom.xml
@@ -470,21 +470,11 @@
           <artifactId>japicmp-maven-plugin</artifactId>
           <version>0.21.1</version>
           <configuration>
-            <skip>${gson.isTestModule}</skip>
+            <skip>${gson.isInternalModule}</skip>
 
-            <oldVersion>
-              <dependency>
-                <groupId>${project.groupId}</groupId>
-                <artifactId>${project.artifactId}</artifactId>
-                <!-- This is set by the GitHub workflow -->
-                <version>JAPICMP-OLD</version>
-              </dependency>
-            </oldVersion>
-            <newVersion>
-              <file>
-                <path>${project.build.directory}/${project.build.finalName}.${project.packaging}</path>
-              </file>
-            </newVersion>
+            <!-- 'Old version' is automatically the last release, 'new version' are the artifacts of the
+              current build -->
+
             <parameter>
               <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
               <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>


### PR DESCRIPTION
### Purpose
Run japicmp against last release instead of previous commit

### Description
This will also fix the recent build failures, e.g. in #2690, which are caused by the currently used `JAPICMP-OLD` version which seems to cause issues when the new JPMS module test (#2685) tries to use it as version for the `module-info.class`:
> Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.13.0:compile (default-compile) on project jpms-test: Fatal error compiling: error: bad value for --module-version option: 'JAPICMP-OLD'

Advantages:
- Simplifies setup (no need to build a 'JAPICMP-OLD' version anymore)
This also allows easily running it locally now; though it is currently not part of the normal Maven build to allow having a separate GitHub workflow which also separately attaches the API change report as artifact.
- No spurious incompatibility failures anymore when API is changed which was added in the current SNAPSHOT by a previous pull request (but had not been released yet)

Disadvantages:
- japicmp cannot be used for not published modules 'extras' and 'proto' anymore
- Minor: For pull requests the API diff report generated by the GitHub workflow and attached as artifact now contains the diff to the last release and not the changes introduced by the pull request (e.g. added methods, ...)
- If we ever intentionally decide to perform a breaking change (or if there is a japicmp bug), the workflow will keep failing for all subsequent pull requests until the next release


Here is also a small demo showing that this still works (performs incompatible change of `JsonArray#add` return type): https://github.com/Marcono1234/gson/actions/runs/9310443366