### PR TITLE
Use JsonIOException for unchecked exceptions instead of RuntimeException in ConstructorConstructor

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
+++ b/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
@@ -270,15 +270,13 @@ public final class ConstructorConstructor {
       // Note: InstantiationException should be impossible because check at start of method made
       // sure that class is not abstract
       catch (InstantiationException e) {
-        throw new RuntimeException(
+        throw new JsonIOException(
             "Failed to invoke constructor '"
                 + ReflectionHelper.constructorToString(constructor)
                 + "' with no args",
             e);
       } catch (InvocationTargetException e) {
-        // TODO: don't wrap if cause is unchecked?
-        // TODO: JsonParseException ?
-        throw new RuntimeException(
+        throw new JsonIOException(
             "Failed to invoke constructor '"
                 + ReflectionHelper.constructorToString(constructor)
                 + "' with no args",

--- a/gson/src/test/java/com/google/gson/functional/ObjectTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ObjectTest.java
@@ -727,10 +727,9 @@ public class ObjectTest {
 
   @Test
   public void testThrowingDefaultConstructor() {
-    // TODO: Adjust this once Gson throws more specific exception type
     var e =
         assertThrows(
-            RuntimeException.class, () -> gson.fromJson("{}", ClassWithThrowingConstructor.class));
+            JsonIOException.class, () -> gson.fromJson("{}", ClassWithThrowingConstructor.class));
     assertThat(e)
         .hasMessageThat()
         .isEqualTo(


### PR DESCRIPTION
In the `newDefaultConstructor` method in `ConstructorConstructor` we throw `RuntimeException` when _Failed to invoke constructor_. However, as noted in the TODO, we should throw something specific like `JsonIOException` when an unchecked exception occurs. In this method we already throw `JsonIOException` on similar exceptions. I believe this change will give more readability, but more importantly, more semantic precision