### PR TITLE
Fix some new Error Prone warnings.

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonIOException.java
+++ b/gson/src/main/java/com/google/gson/JsonIOException.java
@@ -21,6 +21,7 @@ package com.google.gson;
  * @author Inderjeet Singh
  * @author Joel Leitch
  */
+@SuppressWarnings("MemberName") // class name is part of the public API
 public final class JsonIOException extends JsonParseException {
   private static final long serialVersionUID = 1L;
 

--- a/gson/src/main/java/com/google/gson/internal/$Gson$Preconditions.java
+++ b/gson/src/main/java/com/google/gson/internal/$Gson$Preconditions.java
@@ -31,6 +31,7 @@ import java.util.Objects;
  * @author Inderjeet Singh
  * @author Joel Leitch
  */
+@SuppressWarnings("MemberName") // legacy class name
 public final class $Gson$Preconditions {
   private $Gson$Preconditions() {
     throw new UnsupportedOperationException();

--- a/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
+++ b/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
@@ -42,6 +42,7 @@ import java.util.Properties;
  * @author Bob Lee
  * @author Jesse Wilson
  */
+@SuppressWarnings("MemberName") // legacy class name
 public final class $Gson$Types {
   static final Type[] EMPTY_TYPE_ARRAY = new Type[] {};
 

--- a/gson/src/main/java/com/google/gson/internal/bind/util/ISO8601Utils.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/util/ISO8601Utils.java
@@ -35,6 +35,7 @@ import java.util.TimeZone;
  */
 // Date parsing code from Jackson databind ISO8601Utils.java
 // https://github.com/FasterXML/jackson-databind/blob/2.8/src/main/java/com/fasterxml/jackson/databind/util/ISO8601Utils.java
+@SuppressWarnings("MemberName") // legacy class name
 public class ISO8601Utils {
   private ISO8601Utils() {}
 

--- a/gson/src/test/java/com/google/gson/functional/ReflectionAccessFilterTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ReflectionAccessFilterTest.java
@@ -18,7 +18,6 @@ package com.google.gson.functional;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assume.assumeNotNull;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -81,12 +80,12 @@ public class ReflectionAccessFilterTest {
 
     // But serialization should succeed for classes with only public fields.
     // Not many JDK classes have mutable public fields, thank goodness, but java.awt.Point does.
-    Class<?> pointClass = null;
+    Class<?> pointClass;
     try {
       pointClass = Class.forName("java.awt.Point");
     } catch (ClassNotFoundException ignored) {
+      return; // If not found then we don't have AWT and the rest of the test can be skipped.
     }
-    assumeNotNull(pointClass);
     Constructor<?> pointConstructor = pointClass.getConstructor(int.class, int.class);
     Object point = pointConstructor.newInstance(1, 2);
     String json = gson.toJson(point);

--- a/gson/src/test/java/com/google/gson/functional/TypeHierarchyAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/functional/TypeHierarchyAdapterTest.java
@@ -222,6 +222,7 @@ public final class TypeHierarchyAdapterTest {
     Employee[] minions;
   }
 
+  @SuppressWarnings("MemberName")
   static class CEO extends Manager {
     Employee assistant;
   }

--- a/gson/src/test/java/com/google/gson/functional/VersioningTest.java
+++ b/gson/src/test/java/com/google/gson/functional/VersioningTest.java
@@ -187,11 +187,13 @@ public class VersioningTest {
     int b = B;
   }
 
+  @SuppressWarnings("MemberName")
   private static class Version1_1 extends Version1 {
     @Since(1.1)
     int c = C;
   }
 
+  @SuppressWarnings("MemberName")
   @Since(1.2)
   private static class Version1_2 extends Version1_1 {
     @SuppressWarnings("unused")

--- a/gson/src/test/java/com/google/gson/integration/OSGiManifestIT.java
+++ b/gson/src/test/java/com/google/gson/integration/OSGiManifestIT.java
@@ -45,7 +45,7 @@ import org.junit.Test;
  * Running Maven's {@code clean} phase is necessary due to a <a
  * href="https://github.com/bndtools/bnd/issues/6221">bnd-maven-plugin bug</a>.
  */
-@SuppressWarnings("MemberName") // test name does not conform to Google Style
+@SuppressWarnings("MemberName") // class name must end with 'IT' for Maven Failsafe Plugin
 public class OSGiManifestIT {
   private static class ManifestData {
     public final URL url;

--- a/gson/src/test/java/com/google/gson/integration/OSGiManifestIT.java
+++ b/gson/src/test/java/com/google/gson/integration/OSGiManifestIT.java
@@ -45,6 +45,7 @@ import org.junit.Test;
  * Running Maven's {@code clean} phase is necessary due to a <a
  * href="https://github.com/bndtools/bnd/issues/6221">bnd-maven-plugin bug</a>.
  */
+@SuppressWarnings("MemberName") // test name does not conform to Google Style
 public class OSGiManifestIT {
   private static class ManifestData {
     public final URL url;

--- a/gson/src/test/java/com/google/gson/internal/bind/util/ISO8601UtilsTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/util/ISO8601UtilsTest.java
@@ -28,6 +28,7 @@ import java.util.Locale;
 import java.util.TimeZone;
 import org.junit.Test;
 
+@SuppressWarnings("MemberName") // class name
 public class ISO8601UtilsTest {
 
   private static TimeZone utcTimeZone() {

--- a/test-shrinker/src/test/java/com/google/gson/it/ShrinkingIT.java
+++ b/test-shrinker/src/test/java/com/google/gson/it/ShrinkingIT.java
@@ -40,6 +40,7 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 /** Integration test verifying behavior of shrunken and obfuscated JARs. */
+@SuppressWarnings("MemberName") // class name
 @RunWith(Parameterized.class)
 public class ShrinkingIT {
   // These JAR files are prepared by the Maven build

--- a/test-shrinker/src/test/java/com/google/gson/it/ShrinkingIT.java
+++ b/test-shrinker/src/test/java/com/google/gson/it/ShrinkingIT.java
@@ -40,7 +40,7 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 /** Integration test verifying behavior of shrunken and obfuscated JARs. */
-@SuppressWarnings("MemberName") // class name
+@SuppressWarnings("MemberName") // class name must end with 'IT' for Maven Failsafe Plugin
 @RunWith(Parameterized.class)
 public class ShrinkingIT {
   // These JAR files are prepared by the Maven build


### PR DESCRIPTION
These break the build because we compile with `-Werror`.

The new warnings about class names are intrusive and should perhaps be refined.