### PR TITLE
Allow registering adapters for `JsonElement` again

### DIFF
--- a/gson/src/test/java/com/google/gson/GsonBuilderTest.java
+++ b/gson/src/test/java/com/google/gson/GsonBuilderTest.java
@@ -28,6 +28,7 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.text.DateFormat;
 import java.util.Date;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -251,7 +252,10 @@ public class GsonBuilderTest {
   public void testRegisterTypeAdapterForObjectAndJsonElements() {
     String errorMessage = "Cannot override built-in adapter for ";
     Type[] types = {
-      Object.class, JsonElement.class, JsonArray.class,
+      Object.class,
+      // TODO: Registering adapter for JsonElement is allowed (for now) for backward compatibility,
+      //   see https://github.com/google/gson/issues/2787
+      // JsonElement.class, JsonArray.class,
     };
     GsonBuilder gsonBuilder = new GsonBuilder();
     for (Type type : types) {
@@ -263,6 +267,22 @@ public class GsonBuilderTest {
     }
   }
 
+  /**
+   * Verifies that (for now) registering adapter for {@link JsonElement} and subclasses is possible,
+   * but has no effect. See {@link #testRegisterTypeAdapterForObjectAndJsonElements()}.
+   */
+  @Test
+  public void testRegisterTypeAdapterForJsonElements() {
+    Gson gson = new GsonBuilder().registerTypeAdapter(JsonArray.class, NULL_TYPE_ADAPTER).create();
+    TypeAdapter<JsonArray> adapter = gson.getAdapter(JsonArray.class);
+    // Does not use registered adapter
+    assertThat(adapter).isNotSameInstanceAs(NULL_TYPE_ADAPTER);
+    assertThat(adapter.toJson(new JsonArray())).isEqualTo("[]");
+  }
+
+  @Ignore(
+      "Registering adapter for JsonElement is allowed (for now) for backward compatibility, see"
+          + " https://github.com/google/gson/issues/2787")
   @Test
   public void testRegisterTypeHierarchyAdapterJsonElements() {
     String errorMessage = "Cannot override built-in adapter for ";
@@ -280,6 +300,20 @@ public class GsonBuilderTest {
     }
     // But registering type hierarchy adapter for Object should be allowed
     gsonBuilder.registerTypeHierarchyAdapter(Object.class, NULL_TYPE_ADAPTER);
+  }
+
+  /**
+   * Verifies that (for now) registering hierarchy adapter for {@link JsonElement} and subclasses is
+   * possible, but has no effect. See {@link #testRegisterTypeHierarchyAdapterJsonElements()}.
+   */
+  @Test
+  public void testRegisterTypeHierarchyAdapterJsonElements_Allowed() {
+    Gson gson =
+        new GsonBuilder().registerTypeHierarchyAdapter(JsonArray.class, NULL_TYPE_ADAPTER).create();
+    TypeAdapter<JsonArray> adapter = gson.getAdapter(JsonArray.class);
+    // Does not use registered adapter
+    assertThat(adapter).isNotSameInstanceAs(NULL_TYPE_ADAPTER);
+    assertThat(adapter.toJson(new JsonArray())).isEqualTo("[]");
   }
 
   @Test


### PR DESCRIPTION
### Purpose
Fixes #2787

### Description
This is done for backward compatibility, however registering the adapter still has no effect because the built-in adapter has higher precedence (like it is the case for multiple years already).

The Javadoc for the GsonBuilder methods has not been adjusted, to discourage users from trying to register adapters for JsonElement.

Registering an adapter for `Object` is still not allowed, it is less likely there that users have done this _and_ have not noticed that the code has no effect for multiple years since unlike for `JsonElement` there might not be a canonical implementation for such an adapter, or at least the implementation wouldn't be as simple as for `JsonElement`.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [x] If necessary, new unit tests have been added  
  - [x] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [x] No JUnit 3 features are used (such as extending class `TestCase`)
  - [x] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
