### PR TITLE
Improve Maven plugin configuration

### DIFF
--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -257,6 +257,7 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <version>3.3.1</version>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,7 @@
             <compilerArgs>
               <!-- Args related to Error Prone, see: https://errorprone.info/docs/installation#maven -->
               <arg>-XDcompilePolicy=simple</arg>
+              <arg>--should-stop=ifError=FLOW</arg>
               <arg>-Xplugin:ErrorProne
                 -XepExcludedPaths:.*/generated-test-sources/protobuf/.*
                 -Xep:NotJavadoc:OFF <!-- Triggered by local class. -->
@@ -403,6 +404,7 @@
           </configuration>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
           <version>3.1.0</version>
           <executions>

--- a/test-shrinker/pom.xml
+++ b/test-shrinker/pom.xml
@@ -198,7 +198,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.5.1</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
### Description
Consists of multiple small changes, but maybe not worth it having separate pull requests for this:

- Explicitly specifies `org.apache.maven.plugins` group ID, instead of relying on it being used implicitly
- Removes redundant `maven-failsafe-plugin` version in `test-shrinker` module; this is inherited from the `gson-parent` POM
- Adds required Error Prone compiler arg, see https://github.com/google/error-prone/releases/tag/v2.34.0 and current version of https://errorprone.info/docs/installation#maven, related to #2773
It looks like Error Prone was supposed to enforce usage of `--should-stop=ifError=FLOW` in the latest version, but for usage with Maven this check was not performed, see https://github.com/google/error-prone/pull/4644. So would probably cause a build failure for the next version.
