### PR TITLE
Support Properties subclasses in GsonTypes.getMapKeyAndValueTypes

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
+++ b/gson/src/main/java/com/google/gson/internal/$Gson$Types.java
@@ -328,8 +328,8 @@ public final class $Gson$Types {
      * class should extend Hashtable<String, String>, but it's declared to
      * extend Hashtable<Object, Object>.
      */
-    if (context == Properties.class) {
-      return new Type[] {String.class, String.class}; // TODO: test subclasses of Properties!
+    if (Properties.class.isAssignableFrom(contextRawType)) {
+      return new Type[] {String.class, String.class};
     }
 
     Type mapType = getSupertype(context, contextRawType, Map.class);

--- a/gson/src/test/java/com/google/gson/internal/GsonTypesTest.java
+++ b/gson/src/test/java/com/google/gson/internal/GsonTypesTest.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.List;
+import java.util.Properties;
 import org.junit.Test;
 
 @SuppressWarnings("ClassNamedLikeTypeParameter") // for dummy classes A, B, ...
@@ -132,5 +133,18 @@ public final class GsonTypesTest {
     public <T> T method() {
       return null;
     }
+  }
+
+  @Test
+  public void testGetMapKeyAndValueTypesForPropertiesSubclass() throws Exception {
+    class CustomProperties extends Properties {
+      private static final long serialVersionUID = 4112578634029874840L;
+    }
+
+    Type[] types =
+        $Gson$Types.getMapKeyAndValueTypes(CustomProperties.class, CustomProperties.class);
+
+    assertThat(types[0]).isEqualTo(String.class);
+    assertThat(types[1]).isEqualTo(String.class);
   }
 }


### PR DESCRIPTION
There is a `TODO` in this method that calls to test it with the `Properties` subclasses. They are supposed to return `new Type[] {String.class, String.class}`, just like if you cast the `Properties` class itself. But still when you pass a subclass of `Properties`, such as `CustomProperties`, the method returns `new Type[] {Object.class, Object.class}`, which is incorrect. Here I tried to fix this problem by using `isAssignableFrom()` and also wrote tests which indicate that the problem is solved