### PR TITLE
Rename `$Gson$Preconditions` and `$Gson$Types`.

### DIFF
--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -32,8 +32,8 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.InlineMe;
 import com.google.gson.annotations.Since;
 import com.google.gson.annotations.Until;
-import com.google.gson.internal.$Gson$Preconditions;
 import com.google.gson.internal.Excluder;
+import com.google.gson.internal.GsonPreconditions;
 import com.google.gson.internal.bind.DefaultDateTypeAdapter;
 import com.google.gson.internal.bind.TreeTypeAdapter;
 import com.google.gson.internal.bind.TypeAdapters;
@@ -704,7 +704,7 @@ public final class GsonBuilder {
   @CanIgnoreReturnValue
   public GsonBuilder registerTypeAdapter(Type type, Object typeAdapter) {
     Objects.requireNonNull(type);
-    $Gson$Preconditions.checkArgument(
+    GsonPreconditions.checkArgument(
         typeAdapter instanceof JsonSerializer<?>
             || typeAdapter instanceof JsonDeserializer<?>
             || typeAdapter instanceof InstanceCreator<?>
@@ -778,7 +778,7 @@ public final class GsonBuilder {
   @CanIgnoreReturnValue
   public GsonBuilder registerTypeHierarchyAdapter(Class<?> baseType, Object typeAdapter) {
     Objects.requireNonNull(baseType);
-    $Gson$Preconditions.checkArgument(
+    GsonPreconditions.checkArgument(
         typeAdapter instanceof JsonSerializer<?>
             || typeAdapter instanceof JsonDeserializer<?>
             || typeAdapter instanceof TypeAdapter<?>);

--- a/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
+++ b/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
@@ -367,7 +367,7 @@ public final class ConstructorConstructor {
     if (typeArguments.length == 0) {
       return false;
     }
-    return $Gson$Types.getRawType(typeArguments[0]) == String.class;
+    return GsonTypes.getRawType(typeArguments[0]) == String.class;
   }
 
   private static ObjectConstructor<? extends Map<? extends Object, Object>> newMapConstructor(

--- a/gson/src/main/java/com/google/gson/internal/GsonPreconditions.java
+++ b/gson/src/main/java/com/google/gson/internal/GsonPreconditions.java
@@ -32,8 +32,8 @@ import java.util.Objects;
  * @author Joel Leitch
  */
 @SuppressWarnings("MemberName") // legacy class name
-public final class $Gson$Preconditions {
-  private $Gson$Preconditions() {
+public final class GsonPreconditions {
+  private GsonPreconditions() {
     throw new UnsupportedOperationException();
   }
 

--- a/gson/src/main/java/com/google/gson/internal/GsonTypes.java
+++ b/gson/src/main/java/com/google/gson/internal/GsonTypes.java
@@ -16,7 +16,7 @@
 
 package com.google.gson.internal;
 
-import static com.google.gson.internal.$Gson$Preconditions.checkArgument;
+import static com.google.gson.internal.GsonPreconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import java.io.Serializable;
@@ -43,10 +43,10 @@ import java.util.Properties;
  * @author Jesse Wilson
  */
 @SuppressWarnings("MemberName") // legacy class name
-public final class $Gson$Types {
+public final class GsonTypes {
   static final Type[] EMPTY_TYPE_ARRAY = new Type[] {};
 
-  private $Gson$Types() {
+  private GsonTypes() {
     throw new UnsupportedOperationException();
   }
 
@@ -288,9 +288,7 @@ public final class $Gson$Types {
     }
     checkArgument(supertype.isAssignableFrom(contextRawType));
     return resolve(
-        context,
-        contextRawType,
-        $Gson$Types.getGenericSupertype(context, contextRawType, supertype));
+        context, contextRawType, GsonTypes.getGenericSupertype(context, contextRawType, supertype));
   }
 
   /**
@@ -555,7 +553,7 @@ public final class $Gson$Types {
     @Override
     public boolean equals(Object other) {
       return other instanceof ParameterizedType
-          && $Gson$Types.equals(this, (ParameterizedType) other);
+          && GsonTypes.equals(this, (ParameterizedType) other);
     }
 
     private static int hashCodeOrZero(Object o) {
@@ -604,7 +602,7 @@ public final class $Gson$Types {
 
     @Override
     public boolean equals(Object o) {
-      return o instanceof GenericArrayType && $Gson$Types.equals(this, (GenericArrayType) o);
+      return o instanceof GenericArrayType && GsonTypes.equals(this, (GenericArrayType) o);
     }
 
     @Override
@@ -664,7 +662,7 @@ public final class $Gson$Types {
 
     @Override
     public boolean equals(Object other) {
-      return other instanceof WildcardType && $Gson$Types.equals(this, (WildcardType) other);
+      return other instanceof WildcardType && GsonTypes.equals(this, (WildcardType) other);
     }
 
     @Override

--- a/gson/src/main/java/com/google/gson/internal/bind/ArrayTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ArrayTypeAdapter.java
@@ -19,7 +19,7 @@ package com.google.gson.internal.bind;
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
-import com.google.gson.internal.$Gson$Types;
+import com.google.gson.internal.GsonTypes;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
@@ -42,13 +42,12 @@ public final class ArrayTypeAdapter<E> extends TypeAdapter<Object> {
             return null;
           }
 
-          Type componentType = $Gson$Types.getArrayComponentType(type);
+          Type componentType = GsonTypes.getArrayComponentType(type);
           TypeAdapter<?> componentTypeAdapter = gson.getAdapter(TypeToken.get(componentType));
 
           @SuppressWarnings({"unchecked", "rawtypes"})
           TypeAdapter<T> arrayAdapter =
-              new ArrayTypeAdapter(
-                  gson, componentTypeAdapter, $Gson$Types.getRawType(componentType));
+              new ArrayTypeAdapter(gson, componentTypeAdapter, GsonTypes.getRawType(componentType));
           return arrayAdapter;
         }
       };

--- a/gson/src/main/java/com/google/gson/internal/bind/CollectionTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/CollectionTypeAdapterFactory.java
@@ -19,8 +19,8 @@ package com.google.gson.internal.bind;
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
-import com.google.gson.internal.$Gson$Types;
 import com.google.gson.internal.ConstructorConstructor;
+import com.google.gson.internal.GsonTypes;
 import com.google.gson.internal.ObjectConstructor;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
@@ -47,7 +47,7 @@ public final class CollectionTypeAdapterFactory implements TypeAdapterFactory {
       return null;
     }
 
-    Type elementType = $Gson$Types.getCollectionElementType(type, rawType);
+    Type elementType = GsonTypes.getCollectionElementType(type, rawType);
     TypeAdapter<?> elementTypeAdapter = gson.getAdapter(TypeToken.get(elementType));
     TypeAdapter<?> wrappedTypeAdapter =
         new TypeAdapterRuntimeTypeWrapper<>(gson, elementTypeAdapter, elementType);

--- a/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
@@ -22,8 +22,8 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
-import com.google.gson.internal.$Gson$Types;
 import com.google.gson.internal.ConstructorConstructor;
+import com.google.gson.internal.GsonTypes;
 import com.google.gson.internal.JsonReaderInternalAccess;
 import com.google.gson.internal.ObjectConstructor;
 import com.google.gson.internal.Streams;
@@ -131,7 +131,7 @@ public final class MapTypeAdapterFactory implements TypeAdapterFactory {
       return null;
     }
 
-    Type[] keyAndValueTypes = $Gson$Types.getMapKeyAndValueTypes(type, rawType);
+    Type[] keyAndValueTypes = GsonTypes.getMapKeyAndValueTypes(type, rawType);
     Type keyType = keyAndValueTypes[0];
     Type valueType = keyAndValueTypes[1];
     TypeAdapter<?> keyAdapter = getKeyAdapter(gson, keyType);

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -27,9 +27,9 @@ import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
-import com.google.gson.internal.$Gson$Types;
 import com.google.gson.internal.ConstructorConstructor;
 import com.google.gson.internal.Excluder;
+import com.google.gson.internal.GsonTypes;
 import com.google.gson.internal.ObjectConstructor;
 import com.google.gson.internal.Primitives;
 import com.google.gson.internal.ReflectionAccessFilterHelper;
@@ -387,7 +387,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
           ReflectionHelper.makeAccessible(field);
         }
 
-        Type fieldType = $Gson$Types.resolve(type.getType(), raw, field.getGenericType());
+        Type fieldType = GsonTypes.resolve(type.getType(), raw, field.getGenericType());
         List<String> fieldNames = getFieldNames(field);
         String serializedName = fieldNames.get(0);
         BoundField boundField =
@@ -417,7 +417,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
           }
         }
       }
-      type = TypeToken.get($Gson$Types.resolve(type.getType(), raw, raw.getGenericSuperclass()));
+      type = TypeToken.get(GsonTypes.resolve(type.getType(), raw, raw.getGenericSuperclass()));
       raw = type.getRawType();
     }
     return new FieldsData(deserializedFields, new ArrayList<>(serializedFields.values()));

--- a/gson/src/main/java/com/google/gson/internal/bind/TreeTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TreeTypeAdapter.java
@@ -25,7 +25,7 @@ import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
-import com.google.gson.internal.$Gson$Preconditions;
+import com.google.gson.internal.GsonPreconditions;
 import com.google.gson.internal.Streams;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
@@ -162,7 +162,7 @@ public final class TreeTypeAdapter<T> extends SerializationDelegatingTypeAdapter
       serializer = typeAdapter instanceof JsonSerializer ? (JsonSerializer<?>) typeAdapter : null;
       deserializer =
           typeAdapter instanceof JsonDeserializer ? (JsonDeserializer<?>) typeAdapter : null;
-      $Gson$Preconditions.checkArgument(serializer != null || deserializer != null);
+      GsonPreconditions.checkArgument(serializer != null || deserializer != null);
       this.exactType = exactType;
       this.matchRawType = matchRawType;
       this.hierarchyType = hierarchyType;

--- a/gson/src/main/java/com/google/gson/reflect/TypeToken.java
+++ b/gson/src/main/java/com/google/gson/reflect/TypeToken.java
@@ -16,7 +16,7 @@
 
 package com.google.gson.reflect;
 
-import com.google.gson.internal.$Gson$Types;
+import com.google.gson.internal.GsonTypes;
 import com.google.gson.internal.TroubleshootingGuide;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.ParameterizedType;
@@ -72,15 +72,15 @@ public class TypeToken<T> {
   @SuppressWarnings("unchecked")
   protected TypeToken() {
     this.type = getTypeTokenTypeArgument();
-    this.rawType = (Class<? super T>) $Gson$Types.getRawType(type);
+    this.rawType = (Class<? super T>) GsonTypes.getRawType(type);
     this.hashCode = type.hashCode();
   }
 
   /** Unsafe. Constructs a type literal manually. */
   @SuppressWarnings("unchecked")
   private TypeToken(Type type) {
-    this.type = $Gson$Types.canonicalize(Objects.requireNonNull(type));
-    this.rawType = (Class<? super T>) $Gson$Types.getRawType(this.type);
+    this.type = GsonTypes.canonicalize(Objects.requireNonNull(type));
+    this.rawType = (Class<? super T>) GsonTypes.getRawType(this.type);
     this.hashCode = this.type.hashCode();
   }
 
@@ -90,14 +90,14 @@ public class TypeToken<T> {
 
   /**
    * Verifies that {@code this} is an instance of a direct subclass of TypeToken and returns the
-   * type argument for {@code T} in {@link $Gson$Types#canonicalize canonical form}.
+   * type argument for {@code T} in {@link GsonTypes#canonicalize canonical form}.
    */
   private Type getTypeTokenTypeArgument() {
     Type superclass = getClass().getGenericSuperclass();
     if (superclass instanceof ParameterizedType) {
       ParameterizedType parameterized = (ParameterizedType) superclass;
       if (parameterized.getRawType() == TypeToken.class) {
-        Type typeArgument = $Gson$Types.canonicalize(parameterized.getActualTypeArguments()[0]);
+        Type typeArgument = GsonTypes.canonicalize(parameterized.getActualTypeArguments()[0]);
 
         if (isCapturingTypeVariablesForbidden()) {
           verifyNoTypeVariable(typeArgument);
@@ -193,11 +193,11 @@ public class TypeToken<T> {
     }
 
     if (type instanceof Class<?>) {
-      return rawType.isAssignableFrom($Gson$Types.getRawType(from));
+      return rawType.isAssignableFrom(GsonTypes.getRawType(from));
     } else if (type instanceof ParameterizedType) {
       return isAssignableFrom(from, (ParameterizedType) type, new HashMap<String, Type>());
     } else if (type instanceof GenericArrayType) {
-      return rawType.isAssignableFrom($Gson$Types.getRawType(from))
+      return rawType.isAssignableFrom(GsonTypes.getRawType(from))
           && isAssignableFrom(from, (GenericArrayType) type);
     } else {
       throw buildUnsupportedTypeException(
@@ -253,7 +253,7 @@ public class TypeToken<T> {
     }
 
     // First figure out the class and any type information.
-    Class<?> clazz = $Gson$Types.getRawType(from);
+    Class<?> clazz = GsonTypes.getRawType(from);
     ParameterizedType ptype = null;
     if (from instanceof ParameterizedType) {
       ptype = (ParameterizedType) from;
@@ -343,12 +343,12 @@ public class TypeToken<T> {
 
   @Override
   public final boolean equals(Object o) {
-    return o instanceof TypeToken<?> && $Gson$Types.equals(type, ((TypeToken<?>) o).type);
+    return o instanceof TypeToken<?> && GsonTypes.equals(type, ((TypeToken<?>) o).type);
   }
 
   @Override
   public final String toString() {
-    return $Gson$Types.typeToString(type);
+    return GsonTypes.typeToString(type);
   }
 
   /** Gets type literal for the given {@code Type} instance. */
@@ -412,7 +412,7 @@ public class TypeToken<T> {
     }
 
     // Check for this here to avoid misleading exception thrown by ParameterizedTypeImpl
-    if ($Gson$Types.requiresOwnerType(rawType)) {
+    if (GsonTypes.requiresOwnerType(rawType)) {
       throw new IllegalArgumentException(
           "Raw type "
               + rawClass.getName()
@@ -422,11 +422,11 @@ public class TypeToken<T> {
     for (int i = 0; i < expectedArgsCount; i++) {
       Type typeArgument =
           Objects.requireNonNull(typeArguments[i], "Type argument must not be null");
-      Class<?> rawTypeArgument = $Gson$Types.getRawType(typeArgument);
+      Class<?> rawTypeArgument = GsonTypes.getRawType(typeArgument);
       TypeVariable<?> typeVariable = typeVariables[i];
 
       for (Type bound : typeVariable.getBounds()) {
-        Class<?> rawBound = $Gson$Types.getRawType(bound);
+        Class<?> rawBound = GsonTypes.getRawType(bound);
 
         if (!rawBound.isAssignableFrom(rawTypeArgument)) {
           throw new IllegalArgumentException(
@@ -440,14 +440,13 @@ public class TypeToken<T> {
       }
     }
 
-    return new TypeToken<>(
-        $Gson$Types.newParameterizedTypeWithOwner(null, rawClass, typeArguments));
+    return new TypeToken<>(GsonTypes.newParameterizedTypeWithOwner(null, rawClass, typeArguments));
   }
 
   /**
    * Gets type literal for the array type whose elements are all instances of {@code componentType}.
    */
   public static TypeToken<?> getArray(Type componentType) {
-    return new TypeToken<>($Gson$Types.arrayOf(componentType));
+    return new TypeToken<>(GsonTypes.arrayOf(componentType));
   }
 }

--- a/gson/src/test/java/com/google/gson/GenericArrayTypeTest.java
+++ b/gson/src/test/java/com/google/gson/GenericArrayTypeTest.java
@@ -18,7 +18,7 @@ package com.google.gson;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.gson.internal.$Gson$Types;
+import com.google.gson.internal.GsonTypes;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Type;
@@ -27,7 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Unit tests for the {@code GenericArrayType}s created by the {@link $Gson$Types} class.
+ * Unit tests for the {@code GenericArrayType}s created by the {@link GsonTypes} class.
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
@@ -38,8 +38,7 @@ public class GenericArrayTypeTest {
   @Before
   public void setUp() throws Exception {
     ourType =
-        $Gson$Types.arrayOf(
-            $Gson$Types.newParameterizedTypeWithOwner(null, List.class, String.class));
+        GsonTypes.arrayOf(GsonTypes.newParameterizedTypeWithOwner(null, List.class, String.class));
   }
 
   @Test

--- a/gson/src/test/java/com/google/gson/ParameterizedTypeFixtures.java
+++ b/gson/src/test/java/com/google/gson/ParameterizedTypeFixtures.java
@@ -16,7 +16,7 @@
 
 package com.google.gson;
 
-import com.google.gson.internal.$Gson$Types;
+import com.google.gson.internal.GsonTypes;
 import com.google.gson.internal.Primitives;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
@@ -139,7 +139,7 @@ public class ParameterizedTypeFixtures {
         JsonElement json, Type typeOfT, JsonDeserializationContext context)
         throws JsonParseException {
       Type genericClass = ((ParameterizedType) typeOfT).getActualTypeArguments()[0];
-      Class<?> rawType = $Gson$Types.getRawType(genericClass);
+      Class<?> rawType = GsonTypes.getRawType(genericClass);
       String className = rawType.getSimpleName();
       JsonElement jsonElement = json.getAsJsonObject().get(className);
 

--- a/gson/src/test/java/com/google/gson/ParameterizedTypeTest.java
+++ b/gson/src/test/java/com/google/gson/ParameterizedTypeTest.java
@@ -18,7 +18,7 @@ package com.google.gson;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.gson.internal.$Gson$Types;
+import com.google.gson.internal.GsonTypes;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -27,7 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Unit tests for {@code ParameterizedType}s created by the {@link $Gson$Types} class.
+ * Unit tests for {@code ParameterizedType}s created by the {@link GsonTypes} class.
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
@@ -37,7 +37,7 @@ public class ParameterizedTypeTest {
 
   @Before
   public void setUp() throws Exception {
-    ourType = $Gson$Types.newParameterizedTypeWithOwner(null, List.class, String.class);
+    ourType = GsonTypes.newParameterizedTypeWithOwner(null, List.class, String.class);
   }
 
   @Test

--- a/gson/src/test/java/com/google/gson/functional/MapTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MapTest.java
@@ -32,7 +32,7 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializer;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.common.TestTypes;
-import com.google.gson.internal.$Gson$Types;
+import com.google.gson.internal.GsonTypes;
 import com.google.gson.internal.LinkedTreeMap;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
@@ -368,8 +368,7 @@ public class MapTest {
 
   @Test
   public void testCustomSerializerForSpecificMapType() {
-    Type type =
-        $Gson$Types.newParameterizedTypeWithOwner(null, Map.class, String.class, Long.class);
+    Type type = GsonTypes.newParameterizedTypeWithOwner(null, Map.class, String.class, Long.class);
     Gson gson =
         new GsonBuilder()
             .registerTypeAdapter(

--- a/gson/src/test/java/com/google/gson/internal/GsonTypesTest.java
+++ b/gson/src/test/java/com/google/gson/internal/GsonTypesTest.java
@@ -33,25 +33,24 @@ public final class GsonTypesTest {
   @Test
   public void testNewParameterizedTypeWithoutOwner() throws Exception {
     // List<A>. List is a top-level class
-    ParameterizedType type = $Gson$Types.newParameterizedTypeWithOwner(null, List.class, A.class);
+    ParameterizedType type = GsonTypes.newParameterizedTypeWithOwner(null, List.class, A.class);
     assertThat(type.getOwnerType()).isNull();
     assertThat(type.getRawType()).isEqualTo(List.class);
     assertThat(type.getActualTypeArguments()).asList().containsExactly(A.class);
 
     // A<B>. A is a static inner class.
-    type = $Gson$Types.newParameterizedTypeWithOwner(null, A.class, B.class);
+    type = GsonTypes.newParameterizedTypeWithOwner(null, A.class, B.class);
     assertThat(getFirstTypeArgument(type)).isEqualTo(B.class);
 
     IllegalArgumentException e =
         assertThrows(
             IllegalArgumentException.class,
             // NonStaticInner<A> is not allowed without owner
-            () -> $Gson$Types.newParameterizedTypeWithOwner(null, NonStaticInner.class, A.class));
+            () -> GsonTypes.newParameterizedTypeWithOwner(null, NonStaticInner.class, A.class));
     assertThat(e).hasMessageThat().isEqualTo("Must specify owner type for " + NonStaticInner.class);
 
     type =
-        $Gson$Types.newParameterizedTypeWithOwner(
-            GsonTypesTest.class, NonStaticInner.class, A.class);
+        GsonTypes.newParameterizedTypeWithOwner(GsonTypesTest.class, NonStaticInner.class, A.class);
     assertThat(type.getOwnerType()).isEqualTo(GsonTypesTest.class);
     assertThat(type.getRawType()).isEqualTo(NonStaticInner.class);
     assertThat(type.getActualTypeArguments()).asList().containsExactly(A.class);
@@ -59,13 +58,13 @@ public final class GsonTypesTest {
     final class D {}
 
     // D<A> is allowed since D has no owner type
-    type = $Gson$Types.newParameterizedTypeWithOwner(null, D.class, A.class);
+    type = GsonTypes.newParameterizedTypeWithOwner(null, D.class, A.class);
     assertThat(type.getOwnerType()).isNull();
     assertThat(type.getRawType()).isEqualTo(D.class);
     assertThat(type.getActualTypeArguments()).asList().containsExactly(A.class);
 
     // A<D> is allowed.
-    type = $Gson$Types.newParameterizedTypeWithOwner(null, A.class, D.class);
+    type = GsonTypes.newParameterizedTypeWithOwner(null, A.class, D.class);
     assertThat(getFirstTypeArgument(type)).isEqualTo(D.class);
   }
 
@@ -73,7 +72,7 @@ public final class GsonTypesTest {
   public void testGetFirstTypeArgument() throws Exception {
     assertThat(getFirstTypeArgument(A.class)).isNull();
 
-    Type type = $Gson$Types.newParameterizedTypeWithOwner(null, A.class, B.class, C.class);
+    Type type = GsonTypes.newParameterizedTypeWithOwner(null, A.class, B.class, C.class);
     assertThat(getFirstTypeArgument(type)).isEqualTo(B.class);
   }
 
@@ -99,7 +98,7 @@ public final class GsonTypesTest {
     if (actualTypeArguments.length == 0) {
       return null;
     }
-    return $Gson$Types.canonicalize(actualTypeArguments[0]);
+    return GsonTypes.canonicalize(actualTypeArguments[0]);
   }
 
   @Test
@@ -110,7 +109,7 @@ public final class GsonTypesTest {
     Type rt1 = m1.getGenericReturnType();
     Type rt2 = m2.getGenericReturnType();
 
-    assertThat($Gson$Types.equals(rt1, rt2)).isTrue();
+    assertThat(GsonTypes.equals(rt1, rt2)).isTrue();
   }
 
   @Test
@@ -121,7 +120,7 @@ public final class GsonTypesTest {
     Type rt1 = c1.getGenericParameterTypes()[0];
     Type rt2 = c2.getGenericParameterTypes()[0];
 
-    assertThat($Gson$Types.equals(rt1, rt2)).isTrue();
+    assertThat(GsonTypes.equals(rt1, rt2)).isTrue();
   }
 
   private static final class TypeVariableTest {
@@ -141,8 +140,7 @@ public final class GsonTypesTest {
       private static final long serialVersionUID = 4112578634029874840L;
     }
 
-    Type[] types =
-        $Gson$Types.getMapKeyAndValueTypes(CustomProperties.class, CustomProperties.class);
+    Type[] types = GsonTypes.getMapKeyAndValueTypes(CustomProperties.class, CustomProperties.class);
 
     assertThat(types[0]).isEqualTo(String.class);
     assertThat(types[1]).isEqualTo(String.class);

--- a/gson/src/test/java/com/google/gson/internal/bind/RecursiveTypesResolveTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/RecursiveTypesResolveTest.java
@@ -20,11 +20,11 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
-import com.google.gson.internal.$Gson$Types;
+import com.google.gson.internal.GsonTypes;
 import org.junit.Test;
 
 /**
- * Test fixes for infinite recursion on {@link $Gson$Types#resolve(java.lang.reflect.Type, Class,
+ * Test fixes for infinite recursion on {@link GsonTypes#resolve(java.lang.reflect.Type, Class,
  * java.lang.reflect.Type)}, described at <a href="https://github.com/google/gson/issues/440">Issue
  * #440</a> and similar issues.
  *
@@ -55,26 +55,26 @@ public class RecursiveTypesResolveTest {
   /** Tests below check the behavior of the methods changed for the fix. */
   @Test
   public void testDoubleSupertype() {
-    assertThat($Gson$Types.supertypeOf($Gson$Types.supertypeOf(Number.class)))
-        .isEqualTo($Gson$Types.supertypeOf(Number.class));
+    assertThat(GsonTypes.supertypeOf(GsonTypes.supertypeOf(Number.class)))
+        .isEqualTo(GsonTypes.supertypeOf(Number.class));
   }
 
   @Test
   public void testDoubleSubtype() {
-    assertThat($Gson$Types.subtypeOf($Gson$Types.subtypeOf(Number.class)))
-        .isEqualTo($Gson$Types.subtypeOf(Number.class));
+    assertThat(GsonTypes.subtypeOf(GsonTypes.subtypeOf(Number.class)))
+        .isEqualTo(GsonTypes.subtypeOf(Number.class));
   }
 
   @Test
   public void testSuperSubtype() {
-    assertThat($Gson$Types.supertypeOf($Gson$Types.subtypeOf(Number.class)))
-        .isEqualTo($Gson$Types.subtypeOf(Object.class));
+    assertThat(GsonTypes.supertypeOf(GsonTypes.subtypeOf(Number.class)))
+        .isEqualTo(GsonTypes.subtypeOf(Object.class));
   }
 
   @Test
   public void testSubSupertype() {
-    assertThat($Gson$Types.subtypeOf($Gson$Types.supertypeOf(Number.class)))
-        .isEqualTo($Gson$Types.subtypeOf(Object.class));
+    assertThat(GsonTypes.subtypeOf(GsonTypes.supertypeOf(Number.class)))
+        .isEqualTo(GsonTypes.subtypeOf(Object.class));
   }
 
   /** Tests for recursion while resolving type variables. */

--- a/gson/src/test/java/com/google/gson/reflect/TypeTokenTest.java
+++ b/gson/src/test/java/com/google/gson/reflect/TypeTokenTest.java
@@ -95,7 +95,7 @@ public final class TypeTokenTest {
         .isEqualTo(
             "Unsupported type, expected one of: java.lang.Class,"
                 + " java.lang.reflect.ParameterizedType, java.lang.reflect.GenericArrayType, but"
-                + " got: com.google.gson.internal.$Gson$Types$WildcardTypeImpl, for type token: "
+                + " got: com.google.gson.internal.GsonTypes$WildcardTypeImpl, for type token: "
                 + wildcardTypeToken);
   }
 


### PR DESCRIPTION
There might have been good reasons to use these weird names back in the day, but they cause problems now and there doesn't seem to be a compelling reason to avoid the more obvious names `GsonPreconditions` and `GsonTypes`.

Closes #1745. Fixes #1744.
