### PR TITLE
OSGi / bnd: Remove the self-Import of gson.annotations

### DIFF
--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -147,7 +147,7 @@
 
                 -exportcontents:\
                     com.google.gson,\
-                    com.google.gson.annotations,\
+                    com.google.gson.annotations;-noimport:=true,\
                     com.google.gson.reflect,\
                     com.google.gson.stream
               ]]></bnd>

--- a/gson/src/test/java/com/google/gson/regression/OSGiTest.java
+++ b/gson/src/test/java/com/google/gson/regression/OSGiTest.java
@@ -34,9 +34,9 @@ public class OSGiTest {
     Manifest mf = findManifest("com.google.gson");
     String importPkg = mf.getMainAttributes().getValue("Import-Package");
     assertWithMessage("Import-Package statement is there").that(importPkg).isNotNull();
-    assertWithMessage("There should be com.google.gson.annotations dependency")
+    assertWithMessage("There should be no com.google.gson.annotations dependency")
         .that(importPkg)
-        .contains("com.google.gson.annotations");
+        .doesNotContain("com.google.gson.annotations");
   }
 
   @Test


### PR DESCRIPTION
Closes #2725 

<!--
    Thank you for your contribution!
    Please see the contributing guide: https://github.com/google/.github/blob/master/CONTRIBUTING.md

    Keep in mind that Gson is in maintenance mode. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.
-->

### Purpose
<!-- Describe the purpose of this pull request, for example which new feature it adds or which bug it fixes -->
<!-- If this pull request closes a GitHub issue, please write "Closes #<issue>", for example "Closes #123" -->


Fixes a runtime issue in OSGi environments using multiple versions of GSON.


### Description
<!-- If necessary provide more information, for example relevant implementation details or corner cases which are not covered yet -->
<!-- If there are related issues or pull requests, link to them by referencing their number, for example "pull request #123" -->

Based on https://github.com/bndtools/bnd/issues/6220#issuecomment-2312660794 append `-noimport:=true` to all exports which we do not want to re-import.
This will remove the package from the `Import-Package` instruction in the resulting `MANIFEST.MF`

This avoids issues in OSGi environments where multiple versions of gson are deployed and required by different consumers and `com.google.gson.annotations` causes wiring conflicts between these different gson versions.

For further information about the `-noimport` check the [bnd manual](https://bnd.bndtools.org/heads/export_package.html).




### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [ ] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors

Mentioning @Marcono1234 since he was involved in the discussions.