### PR TITLE
Remove `GsonPreconditions#checkNotNull`

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/GsonPreconditions.java
+++ b/gson/src/main/java/com/google/gson/internal/GsonPreconditions.java
@@ -16,8 +16,6 @@
 
 package com.google.gson.internal;
 
-import java.util.Objects;
-
 /**
  * A simple utility class used to check method Preconditions.
  *
@@ -35,19 +33,6 @@ import java.util.Objects;
 public final class GsonPreconditions {
   private GsonPreconditions() {
     throw new UnsupportedOperationException();
-  }
-
-  /**
-   * @deprecated This is an internal Gson method. Use {@link Objects#requireNonNull(Object)}
-   *     instead.
-   */
-  // Only deprecated for now because external projects might be using this by accident
-  @Deprecated
-  public static <T> T checkNotNull(T obj) {
-    if (obj == null) {
-      throw new NullPointerException();
-    }
-    return obj;
   }
 
   public static void checkArgument(boolean condition) {


### PR DESCRIPTION
The method is not used within the Gson code and was only kept for backward compatibility in case external projects used it, see https://github.com/google/gson/pull/2180#discussion_r950869693.
However, #2838 renamed the enclosing class, which already broke backward compatibility. Therefore it should be safe to remove the method now.
