### PR TITLE
Improve `JsonWriter#value(Number)` performance

### DIFF
--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -646,9 +646,9 @@ public class JsonWriter implements Closeable, Flushable {
         if (strictness != Strictness.LENIENT) {
           throw new IllegalArgumentException("Numeric values must be finite, but was " + string);
         }
-      } else if (!(numberClass == Float.class
-          || numberClass == Double.class
-          || VALID_JSON_NUMBER_PATTERN.matcher(string).matches())) {
+      } else if (numberClass != Float.class
+          && numberClass != Double.class
+          && !VALID_JSON_NUMBER_PATTERN.matcher(string).matches()) {
         throw new IllegalArgumentException(
             "String created by " + numberClass + " is not a valid JSON number: " + string);
       }


### PR DESCRIPTION
### Purpose
Improve `JsonWriter#value(Number)` performance for JDK number types

### Description
For JDK number types other than `Float` and `Double` there is no need to check if the number string is NaN or Infinity.

This was an oversight when I originally added the validation in #2060.