### PR TITLE
Add multi-catch support to the code base

### DIFF
--- a/extras/src/main/java/com/google/gson/typeadapters/UtcDateTypeAdapter.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/UtcDateTypeAdapter.java
@@ -223,11 +223,7 @@ public final class UtcDateTypeAdapter extends TypeAdapter<Date> {
       return calendar.getTime();
       // If we get a ParseException it'll already have the right message/offset.
       // Other exception types can convert here.
-    } catch (IndexOutOfBoundsException e) {
-      fail = e;
-    } catch (NumberFormatException e) {
-      fail = e;
-    } catch (IllegalArgumentException e) {
+    } catch (IndexOutOfBoundsException | IllegalArgumentException e) {
       fail = e;
     }
     String input = (date == null) ? null : ("'" + date + "'");

--- a/gson/src/main/java/com/google/gson/JsonParser.java
+++ b/gson/src/main/java/com/google/gson/JsonParser.java
@@ -112,12 +112,10 @@ public final class JsonParser {
         throw new JsonSyntaxException("Did not consume the entire document.");
       }
       return element;
-    } catch (MalformedJsonException e) {
+    } catch (MalformedJsonException | NumberFormatException e) {
       throw new JsonSyntaxException(e);
     } catch (IOException e) {
       throw new JsonIOException(e);
-    } catch (NumberFormatException e) {
-      throw new JsonSyntaxException(e);
     }
   }
 
@@ -144,9 +142,7 @@ public final class JsonParser {
     }
     try {
       return Streams.parse(reader);
-    } catch (StackOverflowError e) {
-      throw new JsonParseException("Failed parsing JSON source: " + reader + " to Json", e);
-    } catch (OutOfMemoryError e) {
+    } catch (StackOverflowError | OutOfMemoryError e) {
       throw new JsonParseException("Failed parsing JSON source: " + reader + " to Json", e);
     } finally {
       reader.setStrictness(strictness);

--- a/gson/src/main/java/com/google/gson/JsonStreamParser.java
+++ b/gson/src/main/java/com/google/gson/JsonStreamParser.java
@@ -87,9 +87,7 @@ public final class JsonStreamParser implements Iterator<JsonElement> {
 
     try {
       return Streams.parse(parser);
-    } catch (StackOverflowError e) {
-      throw new JsonParseException("Failed parsing JSON source to Json", e);
-    } catch (OutOfMemoryError e) {
+    } catch (StackOverflowError | OutOfMemoryError e) {
       throw new JsonParseException("Failed parsing JSON source to Json", e);
     }
   }


### PR DESCRIPTION
Multi-catch appeared in java 7 and I think we can add it to the code base. It's a small fix, but I think it will kind of freshen up those code sections and make some code sections shorter