### PR TITLE
EnumTypeAdapter constructor optimization

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/EnumTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/EnumTypeAdapter.java
@@ -67,7 +67,8 @@ public class EnumTypeAdapter<T extends Enum<T>> extends TypeAdapter<T> {
         }
       }
 
-      // Trim the array to the new length
+      // Trim the array to the new length. Every enum type can be expected to have at least
+      // one declared field which is not an enum constant, namely the implicit $VALUES array
       fields = Arrays.copyOf(fields, constantCount);
 
       AccessibleObject.setAccessible(fields, true);

--- a/gson/src/main/java/com/google/gson/internal/bind/EnumTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/EnumTypeAdapter.java
@@ -27,7 +27,7 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -59,14 +59,17 @@ public class EnumTypeAdapter<T extends Enum<T>> extends TypeAdapter<T> {
       // Uses reflection to find enum constants to work around name mismatches for obfuscated
       // classes
       Field[] fields = classOfT.getDeclaredFields();
-      ArrayList<Field> constantFieldsList = new ArrayList<>(fields.length);
+      Field[] constantFields = new Field[fields.length];
+      int constantCount = 0;
       for (Field f : fields) {
         if (f.isEnumConstant()) {
-          constantFieldsList.add(f);
+          constantFields[constantCount++] = f;
         }
       }
 
-      Field[] constantFields = constantFieldsList.toArray(new Field[0]);
+      // Truncate the constantFields array
+      constantFields = Arrays.copyOf(constantFields, constantCount);
+
       AccessibleObject.setAccessible(constantFields, true);
 
       for (Field constantField : constantFields) {

--- a/gson/src/main/java/com/google/gson/internal/bind/EnumTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/EnumTypeAdapter.java
@@ -59,20 +59,20 @@ public class EnumTypeAdapter<T extends Enum<T>> extends TypeAdapter<T> {
       // Uses reflection to find enum constants to work around name mismatches for obfuscated
       // classes
       Field[] fields = classOfT.getDeclaredFields();
-      Field[] constantFields = new Field[fields.length];
       int constantCount = 0;
       for (Field f : fields) {
+        // Filter out non-constant fields, replacing elements as we go
         if (f.isEnumConstant()) {
-          constantFields[constantCount++] = f;
+          fields[constantCount++] = f;
         }
       }
 
-      // Truncate the constantFields array
-      constantFields = Arrays.copyOf(constantFields, constantCount);
+      // Trim the array to the new length
+      fields = Arrays.copyOf(fields, constantCount);
 
-      AccessibleObject.setAccessible(constantFields, true);
+      AccessibleObject.setAccessible(fields, true);
 
-      for (Field constantField : constantFields) {
+      for (Field constantField : fields) {
         @SuppressWarnings("unchecked")
         T constant = (T) constantField.get(null);
         String name = constant.name();


### PR DESCRIPTION
### Purpose
Improve the runtime performance of `EnumTypeAdapter(Class)`.


### Description
Eliminate the temporary `ArrayList` in favor of array truncation via `<T> java.util.Arrays.copyOf(T[],int)`.
