### PR TITLE
Fix `GraphAdapterBuilder#addType(Type)` delegating to previous creator

### DIFF
--- a/extras/src/main/java/com/google/gson/graph/GraphAdapterBuilder.java
+++ b/extras/src/main/java/com/google/gson/graph/GraphAdapterBuilder.java
@@ -20,7 +20,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.InstanceCreator;
 import com.google.gson.JsonElement;
-import com.google.gson.ReflectionAccessFilter;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
 import com.google.gson.internal.ConstructorConstructor;
@@ -77,8 +76,7 @@ public final class GraphAdapterBuilder {
   public GraphAdapterBuilder() {
     this.instanceCreators = new HashMap<>();
     this.constructorConstructor =
-        new ConstructorConstructor(
-            instanceCreators, true, Collections.<ReflectionAccessFilter>emptyList());
+        new ConstructorConstructor(Collections.emptyMap(), true, Collections.emptyList());
   }
 
   /**

--- a/extras/src/main/java/com/google/gson/graph/GraphAdapterBuilder.java
+++ b/extras/src/main/java/com/google/gson/graph/GraphAdapterBuilder.java
@@ -121,6 +121,8 @@ public final class GraphAdapterBuilder {
    * @param gsonBuilder the {@code GsonBuilder} on which to register the graph adapter
    */
   public void registerOn(GsonBuilder gsonBuilder) {
+    // Create copy to allow reusing GraphAdapterBuilder without affecting adapter factory
+    Map<Type, InstanceCreator<?>> instanceCreators = new HashMap<>(this.instanceCreators);
     Factory factory = new Factory(instanceCreators);
     gsonBuilder.registerTypeAdapterFactory(factory);
     for (Map.Entry<Type, InstanceCreator<?>> entry : instanceCreators.entrySet()) {

--- a/extras/src/test/java/com/google/gson/graph/GraphAdapterBuilderTest.java
+++ b/extras/src/test/java/com/google/gson/graph/GraphAdapterBuilderTest.java
@@ -207,6 +207,33 @@ public final class GraphAdapterBuilderTest {
     assertThat(joel.company).isSameInstanceAs(company);
   }
 
+  @Test
+  public void testBuilderReuse() {
+    GsonBuilder gsonBuilder = new GsonBuilder();
+    GraphAdapterBuilder graphAdapterBuilder =
+        new GraphAdapterBuilder()
+            .addType(Company.class, type -> new Company("custom"))
+            .addType(Employee.class);
+    graphAdapterBuilder.registerOn(gsonBuilder);
+    Gson gson = gsonBuilder.create();
+
+    Company company = gson.fromJson("{'0x1':{}}", Company.class);
+    assertThat(company.name).isEqualTo("custom");
+
+    GsonBuilder gsonBuilder2 = new GsonBuilder();
+    // Reuse builder and overwrite creator
+    graphAdapterBuilder.addType(Company.class, type -> new Company("custom-2"));
+    graphAdapterBuilder.registerOn(gsonBuilder2);
+    Gson gson2 = gsonBuilder2.create();
+
+    company = gson2.fromJson("{'0x1':{}}", Company.class);
+    assertThat(company.name).isEqualTo("custom-2");
+
+    // But first adapter should not have been affected
+    company = gson.fromJson("{'0x1':{}}", Company.class);
+    assertThat(company.name).isEqualTo("custom");
+  }
+
   static class Roshambo {
     String name;
     Roshambo beats;

--- a/extras/src/test/java/com/google/gson/graph/GraphAdapterBuilderTest.java
+++ b/extras/src/test/java/com/google/gson/graph/GraphAdapterBuilderTest.java
@@ -20,7 +20,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.InstanceCreator;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -85,14 +84,7 @@ public final class GraphAdapterBuilderTest {
   public void testAddTypeCustomInstanceCreator() {
     GsonBuilder gsonBuilder = new GsonBuilder();
     new GraphAdapterBuilder()
-        .addType(
-            Company.class,
-            new InstanceCreator<Company>() {
-              @Override
-              public Company createInstance(Type type) {
-                return new Company("custom");
-              }
-            })
+        .addType(Company.class, type -> new Company("custom"))
         .addType(Employee.class)
         .registerOn(gsonBuilder);
     Gson gson = gsonBuilder.create();
@@ -110,23 +102,9 @@ public final class GraphAdapterBuilderTest {
   public void testAddTypeOverwrite() {
     GsonBuilder gsonBuilder = new GsonBuilder();
     new GraphAdapterBuilder()
-        .addType(
-            Company.class,
-            new InstanceCreator<Company>() {
-              @Override
-              public Company createInstance(Type type) {
-                return new Company("custom");
-              }
-            })
+        .addType(Company.class, type -> new Company("custom"))
         // Overwrite Company creator with different custom one
-        .addType(
-            Company.class,
-            new InstanceCreator<Company>() {
-              @Override
-              public Company createInstance(Type type) {
-                return new Company("custom-2");
-              }
-            })
+        .addType(Company.class, type -> new Company("custom-2"))
         .addType(Employee.class)
         .registerOn(gsonBuilder);
     Gson gson = gsonBuilder.create();
@@ -136,14 +114,7 @@ public final class GraphAdapterBuilderTest {
 
     gsonBuilder = new GsonBuilder();
     new GraphAdapterBuilder()
-        .addType(
-            Company.class,
-            new InstanceCreator<Company>() {
-              @Override
-              public Company createInstance(Type type) {
-                return new Company("custom");
-              }
-            })
+        .addType(Company.class, type -> new Company("custom"))
         // Overwrite Company creator with default one
         .addType(Company.class)
         .addType(Employee.class)


### PR DESCRIPTION
### Purpose
Fix `GraphAdapterBuilder#addType(Type)` delegating to previous creator

### Description
When `addType(Type, InstanceCreator)` is used, it adds the creator to the `instanceCreators` map. However, previously that map was also used by the `constructorConstructor`.
So when `addType(Type)` was used afterwards, instead of actually obtaining the default creator from `constructorConstructor`, it obtained the previously registered creator. That does not seem intended to me.

Side note: Passing `instanceCreators` to the `ConstructorConstructor` constructor was done in https://github.com/google/gson/commit/1d9e86e27c97cd85d898104b4ac42bb487d0d7d0. But I am not sure if this was done intentionally, or just to solve a compilation error due to the removal of the no-args `ConstructorConstructor` constructor in https://github.com/google/gson/commit/040bae34d701172375e5aaef7492a5782933d46d (?).

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [x] If necessary, new unit tests have been added  
  - [x] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [x] No JUnit 3 features are used (such as extending class `TestCase`)
  - [x] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
