### PR TITLE
Update exec-maven-plugin to 3.6.0

### DIFF
--- a/test-shrinker/pom.xml
+++ b/test-shrinker/pom.xml
@@ -32,13 +32,13 @@
     <gson.isTestModule>true</gson.isTestModule>
   </properties>
 
-  <pluginRepositories>
+  <repositories>
     <!-- R8 currently only exists in Google Maven repository -->
-    <pluginRepository>
+    <repository>
       <id>google</id>
       <url>https://maven.google.com</url>
-    </pluginRepository>
-  </pluginRepositories>
+    </repository>
+  </repositories>
 
   <dependencies>
     <dependency>
@@ -145,7 +145,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <id>r8</id>


### PR DESCRIPTION
Plugin is now using the configured regular repositories for downloading dependencies. See https://redirect.github.com/mojohaus/exec-maven-plugin/pull/480

See also https://github.com/google/gson/pull/2914#issuecomment-3363683962