### PR TITLE
Use boxed `true` to satisfy Error Prone

### DIFF
--- a/gson/src/test/java/com/google/gson/JsonPrimitiveTest.java
+++ b/gson/src/test/java/com/google/gson/JsonPrimitiveTest.java
@@ -43,7 +43,7 @@ public class JsonPrimitiveTest {
 
   @Test
   public void testBoolean() {
-    JsonPrimitive json = new JsonPrimitive(Boolean.TRUE);
+    JsonPrimitive json = new JsonPrimitive(true);
 
     assertThat(json.isBoolean()).isTrue();
     assertThat(json.getAsBoolean()).isTrue();


### PR DESCRIPTION
(I think this particular suggestion is kind of questionable.)
