### PR TITLE
Fix outdated version comment for `github/codeql-action`

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -32,7 +32,7 @@ jobs:
         path: ./out/artifacts
     - name: Upload Sarif
       if: always() && steps.build.outcome == 'success'
-      uses: github/codeql-action/upload-sarif@3c3833e0f8c1c83d449a7478aa59c036a9165498  # v3.29.5
+      uses: github/codeql-action/upload-sarif@3c3833e0f8c1c83d449a7478aa59c036a9165498  # v3.29.11
       with:
         # Path to SARIF file relative to the root of the repository
         sarif_file: cifuzz-sarif/results.sarif

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,7 +45,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@3c3833e0f8c1c83d449a7478aa59c036a9165498  # v3.29.5
+      uses: github/codeql-action/init@3c3833e0f8c1c83d449a7478aa59c036a9165498  # v3.29.11
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -61,6 +61,6 @@ jobs:
         mvn compile --batch-mode --no-transfer-progress
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@3c3833e0f8c1c83d449a7478aa59c036a9165498  # v3.29.5
+      uses: github/codeql-action/analyze@3c3833e0f8c1c83d449a7478aa59c036a9165498  # v3.29.11
       with:
         category: "/language:${{ matrix.language }}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -73,6 +73,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.5
+        uses: github/codeql-action/upload-sarif@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.11
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
In https://github.com/google/gson/pull/2894 Dependabot did not update the version comments.

See also https://github.com/dependabot/dependabot-core/issues/13197. The assumption there is that this happened because `github/codeql-action` used two different tags ([v3.29.5](https://github.com/github/codeql-action/releases/tag/v3.29.5) and [v3.29.7](https://github.com/github/codeql-action/releases/tag/v3.29.7)) for the same commit. So when Dependabot updated the version, it thought it was updating from `v3.29.7`. When updating the version comment it checks for text matching the previous version number. Thus the old `v3.29.5` did not match and was not updated.