### PR TITLE
Update sources to satisfy a new Error Prone check.

### DIFF
--- a/extras/src/test/java/com/google/gson/interceptors/InterceptorTest.java
+++ b/extras/src/test/java/com/google/gson/interceptors/InterceptorTest.java
@@ -157,7 +157,7 @@ public final class InterceptorTest {
     String email;
     Address address;
 
-    public User(String name, String password) {
+    User(String name, String password) {
       this.name = name;
       this.password = password;
     }

--- a/gson/src/main/java/com/google/gson/internal/GsonTypes.java
+++ b/gson/src/main/java/com/google/gson/internal/GsonTypes.java
@@ -520,7 +520,7 @@ public final class GsonTypes {
     @SuppressWarnings("serial")
     private final Type[] typeArguments;
 
-    public ParameterizedTypeImpl(Type ownerType, Class<?> rawType, Type... typeArguments) {
+    ParameterizedTypeImpl(Type ownerType, Class<?> rawType, Type... typeArguments) {
       requireNonNull(rawType);
 
       if (ownerType == null && requiresOwnerType(rawType)) {
@@ -592,7 +592,7 @@ public final class GsonTypes {
     @SuppressWarnings("serial")
     private final Type componentType;
 
-    public GenericArrayTypeImpl(Type componentType) {
+    GenericArrayTypeImpl(Type componentType) {
       requireNonNull(componentType);
       this.componentType = canonicalize(componentType);
     }
@@ -633,7 +633,7 @@ public final class GsonTypes {
     @SuppressWarnings("serial")
     private final Type lowerBound;
 
-    public WildcardTypeImpl(Type[] upperBounds, Type[] lowerBounds) {
+    WildcardTypeImpl(Type[] upperBounds, Type[] lowerBounds) {
       if (lowerBounds.length > 1) {
         throw new IllegalArgumentException("At most one lower bound is supported");
       }

--- a/gson/src/main/java/com/google/gson/internal/ReflectionAccessFilterHelper.java
+++ b/gson/src/main/java/com/google/gson/internal/ReflectionAccessFilterHelper.java
@@ -78,7 +78,7 @@ public class ReflectionAccessFilterHelper {
   }
 
   private abstract static class AccessChecker {
-    public static final AccessChecker INSTANCE;
+    static final AccessChecker INSTANCE;
 
     static {
       AccessChecker accessChecker = null;
@@ -116,6 +116,6 @@ public class ReflectionAccessFilterHelper {
       INSTANCE = accessChecker;
     }
 
-    public abstract boolean canAccess(AccessibleObject accessibleObject, Object object);
+    abstract boolean canAccess(AccessibleObject accessibleObject, Object object);
   }
 }

--- a/gson/src/main/java/com/google/gson/internal/bind/CollectionTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/CollectionTypeAdapterFactory.java
@@ -65,7 +65,7 @@ public final class CollectionTypeAdapterFactory implements TypeAdapterFactory {
     private final TypeAdapter<E> elementTypeAdapter;
     private final ObjectConstructor<? extends Collection<E>> constructor;
 
-    public Adapter(
+    Adapter(
         TypeAdapter<E> elementTypeAdapter, ObjectConstructor<? extends Collection<E>> constructor) {
       this.elementTypeAdapter = elementTypeAdapter;
       this.constructor = constructor;

--- a/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
@@ -163,7 +163,7 @@ public final class MapTypeAdapterFactory implements TypeAdapterFactory {
     private final TypeAdapter<V> valueTypeAdapter;
     private final ObjectConstructor<? extends Map<K, V>> constructor;
 
-    public Adapter(
+    Adapter(
         TypeAdapter<K> keyTypeAdapter,
         TypeAdapter<V> valueTypeAdapter,
         ObjectConstructor<? extends Map<K, V>> constructor) {

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -286,16 +286,14 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
   }
 
   private static class FieldsData {
-    static final FieldsData EMPTY =
-        new FieldsData(Collections.emptyMap(), Collections.emptyList());
+    static final FieldsData EMPTY = new FieldsData(Collections.emptyMap(), Collections.emptyList());
 
     /** Maps from JSON member name to field */
     final Map<String, BoundField> deserializedFields;
 
     final List<BoundField> serializedFields;
 
-    FieldsData(
-        Map<String, BoundField> deserializedFields, List<BoundField> serializedFields) {
+    FieldsData(Map<String, BoundField> deserializedFields, List<BoundField> serializedFields) {
       this.deserializedFields = deserializedFields;
       this.serializedFields = serializedFields;
     }

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -286,15 +286,15 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
   }
 
   private static class FieldsData {
-    public static final FieldsData EMPTY =
+    static final FieldsData EMPTY =
         new FieldsData(Collections.emptyMap(), Collections.emptyList());
 
     /** Maps from JSON member name to field */
-    public final Map<String, BoundField> deserializedFields;
+    final Map<String, BoundField> deserializedFields;
 
-    public final List<BoundField> serializedFields;
+    final List<BoundField> serializedFields;
 
-    public FieldsData(
+    FieldsData(
         Map<String, BoundField> deserializedFields, List<BoundField> serializedFields) {
       this.deserializedFields = deserializedFields;
       this.serializedFields = serializedFields;

--- a/gson/src/main/java/com/google/gson/internal/reflect/ReflectionHelper.java
+++ b/gson/src/main/java/com/google/gson/internal/reflect/ReflectionHelper.java
@@ -227,7 +227,7 @@ public class ReflectionHelper {
 
     abstract <T> Constructor<T> getCanonicalRecordConstructor(Class<T> raw);
 
-    public abstract Method getAccessor(Class<?> raw, Field field);
+    abstract Method getAccessor(Class<?> raw, Field field);
   }
 
   private static class RecordSupportedHelper extends RecordHelper {

--- a/gson/src/test/java/com/google/gson/ExposeAnnotationExclusionStrategyTest.java
+++ b/gson/src/test/java/com/google/gson/ExposeAnnotationExclusionStrategyTest.java
@@ -83,22 +83,22 @@ public class ExposeAnnotationExclusionStrategyTest {
   }
 
   private static Field createFieldAttributes(String fieldName) throws Exception {
-    return MockObject.class.getField(fieldName);
+    return MockObject.class.getDeclaredField(fieldName);
   }
 
   @SuppressWarnings("unused")
   private static class MockObject {
-    @Expose public final int exposedField = 0;
+    @Expose final int exposedField = 0;
 
     @Expose(serialize = true, deserialize = true)
-    public final int explicitlyExposedField = 0;
+    final int explicitlyExposedField = 0;
 
     @Expose(serialize = false, deserialize = false)
-    public final int explicitlyHiddenField = 0;
+    final int explicitlyHiddenField = 0;
 
     @Expose(serialize = true, deserialize = false)
-    public final int explicitlyDifferentModeField = 0;
+    final int explicitlyDifferentModeField = 0;
 
-    public final int hiddenField = 0;
+    final int hiddenField = 0;
   }
 }

--- a/gson/src/test/java/com/google/gson/FieldAttributesTest.java
+++ b/gson/src/test/java/com/google/gson/FieldAttributesTest.java
@@ -75,7 +75,7 @@ public class FieldAttributesTest {
   }
 
   private static class Foo {
-    @SuppressWarnings("unused")
+    @SuppressWarnings({"unused", "EffectivelyPrivate"})
     public transient List<String> bar;
   }
 }

--- a/gson/src/test/java/com/google/gson/GsonBuilderTest.java
+++ b/gson/src/test/java/com/google/gson/GsonBuilderTest.java
@@ -202,7 +202,7 @@ public class GsonBuilderTest {
   }
 
   private static class ClassWithoutNoArgsConstructor {
-    @SuppressWarnings("unused")
+    @SuppressWarnings({"unused", "EffectivelyPrivate"})
     public ClassWithoutNoArgsConstructor(String s) {}
   }
 

--- a/gson/src/test/java/com/google/gson/GsonTest.java
+++ b/gson/src/test/java/com/google/gson/GsonTest.java
@@ -664,11 +664,12 @@ public final class GsonTest {
 
     final String s;
 
+    @SuppressWarnings("EffectivelyPrivate")
     public CustomClass3(String s) {
       this.s = s;
     }
 
-    @SuppressWarnings("unused") // called by Gson
+    @SuppressWarnings({"unused", "EffectivelyPrivate"}) // called by Gson
     public CustomClass3() {
       this(NO_ARG_CONSTRUCTOR_VALUE);
     }

--- a/gson/src/test/java/com/google/gson/functional/CollectionTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CollectionTest.java
@@ -178,7 +178,7 @@ public class CollectionTest {
 
   private static class CollectionWithoutNoArgsConstructor<E> extends AbstractCollection<E> {
     // Remove implicit no-args constructor
-    public CollectionWithoutNoArgsConstructor(int unused) {}
+    CollectionWithoutNoArgsConstructor(int unused) {}
 
     @Override
     public boolean add(E e) {
@@ -440,11 +440,11 @@ public class CollectionTest {
   private static class ObjectWithWildcardCollection {
     private final Collection<? extends BagOfPrimitives> collection;
 
-    public ObjectWithWildcardCollection(Collection<? extends BagOfPrimitives> collection) {
+    ObjectWithWildcardCollection(Collection<? extends BagOfPrimitives> collection) {
       this.collection = collection;
     }
 
-    public Collection<? extends BagOfPrimitives> getCollection() {
+    Collection<? extends BagOfPrimitives> getCollection() {
       return collection;
     }
   }

--- a/gson/src/test/java/com/google/gson/functional/ConcurrencyTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ConcurrencyTest.java
@@ -144,7 +144,7 @@ public class ConcurrencyTest {
       this("hello", "world", 42);
     }
 
-    public MyObject(String a, String b, int i) {
+    MyObject(String a, String b, int i) {
       this.a = a;
       this.b = b;
       this.i = i;

--- a/gson/src/test/java/com/google/gson/functional/CustomDeserializerTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CustomDeserializerTest.java
@@ -78,11 +78,11 @@ public class CustomDeserializerTest {
       throw new IllegalStateException();
     }
 
-    public DataHolder(String data) {
+    DataHolder(String data) {
       this.data = data;
     }
 
-    public String getData() {
+    String getData() {
       return data;
     }
   }
@@ -96,11 +96,11 @@ public class CustomDeserializerTest {
       this(new DataHolder(DEFAULT_VALUE));
     }
 
-    public DataHolderWrapper(DataHolder data) {
+    DataHolderWrapper(DataHolder data) {
       this.wrappedData = data;
     }
 
-    public DataHolder getWrappedData() {
+    DataHolder getWrappedData() {
       return wrappedData;
     }
   }
@@ -148,7 +148,7 @@ public class CustomDeserializerTest {
       this.subClass = subClass;
     }
 
-    public Type getSubclass() {
+    Type getSubclass() {
       return subClass;
     }
   }

--- a/gson/src/test/java/com/google/gson/functional/CustomTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CustomTypeAdaptersTest.java
@@ -304,13 +304,13 @@ public class CustomTypeAdaptersTest {
     String part1;
     String part2;
 
-    public StringHolder(String string) {
+    StringHolder(String string) {
       List<String> parts = Splitter.on(':').splitToList(string);
       part1 = parts.get(0);
       part2 = parts.get(1);
     }
 
-    public StringHolder(String part1, String part2) {
+    StringHolder(String part1, String part2) {
       this.part1 = part1;
       this.part2 = part2;
     }
@@ -466,7 +466,7 @@ public class CustomTypeAdaptersTest {
   private static class DataHolder {
     final String data;
 
-    public DataHolder(String data) {
+    DataHolder(String data) {
       this.data = data;
     }
   }
@@ -474,7 +474,7 @@ public class CustomTypeAdaptersTest {
   private static class DataHolderWrapper {
     final DataHolder wrappedData;
 
-    public DataHolderWrapper(DataHolder data) {
+    DataHolderWrapper(DataHolder data) {
       this.wrappedData = data;
     }
   }

--- a/gson/src/test/java/com/google/gson/functional/DelegateTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DelegateTypeAdapterTest.java
@@ -72,8 +72,8 @@ public class DelegateTypeAdapterTest {
   }
 
   private static class StatsTypeAdapterFactory implements TypeAdapterFactory {
-    public int numReads = 0;
-    public int numWrites = 0;
+    int numReads = 0;
+    int numWrites = 0;
 
     @Override
     public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {

--- a/gson/src/test/java/com/google/gson/functional/EnumTest.java
+++ b/gson/src/test/java/com/google/gson/functional/EnumTest.java
@@ -113,7 +113,7 @@ public class EnumTest {
     private final MyEnum value1 = MyEnum.VALUE1;
     private final MyEnum value2 = MyEnum.VALUE2;
 
-    public String getExpectedJson() {
+    String getExpectedJson() {
       return "{\"value1\":\"" + value1 + "\",\"value2\":\"" + value2 + "\"}";
     }
   }

--- a/gson/src/test/java/com/google/gson/functional/ExclusionStrategyFunctionalTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ExclusionStrategyFunctionalTest.java
@@ -189,11 +189,11 @@ public class ExclusionStrategyFunctionalTest {
     private final String stringField;
     private final long longField;
 
-    public SampleObjectForTest() {
+    SampleObjectForTest() {
       this(5, "someDefaultValue", 12345L);
     }
 
-    public SampleObjectForTest(int annotatedField, String stringField, long longField) {
+    SampleObjectForTest(int annotatedField, String stringField, long longField) {
       this.annotatedField = annotatedField;
       this.stringField = stringField;
       this.longField = longField;

--- a/gson/src/test/java/com/google/gson/functional/ExposeFieldsTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ExposeFieldsTest.java
@@ -138,11 +138,11 @@ public class ExposeFieldsTest {
     @Keep
     final char e;
 
-    public ClassWithExposedFields(Integer a, Integer b) {
+    ClassWithExposedFields(Integer a, Integer b) {
       this(a, b, 1L, 2.0, 'a');
     }
 
-    public ClassWithExposedFields(Integer a, Integer b, long c, double d, char e) {
+    ClassWithExposedFields(Integer a, Integer b, long c, double d, char e) {
       this.a = a;
       this.b = b;
       this.c = c;
@@ -150,7 +150,7 @@ public class ExposeFieldsTest {
       this.e = e;
     }
 
-    public String getExpectedJson() {
+    String getExpectedJson() {
       StringBuilder sb = new StringBuilder("{");
       if (a != null) {
         sb.append("\"a\":").append(a).append(",");
@@ -184,7 +184,7 @@ public class ExposeFieldsTest {
   private static class ClassWithInterfaceField {
     @Expose private final SomeInterface interfaceField;
 
-    public ClassWithInterfaceField(SomeInterface interfaceField) {
+    ClassWithInterfaceField(SomeInterface interfaceField) {
       this.interfaceField = interfaceField;
     }
   }

--- a/gson/src/test/java/com/google/gson/functional/FieldExclusionTest.java
+++ b/gson/src/test/java/com/google/gson/functional/FieldExclusionTest.java
@@ -78,7 +78,7 @@ public class FieldExclusionTest {
 
     @SuppressWarnings("ClassCanBeStatic")
     private class Inner extends NestedClass {
-      public Inner(String value) {
+      Inner(String value) {
         super(value);
       }
     }
@@ -87,11 +87,11 @@ public class FieldExclusionTest {
   private static class NestedClass {
     private final String value;
 
-    public NestedClass(String value) {
+    NestedClass(String value) {
       this.value = value;
     }
 
-    public String toJson() {
+    String toJson() {
       return "{\"value\":\"" + value + "\"}";
     }
   }

--- a/gson/src/test/java/com/google/gson/functional/InheritanceTest.java
+++ b/gson/src/test/java/com/google/gson/functional/InheritanceTest.java
@@ -156,7 +156,7 @@ public class InheritanceTest {
   private static class SubTypeOfNested extends Nested {
     private final long value = 5;
 
-    public SubTypeOfNested(BagOfPrimitives primitive1, BagOfPrimitives primitive2) {
+    SubTypeOfNested(BagOfPrimitives primitive1, BagOfPrimitives primitive2) {
       super(primitive1, primitive2);
     }
 
@@ -215,7 +215,7 @@ public class InheritanceTest {
     private Set<Float> set;
     private SortedSet<Character> sortedSet;
 
-    public ClassWithSubInterfacesOfCollection(
+    ClassWithSubInterfacesOfCollection(
         List<Integer> list, Queue<Long> queue, Set<Float> set, SortedSet<Character> sortedSet) {
       this.list = list;
       this.queue = queue;
@@ -259,7 +259,7 @@ public class InheritanceTest {
       return true;
     }
 
-    public String getExpectedJson() {
+    String getExpectedJson() {
       StringBuilder sb = new StringBuilder();
       sb.append("{");
       sb.append("\"list\":");

--- a/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java
@@ -180,7 +180,7 @@ public final class JsonAdapterAnnotationOnClassesTest {
   private static class WithNullReturningFactory<T> {
     T t;
 
-    public WithNullReturningFactory(T t) {
+    WithNullReturningFactory(T t) {
       this.t = t;
     }
 
@@ -761,11 +761,11 @@ public final class JsonAdapterAnnotationOnClassesTest {
       private final String value;
 
       @SuppressWarnings("unused")
-      public Serializer() {
+      Serializer() {
         throw new AssertionError("should not be called");
       }
 
-      public Serializer(String value) {
+      Serializer(String value) {
         this.value = value;
       }
 
@@ -792,7 +792,7 @@ public final class JsonAdapterAnnotationOnClassesTest {
 
       // Explicit constructor with args to remove implicit no-args constructor
       @SuppressWarnings("unused")
-      public Serializer(int i) {
+      Serializer(int i) {
         throw new AssertionError("should not be called");
       }
 

--- a/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnFieldsTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnFieldsTest.java
@@ -126,7 +126,7 @@ public final class JsonAdapterAnnotationOnFieldsTest {
   private static final class Part {
     final String name;
 
-    public Part(String name) {
+    Part(String name) {
       this.name = name;
     }
   }
@@ -173,7 +173,7 @@ public final class JsonAdapterAnnotationOnFieldsTest {
 
   @JsonAdapter(UserClassAnnotationAdapter.class)
   private static class User {
-    public final String name;
+    final String name;
 
     private User(String name) {
       this.name = name;

--- a/gson/src/test/java/com/google/gson/functional/JsonAdapterSerializerDeserializerTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonAdapterSerializerDeserializerTest.java
@@ -76,7 +76,7 @@ public final class JsonAdapterSerializerDeserializerTest {
   }
 
   private static final class User {
-    public final String name;
+    final String name;
 
     private User(String name) {
       this.name = name;
@@ -131,7 +131,7 @@ public final class JsonAdapterSerializerDeserializerTest {
 
   @JsonAdapter(UserSerializerDeserializer2.class)
   private static final class User2 {
-    public final String name;
+    final String name;
 
     private User2(String name) {
       this.name = name;

--- a/gson/src/test/java/com/google/gson/functional/JsonTreeTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonTreeTest.java
@@ -104,7 +104,7 @@ public class JsonTreeTest {
     @SuppressWarnings("unused")
     float f = 1.2F;
 
-    public SubTypeOfBagOfPrimitives(long l, int i, boolean b, String string, float f) {
+    SubTypeOfBagOfPrimitives(long l, int i, boolean b, String string, float f) {
       super(l, i, b, string);
       this.f = f;
     }

--- a/gson/src/test/java/com/google/gson/functional/MapTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MapTest.java
@@ -393,7 +393,7 @@ public class MapTest {
 
   private static class MapWithoutNoArgsConstructor<K, V> extends AbstractMap<K, V> {
     // Remove implicit no-args constructor
-    public MapWithoutNoArgsConstructor(int unused) {}
+    MapWithoutNoArgsConstructor(int unused) {}
 
     @Override
     public V put(K key, V value) {

--- a/gson/src/test/java/com/google/gson/functional/NamingPolicyTest.java
+++ b/gson/src/test/java/com/google/gson/functional/NamingPolicyTest.java
@@ -324,20 +324,20 @@ public class NamingPolicyTest {
 
   @SuppressWarnings("unused")
   private static class ClassWithDuplicateFields {
-    public Integer a;
+    Integer a;
 
     @SerializedName("a")
-    public Double b;
+    Double b;
 
-    public ClassWithDuplicateFields(Integer a) {
+    ClassWithDuplicateFields(Integer a) {
       this(a, null);
     }
 
-    public ClassWithDuplicateFields(Double b) {
+    ClassWithDuplicateFields(Double b) {
       this(null, b);
     }
 
-    public ClassWithDuplicateFields(Integer a, Double b) {
+    ClassWithDuplicateFields(Integer a, Double b) {
       this.a = a;
       this.b = b;
     }
@@ -345,7 +345,7 @@ public class NamingPolicyTest {
 
   private static class ClassWithComplexFieldName {
     @SerializedName("@value\"_s$\\")
-    public final long value;
+    final long value;
 
     ClassWithComplexFieldName(long value) {
       this.value = value;
@@ -354,9 +354,9 @@ public class NamingPolicyTest {
 
   @SuppressWarnings("unused")
   private static class ClassWithTwoFields {
-    public int a;
-    public int b;
+    int a;
+    int b;
 
-    public ClassWithTwoFields() {}
+    ClassWithTwoFields() {}
   }
 }

--- a/gson/src/test/java/com/google/gson/functional/ObjectTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ObjectTest.java
@@ -497,7 +497,7 @@ public class ObjectTest {
   private static class ArrayOfArrays {
     private final BagOfPrimitives[][] elements;
 
-    public ArrayOfArrays() {
+    ArrayOfArrays() {
       elements = new BagOfPrimitives[3][2];
       for (int i = 0; i < elements.length; ++i) {
         BagOfPrimitives[] row = elements[i];
@@ -507,7 +507,7 @@ public class ObjectTest {
       }
     }
 
-    public String getExpectedJson() {
+    String getExpectedJson() {
       StringBuilder sb = new StringBuilder("{\"elements\":[");
       boolean first = true;
       for (BagOfPrimitives[] row : elements) {
@@ -534,7 +534,7 @@ public class ObjectTest {
   }
 
   private static class ClassWithPrivateNoArgsConstructor {
-    public int a;
+    int a;
 
     private ClassWithPrivateNoArgsConstructor() {
       a = 10;

--- a/gson/src/test/java/com/google/gson/functional/ParameterizedTypesTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ParameterizedTypesTest.java
@@ -305,7 +305,7 @@ public class ParameterizedTypesTest {
       this(null, null, null, null, null, null);
     }
 
-    public ObjectWithTypeVariables(
+    ObjectWithTypeVariables(
         T obj,
         T[] array,
         List<T> list,
@@ -320,7 +320,7 @@ public class ParameterizedTypesTest {
       this.arrayOfListOfWildcardTypeParameters = arrayOfWildcardList;
     }
 
-    public String getExpectedJson() {
+    String getExpectedJson() {
       StringBuilder sb = new StringBuilder().append("{");
 
       boolean needsComma = false;
@@ -410,7 +410,7 @@ public class ParameterizedTypesTest {
       }
     }
 
-    public String toString(T obj) {
+    String toString(T obj) {
       return obj.toString();
     }
   }

--- a/gson/src/test/java/com/google/gson/functional/ReflectionAccessFilterTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ReflectionAccessFilterTest.java
@@ -190,12 +190,12 @@ public class ReflectionAccessFilterTest {
 
   private static class SubTestClass extends SuperTestClass {
     @SuppressWarnings("unused")
-    public int i = 1;
+    int i = 1;
   }
 
   private static class OtherClass {
     @SuppressWarnings("unused")
-    public int i = 2;
+    int i = 2;
   }
 
   @Test
@@ -329,9 +329,9 @@ public class ReflectionAccessFilterTest {
   }
 
   private static class ClassWithoutNoArgsConstructor {
-    public String s;
+    String s;
 
-    public ClassWithoutNoArgsConstructor(String s) {
+    ClassWithoutNoArgsConstructor(String s) {
       this.s = s;
     }
   }

--- a/gson/src/test/java/com/google/gson/functional/ReusedTypeVariablesFullyResolveTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ReusedTypeVariablesFullyResolveTest.java
@@ -68,6 +68,6 @@ public class ReusedTypeVariablesFullyResolveTest {
   private static class SetCollection<T> extends BaseCollection<T, Set<T>> {}
 
   private static class BaseCollection<U, C extends Collection<U>> {
-    public C collection;
+    C collection;
   }
 }

--- a/gson/src/test/java/com/google/gson/functional/RuntimeTypeAdapterFactoryFunctionalTest.java
+++ b/gson/src/test/java/com/google/gson/functional/RuntimeTypeAdapterFactoryFunctionalTest.java
@@ -67,7 +67,7 @@ public final class RuntimeTypeAdapterFactoryFunctionalTest {
     }
 
     private static final class JsonAdapterFactory extends RuntimeTypeAdapterFactory<Shape> {
-      public JsonAdapterFactory() {
+      JsonAdapterFactory() {
         super(Shape.class, "type");
         registerSubtype(Circle.class, ShapeType.CIRCLE.toString());
         registerSubtype(Square.class, ShapeType.SQUARE.toString());

--- a/gson/src/test/java/com/google/gson/functional/TreeTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/TreeTypeAdaptersTest.java
@@ -91,7 +91,7 @@ public class TreeTypeAdaptersTest {
       this.typeOfId = typeOfId;
     }
 
-    public String getValue() {
+    String getValue() {
       return value;
     }
   }
@@ -127,7 +127,7 @@ public class TreeTypeAdaptersTest {
       this(null, null);
     }
 
-    public Student(Id<Student> id, String name) {
+    Student(Id<Student> id, String name) {
       this.id = id;
       this.name = name;
     }
@@ -144,7 +144,7 @@ public class TreeTypeAdaptersTest {
       this(null, 0, null, new ArrayList<>());
     }
 
-    public Course(
+    Course(
         Id<Course<T>> courseId,
         int numAssignments,
         Assignment<T> assignment,
@@ -155,7 +155,7 @@ public class TreeTypeAdaptersTest {
       this.students = players;
     }
 
-    public Id<Course<T>> getId() {
+    Id<Course<T>> getId() {
       return courseId;
     }
 
@@ -173,7 +173,7 @@ public class TreeTypeAdaptersTest {
       this(null, null);
     }
 
-    public Assignment(Id<Assignment<T>> id, T data) {
+    Assignment(Id<Assignment<T>> id, T data) {
       this.id = id;
       this.data = data;
     }

--- a/gson/src/test/java/com/google/gson/functional/TypeAdapterRuntimeTypeWrapperTest.java
+++ b/gson/src/test/java/com/google/gson/functional/TypeAdapterRuntimeTypeWrapperTest.java
@@ -185,7 +185,7 @@ public class TypeAdapterRuntimeTypeWrapperTest {
     @SuppressWarnings("unused")
     int i;
 
-    public CyclicSub(int i) {
+    CyclicSub(int i) {
       this.i = i;
     }
   }

--- a/gson/src/test/java/com/google/gson/integration/OSGiManifestIT.java
+++ b/gson/src/test/java/com/google/gson/integration/OSGiManifestIT.java
@@ -48,10 +48,10 @@ import org.junit.Test;
 @SuppressWarnings("MemberName") // class name must end with 'IT' for Maven Failsafe Plugin
 public class OSGiManifestIT {
   private static class ManifestData {
-    public final URL url;
-    public final Manifest manifest;
+    final URL url;
+    final Manifest manifest;
 
-    public ManifestData(URL url, Manifest manifest) {
+    ManifestData(URL url, Manifest manifest) {
       this.url = url;
       this.manifest = manifest;
     }

--- a/gson/src/test/java/com/google/gson/internal/ConstructorConstructorTest.java
+++ b/gson/src/test/java/com/google/gson/internal/ConstructorConstructorTest.java
@@ -43,7 +43,7 @@ public class ConstructorConstructorTest {
 
   private abstract static class AbstractClass {
     @SuppressWarnings("unused")
-    public AbstractClass() {}
+    AbstractClass() {}
   }
 
   private interface Interface {}

--- a/gson/src/test/java/com/google/gson/internal/GsonTypesTest.java
+++ b/gson/src/test/java/com/google/gson/internal/GsonTypesTest.java
@@ -113,8 +113,8 @@ public final class GsonTypesTest {
 
   @Test
   public void testEqualsOnMethodTypeVariables() throws Exception {
-    Method m1 = TypeVariableTest.class.getMethod("method");
-    Method m2 = TypeVariableTest.class.getMethod("method");
+    Method m1 = TypeVariableTest.class.getDeclaredMethod("method");
+    Method m2 = TypeVariableTest.class.getDeclaredMethod("method");
 
     Type rt1 = m1.getGenericReturnType();
     Type rt2 = m2.getGenericReturnType();
@@ -124,8 +124,8 @@ public final class GsonTypesTest {
 
   @Test
   public void testEqualsOnConstructorParameterTypeVariables() throws Exception {
-    Constructor<TypeVariableTest> c1 = TypeVariableTest.class.getConstructor(Object.class);
-    Constructor<TypeVariableTest> c2 = TypeVariableTest.class.getConstructor(Object.class);
+    Constructor<TypeVariableTest> c1 = TypeVariableTest.class.getDeclaredConstructor(Object.class);
+    Constructor<TypeVariableTest> c2 = TypeVariableTest.class.getDeclaredConstructor(Object.class);
 
     Type rt1 = c1.getGenericParameterTypes()[0];
     Type rt2 = c2.getGenericParameterTypes()[0];
@@ -136,10 +136,10 @@ public final class GsonTypesTest {
   private static final class TypeVariableTest {
 
     @SuppressWarnings("unused")
-    public <T> TypeVariableTest(T parameter) {}
+    <T> TypeVariableTest(T parameter) {}
 
     @SuppressWarnings({"unused", "TypeParameterUnusedInFormals"})
-    public <T> T method() {
+    <T> T method() {
       return null;
     }
   }

--- a/gson/src/test/java/com/google/gson/internal/LinkedTreeMapSuiteTest.java
+++ b/gson/src/test/java/com/google/gson/internal/LinkedTreeMapSuiteTest.java
@@ -25,7 +25,7 @@ public class LinkedTreeMapSuiteTest {
   private static class MapGenerator extends TestStringMapGenerator {
     private final boolean allowNullValues;
 
-    public MapGenerator(boolean allowNullValues) {
+    MapGenerator(boolean allowNullValues) {
       this.allowNullValues = allowNullValues;
     }
 

--- a/gson/src/test/java/com/google/gson/internal/bind/Java17ReflectiveTypeAdapterFactoryTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/Java17ReflectiveTypeAdapterFactoryTest.java
@@ -47,7 +47,7 @@ public class Java17ReflectiveTypeAdapterFactoryTest {
   // Class for which the normal reflection based adapter is used
   private static class DummyClass {
     @SuppressWarnings("unused")
-    public String s;
+    String s;
   }
 
   @Test

--- a/gson/src/test/java/com/google/gson/internal/bind/RecursiveTypesResolveTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/RecursiveTypesResolveTest.java
@@ -36,12 +36,12 @@ public class RecursiveTypesResolveTest {
 
   @SuppressWarnings("unused")
   private static class Foo1<A> {
-    public Foo2<? extends A> foo2;
+    Foo2<? extends A> foo2;
   }
 
   @SuppressWarnings("unused")
   private static class Foo2<B> {
-    public Foo1<? super B> foo1;
+    Foo1<? super B> foo1;
   }
 
   /** Test simplest case of recursion. */

--- a/gson/src/test/java/com/google/gson/metrics/PerformanceTest.java
+++ b/gson/src/test/java/com/google/gson/metrics/PerformanceTest.java
@@ -83,8 +83,8 @@ public class PerformanceTest {
   }
 
   private static class ExceptionHolder {
-    public final String message;
-    public final String stackTrace;
+    final String message;
+    final String stackTrace;
 
     // For use by Gson
     @SuppressWarnings("unused")
@@ -92,7 +92,7 @@ public class PerformanceTest {
       this("", "");
     }
 
-    public ExceptionHolder(String message, String stackTrace) {
+    ExceptionHolder(String message, String stackTrace) {
       this.message = message;
       this.stackTrace = stackTrace;
     }
@@ -334,7 +334,7 @@ public class PerformanceTest {
       this("");
     }
 
-    public ClassWithField(String field) {
+    ClassWithField(String field) {
       this.field = field;
     }
   }


### PR DESCRIPTION
The latest Error Prone release includes a new check `EffectivelyPrivate`, which flags class members that are public or protected when the enclosing class isn't. This is only a warning in Error Prone, but because we treat warnings as errors it currently breaks the build.

Nearly all cases were in private nested classes in tests. For the most part the members didn't need to be public. In a couple of places they were accessed through reflection in the test, and it was enough to change `getField` to `getDeclaredField` (etc). (`getField` only retrieves public fields.) I don't believe any of these tests depended on the public members for the correctness of what they were testing. Although `getField` works when the target field is public, regardless of the visibility of the containing class, actually reading or writing a field requires both the field and its containing class to be public unless `Field.setAccessible(true)` is called, and likewise for constructors and methods.

