### PR TITLE
Fix API compatibility workflow failing when building previous version

### DIFF
--- a/.github/workflows/check-api-compatibility.yml
+++ b/.github/workflows/check-api-compatibility.yml
@@ -8,8 +8,17 @@ jobs:
   check-api-compatibility:
     runs-on: ubuntu-latest
 
+    # This setup tries to determine API incompatibility only for the changes introduced by the
+    # pull request. It does this by first checking out the 'old' version and installing it into
+    # the local Maven repository before then using japicmp to compare it to the current changes.
+    #
+    # Alternatively it would also be possible to compare against the last release version instead.
+    #
+    # Both approaches have their advantages and disadvantages, see description of
+    # https://github.com/google/gson/pull/2692 for details.
+
     steps:
-      - name: Checkout old version
+      - name: Check out old version
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b  # v4.1.4
         with:
           ref: ${{ github.event.pull_request.base.sha }}
@@ -26,11 +35,11 @@ jobs:
         run: |
           cd gson-old-japicmp
           # Set dummy version
-          mvn --batch-mode --no-transfer-progress org.codehaus.mojo:versions-maven-plugin:2.11.0:set -DnewVersion=JAPICMP-OLD
+          mvn --batch-mode --no-transfer-progress org.codehaus.mojo:versions-maven-plugin:2.16.2:set "-DnewVersion=0.0.0-JAPICMP-OLD"
           # Install artifacts with dummy version in local repository; used later by Maven plugin for comparison
           mvn --batch-mode --no-transfer-progress install -DskipTests
 
-      - name: Checkout new version
+      - name: Check out new version
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b  # v4.1.4
 
       - name: Check API compatibility

--- a/pom.xml
+++ b/pom.xml
@@ -477,14 +477,12 @@
                 <groupId>${project.groupId}</groupId>
                 <artifactId>${project.artifactId}</artifactId>
                 <!-- This is set by the GitHub workflow -->
-                <version>JAPICMP-OLD</version>
+                <version>0.0.0-JAPICMP-OLD</version>
               </dependency>
             </oldVersion>
-            <newVersion>
-              <file>
-                <path>${project.build.directory}/${project.build.finalName}.${project.packaging}</path>
-              </file>
-            </newVersion>
+
+            <!-- 'new version' is automatically the version currently being build -->
+
             <parameter>
               <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
               <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>


### PR DESCRIPTION
### Purpose
Fixes the current API compatibility workflows failures

### Description
The workflow is currently failing for the jpms-test module:
> Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.13.0:compile (default-compile) on project jpms-test:
> Fatal error compiling: error: bad value for --module-version option: 'JAPICMP-OLD'

Therefore this pull request changes the dummy version number format, so that it is not rejected anymore.

