### PR TITLE
Add adapters for Guava's immutable ccollections.

### DIFF
--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -145,9 +145,10 @@
                 Bundle-Vendor: Google Gson Project
                 Bundle-ContactAddress: ${project.parent.url}
 
-                # Optional dependency for JDK's sun.misc.Unsafe
+                # Optional dependencies for JDK's sun.misc.Unsafe and Guava's collections.
+                # Both are only accessed through reflection and the code works without them.
                 # https://bnd.bndtools.org/chapters/920-faq.html#remove-unwanted-imports-
-                Import-Package: sun.misc;resolution:=optional, *
+                Import-Package: sun.misc;resolution:=optional, com.google.common.collect;resolution:=optional, *
 
                 -removeheaders: Private-Package
 

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -1109,7 +1109,8 @@ public final class Gson {
    * @see #fromJson(String, TypeToken)
    */
   public <T> T fromJson(String json, Class<T> classOfT) throws JsonSyntaxException {
-    return fromJson(json, TypeToken.get(classOfT));
+    T object = fromJson(json, TypeToken.get(classOfT));
+    return Primitives.wrap(classOfT).cast(object);
   }
 
   /**
@@ -1200,7 +1201,8 @@ public final class Gson {
    */
   public <T> T fromJson(Reader json, Class<T> classOfT)
       throws JsonSyntaxException, JsonIOException {
-    return fromJson(json, TypeToken.get(classOfT));
+    T object = fromJson(json, TypeToken.get(classOfT));
+    return Primitives.wrap(classOfT).cast(object);
   }
 
   /**
@@ -1361,19 +1363,7 @@ public final class Gson {
       JsonToken unused = reader.peek();
       isEmpty = false;
       TypeAdapter<T> typeAdapter = getAdapter(typeOfT);
-      T object = typeAdapter.read(reader);
-      Class<?> expectedTypeWrapped = Primitives.wrap(typeOfT.getRawType());
-      if (object != null && !expectedTypeWrapped.isInstance(object)) {
-        throw new ClassCastException(
-            "Type adapter '"
-                + typeAdapter
-                + "' returned wrong type; requested "
-                + typeOfT.getRawType()
-                + " but got instance of "
-                + object.getClass()
-                + "\nVerify that the adapter was registered for the correct type.");
-      }
-      return object;
+      return typeAdapter.read(reader);
     } catch (EOFException e) {
       /*
        * For compatibility with JSON 1.5 and earlier, we return null for empty
@@ -1418,7 +1408,8 @@ public final class Gson {
    * @see #fromJson(JsonElement, TypeToken)
    */
   public <T> T fromJson(JsonElement json, Class<T> classOfT) throws JsonSyntaxException {
-    return fromJson(json, TypeToken.get(classOfT));
+    T object = fromJson(json, TypeToken.get(classOfT));
+    return Primitives.wrap(classOfT).cast(object);
   }
 
   /**

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -1580,9 +1580,9 @@ public final class Gson {
    */
   public static final ReflectionAccessFilter ALLOW_PROTO_REFLECTION =
       rawClass ->
-        MESSAGE_LITE_CLASS != null && MESSAGE_LITE_CLASS.isAssignableFrom(rawClass)
-            ? ReflectionAccessFilter.FilterResult.ALLOW
-            : ReflectionAccessFilter.FilterResult.INDECISIVE;
+          MESSAGE_LITE_CLASS != null && MESSAGE_LITE_CLASS.isAssignableFrom(rawClass)
+              ? ReflectionAccessFilter.FilterResult.ALLOW
+              : ReflectionAccessFilter.FilterResult.INDECISIVE;
 
   // end google3 patch
 }

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -1558,31 +1558,4 @@ public final class Gson {
       return false;
     }
   }
-
-  // begin google3 patch
-
-  private static final Class<?> MESSAGE_LITE_CLASS;
-
-  static {
-    Class<?> messageLiteClass = null;
-    try {
-      messageLiteClass = Class.forName("com.google.protobuf.MessageLite");
-    } catch (ClassNotFoundException e) {
-      // OK: not on the classpath
-    }
-    MESSAGE_LITE_CLASS = messageLiteClass;
-  }
-
-  /**
-   * Allows proto messages to be serialized via reflection on the private fields of their Java
-   * classes. This has historically been allowed by default, but the result is very ugly and
-   * fragile. New code should prefer alternatives such as {@code ProtoTypeAdapter}. See b/388285853.
-   */
-  public static final ReflectionAccessFilter ALLOW_PROTO_REFLECTION =
-      rawClass ->
-          MESSAGE_LITE_CLASS != null && MESSAGE_LITE_CLASS.isAssignableFrom(rawClass)
-              ? ReflectionAccessFilter.FilterResult.ALLOW
-              : ReflectionAccessFilter.FilterResult.INDECISIVE;
-
-  // end google3 patch
 }

--- a/gson/src/main/java/com/google/gson/internal/bind/GuavaTypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/GuavaTypeAdapters.java
@@ -364,8 +364,6 @@ public final class GuavaTypeAdapters {
             keyType = Object.class;
             valueType = Object.class;
           }
-          TypeAdapter<?> keyTypeAdapter = gson.getAdapter(TypeToken.get(keyType));
-          TypeAdapter<?> valueTypeAdapter = gson.getAdapter(TypeToken.get(valueType));
           TypeToken<?> mapKToCollectionOfV =
               TypeToken.getParameterized(
                   Map.class,

--- a/gson/src/main/java/com/google/gson/internal/bind/GuavaTypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/GuavaTypeAdapters.java
@@ -1,0 +1,432 @@
+/*
+ * Copyright (C) 2025 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson.internal.bind;
+
+import static java.util.Arrays.asList;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toList;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.gson.Gson;
+import com.google.gson.JsonIOException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.internal.$Gson$Types;
+import com.google.gson.internal.JsonReaderInternalAccess;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Defines {@link TypeAdapterFactory} instances for Guava's immutable collections and maps.
+ * Specifically, this defines adapters for {@code ImmutableList}, {@code ImmutableSet}, {@code
+ * ImmutableSortedSet}, {@code ImmutableMap}, {@code ImmutableSortedMap}, and {@code
+ * ImmutableBiMap}. Other immutable types may be added in the future.
+ *
+ * <p>The reason for having these adapters is that Gson's default way to build a collection or map
+ * is to instantiate an empty one and then add elements as they come in. That obviously can't work
+ * for immutable collections. Instead, we use their builders.
+ *
+ * <p>For {@code ImmutableSortedSet} and {@code ImmutableSortedMap}, the comparator is not included
+ * in the serialized JSON.
+ *
+ * <p>This class has no compile-time dependency on Guava. It uses reflection for everything.
+ * Although an optional dependency on Guava would probably work with the open-source build, Google's
+ * internal build system doesn't have a notion of optional dependencies.
+ */
+public final class GuavaTypeAdapters {
+  public static List<TypeAdapterFactory> factories() {
+    return asList(
+        new GuavaCollectionTypeAdapterFactory(),
+        new GuavaMapTypeAdapterFactory(),
+        new GuavaMultimapTypeAdapterFactory());
+  }
+
+  /** Shared parent class with reflective information for Guava collection and map types. */
+  private abstract static class GuavaType {
+    final Class<?> collectionClass;
+    final Class<?> builderClass;
+    final Method builderMethod;
+    final Method buildMethod;
+
+    GuavaType(String className, String builderMethodName) {
+      try {
+        this.collectionClass = Class.forName(className);
+      } catch (ClassNotFoundException e) {
+        throw new RuntimeException(e);
+      }
+      this.builderMethod = getMethod(collectionClass, builderMethodName);
+      this.builderClass = builderMethod.getReturnType();
+      this.buildMethod = getMethod(builderClass, "build");
+    }
+
+    Object createBuilder() {
+      return invoke(builderMethod, null);
+    }
+
+    Object build(Object builder) {
+      return invoke(buildMethod, builder);
+    }
+  }
+
+  private static final class GuavaCollectionType extends GuavaType {
+    private final Method addMethod;
+
+    GuavaCollectionType(String className, String builderMethodName) {
+      super(className, builderMethodName);
+      this.addMethod = getMethod(builderClass, "add", Object.class);
+    }
+
+    void add(Object builder, Object element) {
+      invoke(addMethod, builder, element);
+    }
+  }
+
+  private static class GuavaMapType extends GuavaType {
+    private final Method putMethod;
+
+    GuavaMapType(String className, String builderMethodName) {
+      super(className, builderMethodName);
+      this.putMethod = getMethod(builderClass, "put", Object.class, Object.class);
+    }
+
+    void put(Object builder, Object key, Object value) {
+      invoke(putMethod, builder, key, value);
+    }
+  }
+
+  private static final class GuavaMultimapType extends GuavaMapType {
+    private final Method asMapMethod;
+    private final Method putAllMethod;
+
+    GuavaMultimapType(String className, String builderMethodName) {
+      super(className, builderMethodName);
+      this.asMapMethod = getMethod(collectionClass, "asMap");
+      this.putAllMethod = getMethod(builderClass, "putAll", Object.class, Iterable.class);
+    }
+
+    Map<?, ?> asMap(Object multimap) {
+      return (Map<?, ?>) invoke(asMapMethod, multimap);
+    }
+
+    void putAll(Object builder, Object key, Iterable<?> values) {
+      invoke(putAllMethod, builder, key, values);
+    }
+  }
+
+  /**
+   * A {@link TypeAdapterFactory} that creates {@link TypeAdapter}s for Guava immutable collections.
+   */
+  private static final class GuavaCollectionTypeAdapterFactory implements TypeAdapterFactory {
+    // ImmutableSet must follow ImmutableSortedSet since it is a superclass. Otherwise ImmutableSet
+    // would match both ImmutableSortedSet and ImmutableSet.
+    private static final String[][] GUAVA_COLLECTION_CLASS_NAMES = {
+      {"com.google.common.collect.ImmutableList", "builder"},
+      {"com.google.common.collect.ImmutableSortedSet", "naturalOrder"},
+      {"com.google.common.collect.ImmutableSet", "builder"},
+      {"com.google.common.collect.ImmutableMultiset", "builder"},
+    };
+
+    private static final List<GuavaCollectionType> GUAVA_COLLECTION_CLASSES =
+        stream(GUAVA_COLLECTION_CLASS_NAMES)
+            .map(strings -> new GuavaCollectionType(strings[0], strings[1]))
+            .collect(toList());
+
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
+      Type type = typeToken.getType();
+      Class<?> rawClass = typeToken.getRawType();
+      for (GuavaCollectionType guavaType : GUAVA_COLLECTION_CLASSES) {
+        if (guavaType.collectionClass.isAssignableFrom(rawClass)) {
+          Type elementType = $Gson$Types.getCollectionElementType(type, rawClass);
+          TypeAdapter<?> elementTypeAdapter = gson.getAdapter(TypeToken.get(elementType));
+          @SuppressWarnings("unchecked")
+          TypeAdapter<Object> delegate =
+              (TypeAdapter<Object>) gson.getDelegateAdapter(this, typeToken);
+          @SuppressWarnings("unchecked")
+          TypeAdapter<T> adapter =
+              (TypeAdapter<T>)
+                  new GuavaCollectionTypeAdapter(guavaType, delegate, elementTypeAdapter);
+          return adapter;
+        }
+      }
+      return null;
+    }
+  }
+
+  /**
+   * A {@link TypeAdapter} for an individual immutable collection with a given element type. It
+   * serializes using the standard logic for collections, and deserializes by creating the
+   * appropriate builder and adding elements one by one.
+   */
+  private static class GuavaCollectionTypeAdapter extends TypeAdapter<Object> {
+    private final GuavaCollectionType guavaType;
+    private final TypeAdapter<Object> delegate;
+    private final TypeAdapter<?> elementTypeAdapter;
+
+    GuavaCollectionTypeAdapter(
+        GuavaCollectionType guavaType,
+        TypeAdapter<Object> delegate,
+        TypeAdapter<?> elementTypeAdapter) {
+      this.guavaType = guavaType;
+      this.delegate = delegate;
+      this.elementTypeAdapter = elementTypeAdapter;
+    }
+
+    @Override
+    public void write(JsonWriter out, Object value) throws IOException {
+      delegate.write(out, value);
+    }
+
+    @Override
+    public Object read(JsonReader in) throws IOException {
+      // This is basically the same as the code in CollectionTypeAdapterFactory.Adapter.read, except
+      // using a builder rather than a mutable collection.
+      if (in.peek() == JsonToken.NULL) {
+        in.nextNull();
+        return null;
+      }
+      Object builder = guavaType.createBuilder();
+      in.beginArray();
+      while (in.hasNext()) {
+        Object element = elementTypeAdapter.read(in);
+        guavaType.add(builder, element);
+      }
+      in.endArray();
+      return guavaType.build(builder);
+    }
+  }
+
+  /** A {@link TypeAdapterFactory} that creates {@link TypeAdapter}s for Guava immutable maps. */
+  private static final class GuavaMapTypeAdapterFactory implements TypeAdapterFactory {
+    // ImmutableMap must follow ImmutableSortedMap since it is a superclass. Otherwise ImmutableMap
+    // would match both ImmutableSortedMap and ImmutableMap. Likewise for ImmutableMultimap (which
+    // people probably shouldn't use anyway).
+    private static final String[][] GUAVA_MAP_CLASS_NAMES = {
+      {"com.google.common.collect.ImmutableBiMap", "builder"},
+      {"com.google.common.collect.ImmutableSortedMap", "naturalOrder"},
+      {"com.google.common.collect.ImmutableMap", "builder"},
+      // TODO: support immutable multimaps
+    };
+
+    private static final List<GuavaMapType> GUAVA_MAP_CLASSES =
+        stream(GUAVA_MAP_CLASS_NAMES)
+            .map(strings -> new GuavaMapType(strings[0], strings[1]))
+            .collect(toList());
+
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
+      Type type = typeToken.getType();
+      Class<?> rawClass = typeToken.getRawType();
+      for (GuavaMapType guavaType : GUAVA_MAP_CLASSES) {
+        if (guavaType.collectionClass.isAssignableFrom(rawClass)) {
+          Type[] keyAndValueTypes = $Gson$Types.getMapKeyAndValueTypes(type, rawClass);
+          Type keyType = keyAndValueTypes[0];
+          Type valueType = keyAndValueTypes[1];
+          TypeToken<?> mapKToV =
+              TypeToken.getParameterized(Map.class, keyType, valueType);
+          @SuppressWarnings("unchecked")
+          TypeAdapter<Object> delegate =
+              (TypeAdapter<Object>) gson.getDelegateAdapter(this, mapKToV);
+          TypeAdapter<?> keyTypeAdapter = gson.getAdapter(TypeToken.get(keyType));
+          TypeAdapter<?> valueTypeAdapter = gson.getAdapter(TypeToken.get(valueType));
+          @SuppressWarnings("unchecked")
+          TypeAdapter<T> adapter =
+              (TypeAdapter<T>)
+                  new GuavaMapTypeAdapter(guavaType, delegate, keyTypeAdapter, valueTypeAdapter);
+          return adapter;
+        }
+      }
+      return null;
+    }
+  }
+
+  /**
+   * A {@link TypeAdapter} for an individual immutable map with given key and value types. It
+   * serializes using the standard logic for maps, and deserializes by creating the appropriate
+   * builder and adding entries one by one.
+   */
+  private static class GuavaMapTypeAdapter extends TypeAdapter<Object> {
+    private final GuavaMapType guavaType;
+    private final TypeAdapter<Object> delegate;
+    private final TypeAdapter<?> keyTypeAdapter;
+    private final TypeAdapter<?> valueTypeAdapter;
+
+    GuavaMapTypeAdapter(
+        GuavaMapType guavaType,
+        TypeAdapter<Object> delegate,
+        TypeAdapter<?> keyTypeAdapter,
+        TypeAdapter<?> valueTypeAdapter) {
+      this.guavaType = guavaType;
+      this.delegate = delegate;
+      this.keyTypeAdapter = keyTypeAdapter;
+      this.valueTypeAdapter = valueTypeAdapter;
+    }
+
+    @Override
+    public void write(JsonWriter out, Object value) throws IOException {
+      delegate.write(out, value);
+    }
+
+    @Override
+    public Object read(JsonReader in) throws IOException {
+      switch (in.peek()) {
+        case NULL:
+          in.nextNull();
+          return null;
+        case BEGIN_ARRAY:
+          // This is Gson's "complex map key serialization", where it serializes a map as an array
+          // of [key, value] arrays. We don't try to be efficient for this unusual case: we just
+          // deserialize it into a map and then copy it into an ImmutableMap.
+          Map<?, ?> map = (Map<?, ?>) delegate.read(in);
+          Method copyOfMethod = getMethod(guavaType.collectionClass, "copyOf", Map.class);
+          return invoke(copyOfMethod, null, map);
+        default:
+          // Regular Gson map serialization, using a JSON map.
+          // This is basically the same as the code in MapTypeAdapterFactory.Adapter.read, except
+          // using a builder rather than a mutable map.
+          Object builder = guavaType.createBuilder();
+          in.beginObject();
+          while (in.hasNext()) {
+            JsonReaderInternalAccess.INSTANCE.promoteNameToValue(in);
+            Object key = keyTypeAdapter.read(in);
+            Object value = valueTypeAdapter.read(in);
+            guavaType.put(builder, key, value);
+          }
+          in.endObject();
+          return guavaType.build(builder);
+      }
+    }
+  }
+
+  /**
+   * A {@link TypeAdapterFactory} that creates {@link TypeAdapter}s for Guava immutable multimaps.
+   */
+  private static final class GuavaMultimapTypeAdapterFactory implements TypeAdapterFactory {
+    // ImmutableMultimap must follow the others since it is a superclass. Otherwise
+    // ImmutableListMultimap would match both ImmutableListMultimap and ImmutableMultimap.
+    private static final String[] GUAVA_MULTIMAP_CLASS_NAMES = {
+      "com.google.common.collect.ImmutableListMultimap",
+      "com.google.common.collect.ImmutableSetMultimap",
+      "com.google.common.collect.ImmutableMultimap",
+    };
+
+    private static final List<GuavaMultimapType> GUAVA_MULTIMAP_CLASSES =
+        stream(GUAVA_MULTIMAP_CLASS_NAMES)
+            .map(className -> new GuavaMultimapType(className, "builder"))
+            .collect(toList());
+
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
+      Type type = typeToken.getType();
+      Class<?> rawClass = typeToken.getRawType();
+      for (GuavaMultimapType guavaType : GUAVA_MULTIMAP_CLASSES) {
+        if (guavaType.collectionClass.isAssignableFrom(rawClass)) {
+          Type keyType;
+          Type valueType;
+          if (type instanceof ParameterizedType) {
+            ParameterizedType parameterizedType = (ParameterizedType) type;
+            Type[] keyAndValueTypes = parameterizedType.getActualTypeArguments();
+            keyType = keyAndValueTypes[0];
+            valueType = keyAndValueTypes[1];
+          } else {
+            keyType = Object.class;
+            valueType = Object.class;
+          }
+          TypeAdapter<?> keyTypeAdapter = gson.getAdapter(TypeToken.get(keyType));
+          TypeAdapter<?> valueTypeAdapter = gson.getAdapter(TypeToken.get(valueType));
+          TypeToken<?> mapKToCollectionOfV =
+              TypeToken.getParameterized(
+                  Map.class,
+                  keyType,
+                  TypeToken.getParameterized(Collection.class, valueType).getType());
+          @SuppressWarnings("unchecked")
+          TypeAdapter<Object> mapKToCollectionOfVDelegate =
+              (TypeAdapter<Object>) gson.getAdapter(mapKToCollectionOfV);
+          @SuppressWarnings("unchecked")
+          TypeAdapter<T> adapter =
+              (TypeAdapter<T>) new GuavaMultimapTypeAdapter(guavaType, mapKToCollectionOfVDelegate);
+          return adapter;
+        }
+      }
+      return null;
+    }
+  }
+
+  /**
+   * A {@link TypeAdapter} for an individual immutable map with given key and value types. The JSON
+   * serialization comes from the {@code asMap()} view, so it is a {@code Map<K, Collection<V>>}. To
+   * deserialize, we read that same {@code Map<K, Collection<V>>} and then use {@code putAll} to
+   * populate a multimap builder.
+   */
+  private static class GuavaMultimapTypeAdapter extends TypeAdapter<Object> {
+    private final GuavaMultimapType guavaType;
+    private final TypeAdapter<Object> mapKToCollectionOfVDelegate;
+
+    GuavaMultimapTypeAdapter(
+        GuavaMultimapType guavaType,
+        TypeAdapter<Object> mapKToCollectionOfVDelegate) {
+      this.guavaType = guavaType;
+      this.mapKToCollectionOfVDelegate = mapKToCollectionOfVDelegate;
+    }
+
+    @Override
+    public void write(JsonWriter out, Object value) throws IOException {
+      Object map = guavaType.asMap(value);
+      mapKToCollectionOfVDelegate.write(out, map);
+    }
+
+    @Override
+    public Object read(JsonReader in) throws IOException {
+      if (in.peek() == JsonToken.NULL) {
+        in.nextNull();
+        return null;
+      }
+      Object builder = guavaType.createBuilder();
+      Map<?, ?> map = (Map<?, ?>) mapKToCollectionOfVDelegate.read(in);
+      map.forEach((key, value) -> guavaType.putAll(builder, key, (Iterable<?>) value));
+      return guavaType.build(builder);
+    }
+  }
+
+  @CanIgnoreReturnValue
+  private static Object invoke(Method method, Object target, Object... args) {
+    try {
+      return method.invoke(target, args);
+    } catch (ReflectiveOperationException e) {
+      throw new JsonIOException("Failed to invoke " + method.getName(), e);
+    }
+  }
+
+  private static Method getMethod(Class<?> clazz, String methodName, Class<?>... parameterTypes) {
+    try {
+      return clazz.getMethod(methodName, parameterTypes);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private GuavaTypeAdapters() {}
+}

--- a/gson/src/test/java/com/google/gson/functional/GuavaTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/GuavaTypeAdaptersTest.java
@@ -1,0 +1,343 @@
+/*
+ * Copyright (C) 2025 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gson.functional;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableBiMap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.gson.Gson;
+import com.google.gson.common.TestTypes.BagOfPrimitives;
+import com.google.gson.reflect.TypeToken;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Functional tests for Json serialization and deserialization of Guava collections. */
+public class GuavaTypeAdaptersTest {
+  private Gson gson;
+
+  @Before
+  public void setUp() throws Exception {
+    gson = new Gson();
+  }
+
+  // Many test methods here were copied from CollectionTest.
+
+  @Test
+  public void testTopLevelListOfIntegerCollectionsDeserialization() {
+    String json = "[[1,2,3],[4,5,6],[7,8,9]]";
+    Type collectionType = new TypeToken<ImmutableList<ImmutableList<Integer>>>() {}.getType();
+    ImmutableList<ImmutableList<Integer>> target = gson.fromJson(json, collectionType);
+    int[][] expected = new int[3][3];
+    for (int i = 0; i < 3; ++i) {
+      int start = (3 * i) + 1;
+      for (int j = 0; j < 3; ++j) {
+        expected[i][j] = start + j;
+      }
+    }
+
+    for (int i = 0; i < 3; i++) {
+      assertThat(toIntArray(target.get(i))).isEqualTo(expected[i]);
+    }
+  }
+
+  @Test
+  public void testCollectionOfObjectSerialization() {
+    ImmutableList<Object> target = ImmutableList.of("Hello", "World");
+    assertThat(gson.toJson(target)).isEqualTo("[\"Hello\",\"World\"]");
+
+    Type type = new TypeToken<ImmutableList<Object>>() {}.getType();
+    assertThat(gson.toJson(target, type)).isEqualTo("[\"Hello\",\"World\"]");
+  }
+
+  @Test
+  public void testCollectionOfStringsSerialization() {
+    ImmutableList<String> target = ImmutableList.of("Hello", "World");
+    assertThat(gson.toJson(target)).isEqualTo("[\"Hello\",\"World\"]");
+    Type type = new TypeToken<ImmutableList<Object>>() {}.getType();
+    assertThat(gson.toJson(target, type)).isEqualTo("[\"Hello\",\"World\"]");
+  }
+
+  @Test
+  public void testCollectionOfBagOfPrimitivesSerialization() {
+    ImmutableList<BagOfPrimitives> target =
+        ImmutableList.of(
+            new BagOfPrimitives(3L, 1, true, "blah"), new BagOfPrimitives(2L, 6, false, "blahB"));
+
+    String result =
+        gson.toJson(target, new TypeToken<ImmutableList<BagOfPrimitives>>() {}.getType());
+    assertThat(result).startsWith("[");
+    assertThat(result).endsWith("]");
+    for (BagOfPrimitives obj : target) {
+      assertThat(result).contains(obj.getExpectedJson());
+    }
+  }
+
+  @Test
+  public void testCollectionOfStringsDeserialization() {
+    String json = "[\"Hello\",\"World\"]";
+    Type collectionType = new TypeToken<ImmutableList<String>>() {}.getType();
+    ImmutableList<String> target = gson.fromJson(json, collectionType);
+
+    assertThat(target).containsExactly("Hello", "World").inOrder();
+  }
+
+  @Test
+  public void testRawCollectionDeserialization() {
+    String json = "[0,1,2,3,4,5,6,7,8,9]";
+    ImmutableList<?> integers = gson.fromJson(json, ImmutableList.class);
+    // JsonReader converts numbers to double by default so we need a floating point comparison
+    assertThat(integers)
+        .containsExactly(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0)
+        .inOrder();
+
+    json = "[\"Hello\", \"World\"]";
+    Collection<?> strings = gson.fromJson(json, ImmutableList.class);
+    assertThat(strings).containsExactly("Hello", "World").inOrder();
+  }
+
+  @Test
+  public void testRawCollectionOfBagOfPrimitivesNotAllowed() {
+    BagOfPrimitives bag = new BagOfPrimitives(10, 20, false, "stringValue");
+    String json = '[' + bag.getExpectedJson() + ',' + bag.getExpectedJson() + ']';
+    ImmutableList<?> target = gson.fromJson(json, ImmutableList.class);
+    assertThat(target.size()).isEqualTo(2);
+    for (Object bag1 : target) {
+      // Gson 2.0 converts raw objects into maps
+      @SuppressWarnings("unchecked")
+      Map<String, Object> map = (Map<String, Object>) bag1;
+      assertThat(map.values()).containsExactly(10.0, 20.0, false, "stringValue");
+    }
+  }
+
+  @Test
+  public void testWildcardPrimitiveCollectionSerilaization() {
+    ImmutableList<? extends Integer> target = ImmutableList.of(1, 2, 3, 4, 5, 6, 7, 8, 9);
+    Type collectionType = new TypeToken<ImmutableList<? extends Integer>>() {}.getType();
+    String json = gson.toJson(target, collectionType);
+    assertThat(json).isEqualTo("[1,2,3,4,5,6,7,8,9]");
+
+    json = gson.toJson(target);
+    assertThat(json).isEqualTo("[1,2,3,4,5,6,7,8,9]");
+  }
+
+  @Test
+  public void testWildcardPrimitiveCollectionDeserilaization() {
+    String json = "[1,2,3,4,5,6,7,8,9]";
+    Type collectionType = new TypeToken<ImmutableList<? extends Integer>>() {}.getType();
+    ImmutableList<? extends Integer> target = gson.fromJson(json, collectionType);
+    assertThat(target.size()).isEqualTo(9);
+    assertThat(target).contains(1);
+    assertThat(target).contains(2);
+  }
+
+  @Test
+  public void testWildcardCollectionField() {
+    BagOfPrimitives objA = new BagOfPrimitives(3L, 1, true, "blah");
+    BagOfPrimitives objB = new BagOfPrimitives(2L, 6, false, "blahB");
+    ImmutableList<BagOfPrimitives> collection = ImmutableList.of(objA, objB);
+
+    ObjectWithWildcardImmutableList target = new ObjectWithWildcardImmutableList(collection);
+    String json = gson.toJson(target);
+    assertThat(json).contains(objA.getExpectedJson());
+    assertThat(json).contains(objB.getExpectedJson());
+
+    target = gson.fromJson(json, ObjectWithWildcardImmutableList.class);
+    ImmutableList<? extends BagOfPrimitives> deserializedCollection = target.getCollection();
+    assertThat(deserializedCollection).containsExactly(objA, objB).inOrder();
+  }
+
+  private static int[] toIntArray(Collection<?> collection) {
+    int[] ints = new int[collection.size()];
+    int i = 0;
+    for (Iterator<?> iterator = collection.iterator(); iterator.hasNext(); ++i) {
+      Object obj = iterator.next();
+      if (obj instanceof Integer) {
+        ints[i] = (Integer) obj;
+      } else if (obj instanceof Long) {
+        ints[i] = ((Long) obj).intValue();
+      }
+    }
+    return ints;
+  }
+
+  private static class ObjectWithWildcardImmutableList {
+    private final ImmutableList<? extends BagOfPrimitives> collection;
+
+    public ObjectWithWildcardImmutableList(ImmutableList<? extends BagOfPrimitives> collection) {
+      this.collection = collection;
+    }
+
+    public ImmutableList<? extends BagOfPrimitives> getCollection() {
+      return collection;
+    }
+  }
+
+  private static class Entry implements Comparable<Entry> {
+    int value;
+
+    Entry(int value) {
+      this.value = value;
+    }
+
+    @Override
+    public int compareTo(Entry other) {
+      return Integer.compare(value, other.value);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (other instanceof Entry) {
+        return value == ((Entry) other).value;
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      return value;
+    }
+  }
+
+  @Test
+  public void testSetSerialization() {
+    ImmutableSet<Entry> set = ImmutableSet.of(new Entry(1), new Entry(2));
+    String json = gson.toJson(set);
+    assertThat(json).contains("1");
+    assertThat(json).contains("2");
+  }
+
+  @Test
+  public void testSetDeserialization() {
+    String json = "[{value:1},{value:2}]";
+    Type type = new TypeToken<ImmutableSet<Entry>>() {}.getType();
+    ImmutableSet<Entry> set = gson.fromJson(json, type);
+    assertThat(set).containsExactly(new Entry(1), new Entry(2)).inOrder();
+  }
+
+  @Test
+  public void testSortedSetDeserialization() {
+    String json = "[{value:2},{value:1}]";
+    Type type = new TypeToken<ImmutableSortedSet<Entry>>() {}.getType();
+    ImmutableSortedSet<Entry> set = gson.fromJson(json, type);
+    assertThat(set).containsExactly(new Entry(1), new Entry(2)).inOrder();
+  }
+
+  @Test
+  public void testMultiset() {
+    ImmutableMultiset<String> multiset = ImmutableMultiset.of("a", "a", "a", "b", "b", "c");
+    String json = gson.toJson(multiset);
+    assertThat(json).isEqualTo("[\"a\",\"a\",\"a\",\"b\",\"b\",\"c\"]");
+    ImmutableMultiset<String> deserialized =
+        gson.fromJson(json, new TypeToken<ImmutableMultiset<String>>() {});
+    assertThat(deserialized).containsExactly("a", "a", "a", "b", "b", "c");
+  }
+
+  @Test
+  public void testImmutableMap() {
+    ImmutableMap<String, Integer> map = ImmutableMap.of("a", 1, "b", 2);
+    String json = gson.toJson(map);
+    assertThat(json).isEqualTo("{\"a\":1,\"b\":2}");
+
+    ImmutableMap<String, Integer> deserialized =
+        gson.fromJson(json, new TypeToken<ImmutableMap<String, Integer>>() {}.getType());
+    assertThat(deserialized).containsExactly("a", 1, "b", 2);
+  }
+
+  @Test
+  public void testImmutableMap_complexKeys() {
+    Gson complexKeyGson = gson.newBuilder().enableComplexMapKeySerialization().create();
+    ImmutableMap<ImmutableList<Integer>, String> map =
+        ImmutableMap.of(ImmutableList.of(1, 2), "a", ImmutableList.of(3, 4), "b");
+    String json = complexKeyGson.toJson(map);
+    assertThat(json).isEqualTo("[[[1,2],\"a\"],[[3,4],\"b\"]]");
+
+    ImmutableMap<ImmutableList<Integer>, String> deserialized =
+        complexKeyGson.fromJson(
+            json, new TypeToken<ImmutableMap<ImmutableList<Integer>, String>>() {}.getType());
+    assertThat(deserialized)
+        .containsExactly(ImmutableList.of(1, 2), "a", ImmutableList.of(3, 4), "b");
+  }
+
+  @Test
+  public void testImmutableBiMap() {
+    ImmutableBiMap<String, Integer> map = ImmutableBiMap.of("a", 1, "b", 2);
+    String json = gson.toJson(map);
+    assertThat(json).isEqualTo("{\"a\":1,\"b\":2}");
+
+    ImmutableBiMap<String, Integer> deserialized =
+        gson.fromJson(json, new TypeToken<ImmutableBiMap<String, Integer>>() {}.getType());
+    assertThat(deserialized).containsExactly("a", 1, "b", 2);
+  }
+
+  @Test
+  public void testImmutableSortedMap() {
+    ImmutableSortedMap<String, Integer> map = ImmutableSortedMap.of("a", 1, "b", 2);
+    String json = gson.toJson(map);
+    assertThat(json).isEqualTo("{\"a\":1,\"b\":2}");
+
+    ImmutableSortedMap<String, Integer> deserialized =
+        gson.fromJson(json, new TypeToken<ImmutableSortedMap<String, Integer>>() {}.getType());
+    assertThat(deserialized).containsExactly("a", 1, "b", 2);
+  }
+
+  @Test
+  public void testImmutableMultimap() {
+    ImmutableMultimap<String, Integer> map = ImmutableMultimap.of("a", 1, "a", 2, "b", 3);
+    String json = gson.toJson(map);
+    assertThat(json).isEqualTo("{\"a\":[1,2],\"b\":[3]}");
+
+    ImmutableMultimap<String, Integer> deserialized =
+        gson.fromJson(json, new TypeToken<ImmutableMultimap<String, Integer>>() {}.getType());
+    assertThat(deserialized).containsExactly("a", 1, "a", 2, "b", 3);
+  }
+
+  @Test
+  public void testImmutableListMultimap() {
+    ImmutableListMultimap<String, Integer> map = ImmutableListMultimap.of("a", 1, "a", 2, "b", 3);
+    String json = gson.toJson(map);
+    assertThat(json).isEqualTo("{\"a\":[1,2],\"b\":[3]}");
+
+    ImmutableListMultimap<String, Integer> deserialized =
+        gson.fromJson(json, new TypeToken<ImmutableListMultimap<String, Integer>>() {}.getType());
+    assertThat(deserialized).containsExactly("a", 1, "a", 2, "b", 3);
+  }
+
+  @Test
+  public void testImmutableSet() {
+    ImmutableSetMultimap<String, Integer> map =
+        ImmutableSetMultimap.of("a", 1, "a", 2, "a", 1, "b", 3);
+    String json = gson.toJson(map);
+    assertThat(json).isEqualTo("{\"a\":[1,2],\"b\":[3]}");
+
+    ImmutableSetMultimap<String, Integer> deserialized =
+        gson.fromJson(json, new TypeToken<ImmutableSetMultimap<String, Integer>>() {}.getType());
+    assertThat(deserialized).containsExactly("a", 1, "a", 2, "b", 3);
+  }
+}

--- a/gson/src/test/java/com/google/gson/integration/OSGiManifestIT.java
+++ b/gson/src/test/java/com/google/gson/integration/OSGiManifestIT.java
@@ -112,8 +112,9 @@ public class OSGiManifestIT {
 
     assertThat(imports)
         .containsExactly(
-            // Dependency on JDK's sun.misc.Unsafe should be optional
+            // Dependencies on JDK's sun.misc.Unsafe and Guava Collections should be optional
             "sun.misc;resolution:=optional",
+            "com.google.common.collect;resolution:=optional",
             "com.google.errorprone.annotations;version=\"" + errorProneVersionRange + "\"");
 
     // Should not contain any import for Gson's own packages, see


### PR DESCRIPTION
These adapters are added automatically, but only if Guava is on the classpath. They correctly deserialize immutable collections and maps, by creating a builder and adding the incoming elements to it, before finally building the immutable object.

The principal motivation for this change is that #2068, if applied, will trigger a large number of failures from Google's internal tests. Code is incorrectly deserializing `TypeToken<ImmutableList<String>>` and the like, and getting away with it because it doesn't happen to perform any actions that would notice that the deserialized object is actually an `ArrayList`.
