### PR TITLE
Fix numeric conversion to Long when serializing numbers as JsonElement tree

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -496,7 +496,7 @@ public final class Gson {
         }
         float floatValue = value.floatValue();
         checkValidFloatingPoint(floatValue);
-        // For backward compatibility don't call `JsonWriter.value(float)` because that method has
+        // For backward compatibility don't call `JsonWriter#value(float)` because that method has
         // been newly added and not all custom JsonWriter implementations might override it yet
         Number floatNumber = value instanceof Float ? value : floatValue;
         out.value(floatNumber);

--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -210,7 +210,9 @@ public final class TypeAdapters {
           if (value == null) {
             out.nullValue();
           } else {
-            out.value(value.byteValue());
+            // Always wrap as Number; don't use `JsonWriter#value(long)`, which converts number
+            Number byteNumber = value instanceof Byte ? value : value.byteValue();
+            out.value(byteNumber);
           }
         }
       };
@@ -245,7 +247,9 @@ public final class TypeAdapters {
           if (value == null) {
             out.nullValue();
           } else {
-            out.value(value.shortValue());
+            // Always wrap as Number; don't use `JsonWriter#value(long)`, which converts number
+            Number shortNumber = value instanceof Short ? value : value.shortValue();
+            out.value(shortNumber);
           }
         }
       };
@@ -273,7 +277,9 @@ public final class TypeAdapters {
           if (value == null) {
             out.nullValue();
           } else {
-            out.value(value.intValue());
+            // Always wrap as Number; don't use `JsonWriter#value(long)`, which converts number
+            Number intNumber = value instanceof Integer ? value : value.intValue();
+            out.value(intNumber);
           }
         }
       };
@@ -368,7 +374,10 @@ public final class TypeAdapters {
         public void write(JsonWriter out, Number value) throws IOException {
           if (value == null) {
             out.nullValue();
+          } else if (value instanceof Long) {
+            out.value(value);
           } else {
+            // Only perform unwrapping if numeric conversion is necessary
             out.value(value.longValue());
           }
         }
@@ -389,11 +398,13 @@ public final class TypeAdapters {
         public void write(JsonWriter out, Number value) throws IOException {
           if (value == null) {
             out.nullValue();
+          } else if (value instanceof Float) {
+            out.value(value);
           } else {
-            // For backward compatibility don't call `JsonWriter.value(float)` because that method
+            // For backward compatibility don't call `JsonWriter#value(float)` because that method
             // has been newly added and not all custom JsonWriter implementations might override
             // it yet
-            Number floatNumber = value instanceof Float ? value : value.floatValue();
+            Number floatNumber = value.floatValue();
             out.value(floatNumber);
           }
         }
@@ -414,7 +425,10 @@ public final class TypeAdapters {
         public void write(JsonWriter out, Number value) throws IOException {
           if (value == null) {
             out.nullValue();
+          } else if (value instanceof Double) {
+            out.value(value);
           } else {
+            // Only perform unwrapping if numeric conversion is necessary
             out.value(value.doubleValue());
           }
         }

--- a/gson/src/test/java/com/google/gson/functional/JsonTreeTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonTreeTest.java
@@ -19,13 +19,21 @@ package com.google.gson.functional;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.common.TestTypes.BagOfPrimitives;
+import com.google.gson.internal.LazilyParsedNumber;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -88,6 +96,68 @@ public class JsonTreeTest {
     assertThat(jsonElement.has("stringValue")).isFalse();
   }
 
+  @Test
+  public void testToJsonTreeNumbers() {
+    List<Number> numbers =
+        List.of(
+            (byte) 1,
+            (short) 2,
+            3,
+            4L,
+            5f,
+            6d,
+            BigInteger.valueOf(7),
+            new BigDecimal(8),
+            new LazilyParsedNumber("9"));
+
+    Gson gsonSpecialFloats = new GsonBuilder().serializeSpecialFloatingPointValues().create();
+
+    for (Number number : numbers) {
+      JsonElement json = gson.toJsonTree(number);
+      assertIsNumber(json, number);
+
+      json = gsonSpecialFloats.toJsonTree(number);
+      assertIsNumber(json, number);
+    }
+  }
+
+  /**
+   * Tests {@link Gson#toJsonTree(Object)} with {@link AtomicInteger} and {@link AtomicLong}, which
+   * should be serialized as non-atomic (and non-mutable) numbers.
+   */
+  @Test
+  public void testToJsonTreeAtomicNumbers() {
+    JsonElement json = gson.toJsonTree(new AtomicInteger(1));
+    // Current implementation converts int to long, because there is only `JsonWriter#value(long)`
+    assertIsNumber(json, 1L);
+
+    json = gson.toJsonTree(new AtomicLong(1));
+    assertIsNumber(json, 1L);
+  }
+
+  /** Tests numeric conversion when using {@link Gson#toJsonTree(Object, Type)}. */
+  @Test
+  public void testToJsonTreeNumberConversion() {
+    JsonElement json = gson.toJsonTree(1.5f, int.class);
+    assertIsNumber(json, 1);
+
+    json = gson.toJsonTree(500, byte.class);
+    assertIsNumber(json, (byte) -12);
+
+    json = gson.toJsonTree(1, float.class);
+    assertIsNumber(json, 1f);
+
+    json = gson.toJsonTree(1, double.class);
+    assertIsNumber(json, 1d);
+
+    Gson gsonSpecialFloats = new GsonBuilder().serializeSpecialFloatingPointValues().create();
+    json = gsonSpecialFloats.toJsonTree(1, float.class);
+    assertIsNumber(json, 1f);
+
+    json = gsonSpecialFloats.toJsonTree(1, double.class);
+    assertIsNumber(json, 1d);
+  }
+
   private static void assertContains(JsonObject json, JsonPrimitive child) {
     for (Map.Entry<String, JsonElement> entry : json.entrySet()) {
       JsonElement node = entry.getValue();
@@ -98,6 +168,16 @@ public class JsonTreeTest {
       }
     }
     throw new AssertionError("Does not contain " + child);
+  }
+
+  private static void assertIsNumber(JsonElement json, Number expectedNumber) {
+    assertThat(json).isInstanceOf(JsonPrimitive.class);
+    JsonPrimitive jsonPrimitive = (JsonPrimitive) json;
+    assertThat(jsonPrimitive.isNumber()).isTrue();
+    Number number = jsonPrimitive.getAsNumber();
+    assertThat(number).isEqualTo(expectedNumber);
+    // Explicitly check class because Truth's `isEqualTo` is lenient for numeric values
+    assertThat(number.getClass()).isEqualTo(expectedNumber.getClass());
   }
 
   private static class SubTypeOfBagOfPrimitives extends BagOfPrimitives {


### PR DESCRIPTION
### Purpose
Fixes #2680

### Description
As mentioned in #2680, an unintended side-effect of https://github.com/google/gson/commit/3e3266cf48f132928225e1561a6ae4cb5503d08f was that serializing to a `JsonElement` tree is now converting all integral numbers to `Long` instances.

This pull request here tries to solve this by using the `JsonWriter#value(Number)` overload again, boxing the converted number. If the type is already matching (e.g. serializing a `Byte` as `Byte`) then this also has the advantage that it avoids unwrapping and having `JsonTreeWriter` wrap the value again.
But on the other hand when using `JsonWriter` and not `JsonTreeWriter` there might be a bit overhead from `JsonWriter#value(Number)` compared to `JsonWriter#value(long)`.


An alternative to this PR could be to instead revert https://github.com/google/gson/commit/3e3266cf48f132928225e1561a6ae4cb5503d08f partially or completely. After all the underlying issue #2156 had been reported by me (and was not blocking me in any way), so maybe other users would not have cared about the missing numeric conversion.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [x] If necessary, new unit tests have been added  
  - [x] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [x] No JUnit 3 features are used (such as extending class `TestCase`)
  - [x] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
