### PR TITLE
Replace anonymous classes creation with lambdas in tests

### DIFF
--- a/gson/src/test/java/com/google/gson/GsonBuilderTest.java
+++ b/gson/src/test/java/com/google/gson/GsonBuilderTest.java
@@ -24,7 +24,6 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.text.DateFormat;
@@ -57,13 +56,7 @@ public class GsonBuilderTest {
     assertThat(gson).isNotNull();
     assertThat(builder.create()).isNotNull();
 
-    builder.setFieldNamingStrategy(
-        new FieldNamingStrategy() {
-          @Override
-          public String translateName(Field f) {
-            return "test";
-          }
-        });
+    builder.setFieldNamingStrategy(f -> "test");
 
     Gson otherGson = builder.create();
     assertThat(otherGson).isNotNull();
@@ -94,23 +87,15 @@ public class GsonBuilderTest {
             out.value("custom-adapter");
           }
         });
+
     gsonBuilder.registerTypeHierarchyAdapter(
         CustomClass2.class,
-        new JsonSerializer<CustomClass2>() {
-          @Override
-          public JsonElement serialize(
-              CustomClass2 src, Type typeOfSrc, JsonSerializationContext context) {
-            return new JsonPrimitive("custom-hierarchy-adapter");
-          }
-        });
+        (JsonSerializer<CustomClass2>)
+            (src, typeOfSrc, context) -> new JsonPrimitive("custom-hierarchy-adapter"));
+
     gsonBuilder.registerTypeAdapter(
         CustomClass3.class,
-        new InstanceCreator<CustomClass3>() {
-          @Override
-          public CustomClass3 createInstance(Type type) {
-            return new CustomClass3("custom-instance");
-          }
-        });
+        (InstanceCreator<CustomClass3>) type -> new CustomClass3("custom-instance"));
 
     assertDefaultGson(gson);
     // New GsonBuilder created from `gson` should not have been affected by changes

--- a/gson/src/test/java/com/google/gson/GsonTest.java
+++ b/gson/src/test/java/com/google/gson/GsonTest.java
@@ -28,7 +28,6 @@ import com.google.gson.stream.MalformedJsonException;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.lang.reflect.Type;
 import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -486,23 +485,15 @@ public final class GsonTest {
             out.value("custom-adapter");
           }
         });
+
     gsonBuilder.registerTypeHierarchyAdapter(
         CustomClass2.class,
-        new JsonSerializer<CustomClass2>() {
-          @Override
-          public JsonElement serialize(
-              CustomClass2 src, Type typeOfSrc, JsonSerializationContext context) {
-            return new JsonPrimitive("custom-hierarchy-adapter");
-          }
-        });
+        (JsonSerializer<CustomClass2>)
+            (src, typeOfSrc, context) -> new JsonPrimitive("custom-hierarchy-adapter"));
+
     gsonBuilder.registerTypeAdapter(
         CustomClass3.class,
-        new InstanceCreator<CustomClass3>() {
-          @Override
-          public CustomClass3 createInstance(Type type) {
-            return new CustomClass3("custom-instance");
-          }
-        });
+        (InstanceCreator<CustomClass3>) type -> new CustomClass3("custom-instance"));
 
     assertDefaultGson(gson);
     // New GsonBuilder created from `gson` should not have been affected by changes either
@@ -549,21 +540,11 @@ public final class GsonTest {
                 })
             .registerTypeHierarchyAdapter(
                 CustomClass2.class,
-                new JsonSerializer<CustomClass2>() {
-                  @Override
-                  public JsonElement serialize(
-                      CustomClass2 src, Type typeOfSrc, JsonSerializationContext context) {
-                    return new JsonPrimitive("custom-hierarchy-adapter");
-                  }
-                })
+                (JsonSerializer<CustomClass2>)
+                    (src, typeOfSrc, context) -> new JsonPrimitive("custom-hierarchy-adapter"))
             .registerTypeAdapter(
                 CustomClass3.class,
-                new InstanceCreator<CustomClass3>() {
-                  @Override
-                  public CustomClass3 createInstance(Type type) {
-                    return new CustomClass3("custom-instance");
-                  }
-                })
+                (InstanceCreator<CustomClass3>) type -> new CustomClass3("custom-instance"))
             .create();
 
     assertCustomGson(gson);
@@ -585,21 +566,11 @@ public final class GsonTest {
         });
     gsonBuilder.registerTypeHierarchyAdapter(
         CustomClass2.class,
-        new JsonSerializer<CustomClass2>() {
-          @Override
-          public JsonElement serialize(
-              CustomClass2 src, Type typeOfSrc, JsonSerializationContext context) {
-            return new JsonPrimitive("overwritten custom-hierarchy-adapter");
-          }
-        });
+        (JsonSerializer<CustomClass2>)
+            (src, typeOfSrc, context) -> new JsonPrimitive("overwritten custom-hierarchy-adapter"));
     gsonBuilder.registerTypeAdapter(
         CustomClass3.class,
-        new InstanceCreator<CustomClass3>() {
-          @Override
-          public CustomClass3 createInstance(Type type) {
-            return new CustomClass3("overwritten custom-instance");
-          }
-        });
+        (InstanceCreator<CustomClass3>) type -> new CustomClass3("overwritten custom-instance"));
 
     // `gson` object should not have been affected by changes to new GsonBuilder
     assertCustomGson(gson);

--- a/gson/src/test/java/com/google/gson/GsonTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/GsonTypeAdapterTest.java
@@ -152,13 +152,8 @@ public class GsonTypeAdapterTest {
       boolean registerAbstractHierarchyDeserializer,
       Object instance) {
     JsonDeserializer<Abstract> deserializer =
-        new JsonDeserializer<>() {
-          @Override
-          public Abstract deserialize(
-              JsonElement json, Type typeOfT, JsonDeserializationContext context)
-              throws JsonParseException {
-            throw new AssertionError();
-          }
+        (json, typeOfT, context) -> {
+          throw new AssertionError();
         };
     GsonBuilder builder = new GsonBuilder();
     if (registerAbstractDeserializer) {

--- a/gson/src/test/java/com/google/gson/functional/ConcurrencyTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ConcurrencyTest.java
@@ -112,23 +112,20 @@ public class ConcurrencyTest {
     ExecutorService executor = Executors.newFixedThreadPool(10);
     for (int taskCount = 0; taskCount < 10; taskCount++) {
       executor.execute(
-          new Runnable() {
-            @Override
-            public void run() {
-              try {
-                startLatch.await();
-                for (int i = 0; i < 10; i++) {
-                  MyObject deserialized =
-                      gson.fromJson("{'a':'hello','b':'world','i':1}", MyObject.class);
-                  assertThat(deserialized.a).isEqualTo("hello");
-                  assertThat(deserialized.b).isEqualTo("world");
-                  assertThat(deserialized.i).isEqualTo(1);
-                }
-              } catch (Throwable t) {
-                error.set(t);
-              } finally {
-                finishedLatch.countDown();
+          () -> {
+            try {
+              startLatch.await();
+              for (int i = 0; i < 10; i++) {
+                MyObject deserialized =
+                    gson.fromJson("{'a':'hello','b':'world','i':1}", MyObject.class);
+                assertThat(deserialized.a).isEqualTo("hello");
+                assertThat(deserialized.b).isEqualTo("world");
+                assertThat(deserialized.i).isEqualTo(1);
               }
+            } catch (Throwable t) {
+              error.set(t);
+            } finally {
+              finishedLatch.countDown();
             }
           });
     }

--- a/gson/src/test/java/com/google/gson/functional/CustomDeserializerTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CustomDeserializerTest.java
@@ -123,15 +123,12 @@ public class CustomDeserializerTest {
         new GsonBuilder()
             .registerTypeAdapter(
                 MyBase.class,
-                new JsonDeserializer<MyBase>() {
-                  @Override
-                  public MyBase deserialize(
-                      JsonElement json, Type pojoType, JsonDeserializationContext context)
-                      throws JsonParseException {
-                    String type = json.getAsJsonObject().get(MyBase.TYPE_ACCESS).getAsString();
-                    return context.deserialize(json, SubTypes.valueOf(type).getSubclass());
-                  }
-                })
+                (JsonDeserializer<MyBase>)
+                    (json1, pojoType, context) -> {
+                      String type = json1.getAsJsonObject().get(MyBase.TYPE_ACCESS).getAsString();
+
+                      return context.deserialize(json1, SubTypes.valueOf(type).getSubclass());
+                    })
             .create();
     SubType1 target = (SubType1) gson.fromJson(json, MyBase.class);
     assertThat(target.field1).isEqualTo("abc");
@@ -170,15 +167,7 @@ public class CustomDeserializerTest {
     Gson gson =
         new GsonBuilder()
             .registerTypeAdapter(
-                Base.class,
-                new JsonDeserializer<Base>() {
-                  @Override
-                  public Base deserialize(
-                      JsonElement json, Type typeOfT, JsonDeserializationContext context)
-                      throws JsonParseException {
-                    return null;
-                  }
-                })
+                Base.class, (JsonDeserializer<Base>) (json, typeOfT, context) -> null)
             .create();
     String json = "{baseName:'Base',subName:'SubRevised'}";
     Base target = gson.fromJson(json, Base.class);
@@ -190,15 +179,7 @@ public class CustomDeserializerTest {
     Gson gson =
         new GsonBuilder()
             .registerTypeAdapter(
-                Base.class,
-                new JsonDeserializer<Base>() {
-                  @Override
-                  public Base deserialize(
-                      JsonElement json, Type typeOfT, JsonDeserializationContext context)
-                      throws JsonParseException {
-                    return null;
-                  }
-                })
+                Base.class, (JsonDeserializer<Base>) (json, typeOfT, context) -> null)
             .create();
     String json = "{base:{baseName:'Base',subName:'SubRevised'}}";
     ClassWithBaseField target = gson.fromJson(json, ClassWithBaseField.class);
@@ -210,15 +191,7 @@ public class CustomDeserializerTest {
     Gson gson =
         new GsonBuilder()
             .registerTypeAdapter(
-                Base.class,
-                new JsonDeserializer<Base>() {
-                  @Override
-                  public Base deserialize(
-                      JsonElement json, Type typeOfT, JsonDeserializationContext context)
-                      throws JsonParseException {
-                    return null;
-                  }
-                })
+                Base.class, (JsonDeserializer<Base>) (json, typeOfT, context) -> null)
             .create();
     String json = "[{baseName:'Base'},{baseName:'Base'}]";
     Base[] target = gson.fromJson(json, Base[].class);
@@ -231,15 +204,7 @@ public class CustomDeserializerTest {
     Gson gson =
         new GsonBuilder()
             .registerTypeAdapter(
-                Base.class,
-                new JsonDeserializer<Base>() {
-                  @Override
-                  public Base deserialize(
-                      JsonElement json, Type typeOfT, JsonDeserializationContext context)
-                      throws JsonParseException {
-                    return null;
-                  }
-                })
+                Base.class, (JsonDeserializer<Base>) (json, typeOfT, context) -> null)
             .create();
     String json = "{bases:[{baseName:'Base'},{baseName:'Base'}]}";
     ClassWithBaseArray target = gson.fromJson(json, ClassWithBaseArray.class);

--- a/gson/src/test/java/com/google/gson/functional/CustomSerializerTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CustomSerializerTest.java
@@ -23,7 +23,6 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import com.google.gson.common.TestTypes.Base;
 import com.google.gson.common.TestTypes.BaseSerializer;
@@ -31,7 +30,6 @@ import com.google.gson.common.TestTypes.ClassWithBaseArrayField;
 import com.google.gson.common.TestTypes.ClassWithBaseField;
 import com.google.gson.common.TestTypes.Sub;
 import com.google.gson.common.TestTypes.SubSerializer;
-import java.lang.reflect.Type;
 import org.junit.Test;
 
 /**
@@ -98,14 +96,7 @@ public class CustomSerializerTest {
     Gson gson =
         new GsonBuilder()
             .registerTypeAdapter(
-                Base.class,
-                new JsonSerializer<Base>() {
-                  @Override
-                  public JsonElement serialize(
-                      Base src, Type typeOfSrc, JsonSerializationContext context) {
-                    return null;
-                  }
-                })
+                Base.class, (JsonSerializer<Base>) (src, typeOfSrc, context) -> null)
             .create();
     JsonElement json = gson.toJsonTree(new Base());
     assertThat(json.isJsonNull()).isTrue();

--- a/gson/src/test/java/com/google/gson/functional/CustomTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CustomTypeAdaptersTest.java
@@ -63,18 +63,13 @@ public class CustomTypeAdaptersTest {
         builder
             .registerTypeAdapter(
                 ClassWithCustomTypeConverter.class,
-                new JsonSerializer<ClassWithCustomTypeConverter>() {
-                  @Override
-                  public JsonElement serialize(
-                      ClassWithCustomTypeConverter src,
-                      Type typeOfSrc,
-                      JsonSerializationContext context) {
-                    JsonObject json = new JsonObject();
-                    json.addProperty("bag", 5);
-                    json.addProperty("value", 25);
-                    return json;
-                  }
-                })
+                (JsonSerializer<ClassWithCustomTypeConverter>)
+                    (src, typeOfSrc, context) -> {
+                      JsonObject json = new JsonObject();
+                      json.addProperty("bag", 5);
+                      json.addProperty("value", 25);
+                      return json;
+                    })
             .create();
     ClassWithCustomTypeConverter target = new ClassWithCustomTypeConverter();
     assertThat(gson.toJson(target)).isEqualTo("{\"bag\":5,\"value\":25}");
@@ -86,16 +81,13 @@ public class CustomTypeAdaptersTest {
         new GsonBuilder()
             .registerTypeAdapter(
                 ClassWithCustomTypeConverter.class,
-                new JsonDeserializer<ClassWithCustomTypeConverter>() {
-                  @Override
-                  public ClassWithCustomTypeConverter deserialize(
-                      JsonElement json, Type typeOfT, JsonDeserializationContext context) {
-                    JsonObject jsonObject = json.getAsJsonObject();
-                    int value = jsonObject.get("bag").getAsInt();
-                    return new ClassWithCustomTypeConverter(
-                        new BagOfPrimitives(value, value, false, ""), value);
-                  }
-                })
+                (JsonDeserializer<ClassWithCustomTypeConverter>)
+                    (json, typeOfT, context) -> {
+                      JsonObject jsonObject = json.getAsJsonObject();
+                      int value = jsonObject.get("bag").getAsInt();
+                      return new ClassWithCustomTypeConverter(
+                          new BagOfPrimitives(value, value, false, ""), value);
+                    })
             .create();
     String json = "{\"bag\":5,\"value\":25}";
     ClassWithCustomTypeConverter target = gson.fromJson(json, ClassWithCustomTypeConverter.class);
@@ -133,13 +125,7 @@ public class CustomTypeAdaptersTest {
         new GsonBuilder()
             .registerTypeAdapter(
                 BagOfPrimitives.class,
-                new JsonSerializer<BagOfPrimitives>() {
-                  @Override
-                  public JsonElement serialize(
-                      BagOfPrimitives src, Type typeOfSrc, JsonSerializationContext context) {
-                    return new JsonPrimitive(6);
-                  }
-                })
+                (JsonSerializer<BagOfPrimitives>) (src, typeOfSrc, context) -> new JsonPrimitive(6))
             .create();
     ClassWithCustomTypeConverter target = new ClassWithCustomTypeConverter();
     assertThat(gson.toJson(target)).isEqualTo("{\"bag\":6,\"value\":10}");
@@ -151,15 +137,11 @@ public class CustomTypeAdaptersTest {
         new GsonBuilder()
             .registerTypeAdapter(
                 BagOfPrimitives.class,
-                new JsonDeserializer<BagOfPrimitives>() {
-                  @Override
-                  public BagOfPrimitives deserialize(
-                      JsonElement json, Type typeOfT, JsonDeserializationContext context)
-                      throws JsonParseException {
-                    int value = json.getAsInt();
-                    return new BagOfPrimitives(value, value, false, "");
-                  }
-                })
+                (JsonDeserializer<BagOfPrimitives>)
+                    (json, typeOfT, context) -> {
+                      int value = json.getAsInt();
+                      return new BagOfPrimitives(value, value, false, "");
+                    })
             .create();
     String json = "{\"bag\":7,\"value\":25}";
     ClassWithCustomTypeConverter target = gson.fromJson(json, ClassWithCustomTypeConverter.class);
@@ -172,15 +154,12 @@ public class CustomTypeAdaptersTest {
         new GsonBuilder()
             .registerTypeAdapter(
                 Base.class,
-                new JsonSerializer<Base>() {
-                  @Override
-                  public JsonElement serialize(
-                      Base src, Type typeOfSrc, JsonSerializationContext context) {
-                    JsonObject json = new JsonObject();
-                    json.addProperty("value", src.baseValue);
-                    return json;
-                  }
-                })
+                (JsonSerializer<Base>)
+                    (src, typeOfSrc, context) -> {
+                      JsonObject json = new JsonObject();
+                      json.addProperty("value", src.baseValue);
+                      return json;
+                    })
             .create();
     Base b = new Base();
     String json = gson.toJson(b);
@@ -196,15 +175,12 @@ public class CustomTypeAdaptersTest {
         new GsonBuilder()
             .registerTypeAdapter(
                 Base.class,
-                new JsonSerializer<Base>() {
-                  @Override
-                  public JsonElement serialize(
-                      Base src, Type typeOfSrc, JsonSerializationContext context) {
-                    JsonObject json = new JsonObject();
-                    json.addProperty("value", src.baseValue);
-                    return json;
-                  }
-                })
+                (JsonSerializer<Base>)
+                    (src, typeOfSrc, context) -> {
+                      JsonObject json = new JsonObject();
+                      json.addProperty("value", src.baseValue);
+                      return json;
+                    })
             .create();
     Base b = new Base();
     String json = gson.toJson(b);
@@ -260,13 +236,7 @@ public class CustomTypeAdaptersTest {
     Gson gson =
         new GsonBuilder()
             .registerTypeAdapter(
-                boolean.class,
-                new JsonSerializer<Boolean>() {
-                  @Override
-                  public JsonElement serialize(Boolean s, Type t, JsonSerializationContext c) {
-                    return new JsonPrimitive(s ? 1 : 0);
-                  }
-                })
+                boolean.class, (JsonSerializer<Boolean>) (s, t, c) -> new JsonPrimitive(s ? 1 : 0))
             .create();
     assertThat(gson.toJson(true, boolean.class)).isEqualTo("1");
     assertThat(gson.toJson(true, Boolean.class)).isEqualTo("true");
@@ -278,13 +248,7 @@ public class CustomTypeAdaptersTest {
         new GsonBuilder()
             .registerTypeAdapter(
                 boolean.class,
-                new JsonDeserializer<Boolean>() {
-                  @Override
-                  public Boolean deserialize(
-                      JsonElement json, Type t, JsonDeserializationContext context) {
-                    return json.getAsInt() != 0;
-                  }
-                })
+                (JsonDeserializer<Boolean>) (json, t, context) -> json.getAsInt() != 0)
             .create();
     assertThat(gson.fromJson("1", boolean.class)).isEqualTo(Boolean.TRUE);
     assertThat(gson.fromJson("true", Boolean.class)).isEqualTo(Boolean.TRUE);
@@ -296,17 +260,14 @@ public class CustomTypeAdaptersTest {
         new GsonBuilder()
             .registerTypeAdapter(
                 byte[].class,
-                new JsonSerializer<byte[]>() {
-                  @Override
-                  public JsonElement serialize(
-                      byte[] src, Type typeOfSrc, JsonSerializationContext context) {
-                    StringBuilder sb = new StringBuilder(src.length);
-                    for (byte b : src) {
-                      sb.append(b);
-                    }
-                    return new JsonPrimitive(sb.toString());
-                  }
-                })
+                (JsonSerializer<byte[]>)
+                    (src, typeOfSrc, context) -> {
+                      StringBuilder sb = new StringBuilder(src.length);
+                      for (byte b : src) {
+                        sb.append(b);
+                      }
+                      return new JsonPrimitive(sb.toString());
+                    })
             .create();
     byte[] data = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     String json = gson.toJson(data);
@@ -319,19 +280,15 @@ public class CustomTypeAdaptersTest {
         new GsonBuilder()
             .registerTypeAdapter(
                 byte[].class,
-                new JsonDeserializer<byte[]>() {
-                  @Override
-                  public byte[] deserialize(
-                      JsonElement json, Type typeOfT, JsonDeserializationContext context)
-                      throws JsonParseException {
-                    String str = json.getAsString();
-                    byte[] data = new byte[str.length()];
-                    for (int i = 0; i < data.length; ++i) {
-                      data[i] = Byte.parseByte("" + str.charAt(i));
-                    }
-                    return data;
-                  }
-                });
+                (JsonDeserializer<byte[]>)
+                    (json, typeOfT, context) -> {
+                      String str = json.getAsString();
+                      byte[] data = new byte[str.length()];
+                      for (int i = 0; i < data.length; ++i) {
+                        data[i] = Byte.parseByte("" + str.charAt(i));
+                      }
+                      return data;
+                    });
     Gson gson = gsonBuilder.create();
     String json = "'0123456789'";
     byte[] actual = gson.fromJson(json, byte[].class);

--- a/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertThrows;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
@@ -608,14 +607,7 @@ public class DefaultTypeAdaptersTest {
             .setDateFormat(pattern)
             .registerTypeAdapter(
                 Date.class,
-                new JsonDeserializer<Date>() {
-                  @Override
-                  public Date deserialize(
-                      JsonElement json, Type typeOfT, JsonDeserializationContext context)
-                      throws JsonParseException {
-                    return new Date(1315806903103L);
-                  }
-                })
+                (JsonDeserializer<Date>) (json, typeOfT, context) -> new Date(1315806903103L))
             .create();
 
     Date now = new Date(1315806903103L);

--- a/gson/src/test/java/com/google/gson/functional/InstanceCreatorTest.java
+++ b/gson/src/test/java/com/google/gson/functional/InstanceCreatorTest.java
@@ -44,14 +44,7 @@ public class InstanceCreatorTest {
   public void testInstanceCreatorReturnsBaseType() {
     Gson gson =
         new GsonBuilder()
-            .registerTypeAdapter(
-                Base.class,
-                new InstanceCreator<Base>() {
-                  @Override
-                  public Base createInstance(Type type) {
-                    return new Base();
-                  }
-                })
+            .registerTypeAdapter(Base.class, (InstanceCreator<Base>) type -> new Base())
             .create();
     String json = "{baseName:'BaseRevised',subName:'Sub'}";
     Base base = gson.fromJson(json, Base.class);
@@ -62,14 +55,7 @@ public class InstanceCreatorTest {
   public void testInstanceCreatorReturnsSubTypeForTopLevelObject() {
     Gson gson =
         new GsonBuilder()
-            .registerTypeAdapter(
-                Base.class,
-                new InstanceCreator<Base>() {
-                  @Override
-                  public Base createInstance(Type type) {
-                    return new Sub();
-                  }
-                })
+            .registerTypeAdapter(Base.class, (InstanceCreator<Base>) type -> new Sub())
             .create();
 
     String json = "{baseName:'Base',subName:'SubRevised'}";
@@ -85,14 +71,7 @@ public class InstanceCreatorTest {
   public void testInstanceCreatorReturnsSubTypeForField() {
     Gson gson =
         new GsonBuilder()
-            .registerTypeAdapter(
-                Base.class,
-                new InstanceCreator<Base>() {
-                  @Override
-                  public Base createInstance(Type type) {
-                    return new Sub();
-                  }
-                })
+            .registerTypeAdapter(Base.class, (InstanceCreator<Base>) type -> new Sub())
             .create();
     String json = "{base:{baseName:'Base',subName:'SubRevised'}}";
     ClassWithBaseField target = gson.fromJson(json, ClassWithBaseField.class);
@@ -105,13 +84,7 @@ public class InstanceCreatorTest {
   public void testInstanceCreatorForCollectionType() {
     @SuppressWarnings("serial")
     class SubArrayList<T> extends ArrayList<T> {}
-    InstanceCreator<List<String>> listCreator =
-        new InstanceCreator<>() {
-          @Override
-          public List<String> createInstance(Type type) {
-            return new SubArrayList<>();
-          }
-        };
+    InstanceCreator<List<String>> listCreator = type -> new SubArrayList<>();
     Type listOfStringType = new TypeToken<List<String>>() {}.getType();
     Gson gson = new GsonBuilder().registerTypeAdapter(listOfStringType, listCreator).create();
     List<String> list = gson.fromJson("[\"a\"]", listOfStringType);
@@ -123,13 +96,7 @@ public class InstanceCreatorTest {
   public void testInstanceCreatorForParametrizedType() {
     @SuppressWarnings("serial")
     class SubTreeSet<T> extends TreeSet<T> {}
-    InstanceCreator<SortedSet<?>> sortedSetCreator =
-        new InstanceCreator<>() {
-          @Override
-          public SortedSet<?> createInstance(Type type) {
-            return new SubTreeSet<>();
-          }
-        };
+    InstanceCreator<SortedSet<?>> sortedSetCreator = type -> new SubTreeSet<>();
     Gson gson = new GsonBuilder().registerTypeAdapter(SortedSet.class, sortedSetCreator).create();
 
     Type sortedSetType = new TypeToken<SortedSet<String>>() {}.getType();

--- a/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java
@@ -26,7 +26,6 @@ import com.google.gson.InstanceCreator;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
-import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
@@ -98,12 +97,7 @@ public final class JsonAdapterAnnotationOnClassesTest {
   @Test
   public void testRegisteredSerializerOverridesJsonAdapter() {
     JsonSerializer<A> serializer =
-        new JsonSerializer<>() {
-          @Override
-          public JsonElement serialize(A src, Type typeOfSrc, JsonSerializationContext context) {
-            return new JsonPrimitive("registeredSerializer");
-          }
-        };
+        (src, typeOfSrc, context) -> new JsonPrimitive("registeredSerializer");
     Gson gson = new GsonBuilder().registerTypeAdapter(A.class, serializer).create();
     String json = gson.toJson(new A("abcd"));
     assertThat(json).isEqualTo("\"registeredSerializer\"");
@@ -114,14 +108,7 @@ public final class JsonAdapterAnnotationOnClassesTest {
   /** The deserializer overrides Json adapter, but for serializer the jsonAdapter is used. */
   @Test
   public void testRegisteredDeserializerOverridesJsonAdapter() {
-    JsonDeserializer<A> deserializer =
-        new JsonDeserializer<>() {
-          @Override
-          public A deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
-              throws JsonParseException {
-            return new A("registeredDeserializer");
-          }
-        };
+    JsonDeserializer<A> deserializer = (json, typeOfT, context) -> new A("registeredDeserializer");
     Gson gson = new GsonBuilder().registerTypeAdapter(A.class, deserializer).create();
     String json = gson.toJson(new A("abcd"));
     assertThat(json).isEqualTo("\"jsonAdapter\"");

--- a/gson/src/test/java/com/google/gson/functional/MapTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MapTest.java
@@ -27,7 +27,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.common.TestTypes;
@@ -311,14 +310,7 @@ public class MapTest {
   public void testMapSubclassDeserialization() {
     Gson gson =
         new GsonBuilder()
-            .registerTypeAdapter(
-                MyMap.class,
-                new InstanceCreator<MyMap>() {
-                  @Override
-                  public MyMap createInstance(Type type) {
-                    return new MyMap();
-                  }
-                })
+            .registerTypeAdapter(MyMap.class, (InstanceCreator<MyMap>) type -> new MyMap())
             .create();
     String json = "{\"a\":1,\"b\":2}";
     MyMap map = gson.fromJson(json, MyMap.class);
@@ -334,17 +326,14 @@ public class MapTest {
         new GsonBuilder()
             .registerTypeAdapter(
                 type,
-                new JsonSerializer<Map<String, Long>>() {
-                  @Override
-                  public JsonElement serialize(
-                      Map<String, Long> src, Type typeOfSrc, JsonSerializationContext context) {
-                    JsonArray array = new JsonArray();
-                    for (long value : src.values()) {
-                      array.add(new JsonPrimitive(value));
-                    }
-                    return array;
-                  }
-                })
+                (JsonSerializer<Map<String, Long>>)
+                    (src, typeOfSrc, context) -> {
+                      JsonArray array = new JsonArray();
+                      for (long value : src.values()) {
+                        array.add(new JsonPrimitive(value));
+                      }
+                      return array;
+                    })
             .create();
 
     Map<String, Long> src = new LinkedHashMap<>();
@@ -526,13 +515,7 @@ public class MapTest {
         "{\"bases\":{\"Test\":" + baseTypeJson + "},\"subs\":{\"Test\":" + subTypeJson + "}}";
 
     JsonSerializer<TestTypes.Base> baseTypeAdapter =
-        new JsonSerializer<>() {
-          @Override
-          public JsonElement serialize(
-              TestTypes.Base src, Type typeOfSrc, JsonSerializationContext context) {
-            return baseTypeJsonElement;
-          }
-        };
+        (src, typeOfSrc, context) -> baseTypeJsonElement;
 
     Gson gson =
         new GsonBuilder()

--- a/gson/src/test/java/com/google/gson/functional/NullObjectAndFieldTest.java
+++ b/gson/src/test/java/com/google/gson/functional/NullObjectAndFieldTest.java
@@ -20,7 +20,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
@@ -229,13 +228,8 @@ public class NullObjectAndFieldTest {
         new GsonBuilder()
             .registerTypeAdapter(
                 ObjectWithField.class,
-                new JsonSerializer<ObjectWithField>() {
-                  @Override
-                  public JsonElement serialize(
-                      ObjectWithField src, Type typeOfSrc, JsonSerializationContext context) {
-                    return context.serialize(null);
-                  }
-                })
+                (JsonSerializer<ObjectWithField>)
+                    (src, typeOfSrc, context) -> context.serialize(null))
             .create();
     ObjectWithField target = new ObjectWithField();
     target.value = "value1";
@@ -249,13 +243,8 @@ public class NullObjectAndFieldTest {
         new GsonBuilder()
             .registerTypeAdapter(
                 ObjectWithField.class,
-                new JsonDeserializer<ObjectWithField>() {
-                  @Override
-                  public ObjectWithField deserialize(
-                      JsonElement json, Type type, JsonDeserializationContext context) {
-                    return context.deserialize(null, type);
-                  }
-                })
+                (JsonDeserializer<ObjectWithField>)
+                    (json, type, context) -> context.deserialize(null, type))
             .create();
     String json = "{value:'value1'}";
     ObjectWithField target = gson.fromJson(json, ObjectWithField.class);

--- a/gson/src/test/java/com/google/gson/functional/ObjectTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ObjectTest.java
@@ -24,14 +24,11 @@ import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.InstanceCreator;
-import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonIOException;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.common.TestTypes.ArrayOfObjects;
@@ -388,13 +385,8 @@ public class ObjectTest {
         new GsonBuilder()
             .registerTypeHierarchyAdapter(
                 ClassWithNoFields.class,
-                new JsonSerializer<ClassWithNoFields>() {
-                  @Override
-                  public JsonElement serialize(
-                      ClassWithNoFields src, Type typeOfSrc, JsonSerializationContext context) {
-                    return new JsonPrimitive("custom-value");
-                  }
-                })
+                (JsonSerializer<ClassWithNoFields>)
+                    (src, typeOfSrc, context) -> new JsonPrimitive("custom-value"))
             .create();
 
     assertThat(
@@ -409,13 +401,8 @@ public class ObjectTest {
         new GsonBuilder()
             .registerTypeAdapter(
                 Local.class,
-                new JsonSerializer<Local>() {
-                  @Override
-                  public JsonElement serialize(
-                      Local src, Type typeOfSrc, JsonSerializationContext context) {
-                    return new JsonPrimitive("custom-value");
-                  }
-                })
+                (JsonSerializer<Local>)
+                    (src, typeOfSrc, context) -> new JsonPrimitive("custom-value"))
             .create();
     assertThat(gson.toJson(new Local())).isEqualTo("\"custom-value\"");
   }
@@ -426,13 +413,8 @@ public class ObjectTest {
         new GsonBuilder()
             .registerTypeHierarchyAdapter(
                 ClassWithNoFields.class,
-                new JsonDeserializer<ClassWithNoFields>() {
-                  @Override
-                  public ClassWithNoFields deserialize(
-                      JsonElement json, Type typeOfT, JsonDeserializationContext context) {
-                    return new ClassWithNoFields();
-                  }
-                })
+                (JsonDeserializer<ClassWithNoFields>)
+                    (json, typeOfT, context) -> new ClassWithNoFields())
             .create();
 
     assertThat(gson.fromJson("{}", ClassWithNoFields.class)).isNotNull();
@@ -445,13 +427,10 @@ public class ObjectTest {
         new GsonBuilder()
             .registerTypeAdapter(
                 Local.class,
-                new JsonDeserializer<Local>() {
-                  @Override
-                  public Local deserialize(
-                      JsonElement json, Type typeOfT, JsonDeserializationContext context) {
-                    throw new AssertionError("should not be called");
-                  }
-                })
+                (JsonDeserializer<Local>)
+                    (json, typeOfT, context) -> {
+                      throw new AssertionError("should not be called");
+                    })
             .create();
     // Custom deserializer is ignored
     assertThat(gson.fromJson("{}", Local.class)).isNull();

--- a/gson/src/test/java/com/google/gson/functional/TypeAdapterRuntimeTypeWrapperTest.java
+++ b/gson/src/test/java/com/google/gson/functional/TypeAdapterRuntimeTypeWrapperTest.java
@@ -24,7 +24,6 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
@@ -63,13 +62,7 @@ public class TypeAdapterRuntimeTypeWrapperTest {
         new GsonBuilder()
             .registerTypeAdapter(
                 Base.class,
-                new JsonSerializer<Base>() {
-                  @Override
-                  public JsonElement serialize(
-                      Base src, Type typeOfSrc, JsonSerializationContext context) {
-                    return new JsonPrimitive("serializer");
-                  }
-                })
+                (JsonSerializer<Base>) (src, typeOfSrc, context) -> new JsonPrimitive("serializer"))
             .create();
 
     String json = gson.toJson(new Container());
@@ -148,13 +141,8 @@ public class TypeAdapterRuntimeTypeWrapperTest {
             // Register JsonSerializer as delegate
             .registerTypeAdapter(
                 Base.class,
-                new JsonSerializer<Base>() {
-                  @Override
-                  public JsonElement serialize(
-                      Base src, Type typeOfSrc, JsonSerializationContext context) {
-                    return new JsonPrimitive("custom delegate");
-                  }
-                })
+                (JsonSerializer<Base>)
+                    (src, typeOfSrc, context) -> new JsonPrimitive("custom delegate"))
             .registerTypeAdapter(Base.class, new Deserializer())
             .create();
 
@@ -175,22 +163,13 @@ public class TypeAdapterRuntimeTypeWrapperTest {
         new GsonBuilder()
             .registerTypeAdapter(
                 Subclass.class,
-                new JsonDeserializer<Subclass>() {
-                  @Override
-                  public Subclass deserialize(
-                      JsonElement json, Type typeOfT, JsonDeserializationContext context) {
-                    throw new AssertionError("not needed for this test");
-                  }
-                })
+                (JsonDeserializer<Subclass>)
+                    (json, typeOfT, context) -> {
+                      throw new AssertionError("not needed for this test");
+                    })
             .registerTypeAdapter(
                 Base.class,
-                new JsonSerializer<Base>() {
-                  @Override
-                  public JsonElement serialize(
-                      Base src, Type typeOfSrc, JsonSerializationContext context) {
-                    return new JsonPrimitive("base");
-                  }
-                })
+                (JsonSerializer<Base>) (src, typeOfSrc, context) -> new JsonPrimitive("base"))
             .create();
 
     String json = gson.toJson(new Container());


### PR DESCRIPTION
This change will reduce the amount of code in the tests and simplify it in places where the method implementation is too small, such as:
```
        new FieldNamingStrategy() {
          @Override
          public String translateName(Field f) {
            return "test";
          }
        }
```
can be replaced by:
`f -> “test”`
