### PR TITLE
Restructure code to avoid assignment expression warning.

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/Excluder.java
+++ b/gson/src/main/java/com/google/gson/internal/Excluder.java
@@ -147,7 +147,10 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
         // A race might lead to `delegate` being assigned by multiple threads but the last
         // assignment will stick
         TypeAdapter<T> d = delegate;
-        return d != null ? d : (delegate = gson.getDelegateAdapter(Excluder.this, type));
+	if (d == null) {
+	  d = delegate = gson.getDelegateAdapter(Excluder.this, type);
+	}
+	return d;
       }
     };
   }

--- a/gson/src/main/java/com/google/gson/internal/Excluder.java
+++ b/gson/src/main/java/com/google/gson/internal/Excluder.java
@@ -147,10 +147,10 @@ public final class Excluder implements TypeAdapterFactory, Cloneable {
         // A race might lead to `delegate` being assigned by multiple threads but the last
         // assignment will stick
         TypeAdapter<T> d = delegate;
-	if (d == null) {
-	  d = delegate = gson.getDelegateAdapter(Excluder.this, type);
-	}
-	return d;
+        if (d == null) {
+          d = delegate = gson.getDelegateAdapter(Excluder.this, type);
+        }
+        return d;
       }
     };
   }


### PR DESCRIPTION
The latest Error Prone doesn't like nested assignment expressions.