### PR TITLE
Require JDK 17 for building & update plugins and dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,14 @@ jobs:
     name: "Build on JDK ${{ matrix.java }}"
     strategy:
       matrix:
-        java: [ 11, 17, 21 ]
+        java: [ 17, 21 ]
+        # Custom JDK 11 configuration because some of the plugins and test dependencies don't support it anymore,
+        # but it is important to still test with a JDK version without Record classes
+        include:
+          - java: 11
+            # Disable Enforcer check which (intentionally) prevents using JDK 11 for building
+            # Exclude 'test-graal-native-image' module because JUnit 6 requires >= Java 17
+            extra-mvn-args: -Denforcer.fail=false --projects '!:test-graal-native-image'
     runs-on: ubuntu-latest
 
     steps:
@@ -29,7 +36,7 @@ jobs:
           cache: 'maven'
       - name: Build with Maven
         # This also runs javadoc:jar to detect any issues with the Javadoc generated during release
-        run: mvn --batch-mode --no-transfer-progress verify javadoc:jar
+        run: mvn --batch-mode --no-transfer-progress verify javadoc:jar ${{ matrix.extra-mvn-args || '' }}
 
   native-image-test:
     name: "GraalVM Native Image test"
@@ -56,7 +63,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
-      - name: "Set up JDK 17"
+      - name: Set up JDK
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165  # v5.0.0
         with:
           distribution: 'temurin'

--- a/.github/workflows/check-android-compatibility.yml
+++ b/.github/workflows/check-android-compatibility.yml
@@ -22,11 +22,11 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165  # v5.0.0
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           cache: 'maven'
 
       - name: Check Android compatibility

--- a/.github/workflows/check-api-compatibility.yml
+++ b/.github/workflows/check-api-compatibility.yml
@@ -26,11 +26,11 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
           path: 'gson-old-japicmp'
 
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165  # v5.0.0
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           cache: 'maven'
 
       - name: Build old version

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
-    - name: Set up JDK 17
+    - name: Set up JDK
       if: ${{ matrix.language == 'java' }}
       uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165  # v5.0.0
       with:

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Gson uses Maven to build the project:
 mvn clean verify
 ```
 
-JDK 11 or newer is required for building, JDK 17 or 21 is recommended. Newer JDKs are currently not supported for building (but are supported when _using_ Gson).
+JDK 17 or newer is required for building, JDK 21 is recommended. Newer JDKs are currently not supported for building (but are supported when _using_ Gson).
 
 ### Contributing
 

--- a/gson/src/test/java/com/google/gson/functional/Java17RecordTest.java
+++ b/gson/src/test/java/com/google/gson/functional/Java17RecordTest.java
@@ -157,7 +157,9 @@ public final class Java17RecordTest {
     }
 
     // TODO: Adjust this once Gson throws more specific exception type
-    var e = assertThrows(RuntimeException.class, () -> gson.fromJson("{\"s\":\"value\"}", LocalRecord.class));
+    var e =
+        assertThrows(
+            RuntimeException.class, () -> gson.fromJson("{\"s\":\"value\"}", LocalRecord.class));
     assertThat(e)
         .hasMessageThat()
         .isEqualTo(

--- a/pom.xml
+++ b/pom.xml
@@ -116,10 +116,11 @@
 
                 <!-- Enforce that correct JDK version is used to avoid cryptic build errors -->
                 <requireJavaVersion>
-                  <!-- Other plugins of this build require at least JDK 11 -->
-                  <!-- Disallow newer JDK versions; they might introduce new lints, drop support for
-                    older compiler Java target versions or cause issues for some Maven plugins -->
-                  <version>[11,22)</version>
+                  <!-- Some plugins and test dependencies require at least JDK 17 -->
+                  <!-- Also disallow too new JDK versions; they might introduce new lints, drop support
+                    for older compiler Java target versions or cause issues for some Maven plugins.
+                    Failing fast for such versions is better than failing with a confusing error during build. -->
+                  <version>[17,22)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>
@@ -131,7 +132,7 @@
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
-        <version>2.46.1</version>
+        <version>3.0.0</version>
         <executions>
           <execution>
             <goals>
@@ -165,12 +166,6 @@
           </formats>
 
           <java>
-            <excludes>
-              <!-- Exclude classes which need Java 17 for compilation; Google Java Format internally relies on javac,
-                so formatting will fail if build is executed with JDK 11 -->
-              <exclude>src/test/java/com/google/gson/functional/Java17RecordTest.java</exclude>
-              <exclude>src/test/java/com/google/gson/native_test/Java17RecordReflectionTest.java</exclude>
-            </excludes>
             <googleJavaFormat>
               <style>GOOGLE</style>
               <reflowLongStrings>true</reflowLongStrings>
@@ -547,6 +542,27 @@
   </build>
 
   <profiles>
+    <!-- Disable Spotless before Java 17 -->
+    <profile>
+      <id>disable-spotless</id>
+      <activation>
+        <jdk>[,17)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.diffplug.spotless</groupId>
+            <artifactId>spotless-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>default</id>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <!-- Disable Error Prone before Java 17 -->
     <profile>
       <id>disable-error-prone</id>

--- a/test-graal-native-image/pom.xml
+++ b/test-graal-native-image/pom.xml
@@ -39,7 +39,7 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.13.4</version>
+        <version>6.0.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -137,7 +137,7 @@
           <plugin>
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
-            <version>0.11.0</version>
+            <version>0.11.1</version>
             <extensions>true</extensions>
             <executions>
               <execution>


### PR DESCRIPTION
### Purpose
Require JDK 17 for building, and applies some of the version updates of #2914

### Description
Applies the version updates of #2914 which require JDK 17 or newer. I have omitted the other version updates to keep this cleaner; they can be applies independently afterwards.

The CI build still runs on JDK 11 as well (but with a custom configuration) to ensure that Gson works on a version without Record classes properly as well.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
