### PR TITLE
Refactore unreachable default case in `JsonReader#peek`

### DIFF
--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -573,10 +573,9 @@ public class JsonReader implements Closeable {
       case PEEKED_LONG:
       case PEEKED_NUMBER:
         return JsonToken.NUMBER;
-      case PEEKED_EOF:
-        return JsonToken.END_DOCUMENT;
       default:
-        throw new AssertionError();
+        assert (p == PEEKED_EOF);
+        return JsonToken.END_DOCUMENT;
     }
   }
 


### PR DESCRIPTION
<!--
    Thank you for your contribution!
    Please see the contributing guide: https://github.com/google/.github/blob/master/CONTRIBUTING.md

    Keep in mind that Gson is in maintenance mode. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.
-->

### Purpose
<!-- Describe the purpose of this pull request, for example which new feature it adds or which bug it fixes -->
<!-- If this pull request closes a GitHub issue, please write "Closes #<issue>", for example "Closes #123" -->

Refactored unreachable default case in `JsonReader#peek` so that it can be reached while keeping existing functionality.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [X] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [X] If necessary, new public API validates arguments, for example rejects `null`
- [X] New public API has Javadoc
    - [X] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [X] If necessary, new unit tests have been added  
  - [X] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [X] No JUnit 3 features are used (such as extending class `TestCase`)
  - [X] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [X] `mvn clean verify javadoc:jar` passes without errors