### PR TITLE
Fix collection tests for latest guava-testlib update

### DIFF
--- a/gson/src/test/java/com/google/gson/JsonArrayAsListSuiteTest.java
+++ b/gson/src/test/java/com/google/gson/JsonArrayAsListSuiteTest.java
@@ -42,10 +42,14 @@ public class JsonArrayAsListSuiteTest {
     @Override
     public List<JsonElement> create(Object... elements) {
       JsonArray array = new JsonArray();
+      // This is not completely accurate: Because there is no way to directly construct JsonArray or
+      // its List view with existing elements, this has to add the elements individually with
+      // `List#add`
+      var list = array.asList();
       for (Object element : elements) {
-        array.add((JsonElement) element);
+        list.add((JsonElement) element);
       }
-      return array.asList();
+      return list;
     }
   }
 
@@ -54,8 +58,6 @@ public class JsonArrayAsListSuiteTest {
     return ListTestSuiteBuilder.using(new ListGenerator())
         .withFeatures(
             CollectionSize.ANY,
-            // Note: There is current a Guava bug which causes 'null additions' to not be tested if
-            // 'null queries' is enabled, see https://github.com/google/guava/issues/7401
             CollectionFeature.ALLOWS_NULL_QUERIES,
             CollectionFeature.RESTRICTS_ELEMENTS, // List only allows JsonElement
             CollectionFeature.SUPPORTS_ADD,

--- a/gson/src/test/java/com/google/gson/JsonObjectAsMapSuiteTest.java
+++ b/gson/src/test/java/com/google/gson/JsonObjectAsMapSuiteTest.java
@@ -34,11 +34,15 @@ public class JsonObjectAsMapSuiteTest {
     @Override
     public Map<String, JsonElement> create(Object... elements) {
       JsonObject object = new JsonObject();
+      // This is not completely accurate: Because there is no way to directly construct JsonObject
+      // or its Map view with existing entries, this has to add the entries individually with
+      // `Map#put`
+      var map = object.asMap();
       for (Object element : elements) {
         var entry = (Entry<?, ?>) element;
-        object.add((String) entry.getKey(), (JsonElement) entry.getValue());
+        map.put((String) entry.getKey(), (JsonElement) entry.getValue());
       }
-      return object.asMap();
+      return map;
     }
 
     @SuppressWarnings("unchecked")
@@ -70,8 +74,6 @@ public class JsonObjectAsMapSuiteTest {
     return MapTestSuiteBuilder.using(new MapGenerator())
         .withFeatures(
             CollectionSize.ANY,
-            // Note: There is current a Guava bug which causes 'null additions' to not be tested if
-            // 'null queries' is enabled, see https://github.com/google/guava/issues/7401
             MapFeature.ALLOWS_ANY_NULL_QUERIES,
             MapFeature.RESTRICTS_KEYS, // Map only allows String keys
             MapFeature.RESTRICTS_VALUES, // Map only allows JsonElement values

--- a/gson/src/test/java/com/google/gson/internal/LinkedTreeMapSuiteTest.java
+++ b/gson/src/test/java/com/google/gson/internal/LinkedTreeMapSuiteTest.java
@@ -31,6 +31,8 @@ public class LinkedTreeMapSuiteTest {
 
     @Override
     protected Map<String, String> create(Entry<String, String>[] entries) {
+      // This is not completely accurate: Because LinkedTreeMap has no constructor which accepts
+      // existing entries, this has to add the entries individually with `Map#put`
       var map = new LinkedTreeMap<String, String>(allowNullValues);
       for (var entry : entries) {
         map.put(entry.getKey(), entry.getValue());
@@ -47,8 +49,6 @@ public class LinkedTreeMapSuiteTest {
         new ArrayList<Feature<?>>(
             List.of(
                 CollectionSize.ANY,
-                // Note: There is current a Guava bug which causes 'null additions' to not be tested
-                // if 'null queries' is enabled, see https://github.com/google/guava/issues/7401
                 MapFeature.ALLOWS_ANY_NULL_QUERIES,
                 MapFeature.RESTRICTS_KEYS, // Map only allows comparable keys
                 MapFeature.SUPPORTS_PUT,
@@ -74,7 +74,8 @@ public class LinkedTreeMapSuiteTest {
             .named("nullValues=false")
             .createTestSuite();
 
-    TestSuite testSuite = new TestSuite("LinkedTreeMap");
+    // Use qualified class name to make it easier to find this test class in the IDE
+    TestSuite testSuite = new TestSuite(LinkedTreeMapSuiteTest.class.getName());
     testSuite.addTest(nullValuesSuite);
     testSuite.addTest(nonNullValuesSuite);
 


### PR DESCRIPTION
### Purpose
Fixes build failure for #2784

**Important:** Targets the `dependabot/...` branch instead of `main`.

### Description
With the fix in the latest guava-testlib version (see https://github.com/google/guava/issues/7401) null support is now properly checked. But it expects that if a collection does not permit null, then creating it with null should fail as well, see guava-testlib's:
- `MapCreationTester.testCreateWithNullValueUnsupported()`
- `CollectionCreationTester.testCreateWithNull_unsupported()`

However, the previous implementation for the JsonArray and JsonObject test was using methods which implicitly converted null to JsonNull.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
