### PR TITLE
Remove duplicated declaration of required OSGi execution environment

### DIFF
--- a/gson/bnd.bnd
+++ b/gson/bnd.bnd
@@ -3,8 +3,6 @@ Bundle-Name: ${project.name}
 Bundle-Description: ${project.description}
 Bundle-Vendor: Google Gson Project
 Bundle-ContactAddress: ${project.parent.url}
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7, JavaSE-1.8
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
 
 # Optional dependency for JDK's sun.misc.Unsafe
 # https://bnd.bndtools.org/chapters/920-faq.html#remove-unwanted-imports-


### PR DESCRIPTION
### Description

The `bnd-maven-plugin` used to generate the OSGi metadata can determine the required EE automatically based on the version of the generated class-files. This avoids inconsistencies if the release target is raised in the future.

In general there is no need to declare a `Bundle-RequiredExecutionEnvironment` together with an `osgi.ee` requirement. At runtime the former is automatically converted to the later, since the former is deprecated.
Furthermore declaring multiple values for `Bundle-RequiredExecutionEnvironment` is also not useful since the driving requirement is the highest one.

With the change being applied bnd generates the following header:
```
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
```
This matches the minimally required Java version of Java 7 for Gson 2.9 and later and https://github.com/google/gson/issues/1601 or https://github.com/google/gson/issues/1602 should not be re-introduced.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [ ] `mvn clean verify javadoc:jar` passes without errors
