### PR TITLE
Remove redundant warning suppression

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/GsonTypes.java
+++ b/gson/src/main/java/com/google/gson/internal/GsonTypes.java
@@ -41,7 +41,6 @@ import java.util.Properties;
  * @author Bob Lee
  * @author Jesse Wilson
  */
-@SuppressWarnings("MemberName") // legacy class name
 public final class GsonTypes {
   static final Type[] EMPTY_TYPE_ARRAY = new Type[] {};
 


### PR DESCRIPTION
Relates to #2753, which originally added the suppressions due to the `$` in the class names
Follow-up for #2838, which removed the `$` from the class names