### PR TITLE
Fix duplicate resource warning for shrinker test

### DIFF
--- a/test-shrinker/pom.xml
+++ b/test-shrinker/pom.xml
@@ -104,6 +104,7 @@
             <lib>${java.home}/jmods/java.compiler.jmod</lib>
           </libs>
           <!-- Include dependencies in the final JAR -->
+          <!-- Note: Currently causes warnings due to duplicate resource files, see https://github.com/wvengen/proguard-maven-plugin/issues/388 -->
           <includeDependencyInjar>true</includeDependencyInjar>
           <outjar>proguard-output.jar</outjar>
         </configuration>
@@ -132,6 +133,7 @@
                   <excludes>
                     <!-- Ignore duplicate files in dependencies -->
                     <exclude>META-INF/MANIFEST.MF</exclude>
+                    <exclude>META-INF/versions/9/module-info.class</exclude>
                   </excludes>
                 </filter>
               </filters>


### PR DESCRIPTION
### Description
Currently the `test-shrinker` Maven module produces this warning:
```
[WARNING] error_prone_annotations-2.36.0.jar, gson-2.12.2-SNAPSHOT.jar define 1 overlapping classes:
[WARNING]   - META-INF.versions.9.module-info
[WARNING] maven-shade-plugin has detected that some files are
[WARNING] present in two or more JARs. When this happens, only one
[WARNING] single version of the file is copied to the uber jar.
[WARNING] Usually this is not harmful and you can skip these warnings,
[WARNING] otherwise try to manually exclude artifacts based on
[WARNING] mvn dependency:tree -Ddetail=true and the above output.
[WARNING] See https://maven.apache.org/plugins/maven-shade-plugin/
```


Excluding `module-info.class` should probably not affect shrinker behavior.
