### PR TITLE
Change the use of try to try-with-resources in ParseBenchmark resourceToString()

### DIFF
--- a/metrics/src/main/java/com/google/gson/metrics/ParseBenchmark.java
+++ b/metrics/src/main/java/com/google/gson/metrics/ParseBenchmark.java
@@ -145,8 +145,7 @@ public final class ParseBenchmark {
   }
 
   private static String resourceToString(String fileName) throws Exception {
-    ZipFile zipFile = new ZipFile(getResourceFile("/ParseBenchmarkData.zip"));
-    try {
+    try (ZipFile zipFile = new ZipFile(getResourceFile("/ParseBenchmarkData.zip"))) {
       ZipEntry zipEntry = zipFile.getEntry(fileName);
       Reader reader =
           new InputStreamReader(zipFile.getInputStream(zipEntry), StandardCharsets.UTF_8);
@@ -158,9 +157,6 @@ public final class ParseBenchmark {
       }
       reader.close();
       return writer.toString();
-
-    } finally {
-      zipFile.close();
     }
   }
 


### PR DESCRIPTION
Here we will change the use of `try` to use `try-with-resources` in the `resourceToString()` method of the `ParseBenchmark` class.

Since the current version of Gson uses Java 7 as the minimum version, and `try-with-resources` has been around since Java 7, this will be a nice and even desirable change