### PR TITLE
Remove redundant generic type arguments from method calls

### DIFF
--- a/extras/src/main/java/com/google/gson/graph/GraphAdapterBuilder.java
+++ b/extras/src/main/java/com/google/gson/graph/GraphAdapterBuilder.java
@@ -20,7 +20,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.InstanceCreator;
 import com.google.gson.JsonElement;
-import com.google.gson.ReflectionAccessFilter;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
 import com.google.gson.internal.ConstructorConstructor;
@@ -77,8 +76,7 @@ public final class GraphAdapterBuilder {
   public GraphAdapterBuilder() {
     this.instanceCreators = new HashMap<>();
     this.constructorConstructor =
-        new ConstructorConstructor(
-            instanceCreators, true, Collections.<ReflectionAccessFilter>emptyList());
+        new ConstructorConstructor(instanceCreators, true, Collections.emptyList());
   }
 
   /**

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -254,7 +254,7 @@ public final class Gson {
     this(
         Excluder.DEFAULT,
         DEFAULT_FIELD_NAMING_STRATEGY,
-        Collections.<Type, InstanceCreator<?>>emptyMap(),
+        Collections.emptyMap(),
         DEFAULT_SERIALIZE_NULLS,
         DEFAULT_COMPLEX_MAP_KEYS,
         DEFAULT_JSON_NON_EXECUTABLE,
@@ -267,12 +267,12 @@ public final class Gson {
         DEFAULT_DATE_PATTERN,
         DateFormat.DEFAULT,
         DateFormat.DEFAULT,
-        Collections.<TypeAdapterFactory>emptyList(),
-        Collections.<TypeAdapterFactory>emptyList(),
-        Collections.<TypeAdapterFactory>emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
         DEFAULT_OBJECT_TO_NUMBER_STRATEGY,
         DEFAULT_NUMBER_TO_NUMBER_STRATEGY,
-        Collections.<ReflectionAccessFilter>emptyList());
+        Collections.emptyList());
   }
 
   Gson(

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -283,8 +283,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
 
   private static class FieldsData {
     public static final FieldsData EMPTY =
-        new FieldsData(
-            Collections.<String, BoundField>emptyMap(), Collections.<BoundField>emptyList());
+        new FieldsData(Collections.emptyMap(), Collections.emptyList());
 
     /** Maps from JSON member name to field */
     public final Map<String, BoundField> deserializedFields;


### PR DESCRIPTION
### Description
The type arguments can be inferred now (maybe due to our Java 8 migration).

In the test code there is some remaining usage of `gson.<TypeArg>fromJson(..., Type)`, but it seems that is needed to prevent compilation errors due to ambiguous `assertThat` calls.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
