### PR TITLE
Java 8 follow-up changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,12 +10,7 @@ jobs:
     name: "Build on JDK ${{ matrix.java }}"
     strategy:
       matrix:
-        java: [ 11, 17 ]
-        # Custom JDK 21 configuration
-        include:
-          - java: 21
-            # Disable Enforcer check which (intentionally) prevents using JDK 21 for building
-            extra-mvn-args: -Denforcer.fail=false
+        java: [ 11, 17, 21 ]
     runs-on: ubuntu-latest
 
     steps:
@@ -28,7 +23,7 @@ jobs:
           cache: 'maven'
       - name: Build with Maven
         # This also runs javadoc:jar to detect any issues with the Javadoc generated during release
-        run: mvn --batch-mode --no-transfer-progress verify javadoc:jar ${{ matrix.extra-mvn-args || '' }}
+        run: mvn --batch-mode --no-transfer-progress verify javadoc:jar
 
   native-image-test:
     name: "GraalVM Native Image test"

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Gson uses Maven to build the project:
 mvn clean verify
 ```
 
-JDK 11 or newer is required for building, JDK 17 is recommended. Newer JDKs are currently not supported for building (but are supported when _using_ Gson).
+JDK 11 or newer is required for building, JDK 17 or 21 is recommended. Newer JDKs are currently not supported for building (but are supported when _using_ Gson).
 
 ### Contributing
 

--- a/extras/src/main/java/com/google/gson/graph/GraphAdapterBuilder.java
+++ b/extras/src/main/java/com/google/gson/graph/GraphAdapterBuilder.java
@@ -52,7 +52,7 @@ public final class GraphAdapterBuilder {
   }
 
   public GraphAdapterBuilder addType(Type type) {
-    final ObjectConstructor<?> objectConstructor = constructorConstructor.get(TypeToken.get(type));
+    ObjectConstructor<?> objectConstructor = constructorConstructor.get(TypeToken.get(type));
     InstanceCreator<Object> instanceCreator =
         new InstanceCreator<Object>() {
           @Override
@@ -95,8 +95,8 @@ public final class GraphAdapterBuilder {
         return null;
       }
 
-      final TypeAdapter<T> typeAdapter = gson.getDelegateAdapter(this, type);
-      final TypeAdapter<JsonElement> elementAdapter = gson.getAdapter(JsonElement.class);
+      TypeAdapter<T> typeAdapter = gson.getDelegateAdapter(this, type);
+      TypeAdapter<JsonElement> elementAdapter = gson.getAdapter(JsonElement.class);
       return new TypeAdapter<T>() {
         @Override
         public void write(JsonWriter out, T value) throws IOException {

--- a/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
@@ -252,9 +252,9 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
       return null;
     }
 
-    final TypeAdapter<JsonElement> jsonElementAdapter = gson.getAdapter(JsonElement.class);
-    final Map<String, TypeAdapter<?>> labelToDelegate = new LinkedHashMap<>();
-    final Map<Class<?>, TypeAdapter<?>> subtypeToDelegate = new LinkedHashMap<>();
+    TypeAdapter<JsonElement> jsonElementAdapter = gson.getAdapter(JsonElement.class);
+    Map<String, TypeAdapter<?>> labelToDelegate = new LinkedHashMap<>();
+    Map<Class<?>, TypeAdapter<?>> subtypeToDelegate = new LinkedHashMap<>();
     for (Map.Entry<String, Class<?>> entry : labelToSubtype.entrySet()) {
       TypeAdapter<?> delegate = gson.getDelegateAdapter(this, TypeToken.get(entry.getValue()));
       labelToDelegate.put(entry.getKey(), delegate);

--- a/extras/src/test/java/com/google/gson/typeadapters/PostConstructAdapterFactoryTest.java
+++ b/extras/src/test/java/com/google/gson/typeadapters/PostConstructAdapterFactoryTest.java
@@ -88,7 +88,7 @@ public class PostConstructAdapterFactoryTest {
       if (!(o instanceof Sandwich)) {
         return false;
       }
-      final Sandwich other = (Sandwich) o;
+      Sandwich other = (Sandwich) o;
       if (this.bread == null ? other.bread != null : !this.bread.equals(other.bread)) {
         return false;
       }
@@ -115,7 +115,7 @@ public class PostConstructAdapterFactoryTest {
       if (!(o instanceof MultipleSandwiches)) {
         return false;
       }
-      final MultipleSandwiches other = (MultipleSandwiches) o;
+      MultipleSandwiches other = (MultipleSandwiches) o;
       if (this.sandwiches == null
           ? other.sandwiches != null
           : !this.sandwiches.equals(other.sandwiches)) {

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -682,7 +682,7 @@ public final class Gson {
    *   public int numReads = 0;
    *   public int numWrites = 0;
    *   public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
-   *     final TypeAdapter<T> delegate = gson.getDelegateAdapter(this, type);
+   *     TypeAdapter<T> delegate = gson.getDelegateAdapter(this, type);
    *     return new TypeAdapter<T>() {
    *       public void write(JsonWriter out, T value) throws IOException {
    *         ++numWrites;

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -538,7 +538,7 @@ public final class Gson {
     };
   }
 
-  private static TypeAdapter<AtomicLong> atomicLongAdapter(final TypeAdapter<Number> longAdapter) {
+  private static TypeAdapter<AtomicLong> atomicLongAdapter(TypeAdapter<Number> longAdapter) {
     return new TypeAdapter<AtomicLong>() {
       @Override
       public void write(JsonWriter out, AtomicLong value) throws IOException {
@@ -554,7 +554,7 @@ public final class Gson {
   }
 
   private static TypeAdapter<AtomicLongArray> atomicLongArrayAdapter(
-      final TypeAdapter<Number> longAdapter) {
+      TypeAdapter<Number> longAdapter) {
     return new TypeAdapter<AtomicLongArray>() {
       @Override
       public void write(JsonWriter out, AtomicLongArray value) throws IOException {

--- a/gson/src/main/java/com/google/gson/TypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/TypeAdapterFactory.java
@@ -117,7 +117,7 @@ import com.google.gson.reflect.TypeToken;
  *   }
  *
  *   private <E> TypeAdapter<Multiset<E>> newMultisetAdapter(
- *       final TypeAdapter<E> elementAdapter) {
+ *       TypeAdapter<E> elementAdapter) {
  *     return new TypeAdapter<Multiset<E>>() {
  *       public void write(JsonWriter out, Multiset<E> value) throws IOException {
  *         if (value == null) {

--- a/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
+++ b/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
@@ -95,13 +95,13 @@ public final class ConstructorConstructor {
   }
 
   public <T> ObjectConstructor<T> get(TypeToken<T> typeToken) {
-    final Type type = typeToken.getType();
-    final Class<? super T> rawType = typeToken.getRawType();
+    Type type = typeToken.getType();
+    Class<? super T> rawType = typeToken.getRawType();
 
     // first try an instance creator
 
     @SuppressWarnings("unchecked") // types must agree
-    final InstanceCreator<T> typeCreator = (InstanceCreator<T>) instanceCreators.get(type);
+    InstanceCreator<T> typeCreator = (InstanceCreator<T>) instanceCreators.get(type);
     if (typeCreator != null) {
       return new ObjectConstructor<T>() {
         @Override
@@ -113,7 +113,7 @@ public final class ConstructorConstructor {
 
     // Next try raw type match for instance creators
     @SuppressWarnings("unchecked") // types must agree
-    final InstanceCreator<T> rawTypeCreator = (InstanceCreator<T>) instanceCreators.get(rawType);
+    InstanceCreator<T> rawTypeCreator = (InstanceCreator<T>) instanceCreators.get(rawType);
     if (rawTypeCreator != null) {
       return new ObjectConstructor<T>() {
         @Override
@@ -145,7 +145,7 @@ public final class ConstructorConstructor {
 
     // Check whether type is instantiable; otherwise ReflectionAccessFilter recommendation
     // of adjusting filter suggested below is irrelevant since it would not solve the problem
-    final String exceptionMessage = checkInstantiable(rawType);
+    String exceptionMessage = checkInstantiable(rawType);
     if (exceptionMessage != null) {
       return new ObjectConstructor<T>() {
         @Override
@@ -161,7 +161,7 @@ public final class ConstructorConstructor {
       // finally try unsafe
       return newUnsafeAllocator(rawType);
     } else {
-      final String message =
+      String message =
           "Unable to create instance of "
               + rawType
               + "; ReflectionAccessFilter does not permit using reflection or Unsafe. Register an"
@@ -181,7 +181,7 @@ public final class ConstructorConstructor {
    * constructor.
    */
   private static <T> ObjectConstructor<T> newSpecialCollectionConstructor(
-      final Type type, Class<? super T> rawType) {
+      Type type, Class<? super T> rawType) {
     if (EnumSet.class.isAssignableFrom(rawType)) {
       return new ObjectConstructor<T>() {
         @Override
@@ -233,7 +233,7 @@ public final class ConstructorConstructor {
       return null;
     }
 
-    final Constructor<? super T> constructor;
+    Constructor<? super T> constructor;
     try {
       constructor = rawType.getDeclaredConstructor();
     } catch (NoSuchMethodException e) {
@@ -249,7 +249,7 @@ public final class ConstructorConstructor {
                     || Modifier.isPublic(constructor.getModifiers())));
 
     if (!canAccess) {
-      final String message =
+      String message =
           "Unable to invoke no-args constructor of "
               + rawType
               + ";"
@@ -267,7 +267,7 @@ public final class ConstructorConstructor {
     // Only try to make accessible if allowed; in all other cases checks above should
     // have verified that constructor is accessible
     if (filterResult == FilterResult.ALLOW) {
-      final String exceptionMessage = ReflectionHelper.tryMakeAccessible(constructor);
+      String exceptionMessage = ReflectionHelper.tryMakeAccessible(constructor);
       if (exceptionMessage != null) {
         /*
          * Create ObjectConstructor which throws exception.
@@ -323,7 +323,7 @@ public final class ConstructorConstructor {
   /** Constructors for common interface types like Map and List and their subtypes. */
   @SuppressWarnings("unchecked") // use runtime checks to guarantee that 'T' is what it is
   private static <T> ObjectConstructor<T> newDefaultImplementationConstructor(
-      final Type type, Class<? super T> rawType) {
+      Type type, Class<? super T> rawType) {
 
     /*
      * IMPORTANT: Must only create instances for classes with public no-args constructor.
@@ -409,7 +409,7 @@ public final class ConstructorConstructor {
     return null;
   }
 
-  private <T> ObjectConstructor<T> newUnsafeAllocator(final Class<? super T> rawType) {
+  private <T> ObjectConstructor<T> newUnsafeAllocator(Class<? super T> rawType) {
     if (useJdkUnsafe) {
       return new ObjectConstructor<T>() {
         @Override
@@ -444,8 +444,8 @@ public final class ConstructorConstructor {
             " Or adjust your R8 configuration to keep the no-args constructor of the class.";
       }
 
-      // Explicit final variable to allow usage in the anonymous class below
-      final String exceptionMessageF = exceptionMessage;
+      // Separate effectively final variable to allow usage in the anonymous class below
+      String exceptionMessageF = exceptionMessage;
 
       return new ObjectConstructor<T>() {
         @Override

--- a/gson/src/main/java/com/google/gson/internal/Excluder.java
+++ b/gson/src/main/java/com/google/gson/internal/Excluder.java
@@ -108,11 +108,11 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
   }
 
   @Override
-  public <T> TypeAdapter<T> create(final Gson gson, final TypeToken<T> type) {
+  public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
     Class<?> rawType = type.getRawType();
 
-    final boolean skipSerialize = excludeClass(rawType, true);
-    final boolean skipDeserialize = excludeClass(rawType, false);
+    boolean skipSerialize = excludeClass(rawType, true);
+    boolean skipDeserialize = excludeClass(rawType, false);
 
     if (!skipSerialize && !skipDeserialize) {
       return null;

--- a/gson/src/main/java/com/google/gson/internal/LinkedTreeMap.java
+++ b/gson/src/main/java/com/google/gson/internal/LinkedTreeMap.java
@@ -43,7 +43,13 @@ import java.util.Set;
 @SuppressWarnings("serial") // ignore warning about missing serialVersionUID
 public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Serializable {
   @SuppressWarnings({"unchecked", "rawtypes"}) // to avoid Comparable<Comparable<Comparable<...>>>
-  private static final Comparator<Comparable> NATURAL_ORDER = Comparator.naturalOrder();
+  private static final Comparator<Comparable> NATURAL_ORDER =
+      new Comparator<Comparable>() {
+        @Override
+        public int compare(Comparable a, Comparable b) {
+          return a.compareTo(b);
+        }
+      };
 
   private final Comparator<? super K> comparator;
   private final boolean allowNullValues;

--- a/gson/src/main/java/com/google/gson/internal/LinkedTreeMap.java
+++ b/gson/src/main/java/com/google/gson/internal/LinkedTreeMap.java
@@ -43,13 +43,7 @@ import java.util.Set;
 @SuppressWarnings("serial") // ignore warning about missing serialVersionUID
 public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Serializable {
   @SuppressWarnings({"unchecked", "rawtypes"}) // to avoid Comparable<Comparable<Comparable<...>>>
-  private static final Comparator<Comparable> NATURAL_ORDER =
-      new Comparator<Comparable>() {
-        @Override
-        public int compare(Comparable a, Comparable b) {
-          return a.compareTo(b);
-        }
-      };
+  private static final Comparator<Comparable> NATURAL_ORDER = Comparator.naturalOrder();
 
   private final Comparator<? super K> comparator;
   private final boolean allowNullValues;

--- a/gson/src/main/java/com/google/gson/internal/NonNullElementWrapperList.java
+++ b/gson/src/main/java/com/google/gson/internal/NonNullElementWrapperList.java
@@ -19,11 +19,9 @@ package com.google.gson.internal;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.RandomAccess;
-import java.util.Spliterator;
 
 /**
  * {@link List} which wraps another {@code List} but prevents insertion of {@code null} elements.
@@ -110,16 +108,6 @@ public class NonNullElementWrapperList<E> extends AbstractList<E> implements Ran
   }
 
   @Override
-  public Spliterator<E> spliterator() {
-    return delegate.spliterator();
-  }
-
-  @Override
-  public void sort(Comparator<? super E> c) {
-    delegate.sort(c);
-  }
-
-  @Override
   public Object[] toArray() {
     return delegate.toArray();
   }
@@ -138,4 +126,7 @@ public class NonNullElementWrapperList<E> extends AbstractList<E> implements Ran
   public int hashCode() {
     return delegate.hashCode();
   }
+
+  // Maybe also delegate List#sort and List#spliterator in the future, but that
+  // requires Android API level 24
 }

--- a/gson/src/main/java/com/google/gson/internal/NonNullElementWrapperList.java
+++ b/gson/src/main/java/com/google/gson/internal/NonNullElementWrapperList.java
@@ -19,9 +19,11 @@ package com.google.gson.internal;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.RandomAccess;
+import java.util.Spliterator;
 
 /**
  * {@link List} which wraps another {@code List} but prevents insertion of {@code null} elements.
@@ -108,6 +110,16 @@ public class NonNullElementWrapperList<E> extends AbstractList<E> implements Ran
   }
 
   @Override
+  public Spliterator<E> spliterator() {
+    return delegate.spliterator();
+  }
+
+  @Override
+  public void sort(Comparator<? super E> c) {
+    delegate.sort(c);
+  }
+
+  @Override
   public Object[] toArray() {
     return delegate.toArray();
   }
@@ -126,6 +138,4 @@ public class NonNullElementWrapperList<E> extends AbstractList<E> implements Ran
   public int hashCode() {
     return delegate.hashCode();
   }
-
-  // TODO: Once Gson targets Java 8 also override List.sort
 }

--- a/gson/src/main/java/com/google/gson/internal/ReflectionAccessFilterHelper.java
+++ b/gson/src/main/java/com/google/gson/internal/ReflectionAccessFilterHelper.java
@@ -85,7 +85,7 @@ public class ReflectionAccessFilterHelper {
       // TODO: Ideally should use Multi-Release JAR for this version specific code
       if (JavaVersion.isJava9OrLater()) {
         try {
-          final Method canAccessMethod =
+          Method canAccessMethod =
               AccessibleObject.class.getDeclaredMethod("canAccess", Object.class);
           accessChecker =
               new AccessChecker() {

--- a/gson/src/main/java/com/google/gson/internal/UnsafeAllocator.java
+++ b/gson/src/main/java/com/google/gson/internal/UnsafeAllocator.java
@@ -54,8 +54,8 @@ public abstract class UnsafeAllocator {
       Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
       Field f = unsafeClass.getDeclaredField("theUnsafe");
       f.setAccessible(true);
-      final Object unsafe = f.get(null);
-      final Method allocateInstance = unsafeClass.getMethod("allocateInstance", Class.class);
+      Object unsafe = f.get(null);
+      Method allocateInstance = unsafeClass.getMethod("allocateInstance", Class.class);
       return new UnsafeAllocator() {
         @Override
         @SuppressWarnings("unchecked")
@@ -77,8 +77,8 @@ public abstract class UnsafeAllocator {
       Method getConstructorId =
           ObjectStreamClass.class.getDeclaredMethod("getConstructorId", Class.class);
       getConstructorId.setAccessible(true);
-      final int constructorId = (Integer) getConstructorId.invoke(null, Object.class);
-      final Method newInstance =
+      int constructorId = (Integer) getConstructorId.invoke(null, Object.class);
+      Method newInstance =
           ObjectStreamClass.class.getDeclaredMethod("newInstance", Class.class, int.class);
       newInstance.setAccessible(true);
       return new UnsafeAllocator() {
@@ -99,7 +99,7 @@ public abstract class UnsafeAllocator {
     //     Class<?> instantiationClass, Class<?> constructorClass);
     // }
     try {
-      final Method newInstance =
+      Method newInstance =
           ObjectInputStream.class.getDeclaredMethod("newInstance", Class.class, Class.class);
       newInstance.setAccessible(true);
       return new UnsafeAllocator() {

--- a/gson/src/main/java/com/google/gson/internal/bind/EnumTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/EnumTypeAdapter.java
@@ -54,7 +54,7 @@ class EnumTypeAdapter<T extends Enum<T>> extends TypeAdapter<T> {
   private final Map<String, T> stringToConstant = new HashMap<>();
   private final Map<T, String> constantToName = new HashMap<>();
 
-  private EnumTypeAdapter(final Class<T> classOfT) {
+  private EnumTypeAdapter(Class<T> classOfT) {
     try {
       // Uses reflection to find enum constants to work around name mismatches for obfuscated
       // classes

--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
@@ -282,14 +282,14 @@ public final class JsonTreeReader extends JsonReader {
   }
 
   JsonElement nextJsonElement() throws IOException {
-    final JsonToken peeked = peek();
+    JsonToken peeked = peek();
     if (peeked == JsonToken.NAME
         || peeked == JsonToken.END_ARRAY
         || peeked == JsonToken.END_OBJECT
         || peeked == JsonToken.END_DOCUMENT) {
       throw new IllegalStateException("Unexpected " + peeked + " when reading a JsonElement.");
     }
-    final JsonElement element = (JsonElement) peekStack();
+    JsonElement element = (JsonElement) peekStack();
     skipValue();
     return element;
   }

--- a/gson/src/main/java/com/google/gson/internal/bind/NumberTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/NumberTypeAdapter.java
@@ -41,7 +41,7 @@ public final class NumberTypeAdapter extends TypeAdapter<Number> {
   }
 
   private static TypeAdapterFactory newFactory(ToNumberStrategy toNumberStrategy) {
-    final NumberTypeAdapter adapter = new NumberTypeAdapter(toNumberStrategy);
+    NumberTypeAdapter adapter = new NumberTypeAdapter(toNumberStrategy);
     return new TypeAdapterFactory() {
       @SuppressWarnings("unchecked")
       @Override

--- a/gson/src/main/java/com/google/gson/internal/bind/ObjectTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ObjectTypeAdapter.java
@@ -49,7 +49,7 @@ public final class ObjectTypeAdapter extends TypeAdapter<Object> {
     this.toNumberStrategy = toNumberStrategy;
   }
 
-  private static TypeAdapterFactory newFactory(final ToNumberStrategy toNumberStrategy) {
+  private static TypeAdapterFactory newFactory(ToNumberStrategy toNumberStrategy) {
     return new TypeAdapterFactory() {
       @SuppressWarnings("unchecked")
       @Override

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -103,7 +103,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
   }
 
   @Override
-  public <T> TypeAdapter<T> create(Gson gson, final TypeToken<T> type) {
+  public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
     Class<? super T> raw = type.getRawType();
 
     if (!Object.class.isAssignableFrom(raw)) {
@@ -175,18 +175,18 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
   }
 
   private BoundField createBoundField(
-      final Gson context,
-      final Field field,
-      final Method accessor,
-      final String serializedName,
-      final TypeToken<?> fieldType,
-      final boolean serialize,
-      final boolean blockInaccessible) {
+      Gson context,
+      Field field,
+      Method accessor,
+      String serializedName,
+      TypeToken<?> fieldType,
+      boolean serialize,
+      boolean blockInaccessible) {
 
-    final boolean isPrimitive = Primitives.isPrimitive(fieldType.getRawType());
+    boolean isPrimitive = Primitives.isPrimitive(fieldType.getRawType());
 
     int modifiers = field.getModifiers();
-    final boolean isStaticFinalField = Modifier.isStatic(modifiers) && Modifier.isFinal(modifiers);
+    boolean isStaticFinalField = Modifier.isStatic(modifiers) && Modifier.isFinal(modifiers);
 
     JsonAdapter annotation = field.getAnnotation(JsonAdapter.class);
     TypeAdapter<?> mapped = null;
@@ -196,14 +196,14 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
           jsonAdapterFactory.getTypeAdapter(
               constructorConstructor, context, fieldType, annotation, false);
     }
-    final boolean jsonAdapterPresent = mapped != null;
+    boolean jsonAdapterPresent = mapped != null;
     if (mapped == null) {
       mapped = context.getAdapter(fieldType);
     }
 
     @SuppressWarnings("unchecked")
-    final TypeAdapter<Object> typeAdapter = (TypeAdapter<Object>) mapped;
-    final TypeAdapter<Object> writeTypeAdapter;
+    TypeAdapter<Object> typeAdapter = (TypeAdapter<Object>) mapped;
+    TypeAdapter<Object> writeTypeAdapter;
     if (serialize) {
       writeTypeAdapter =
           jsonAdapterPresent

--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -815,7 +815,7 @@ public final class TypeAdapters {
 
   @SuppressWarnings("TypeParameterNaming")
   public static <TT> TypeAdapterFactory newFactory(
-      final TypeToken<TT> type, final TypeAdapter<TT> typeAdapter) {
+      TypeToken<TT> type, TypeAdapter<TT> typeAdapter) {
     return new TypeAdapterFactory() {
       @SuppressWarnings("unchecked") // we use a runtime check to make sure the 'T's equal
       @Override
@@ -826,8 +826,7 @@ public final class TypeAdapters {
   }
 
   @SuppressWarnings("TypeParameterNaming")
-  public static <TT> TypeAdapterFactory newFactory(
-      final Class<TT> type, final TypeAdapter<TT> typeAdapter) {
+  public static <TT> TypeAdapterFactory newFactory(Class<TT> type, TypeAdapter<TT> typeAdapter) {
     return new TypeAdapterFactory() {
       @SuppressWarnings("unchecked") // we use a runtime check to make sure the 'T's equal
       @Override
@@ -844,7 +843,7 @@ public final class TypeAdapters {
 
   @SuppressWarnings("TypeParameterNaming")
   public static <TT> TypeAdapterFactory newFactory(
-      final Class<TT> unboxed, final Class<TT> boxed, final TypeAdapter<? super TT> typeAdapter) {
+      Class<TT> unboxed, Class<TT> boxed, TypeAdapter<? super TT> typeAdapter) {
     return new TypeAdapterFactory() {
       @SuppressWarnings("unchecked") // we use a runtime check to make sure the 'T's equal
       @Override
@@ -868,9 +867,7 @@ public final class TypeAdapters {
 
   @SuppressWarnings("TypeParameterNaming")
   public static <TT> TypeAdapterFactory newFactoryForMultipleTypes(
-      final Class<TT> base,
-      final Class<? extends TT> sub,
-      final TypeAdapter<? super TT> typeAdapter) {
+      Class<TT> base, Class<? extends TT> sub, TypeAdapter<? super TT> typeAdapter) {
     return new TypeAdapterFactory() {
       @SuppressWarnings("unchecked") // we use a runtime check to make sure the 'T's equal
       @Override
@@ -897,12 +894,12 @@ public final class TypeAdapters {
    * that the deserialized type matches the type requested.
    */
   public static <T1> TypeAdapterFactory newTypeHierarchyFactory(
-      final Class<T1> clazz, final TypeAdapter<T1> typeAdapter) {
+      Class<T1> clazz, TypeAdapter<T1> typeAdapter) {
     return new TypeAdapterFactory() {
       @SuppressWarnings("unchecked")
       @Override
       public <T2> TypeAdapter<T2> create(Gson gson, TypeToken<T2> typeToken) {
-        final Class<? super T2> requestedType = typeToken.getRawType();
+        Class<? super T2> requestedType = typeToken.getRawType();
         if (!clazz.isAssignableFrom(requestedType)) {
           return null;
         }

--- a/gson/src/main/java/com/google/gson/internal/reflect/ReflectionHelper.java
+++ b/gson/src/main/java/com/google/gson/internal/reflect/ReflectionHelper.java
@@ -128,8 +128,8 @@ public class ReflectionHelper {
     return stringBuilder.toString();
   }
 
-  // Ideally parameter type would be java.lang.reflect.Executable, but that was added in Android API
-  // level 26
+  // Ideally parameter type would be java.lang.reflect.Executable, but that was added
+  // in Android API level 26
   private static void appendExecutableParameters(
       AccessibleObject executable, StringBuilder stringBuilder) {
     stringBuilder.append('(');

--- a/gson/src/main/java/com/google/gson/internal/reflect/ReflectionHelper.java
+++ b/gson/src/main/java/com/google/gson/internal/reflect/ReflectionHelper.java
@@ -128,7 +128,8 @@ public class ReflectionHelper {
     return stringBuilder.toString();
   }
 
-  // Ideally parameter type would be java.lang.reflect.Executable, but that was added in Java 8
+  // Ideally parameter type would be java.lang.reflect.Executable, but that was added in Android API
+  // level 26
   private static void appendExecutableParameters(
       AccessibleObject executable, StringBuilder stringBuilder) {
     stringBuilder.append('(');

--- a/gson/src/main/java/com/google/gson/internal/sql/SqlTimestampTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/sql/SqlTimestampTypeAdapter.java
@@ -34,7 +34,7 @@ class SqlTimestampTypeAdapter extends TypeAdapter<Timestamp> {
         @Override
         public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
           if (typeToken.getRawType() == Timestamp.class) {
-            final TypeAdapter<Date> dateTypeAdapter = gson.getAdapter(Date.class);
+            TypeAdapter<Date> dateTypeAdapter = gson.getAdapter(Date.class);
             return (TypeAdapter<T>) new SqlTimestampTypeAdapter(dateTypeAdapter);
           } else {
             return null;

--- a/gson/src/test/java/com/google/gson/GsonBuilderTest.java
+++ b/gson/src/test/java/com/google/gson/GsonBuilderTest.java
@@ -254,17 +254,17 @@ public class GsonBuilderTest {
 
   @Test
   public void testSetStrictness() throws IOException {
-    final Strictness STRICTNESS = Strictness.STRICT;
+    Strictness strictness = Strictness.STRICT;
     GsonBuilder builder = new GsonBuilder();
-    builder.setStrictness(STRICTNESS);
+    builder.setStrictness(strictness);
     Gson gson = builder.create();
-    assertThat(gson.newJsonReader(new StringReader("{}")).getStrictness()).isEqualTo(STRICTNESS);
-    assertThat(gson.newJsonWriter(new StringWriter()).getStrictness()).isEqualTo(STRICTNESS);
+    assertThat(gson.newJsonReader(new StringReader("{}")).getStrictness()).isEqualTo(strictness);
+    assertThat(gson.newJsonWriter(new StringWriter()).getStrictness()).isEqualTo(strictness);
   }
 
   @Test
   public void testRegisterTypeAdapterForObjectAndJsonElements() {
-    final String ERROR_MESSAGE = "Cannot override built-in adapter for ";
+    String errorMessage = "Cannot override built-in adapter for ";
     Type[] types = {
       Object.class, JsonElement.class, JsonArray.class,
     };
@@ -274,13 +274,13 @@ public class GsonBuilderTest {
           assertThrows(
               IllegalArgumentException.class,
               () -> gsonBuilder.registerTypeAdapter(type, NULL_TYPE_ADAPTER));
-      assertThat(e).hasMessageThat().isEqualTo(ERROR_MESSAGE + type);
+      assertThat(e).hasMessageThat().isEqualTo(errorMessage + type);
     }
   }
 
   @Test
   public void testRegisterTypeHierarchyAdapterJsonElements() {
-    final String ERROR_MESSAGE = "Cannot override built-in adapter for ";
+    String errorMessage = "Cannot override built-in adapter for ";
     Class<?>[] types = {
       JsonElement.class, JsonArray.class,
     };
@@ -291,7 +291,7 @@ public class GsonBuilderTest {
               IllegalArgumentException.class,
               () -> gsonBuilder.registerTypeHierarchyAdapter(type, NULL_TYPE_ADAPTER));
 
-      assertThat(e).hasMessageThat().isEqualTo(ERROR_MESSAGE + type);
+      assertThat(e).hasMessageThat().isEqualTo(errorMessage + type);
     }
     // But registering type hierarchy adapter for Object should be allowed
     gsonBuilder.registerTypeHierarchyAdapter(Object.class, NULL_TYPE_ADAPTER);

--- a/gson/src/test/java/com/google/gson/GsonTest.java
+++ b/gson/src/test/java/com/google/gson/GsonTest.java
@@ -28,7 +28,6 @@ import com.google.gson.stream.MalformedJsonException;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.text.DateFormat;
 import java.util.ArrayList;
@@ -49,13 +48,7 @@ public final class GsonTest {
   private static final Excluder CUSTOM_EXCLUDER =
       Excluder.DEFAULT.excludeFieldsWithoutExposeAnnotation().disableInnerClassSerialization();
 
-  private static final FieldNamingStrategy CUSTOM_FIELD_NAMING_STRATEGY =
-      new FieldNamingStrategy() {
-        @Override
-        public String translateName(Field f) {
-          return "foo";
-        }
-      };
+  private static final FieldNamingStrategy CUSTOM_FIELD_NAMING_STRATEGY = f -> "foo";
 
   private static final ToNumberStrategy CUSTOM_OBJECT_TO_NUMBER_STRATEGY = ToNumberPolicy.DOUBLE;
   private static final ToNumberStrategy CUSTOM_NUMBER_TO_NUMBER_STRATEGY =
@@ -164,9 +157,9 @@ public final class GsonTest {
       }
     }
 
-    final AtomicInteger adapterInstancesCreated = new AtomicInteger(0);
-    final AtomicReference<TypeAdapter<?>> threadAdapter = new AtomicReference<>();
-    final Class<?> requestedType = Number.class;
+    AtomicInteger adapterInstancesCreated = new AtomicInteger(0);
+    AtomicReference<TypeAdapter<?>> threadAdapter = new AtomicReference<>();
+    Class<?> requestedType = Number.class;
 
     Gson gson =
         new GsonBuilder()
@@ -175,7 +168,7 @@ public final class GsonTest {
                   private volatile boolean isFirstCall = true;
 
                   @Override
-                  public <T> TypeAdapter<T> create(final Gson gson, TypeToken<T> type) {
+                  public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
                     if (isFirstCall) {
                       isFirstCall = false;
 
@@ -253,10 +246,10 @@ public final class GsonTest {
       }
     }
 
-    final CountDownLatch isThreadWaiting = new CountDownLatch(1);
-    final CountDownLatch canThreadProceed = new CountDownLatch(1);
+    CountDownLatch isThreadWaiting = new CountDownLatch(1);
+    CountDownLatch canThreadProceed = new CountDownLatch(1);
 
-    final Gson gson =
+    Gson gson =
         new GsonBuilder()
             .registerTypeAdapterFactory(
                 new TypeAdapterFactory() {
@@ -298,7 +291,7 @@ public final class GsonTest {
                 })
             .create();
 
-    final AtomicReference<TypeAdapter<?>> otherThreadAdapter = new AtomicReference<>();
+    AtomicReference<TypeAdapter<?>> otherThreadAdapter = new AtomicReference<>();
     Thread thread =
         new Thread() {
           @Override

--- a/gson/src/test/java/com/google/gson/TypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/TypeAdapterTest.java
@@ -78,7 +78,7 @@ public class TypeAdapterTest {
    */
   @Test
   public void testToJson_ThrowingIOException() {
-    final IOException exception = new IOException("test");
+    IOException exception = new IOException("test");
     TypeAdapter<Integer> adapter =
         new TypeAdapter<>() {
           @Override

--- a/gson/src/test/java/com/google/gson/common/TestTypes.java
+++ b/gson/src/test/java/com/google/gson/common/TestTypes.java
@@ -144,7 +144,7 @@ public class TestTypes {
 
     @Override
     public int hashCode() {
-      final int prime = 31;
+      int prime = 31;
       int result = 1;
       result = prime * result + (booleanValue ? 1231 : 1237);
       result = prime * result + intValue;

--- a/gson/src/test/java/com/google/gson/functional/ConcurrencyTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ConcurrencyTest.java
@@ -71,9 +71,9 @@ public class ConcurrencyTest {
    */
   @Test
   public void testMultiThreadSerialization() throws InterruptedException {
-    final CountDownLatch startLatch = new CountDownLatch(1);
-    final CountDownLatch finishedLatch = new CountDownLatch(10);
-    final AtomicReference<Throwable> error = new AtomicReference<>(null);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    CountDownLatch finishedLatch = new CountDownLatch(10);
+    AtomicReference<Throwable> error = new AtomicReference<>(null);
     ExecutorService executor = Executors.newFixedThreadPool(10);
     for (int taskCount = 0; taskCount < 10; taskCount++) {
       executor.execute(
@@ -106,9 +106,9 @@ public class ConcurrencyTest {
    */
   @Test
   public void testMultiThreadDeserialization() throws InterruptedException {
-    final CountDownLatch startLatch = new CountDownLatch(1);
-    final CountDownLatch finishedLatch = new CountDownLatch(10);
-    final AtomicReference<Throwable> error = new AtomicReference<>(null);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    CountDownLatch finishedLatch = new CountDownLatch(10);
+    AtomicReference<Throwable> error = new AtomicReference<>(null);
     ExecutorService executor = Executors.newFixedThreadPool(10);
     for (int taskCount = 0; taskCount < 10; taskCount++) {
       executor.execute(

--- a/gson/src/test/java/com/google/gson/functional/DelegateTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DelegateTypeAdapterTest.java
@@ -77,7 +77,7 @@ public class DelegateTypeAdapterTest {
 
     @Override
     public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
-      final TypeAdapter<T> delegate = gson.getDelegateAdapter(this, type);
+      TypeAdapter<T> delegate = gson.getDelegateAdapter(this, type);
       return new TypeAdapter<>() {
         @Override
         public void write(JsonWriter out, T value) throws IOException {

--- a/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java
@@ -263,7 +263,7 @@ public final class JsonAdapterAnnotationOnClassesTest {
 
     static final class JsonAdapterFactory implements TypeAdapterFactory {
       @Override
-      public <T> TypeAdapter<T> create(Gson gson, final TypeToken<T> type) {
+      public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
         return new TypeAdapter<>() {
           @Override
           public void write(JsonWriter out, T value) throws IOException {

--- a/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnFieldsTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnFieldsTest.java
@@ -146,7 +146,7 @@ public final class JsonAdapterAnnotationOnFieldsTest {
 
   private static class GizmoPartTypeAdapterFactory implements TypeAdapterFactory {
     @Override
-    public <T> TypeAdapter<T> create(Gson gson, final TypeToken<T> type) {
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
       return new TypeAdapter<>() {
         @Override
         public void write(JsonWriter out, T value) throws IOException {
@@ -317,7 +317,7 @@ public final class JsonAdapterAnnotationOnFieldsTest {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T> TypeAdapter<T> create(Gson gson, final TypeToken<T> type) {
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
       Class<?> cls = type.getRawType();
       if (Long.class.isAssignableFrom(cls)) {
         return (TypeAdapter<T>) ADAPTER;
@@ -351,7 +351,7 @@ public final class JsonAdapterAnnotationOnFieldsTest {
 
   private static class Gizmo2PartTypeAdapterFactory implements TypeAdapterFactory {
     @Override
-    public <T> TypeAdapter<T> create(Gson gson, final TypeToken<T> type) {
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
       return new TypeAdapter<>() {
         @Override
         public void write(JsonWriter out, T value) throws IOException {

--- a/gson/src/test/java/com/google/gson/functional/MapTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MapTest.java
@@ -520,7 +520,7 @@ public class MapTest {
 
     Gson tempGson = new Gson();
     String subTypeJson = tempGson.toJson(subType);
-    final JsonElement baseTypeJsonElement = tempGson.toJsonTree(subType, TestTypes.Base.class);
+    JsonElement baseTypeJsonElement = tempGson.toJsonTree(subType, TestTypes.Base.class);
     String baseTypeJson = tempGson.toJson(baseTypeJsonElement);
     String expected =
         "{\"bases\":{\"Test\":" + baseTypeJson + "},\"subs\":{\"Test\":" + subTypeJson + "}}";

--- a/gson/src/test/java/com/google/gson/functional/NamingPolicyTest.java
+++ b/gson/src/test/java/com/google/gson/functional/NamingPolicyTest.java
@@ -156,16 +156,7 @@ public class NamingPolicyTest {
 
   @Test
   public void testGsonDuplicateNameDueToBadNamingPolicy() {
-    Gson gson =
-        builder
-            .setFieldNamingStrategy(
-                new FieldNamingStrategy() {
-                  @Override
-                  public String translateName(Field f) {
-                    return "x";
-                  }
-                })
-            .create();
+    Gson gson = builder.setFieldNamingStrategy(f -> "x").create();
 
     var e =
         assertThrows(IllegalArgumentException.class, () -> gson.toJson(new ClassWithTwoFields()));

--- a/gson/src/test/java/com/google/gson/functional/ObjectTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ObjectTest.java
@@ -488,7 +488,7 @@ public class ObjectTest {
 
   @Test
   public void testInnerClassDeserialization() {
-    final Parent p = new Parent();
+    Parent p = new Parent();
     Gson gson =
         new GsonBuilder()
             .registerTypeAdapter(

--- a/gson/src/test/java/com/google/gson/functional/ParameterizedTypesTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ParameterizedTypesTest.java
@@ -437,7 +437,7 @@ public class ParameterizedTypesTest {
 
     @Override
     public int hashCode() {
-      final int prime = 31;
+      int prime = 31;
       int result = 1;
       result = prime * result + ((a == null) ? 0 : a.hashCode());
       result = prime * result + ((b == null) ? 0 : b.hashCode());

--- a/gson/src/test/java/com/google/gson/functional/ReflectionAccessTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ReflectionAccessTest.java
@@ -60,8 +60,8 @@ public class ReflectionAccessTest {
     // Class.getDeclaredFields()
     Class<?> clazz = loadClassWithDifferentClassLoader(ClassWithPrivateMembers.class);
 
-    final Permission accessDeclaredMembers = new RuntimePermission("accessDeclaredMembers");
-    final Permission suppressAccessChecks = new ReflectPermission("suppressAccessChecks");
+    Permission accessDeclaredMembers = new RuntimePermission("accessDeclaredMembers");
+    Permission suppressAccessChecks = new ReflectPermission("suppressAccessChecks");
     SecurityManager original = System.getSecurityManager();
     SecurityManager restrictiveManager =
         new SecurityManager() {
@@ -83,7 +83,7 @@ public class ReflectionAccessTest {
       var e = assertThrows(SecurityException.class, () -> gson.getAdapter(clazz));
       assertThat(e).hasMessageThat().isEqualTo("Gson: no-member-access");
 
-      final AtomicBoolean wasReadCalled = new AtomicBoolean(false);
+      AtomicBoolean wasReadCalled = new AtomicBoolean(false);
       Gson gson2 =
           new GsonBuilder()
               .registerTypeAdapter(

--- a/gson/src/test/java/com/google/gson/functional/RuntimeTypeAdapterFactoryFunctionalTest.java
+++ b/gson/src/test/java/com/google/gson/functional/RuntimeTypeAdapterFactoryFunctionalTest.java
@@ -166,8 +166,8 @@ public final class RuntimeTypeAdapterFactoryFunctionalTest {
         return null;
       }
 
-      final Map<String, TypeAdapter<?>> labelToDelegate = new LinkedHashMap<>();
-      final Map<Class<?>, TypeAdapter<?>> subtypeToDelegate = new LinkedHashMap<>();
+      Map<String, TypeAdapter<?>> labelToDelegate = new LinkedHashMap<>();
+      Map<Class<?>, TypeAdapter<?>> subtypeToDelegate = new LinkedHashMap<>();
       for (Map.Entry<String, Class<?>> entry : labelToSubtype.entrySet()) {
         TypeAdapter<?> delegate = gson.getDelegateAdapter(this, TypeToken.get(entry.getValue()));
         labelToDelegate.put(entry.getKey(), delegate);

--- a/gson/src/test/java/com/google/gson/functional/TypeAdapterPrecedenceTest.java
+++ b/gson/src/test/java/com/google/gson/functional/TypeAdapterPrecedenceTest.java
@@ -139,7 +139,7 @@ public final class TypeAdapterPrecedenceTest {
     }
   }
 
-  private static JsonSerializer<Foo> newSerializer(final String name) {
+  private static JsonSerializer<Foo> newSerializer(String name) {
     return new JsonSerializer<>() {
       @Override
       public JsonElement serialize(Foo src, Type typeOfSrc, JsonSerializationContext context) {
@@ -148,7 +148,7 @@ public final class TypeAdapterPrecedenceTest {
     };
   }
 
-  private static JsonDeserializer<Foo> newDeserializer(final String name) {
+  private static JsonDeserializer<Foo> newDeserializer(String name) {
     return new JsonDeserializer<>() {
       @Override
       public Foo deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
@@ -157,7 +157,7 @@ public final class TypeAdapterPrecedenceTest {
     };
   }
 
-  private static TypeAdapter<Foo> newTypeAdapter(final String name) {
+  private static TypeAdapter<Foo> newTypeAdapter(String name) {
     return new TypeAdapter<>() {
       @Override
       public Foo read(JsonReader in) throws IOException {

--- a/gson/src/test/java/com/google/gson/internal/bind/Java17ReflectiveTypeAdapterFactoryTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/Java17ReflectiveTypeAdapterFactoryTest.java
@@ -87,7 +87,7 @@ public class Java17ReflectiveTypeAdapterFactoryTest {
 
     @Override
     public T read(JsonReader in) throws IOException {
-      final String name = in.nextString();
+      String name = in.nextString();
       // This type adapter is only used for Group and User Principal, both of which are implemented
       // by PrincipalImpl.
       @SuppressWarnings("unchecked")

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonElementReaderTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonElementReaderTest.java
@@ -258,7 +258,7 @@ public final class JsonElementReaderTest {
 
   @Test
   public void testNextJsonElement() throws IOException {
-    final JsonElement element = JsonParser.parseString("{\"A\": 1, \"B\" : {}, \"C\" : []}");
+    JsonElement element = JsonParser.parseString("{\"A\": 1, \"B\" : {}, \"C\" : []}");
     JsonTreeReader reader = new JsonTreeReader(element);
     reader.beginObject();
 

--- a/gson/src/test/java/com/google/gson/internal/bind/util/ISO8601UtilsTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/util/ISO8601UtilsTest.java
@@ -119,7 +119,7 @@ public class ISO8601UtilsTest {
 
   @Test
   public void testDateParseInvalidTime() {
-    final String dateStr = "2018-06-25T61:60:62-03:00";
+    String dateStr = "2018-06-25T61:60:62-03:00";
     assertThrows(ParseException.class, () -> ISO8601Utils.parse(dateStr, new ParsePosition(0)));
   }
 }

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -2171,7 +2171,7 @@ public final class JsonReaderTest {
   }
 
   /** Returns a reader that returns one character at a time. */
-  private static Reader reader(final String s) {
+  private static Reader reader(String s) {
     /* if (true) */ return new StringReader(s);
     /* return new Reader() {
       int position = 0;

--- a/metrics/src/main/java/com/google/gson/metrics/BagOfPrimitives.java
+++ b/metrics/src/main/java/com/google/gson/metrics/BagOfPrimitives.java
@@ -63,7 +63,7 @@ public class BagOfPrimitives {
 
   @Override
   public int hashCode() {
-    final int prime = 31;
+    int prime = 31;
     int result = 1;
     result = prime * result + (booleanValue ? 1231 : 1237);
     result = prime * result + intValue;

--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,6 @@
                 -Xep:UngroupedOverloads:WARN <!-- required by style guide -->
                 -Xep:UnnecessarilyFullyQualified
                 -Xep:UnnecessarilyUsedValue
-                -Xep:UnnecessaryAnonymousClass
                 -Xep:UnnecessaryBoxedVariable:WARN
                 -Xep:UnnecessaryDefaultInEnumSwitch
                 -Xep:UnnecessaryFinal

--- a/pom.xml
+++ b/pom.xml
@@ -127,9 +127,9 @@
                 <!-- Enforce that correct JDK version is used to avoid cryptic build errors -->
                 <requireJavaVersion>
                   <!-- Other plugins of this build require at least JDK 11 -->
-                  <!-- Fail fast when building with JDK > 17 because it causes build failures,
-                    see https://github.com/google/gson/issues/2501 -->
-                  <version>[11,18)</version>
+                  <!-- Disallow newer JDK versions; they might introduce new lints, drop support for
+                    older compiler Java target versions or cause issues for some Maven plugins -->
+                  <version>[11,22)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>
@@ -280,10 +280,10 @@
                 -Xep:UngroupedOverloads:WARN <!-- required by style guide -->
                 -Xep:UnnecessarilyFullyQualified
                 -Xep:UnnecessarilyUsedValue
-                -Xep:UnnecessaryAnonymousClass:OFF <!-- disabled: requires Java 8 -->
+                -Xep:UnnecessaryAnonymousClass
                 -Xep:UnnecessaryBoxedVariable:WARN
                 -Xep:UnnecessaryDefaultInEnumSwitch
-                -Xep:UnnecessaryFinal:OFF <!-- disabled: requires Java 8 -->
+                -Xep:UnnecessaryFinal
                 -Xep:UnnecessaryStaticImport:WARN <!-- required by style guide -->
                 -Xep:UnusedException
                 -Xep:UrlInSee

--- a/proto/src/main/java/com/google/gson/protobuf/ProtoTypeAdapter.java
+++ b/proto/src/main/java/com/google/gson/protobuf/ProtoTypeAdapter.java
@@ -252,10 +252,10 @@ public class ProtoTypeAdapter implements JsonSerializer<Message>, JsonDeserializ
   @Override
   public JsonElement serialize(Message src, Type typeOfSrc, JsonSerializationContext context) {
     JsonObject ret = new JsonObject();
-    final Map<FieldDescriptor, Object> fields = src.getAllFields();
+    Map<FieldDescriptor, Object> fields = src.getAllFields();
 
     for (Map.Entry<FieldDescriptor, Object> fieldPair : fields.entrySet()) {
-      final FieldDescriptor desc = fieldPair.getKey();
+      FieldDescriptor desc = fieldPair.getKey();
       String name = getCustSerializedName(desc);
 
       if (desc.getType() == ENUM_TYPE) {

--- a/proto/src/test/java/com/google/gson/protobuf/functional/ProtosWithComplexAndRepeatedFieldsTest.java
+++ b/proto/src/test/java/com/google/gson/protobuf/functional/ProtosWithComplexAndRepeatedFieldsTest.java
@@ -85,12 +85,12 @@ public class ProtosWithComplexAndRepeatedFieldsTest {
 
   @Test
   public void testSerializeDifferentCaseFormat() {
-    final ProtoWithDifferentCaseFormat proto =
+    ProtoWithDifferentCaseFormat proto =
         ProtoWithDifferentCaseFormat.newBuilder()
             .setAnotherField("foo")
             .addNameThatTestsCaseFormat("bar")
             .build();
-    final JsonObject json = upperCamelGson.toJsonTree(proto).getAsJsonObject();
+    JsonObject json = upperCamelGson.toJsonTree(proto).getAsJsonObject();
     assertThat(json.get("AnotherField").getAsString()).isEqualTo("foo");
     assertThat(json.get("NameThatTestsCaseFormat").getAsJsonArray().get(0).getAsString())
         .isEqualTo("bar");
@@ -98,7 +98,7 @@ public class ProtosWithComplexAndRepeatedFieldsTest {
 
   @Test
   public void testDeserializeDifferentCaseFormat() {
-    final String json = "{NameThatTestsCaseFormat:['bar'],AnotherField:'foo'}";
+    String json = "{NameThatTestsCaseFormat:['bar'],AnotherField:'foo'}";
     ProtoWithDifferentCaseFormat proto =
         upperCamelGson.fromJson(json, ProtoWithDifferentCaseFormat.class);
     assertThat(proto.getAnotherField()).isEqualTo("foo");


### PR DESCRIPTION
### Purpose
Follow-up for #2744
Resolves #2501 (building with JDK 21 is now possible without any custom configuration)

### Description
Regarding the Error Prone warnings:
For the `final` variable warnings, it seems some of those variables were made `final` intentionally, without the compiler requiring it. But for consistency I removed the `final` from them as well.


### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [ ] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
