### PR TITLE
Don't assert exact exception type when StackOverflowError is thrown

### DIFF
--- a/gson/src/test/java/com/google/gson/functional/CircularReferenceTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CircularReferenceTest.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 
 /**
  * Functional tests related to circular reference detection and error reporting.
@@ -52,7 +53,7 @@ public class CircularReferenceTest {
     a.children.add(b);
     b.children.add(a);
     // Circular types should not get printed
-    assertThrows(StackOverflowError.class, () -> gson.toJson(a));
+    assertThrowsStackOverflow(() -> gson.toJson(a));
   }
 
   @Test
@@ -70,7 +71,7 @@ public class CircularReferenceTest {
     objA.children = new ClassWithSelfReferenceArray[] {objA};
 
     // Circular reference to self can not be serialized
-    assertThrows(StackOverflowError.class, () -> gson.toJson(objA));
+    assertThrowsStackOverflow(() -> gson.toJson(objA));
   }
 
   @Test
@@ -96,7 +97,15 @@ public class CircularReferenceTest {
             .create();
 
     // Circular reference to self can not be serialized
-    assertThrows(StackOverflowError.class, () -> gson.toJson(obj));
+    assertThrowsStackOverflow(() -> gson.toJson(obj));
+  }
+
+  /** Asserts that a {@link StackOverflowError} is thrown. */
+  private static void assertThrowsStackOverflow(ThrowingRunnable runnable) {
+    // In most cases a StackOverflowError is thrown; however if that error occurs within the JDK
+    // code, it might actually be wrapped in another exception class, for example InternalError
+    // Because this is JDK implementation dependent assume at least that any Throwable is thrown
+    assertThrows(Throwable.class, runnable);
   }
 
   @Test

--- a/gson/src/test/java/com/google/gson/functional/CircularReferenceTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CircularReferenceTest.java
@@ -18,6 +18,7 @@ package com.google.gson.functional;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
+import com.google.common.base.Throwables;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
@@ -102,10 +103,10 @@ public class CircularReferenceTest {
 
   /** Asserts that a {@link StackOverflowError} is thrown. */
   private static void assertThrowsStackOverflow(ThrowingRunnable runnable) {
-    // In most cases a StackOverflowError is thrown; however if that error occurs within the JDK
-    // code, it might actually be wrapped in another exception class, for example InternalError
-    // Because this is JDK implementation dependent assume at least that any Throwable is thrown
-    assertThrows(Throwable.class, runnable);
+    // Obtain the root cause because the StackOverflowError might occur in JDK code, and that might
+    // wrap it in another exception class, for example InternalError
+    Throwable t = assertThrows(Throwable.class, runnable);
+    assertThat(Throwables.getRootCause(t)).isInstanceOf(StackOverflowError.class);
   }
 
   @Test


### PR DESCRIPTION
### Purpose
Make test more robust

### Description
In https://github.com/google/gson/actions/runs/13467912934/job/37637273646?pr=2814 the JDK 21 build randomly failed:
```
Error:  com.google.gson.functional.CircularReferenceTest.testSelfReferenceArrayFieldSerialization -- Time elapsed: 0.034 s <<< FAILURE!
java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.StackOverflowError> but was:<java.lang.InternalError>
	...
Caused by: java.lang.InternalError: java.lang.StackOverflowError
	at java.base/jdk.internal.reflect.MethodHandleObjectFieldAccessorImpl.get(MethodHandleObjectFieldAccessorImpl.java:63)
	at java.base/java.lang.reflect.Field.get(Field.java:444)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$2.write(ReflectiveTypeAdapterFactory.java:240)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.write(ReflectiveTypeAdapterFactory.java:489)
	at com.google.gson.Gson$FutureTypeAdapter.write(Gson.java:1521)
	at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.write(TypeAdapterRuntimeTypeWrapper.java:73)
	at com.google.gson.internal.bind.ArrayTypeAdapter.write(ArrayTypeAdapter.java:109)
	at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.write(TypeAdapterRuntimeTypeWrapper.java:73)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$2.write(ReflectiveTypeAdapterFactory.java:247)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.write(ReflectiveTypeAdapterFactory.java:489)
	at com.google.gson.Gson$FutureTypeAdapter.write(Gson.java:1521)
	at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.write(TypeAdapterRuntimeTypeWrapper.java:73)
	at com.google.gson.internal.bind.ArrayTypeAdapter.write(ArrayTypeAdapter.java:109)
	...
Caused by: java.lang.StackOverflowError
	at java.base/java.lang.invoke.DirectMethodHandle$Accessor.checkCast(DirectMethodHandle.java:516)
	at java.base/java.lang.invoke.DirectMethodHandle.checkCast(DirectMethodHandle.java:599)
	at java.base/jdk.internal.reflect.MethodHandleObjectFieldAccessorImpl.get(MethodHandleObjectFieldAccessorImpl.java:57)
	at java.base/java.lang.reflect.Field.get(Field.java:444)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$2.write(ReflectiveTypeAdapterFactory.java:240)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.write(ReflectiveTypeAdapterFactory.java:489)
	at com.google.gson.Gson$FutureTypeAdapter.write(Gson.java:1521)
	...
```

The test `CircularReferenceTest#testSelfReferenceArrayFieldSerialization` expects a `StackOverflowError`, and indeed that error occurred. However, it happened inside the JDK code and that wrapped it in an `InternalError`.
So to make the test more reliable it should not assume that the `StackOverflowError` actually reaches the assertion but just that _any_ exception reaches it.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [ ] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
