### PR TITLE
Improve skipping of tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,13 +71,13 @@ jobs:
           cache: 'maven'
 
       - name: "Verify no plugin issues"
-        run: mvn artifact:check-buildplan --batch-mode --no-transfer-progress
+        run: mvn artifact:check-buildplan --batch-mode --no-transfer-progress --projects '!metrics,!test-graal-native-image,!test-jpms,!test-shrinker'
 
       - name: "Verify reproducible build"
         # See https://maven.apache.org/guides/mini/guide-reproducible-builds.html#how-to-test-my-maven-build-reproducibility
         run: |
-          mvn clean install --batch-mode --no-transfer-progress -Dproguard.skip -DskipTests
+          mvn clean install --batch-mode --no-transfer-progress -Dmaven.test.skip --projects '!metrics,!test-graal-native-image,!test-jpms,!test-shrinker'
           # Run with `-Dbuildinfo.attach=false`; otherwise `artifact:compare` fails because it creates a `.buildinfo` file which
           # erroneously references the existing `.buildinfo` file (respectively because it is overwriting it, a file with size 0)
           # See https://issues.apache.org/jira/browse/MARTIFACT-57
-          mvn clean verify artifact:compare --batch-mode --no-transfer-progress -Dproguard.skip -DskipTests -Dbuildinfo.attach=false
+          mvn clean verify artifact:compare --batch-mode --no-transfer-progress -Dmaven.test.skip --projects '!metrics,!test-graal-native-image,!test-jpms,!test-shrinker' -Dbuildinfo.attach=false

--- a/.github/workflows/check-android-compatibility.yml
+++ b/.github/workflows/check-android-compatibility.yml
@@ -31,6 +31,4 @@ jobs:
 
       - name: Check Android compatibility
         run: |
-          # Run 'test' phase because plugin normally expects to be executed after tests have been compiled
-          # Have to skip 'test-jpms' module because it requires that full Gson JAR has been built
-          mvn --batch-mode --no-transfer-progress test animal-sniffer:check@check-android-compatibility -DskipTests --projects '!test-jpms'
+          mvn --batch-mode --no-transfer-progress compile animal-sniffer:check@check-android-compatibility -Dmaven.test.skip --projects '!metrics,!test-graal-native-image,!test-jpms,!test-shrinker'

--- a/.github/workflows/check-api-compatibility.yml
+++ b/.github/workflows/check-api-compatibility.yml
@@ -39,7 +39,7 @@ jobs:
           # Set dummy version
           mvn --batch-mode --no-transfer-progress org.codehaus.mojo:versions-maven-plugin:2.16.2:set "-DnewVersion=0.0.0-JAPICMP-OLD"
           # Install artifacts with dummy version in local repository; used later by Maven plugin for comparison
-          mvn --batch-mode --no-transfer-progress install -DskipTests
+          mvn --batch-mode --no-transfer-progress install -Dmaven.test.skip --projects '!metrics,!test-graal-native-image,!test-jpms,!test-shrinker'
 
       - name: Check out new version
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
@@ -47,7 +47,7 @@ jobs:
       - name: Check API compatibility
         id: check-compatibility
         run: |
-          mvn --batch-mode --fail-at-end --no-transfer-progress package japicmp:cmp -DskipTests
+          mvn --batch-mode --fail-at-end --no-transfer-progress package japicmp:cmp -Dmaven.test.skip --projects '!metrics,!test-graal-native-image,!test-jpms,!test-shrinker'
 
       - name: Upload API differences artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -194,32 +194,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>com.coderplus.maven.plugins</groupId>
-        <artifactId>copy-rename-maven-plugin</artifactId>
-        <version>1.0.1</version>
-        <executions>
-          <execution>
-            <id>pre-obfuscate-class</id>
-            <phase>process-test-classes</phase>
-            <goals>
-              <goal>rename</goal>
-            </goals>
-            <configuration>
-              <fileSets>
-                <fileSet>
-                  <sourceFile>${project.build.directory}/test-classes/com/google/gson/functional/EnumWithObfuscatedTest.class</sourceFile>
-                  <destinationFile>${project.build.directory}/test-classes-obfuscated-injar/com/google/gson/functional/EnumWithObfuscatedTest.class</destinationFile>
-                </fileSet>
-                <fileSet>
-                  <sourceFile>${project.build.directory}/test-classes/com/google/gson/functional/EnumWithObfuscatedTest$Gender.class</sourceFile>
-                  <destinationFile>${project.build.directory}/test-classes-obfuscated-injar/com/google/gson/functional/EnumWithObfuscatedTest$Gender.class</destinationFile>
-                </fileSet>
-              </fileSets>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>com.github.wvengen</groupId>
         <artifactId>proguard-maven-plugin</artifactId>
         <version>2.7.0</version>
@@ -246,6 +220,7 @@
           </dependency>
         </dependencies>
         <configuration>
+          <skip>${maven.test.skip}</skip>
           <obfuscate>true</obfuscate>
           <injar>test-classes-obfuscated-injar</injar>
           <outjar>test-classes-obfuscated-outjar</outjar>
@@ -263,13 +238,46 @@
         <version>3.3.1</version>
         <executions>
           <execution>
+            <id>pre-obfuscate-class</id>
+            <!--
+              Note: This has to run after test compilation is already done; ideally would use `process-test-classes`
+              phase here, but the problem is that within this phase maven-resources-plugin has to run twice:
+              1. maven-resources-plugin: copy original classes
+              2. proguard-maven-plugin: obfuscate classes
+              3. maven-resources-plugin: copy obfuscated classes back
+
+              But Maven does not permit declaring the same plugin at different positions in the POM. Therefore have
+              to use a phase before `process-test-classes` here, and rely on the compiler plugin already being done.
+            -->
+            <phase>test-compile</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <skip>${maven.test.skip}</skip>
+              <outputDirectory>${project.build.directory}/test-classes-obfuscated-injar/com/google/gson/functional</outputDirectory>
+              <overwrite>true</overwrite>
+              <resources>
+                <resource>
+                  <directory>${project.build.directory}/test-classes/com/google/gson/functional</directory>
+                  <includes>
+                    <include>EnumWithObfuscatedTest.class</include>
+                    <include>EnumWithObfuscatedTest$Gender.class</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+          <execution>
             <id>post-obfuscate-class</id>
             <phase>process-test-classes</phase>
             <goals>
               <goal>copy-resources</goal>
             </goals>
             <configuration>
+              <skip>${maven.test.skip}</skip>
               <outputDirectory>${project.build.directory}/test-classes/com/google/gson/functional</outputDirectory>
+              <overwrite>true</overwrite>
               <resources>
                 <resource>
                   <directory>${project.build.directory}/test-classes-obfuscated-outjar/com/google/gson/functional</directory>

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -96,6 +96,9 @@
             <goals>
               <goal>test-compile</goal>
             </goals>
+            <configuration>
+              <skip>${maven.test.skip}</skip>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
### Purpose
Improve skipping of tests and avoid redundant CI builds

### Description
Uses the standard property `${maven.test.skip}` for skipping tests (which also includes skipping compilation of test classes, unlike `skipTests`), and configures test related plugin executions to use `${maven.test.skip}` as well.
As part of this the copy-rename-maven-plugin usage is replaced with maven-resources-plugin, which is probably also good because that former plugin is apparently not maintained anymore, see https://github.com/coderplus/copy-rename-maven-plugin.

Also configures the CI workflows to skip redundant execution of some Maven modules: For reproducible build, Android and API compatibility check it is irrelevant to check the metrics and test modules.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [ ] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
