### PR TITLE
Add Java 24 into the test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,8 @@ jobs:
     name: "Build on JDK ${{ matrix.java }}"
     strategy:
       matrix:
-        java: [ 11, 17, 21 ]
+        # LTS and the latest version.
+        java: [ 11, 17, 21, 24 ]
     runs-on: ubuntu-latest
 
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
                   <!-- Other plugins of this build require at least JDK 11 -->
                   <!-- Disallow newer JDK versions; they might introduce new lints, drop support for
                     older compiler Java target versions or cause issues for some Maven plugins -->
-                  <version>[11,22)</version>
+                  <version>[11,24]</version>
                 </requireJavaVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
### Description

The latest JDK version should be checked on.



### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [ ] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
