### PR TITLE
Remove `AccessController` usage for enum adapter

### DIFF
--- a/gson/src/test/java/com/google/gson/functional/EnumTest.java
+++ b/gson/src/test/java/com/google/gson/functional/EnumTest.java
@@ -308,4 +308,15 @@ public class EnumTest {
       return toString;
     }
   }
+
+  /**
+   * Verifies that the enum adapter works for a public JDK enum class and no {@code
+   * InaccessibleObjectException} is thrown, despite using reflection internally to account for the
+   * constant names possibly being obfuscated.
+   */
+  @Test
+  public void testJdkEnum() {
+    assertThat(gson.toJson(Thread.State.NEW)).isEqualTo("\"NEW\"");
+    assertThat(gson.fromJson("\"NEW\"", Thread.State.class)).isEqualTo(Thread.State.NEW);
+  }
 }


### PR DESCRIPTION
### Purpose
Resolves #2686

### Description
See #2686 and the discussion there

This pull request removes the `AccessController` usage, assuming most users don't depend on it and because it has been marked for removal in the JDK.

Also adds a new test for serialization of a JDK enum class to make sure the adapter works correctly despite strong encapsulation of JDK internals ([JEP 403](https://openjdk.org/jeps/403)).
Though the test is not directly related to the `AccessController` removal.