### PR TITLE
Add NullSafeTypeAdapter to prevent TypeAdapter.nullSafe() from returning nested null-safe type adapters (#2729)

### DIFF
--- a/gson/src/main/java/com/google/gson/TypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/TypeAdapter.java
@@ -289,24 +289,34 @@ public abstract class TypeAdapter<T> {
    * Note that we didn't need to check for nulls in our type adapter after we used nullSafe.
    */
   public final TypeAdapter<T> nullSafe() {
-    return new TypeAdapter<T>() {
-      @Override
-      public void write(JsonWriter out, T value) throws IOException {
-        if (value == null) {
-          out.nullValue();
-        } else {
-          TypeAdapter.this.write(out, value);
-        }
-      }
+    if (!(this instanceof TypeAdapter.NullSafeTypeAdapter)) {
+      return new NullSafeTypeAdapter();
+    }
+    return this;
+  }
 
-      @Override
-      public T read(JsonReader reader) throws IOException {
-        if (reader.peek() == JsonToken.NULL) {
-          reader.nextNull();
-          return null;
-        }
-        return TypeAdapter.this.read(reader);
+  private final class NullSafeTypeAdapter extends TypeAdapter<T> {
+    @Override
+    public void write(JsonWriter out, T value) throws IOException {
+      if (value == null) {
+        out.nullValue();
+      } else {
+        TypeAdapter.this.write(out, value);
       }
-    };
+    }
+
+    @Override
+    public T read(JsonReader reader) throws IOException {
+      if (reader.peek() == JsonToken.NULL) {
+        reader.nextNull();
+        return null;
+      }
+      return TypeAdapter.this.read(reader);
+    }
+
+    @Override
+    public String toString() {
+      return "NullSafeTypeAdapter[" + TypeAdapter.this + "]";
+    }
   }
 }

--- a/gson/src/test/java/com/google/gson/TypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/TypeAdapterTest.java
@@ -28,22 +28,49 @@ import org.junit.Test;
 public class TypeAdapterTest {
   @Test
   public void testNullSafe() throws IOException {
-    TypeAdapter<String> adapter =
-        new TypeAdapter<String>() {
-          @Override
-          public void write(JsonWriter out, String value) {
-            throw new AssertionError("unexpected call");
-          }
-
-          @Override
-          public String read(JsonReader in) {
-            throw new AssertionError("unexpected call");
-          }
-        }.nullSafe();
+    TypeAdapter<String> adapter = assertionErrorAdapter.nullSafe();
 
     assertThat(adapter.toJson(null)).isEqualTo("null");
     assertThat(adapter.fromJson("null")).isNull();
   }
+
+  @Test
+  public void testNullSafe_ReturningSameInstanceOnceNullSafe() {
+    TypeAdapter<?> nullSafeAdapter = assertionErrorAdapter.nullSafe();
+
+    assertThat(nullSafeAdapter.nullSafe()).isSameInstanceAs(nullSafeAdapter);
+    assertThat(nullSafeAdapter.nullSafe().nullSafe()).isSameInstanceAs(nullSafeAdapter);
+    assertThat(nullSafeAdapter.nullSafe().nullSafe().nullSafe()).isSameInstanceAs(nullSafeAdapter);
+  }
+
+  @Test
+  public void testNullSafe_ToString() {
+    TypeAdapter<?> adapter = assertionErrorAdapter;
+
+    assertThat(adapter.toString()).isEqualTo("assertionErrorAdapter");
+    assertThat(adapter.nullSafe().toString())
+        .isEqualTo("NullSafeTypeAdapter[assertionErrorAdapter]");
+    assertThat(adapter.nullSafe().nullSafe().toString())
+        .isEqualTo("NullSafeTypeAdapter[assertionErrorAdapter]");
+  }
+
+  private static final TypeAdapter<String> assertionErrorAdapter =
+      new TypeAdapter<>() {
+        @Override
+        public void write(JsonWriter out, String value) {
+          throw new AssertionError("unexpected call");
+        }
+
+        @Override
+        public String read(JsonReader in) {
+          throw new AssertionError("unexpected call");
+        }
+
+        @Override
+        public String toString() {
+          return "assertionErrorAdapter";
+        }
+      };
 
   /**
    * Tests behavior when {@link TypeAdapter#write(JsonWriter, Object)} manually throws {@link


### PR DESCRIPTION
Add `NullSafeTypeAdapter` to prevent `TypeAdapter.nullSafe()` from returning nested null-safe type adapters (#2729)

### Purpose / Description

Resolves #2729.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [x] If necessary, new public API validates arguments, for example rejects `null`
- [x] New public API has Javadoc
    - [x] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [x] If necessary, new unit tests have been added  
  - [x] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [x] No JUnit 3 features are used (such as extending class `TestCase`)
  - [x] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors

Closes #2729.