### PR TITLE
Don't run GitHub workflows twice for Dependabot PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      # Ignore Dependabot branches because it will also open a pull request, which would cause the
+      # workflow to redundantly run twice
+      - dependabot/**
+  pull_request:
 
 permissions:
   contents: read #  to fetch code (actions/checkout)

--- a/.github/workflows/check-android-compatibility.yml
+++ b/.github/workflows/check-android-compatibility.yml
@@ -4,7 +4,13 @@
 
 name: Check Android compatibility
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      # Ignore Dependabot branches because it will also open a pull request, which would cause the
+      # workflow to redundantly run twice
+      - dependabot/**
+  pull_request:
 
 permissions:
   contents: read #  to fetch code (actions/checkout)


### PR DESCRIPTION
### Purpose
Don't run GitHub workflows twice for Dependabot PRs

### Description
Currently when Dependabot creates a pull request, some of the workflows run twice: One time for the `dependabot/...` branch within the repository and a second time for the PR update.

This is redundant and possibly also leads to confusion when the same workflow fails twice.
