### PR TITLE
Use GraalVM for JDK 21 in GitHub workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: "Set up GraalVM"
         uses: graalvm/setup-graalvm@6f327093bb6a42fe5eac053d21b168c46aa46f22  # v1.2.4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'graalvm'
           # According to documentation in graalvm/setup-graalvm this is used to avoid rate-limiting issues
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/test-graal-native-image/README.md
+++ b/test-graal-native-image/README.md
@@ -12,7 +12,7 @@ Technically it would also be possible to directly configure Native Image test ex
 
 ## Reflection metadata
 
-Native Image creation requires configuring which class members are accessed using reflection, see the [GraalVM documentation](https://www.graalvm.org/22.3/reference-manual/native-image/metadata/#specifying-reflection-metadata-in-json).
+Native Image creation requires configuring which class members are accessed using reflection, see the [GraalVM documentation](https://www.graalvm.org/jdk21/reference-manual/native-image/metadata/#specifying-reflection-metadata-in-json).
 
 The file [`reflect-config.json`](./src/test/resources/META-INF/native-image/reflect-config.json) contains this reflection metadata.
 


### PR DESCRIPTION
### Purpose
Upgrade to GraalVM for JDK 21 to avoid being stuck on old JDK 17 version


### Description
GraalVM for JDK 17 does not receive any updates anymore (at least not under the "GraalVM Free Terms and Conditions")

See https://github.com/graalvm/setup-graalvm/tree/v1.2.4?tab=readme-ov-file#notes-on-oracle-graalvm-for-jdk-17

As mentioned there in the README and in https://github.com/graalvm/setup-graalvm/issues/107#issuecomment-2417563249, we will always be using Oracle GraalVM under the "GraalVM Free Terms and Conditions". After that expires (which for JDK 21 will be in September 2026, see also [GraalVM licensing FAQ](https://www.oracle.com/java/technologies/javase/jdk-faqs.html#GraalVM-licensing)) we will simply be stuck on an unmaintained GraalVM version (unless we already migrated to GraalVM for JDK 25 in the meantime), but we won't accidentally use GraalVM under the Oracle Technology Network License Agreement and violate it by accident.
