### PR TITLE
Bump protobuf-maven-plugin to 4.0.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,8 @@ jobs:
           - java: 11
             # Disable Enforcer check which (intentionally) prevents using JDK 11 for building
             # Exclude 'test-graal-native-image' module because JUnit 6 requires >= Java 17
-            extra-mvn-args: -Denforcer.fail=false --projects '!test-graal-native-image'
+            # Exclude 'proto' module because protobuf-maven-plugin requires >= Java 17
+            extra-mvn-args: -Denforcer.fail=false --projects '!test-graal-native-image,!proto'
           - java: 25
             # Disable Enforcer check which (intentionally) prevents using JDK 25 for building
             # Exclude 'test-shrinker' because ProGuard does not support JDK 25 yet, see

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -79,11 +79,13 @@
       <plugin>
         <groupId>io.github.ascopes</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>4.0.1</version>
         <configuration>
           <skip>${maven.test.skip}</skip>
-          <protocVersion>${protobufVersion}</protocVersion>
+          <protoc>${protobufVersion}</protoc>
           <fatalWarnings>true</fatalWarnings>
+          <!-- Embedding sources is redundant for test execution -->
+          <embedSourcesInClassOutputs>false</embedSourcesInClassOutputs>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
### Purpose
Bump the protobuf-maven-plugin used by the `proto` tests

### Description
Bumps the protobuf-maven-plugin and adjusts the GitHub workflow to skip it for the JDK 11 build because it requires JDK <= 17 now.

This resolves one of the build failures of the Dependabot PR #2934.

Side note: When I introduced that plugin in #2920 I accidentally did not use the latest plugin version back then.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [x] `mvn clean verify javadoc:jar` passes without errors
