### PR TITLE
Remove obsolete comment in pom.xml

### DIFF
--- a/test-shrinker/pom.xml
+++ b/test-shrinker/pom.xml
@@ -104,7 +104,6 @@
             <lib>${java.home}/jmods/java.compiler.jmod</lib>
           </libs>
           <!-- Include dependencies in the final JAR -->
-          <!-- Note: Currently causes warnings due to duplicate resource files, see https://github.com/wvengen/proguard-maven-plugin/issues/388 -->
           <includeDependencyInjar>true</includeDependencyInjar>
           <outjar>proguard-output.jar</outjar>
         </configuration>


### PR DESCRIPTION
Obsolete since the proguard-maven-plugin update to 2.7.0

See https://github.com/google/gson/pull/2831#discussion_r2026722684