### PR TITLE
Add shrinker test for interface implementation being deserialized

### DIFF
--- a/test-shrinker/src/main/java/com/example/InterfaceWithImplementation.java
+++ b/test-shrinker/src/main/java/com/example/InterfaceWithImplementation.java
@@ -1,0 +1,21 @@
+package com.example;
+
+import com.google.gson.annotations.SerializedName;
+
+/** Interface whose implementation class is only referenced for deserialization */
+public interface InterfaceWithImplementation {
+  String getValue();
+
+  // Implementation class which is only referenced in `TypeToken`, but nowhere else
+  public static class Implementation implements InterfaceWithImplementation {
+    public Implementation() {}
+
+    @SerializedName("s")
+    public String s;
+
+    @Override
+    public String getValue() {
+      return s;
+    }
+  }
+}

--- a/test-shrinker/src/main/java/com/example/Main.java
+++ b/test-shrinker/src/main/java/com/example/Main.java
@@ -53,6 +53,8 @@ public class Main {
     testJsonAdapterAnnotation(outputConsumer);
 
     testGenericClasses(outputConsumer);
+
+    testDeserializingInterfaceImpl(outputConsumer);
   }
 
   private static void testTypeTokenWriteRead(
@@ -289,5 +291,26 @@ public class Main {
             gson.fromJson(
                     "{\"g\": {\"t\": 1}}", new TypeToken<GenericUsingGenericClass<DummyClass>>() {})
                 .toString());
+  }
+
+  private static void testDeserializingInterfaceImpl(BiConsumer<String, String> outputConsumer) {
+    Gson gson = new Gson();
+    TestExecutor.run(
+        outputConsumer,
+        "Read: Interface implementation",
+        () -> {
+          try {
+            // Use the interface type here
+            List<? extends InterfaceWithImplementation> list =
+                gson.fromJson(
+                    "[{\"s\": \"value\"}]",
+                    // This is the only place where the implementation class is referenced
+                    new TypeToken<List<InterfaceWithImplementation.Implementation>>() {});
+            return list.get(0).getValue();
+          } catch (ClassCastException e) {
+            // TODO: R8 causes exception, see https://github.com/google/gson/issues/2658
+            return "ClassCastException";
+          }
+        });
   }
 }


### PR DESCRIPTION
Adds a shrinker test which tries to replicate the issue described in #2658.
@alipov, could you please check whether this test, specifically `InterfaceWithImplementation` and the usage in `testDeserializingInterfaceImpl` represents the setup you are using?

For R8 this currently fails, see TODOs in the new code. Not sure if there is something Gson can do at the moment, without making `gson.pro` unconditionally keep classes with `@SerializedName` regardless of whether they are used (which is probably something we want to avoid?). Also note that this might be an uncommon corner case.
Maybe this is actually an R8 bug or limitation.