### PR TITLE
Reference the default nesting limit by name rather than as a constant.

### DIFF
--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -254,7 +254,7 @@ public class JsonReader implements Closeable {
   private Strictness strictness = Strictness.LEGACY_STRICT;
   // Default nesting limit is based on
   // https://github.com/square/moshi/blob/parent-1.15.0/moshi/src/main/java/com/squareup/moshi/JsonReader.java#L228-L230
-  private static final int DEFAULT_NESTING_LIMIT = 255;
+  static final int DEFAULT_NESTING_LIMIT = 255;
   private int nestingLimit = DEFAULT_NESTING_LIMIT;
 
   static final int BUFFER_SIZE = 1024;

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -1753,7 +1753,7 @@ public final class JsonReaderTest {
 
   @Test
   public void testNestingLimitDefault() throws IOException {
-    int defaultLimit = 255;
+    int defaultLimit = JsonReader.DEFAULT_NESTING_LIMIT;
     String json = repeat('[', defaultLimit + 1);
     JsonReader reader = new JsonReader(reader(json));
     assertThat(reader.getNestingLimit()).isEqualTo(defaultLimit);


### PR DESCRIPTION
This simplifies patching it when needed.
