### PR TITLE
Refactor switch-case to if-else in UtcDateTypeAdapter

### DIFF
--- a/extras/src/main/java/com/google/gson/typeadapters/UtcDateTypeAdapter.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/UtcDateTypeAdapter.java
@@ -19,6 +19,7 @@ package com.google.gson.typeadapters;
 import com.google.gson.JsonParseException;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.text.ParseException;
@@ -45,15 +46,14 @@ public final class UtcDateTypeAdapter extends TypeAdapter<Date> {
   @Override
   public Date read(JsonReader in) throws IOException {
     try {
-      switch (in.peek()) {
-        case NULL:
-          in.nextNull();
-          return null;
-        default:
-          String date = in.nextString();
-          // Instead of using iso8601Format.parse(value), we use Jackson's date parsing
-          // This is because Android doesn't support XXX because it is JDK 1.6
-          return parse(date, new ParsePosition(0));
+      if (in.peek().equals(JsonToken.NULL)) {
+        in.nextNull();
+        return null;
+      } else {
+        String date = in.nextString();
+        // Instead of using iso8601Format.parse(value), we use Jackson's date parsing
+        // This is because Android doesn't support XXX because it is JDK 1.6
+        return parse(date, new ParsePosition(0));
       }
     } catch (ParseException e) {
       throw new JsonParseException(e);


### PR DESCRIPTION
The current implementation of the read() method uses a `switch-case` construct that is not needed to handle only two cases. To improve the readability and maintainability of the code, I suggest refactoring into a simpler `if-else` structure