### PR TITLE
Add better support for multiple top-level values

### DIFF
--- a/gson/src/test/java/com/google/gson/GsonTest.java
+++ b/gson/src/test/java/com/google/gson/GsonTest.java
@@ -411,7 +411,11 @@ public final class GsonTest {
 
     // Additional top-level value
     IllegalStateException e = assertThrows(IllegalStateException.class, () -> jsonWriter.value(1));
-    assertThat(e).hasMessageThat().isEqualTo("JSON must have only one top-level value.");
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "Multiple top-level values support has not been enabled, use"
+                + " `JsonWriter.setTopLevelSeparator(String)`");
 
     jsonWriter.close();
     assertThat(writer.toString()).isEqualTo("{\"\\u003ctest2\":true}");

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeReaderTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeReaderTest.java
@@ -195,6 +195,8 @@ public class JsonTreeReaderTest {
             "isLenient()",
             "setStrictness(com.google.gson.Strictness)",
             "getStrictness()",
+            "setMultiTopLevelValuesAllowed(boolean)",
+            "isMultiTopLevelValuesAllowed()",
             "setNestingLimit(int)",
             "getNestingLimit()");
     MoreAsserts.assertOverridesMethods(JsonReader.class, JsonTreeReader.class, ignoredMethods);

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
@@ -272,6 +272,8 @@ public final class JsonTreeWriterTest {
             "isLenient()",
             "setStrictness(com.google.gson.Strictness)",
             "getStrictness()",
+            "setTopLevelSeparator(java.lang.String)",
+            "getTopLevelSeparator()",
             "setIndent(java.lang.String)",
             "setHtmlSafe(boolean)",
             "isHtmlSafe()",


### PR DESCRIPTION
### Purpose
Add better support for reading and writing multiple top-level values

Resolves #2769
Related to #1733
Obsoletes #2779

### Description
Currently reading and writing multiple top-level JSON values is coupled with lenient mode. This might be undesired for users who normally want to use strict mode.
Having multiple top-level values is a common use case when streaming JSON values, see for example [JSON Lines](https://jsonlines.org/). But another problem is that `JsonWriter` currently concatenates multiple JSON values without any separating whitespace, and without any way to configure it.

Other JSON libraries seem to have dedicated classes or configuration for multiple top-level value support, e.g. [Jackson's `MappingIterator` and `SequenceWriter`](https://cowtowncoder.medium.com/line-delimited-json-with-jackson-69c9e4cb6c00) and [kotlinx-serialization's `DecodeSequenceMode.WHITESPACE_SEPARATED`](https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-json/kotlinx.serialization.json/-decode-sequence-mode/-w-h-i-t-e-s-p-a-c-e_-s-e-p-a-r-a-t-e-d/).
However, because Gson's `JsonReader` and `JsonWriter` already had (limited) functionality for multiple top-level values, I added new API to those classes instead of adding completely new classes.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [x] If necessary, new public API validates arguments, for example rejects `null`
- [x] New public API has Javadoc
    - [x] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [x] If necessary, new unit tests have been added  
  - [x] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [x] No JUnit 3 features are used (such as extending class `TestCase`)
  - [x] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
