### PR TITLE
Add CI build using JDK 25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,13 +17,19 @@ jobs:
     strategy:
       matrix:
         java: [ 17, 21 ]
-        # Custom JDK 11 configuration because some of the plugins and test dependencies don't support it anymore,
-        # but it is important to still test with a JDK version without Record classes
         include:
+          # Custom JDK 11 configuration because some of the plugins and test dependencies don't support it anymore,
+          # but it is important to still test with a JDK version without Record classes
           - java: 11
             # Disable Enforcer check which (intentionally) prevents using JDK 11 for building
             # Exclude 'test-graal-native-image' module because JUnit 6 requires >= Java 17
-            extra-mvn-args: -Denforcer.fail=false --projects '!:test-graal-native-image'
+            extra-mvn-args: -Denforcer.fail=false --projects '!test-graal-native-image'
+          - java: 25
+            # Disable Enforcer check which (intentionally) prevents using JDK 25 for building
+            # Exclude 'test-shrinker' because ProGuard does not support JDK 25 yet, see
+            # https://github.com/Guardsquare/proguard/issues/481 and https://github.com/Guardsquare/proguard/issues/473
+            # TODO: Once ProGuard supports JDK 25, also remove the corresponding 'JDK25' profile in `gson/pom.xml`
+            extra-mvn-args: -Denforcer.fail=false --projects '!test-shrinker'
     runs-on: ubuntu-latest
 
     steps:
@@ -39,7 +45,15 @@ jobs:
         run: mvn --batch-mode --no-transfer-progress verify javadoc:jar ${{ matrix.extra-mvn-args || '' }}
 
   native-image-test:
-    name: "GraalVM Native Image test"
+    name: "GraalVM Native Image test (JDK ${{ matrix.java }})"
+    strategy:
+      matrix:
+        java: [ 21 ]
+        include:
+          - java: 25
+            # Disable Enforcer check which (intentionally) prevents using JDK 25 for building
+            # TODO: Remove this once JDK 25 is fully supported for building Gson
+            extra-mvn-args: -Denforcer.fail=false
     runs-on: ubuntu-latest
 
     steps:
@@ -47,7 +61,7 @@ jobs:
       - name: "Set up GraalVM"
         uses: graalvm/setup-graalvm@7f488cf82a3629ee755e4e97342c01d6bed318fa  # v1.3.5
         with:
-          java-version: '21'
+          java-version: ${{ matrix.java }}
           distribution: 'graalvm'
           # According to documentation in graalvm/setup-graalvm this is used to avoid rate-limiting issues
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -55,7 +69,7 @@ jobs:
       - name: Build and run tests
         # Only run tests in `test-graal-native-image` (and implicitly build and run tests in `gson`),
         # everything else is covered already by regular build job above
-        run: mvn test --batch-mode --no-transfer-progress --activate-profiles native-image-test --projects test-graal-native-image --also-make
+        run: mvn test --batch-mode --no-transfer-progress --activate-profiles native-image-test --projects test-graal-native-image --also-make ${{ matrix.extra-mvn-args || '' }}
 
   verify-reproducible-build:
     name: "Verify reproducible build"

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -365,5 +365,27 @@
         <excludeTestCompilation />
       </properties>
     </profile>
+    <!-- For JDK 25+ skip tests which rely on ProGuard because it does not support JDK 25 yet -->
+    <!-- TODO: Remove this once ProGuard supports JDK 25, and there is a solution for https://github.com/Guardsquare/proguard/issues/473 -->
+    <profile>
+      <id>JDK25</id>
+      <activation>
+        <jdk>[25,)</jdk>
+      </activation>
+      <properties>
+        <excludeTestCompilation>com/google/gson/functional/EnumWithObfuscatedTest.java</excludeTestCompilation>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.wvengen</groupId>
+            <artifactId>proguard-maven-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
### Purpose
Add CI build using JDK 25, so that we can be sure Gson works with JDK 25

Supersedes #2847

### Description
However, because building with JDK 25 does not fully work yet, mainly due to issues with ProGuard, still disallow building with JDK 25 by default. This way it fails fast for users locally instead of causing confusing failures later on.


Note that there are a few warnings related to `Unsafe` usage by Maven (respectively its dependencies) and by protobuf-java.

And also one test is causing warnings:
```
[INFO] Running com.google.gson.typeadapters.UtcDateTypeAdapterTest
WARNING: Use of the three-letter time zone ID "NST" is deprecated and it will be removed in a future release
WARNING: Use of the three-letter time zone ID "AST" is deprecated and it will be removed in a future release
WARNING: Use of the three-letter time zone ID "MST" is deprecated and it will be removed in a future release
```
(that test uses all time zones provided by `TimeZone.getAvailableIDs()`)

But besides that the build and Gson itself seems to work fine with JDK 25.