### PR TITLE
Set top-level permissions for CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,9 @@ on:
     # Run every Monday at 16:10
     - cron: '10 16 * * 1'
 
+permissions:
+  contents: read #  to fetch code (actions/checkout)
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})


### PR DESCRIPTION
As recommended by https://scorecard.dev/viewer/?uri=github.com/google/gson
This should hopefully lead to a score of 10 then for "Token-Permissions".

Note however, that this currently most likely has no effect because the `analyze` job already has permissions set (and `contents: read` might be implicit for public repositories).
Nonetheless https://github.com/ossf/scorecard/blob/v5.1.1/docs/checks.md#token-permissions recommends to set reduced top-level permissions so that if an additional job is added in the future and it is missing explicit `permissions` it will inherit the reduced top-level permissions.

Technically because this is a public repository it seems `contents: read` might be redundant for all of the workflows and `permissions: {}` for ["no permissions"](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#defining-access-for-the-github_token-scopes) would work as well (respectively only specifying the additional permissions which are needed), but it might not hurt to keep it. Though if it was 'missing' in a workflow or for a specific job we would not notice it I think.
