### PR TITLE
Update graalvm/setup-graalvm to 1.2.4, fixing workflow failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938  # v4.2.0
       - name: "Set up GraalVM"
-        uses: graalvm/setup-graalvm@22cc13fe88ef133134b3798e128fb208df55e1f5  # v1.2.3
+        uses: graalvm/setup-graalvm@6f327093bb6a42fe5eac053d21b168c46aa46f22  # v1.2.4
         with:
           java-version: '17'
           distribution: 'graalvm'


### PR DESCRIPTION
### Purpose
Fixes a GitHub workflow failure

### Description
The current graalvm/setup-graalvm is causing a build failure, see https://github.com/google/gson/pull/2763#issuecomment-2417274203

According to the release notes this has been fixed in 1.2.4: https://github.com/graalvm/setup-graalvm/releases/tag/v1.2.4
