### PR TITLE
Remove outdated comment in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,9 +190,6 @@
         <executions>
           <execution>
             <goals>
-              <!-- This logs a warning about `source.scm.tag=HEAD`, but this can be ignored;
-                during release Maven Release Plugin temporarily changes the `source.scm.tag`
-                value to the actual Git tag, which will then not cause a warning -->
               <goal>buildinfo</goal>
             </goals>
           </execution>


### PR DESCRIPTION
This warning is not logged anymore since [maven-artifact-plugin 3.6.1](https://redirect.github.com/apache/maven-artifact-plugin/pull/184).

Side note: Currently the plugin is not run though due to #2901.