### PR TITLE
Fix typeArguments array not being cloned when resolving ParameterizedType with changed owner

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
+++ b/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
@@ -392,23 +392,24 @@ public final class $Gson$Types {
         ParameterizedType original = (ParameterizedType) toResolve;
         Type ownerType = original.getOwnerType();
         Type newOwnerType = resolve(context, contextRawType, ownerType, visitedTypeVariables);
-        boolean changed = !equal(newOwnerType, ownerType);
+        boolean ownerChanged = !equal(newOwnerType, ownerType);
 
         Type[] args = original.getActualTypeArguments();
+        boolean argsChanged = false;
         for (int t = 0, length = args.length; t < length; t++) {
           Type resolvedTypeArgument =
               resolve(context, contextRawType, args[t], visitedTypeVariables);
           if (!equal(resolvedTypeArgument, args[t])) {
-            if (!changed) {
+            if (!argsChanged) {
               args = args.clone();
-              changed = true;
+              argsChanged = true;
             }
             args[t] = resolvedTypeArgument;
           }
         }
 
         toResolve =
-            changed
+            ownerChanged || argsChanged
                 ? newParameterizedTypeWithOwner(newOwnerType, original.getRawType(), args)
                 : original;
         break;


### PR DESCRIPTION
### Purpose
This PR fixes an inconsistency in `$Gson$Types#resolve()` where the `ParameterizedType#getActualTypeArguments()` array is only cloned when the resolved owner-type has not changed from the original owner-type.

### Description
In most cases this is a non-issue, as usually all `ParameterizedType` implementations clone the array themselves when invoking the `getActualTypeArguments()` getter. However, this is not guaranteed. 
Cloning the array only when the owner-type didn't change seems like an inconsistency and an oversight, so this PR is trying to fix that.

### Checklist
- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
