### PR TITLE
Add build config for Gson subset

### DIFF
--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -413,7 +413,6 @@
                     <resource>
                       <directory>${project.build.sourceDirectory}</directory>
                       <includes>
-                        <include>com/google/gson/stream/*</include>
                         <include>com/google/gson/FormattingStyle.java</include>
                         <include>com/google/gson/JsonArray.java</include>
                         <include>com/google/gson/JsonElement.java</include>
@@ -421,14 +420,20 @@
                         <include>com/google/gson/JsonNull.java</include>
                         <include>com/google/gson/JsonObject.java</include>
                         <include>com/google/gson/JsonParseException.java</include>
+                        <include>com/google/gson/JsonParser.java</include>
                         <include>com/google/gson/JsonPrimitive.java</include>
+                        <include>com/google/gson/JsonStreamParser.java</include>
                         <include>com/google/gson/JsonSyntaxException.java</include>
                         <include>com/google/gson/Strictness.java</include>
                         <include>com/google/gson/TypeAdapter.java</include>
+                        <include>com/google/gson/package-info.java</include>
+                        <include>com/google/gson/stream/JsonReader.java</include>
+                        <include>com/google/gson/stream/JsonScope.java</include>
+                        <include>com/google/gson/stream/JsonToken.java</include>
+                        <include>com/google/gson/stream/JsonWriter.java</include>
+                        <include>com/google/gson/stream/MalformedJsonException.java</include>
+                        <include>com/google/gson/stream/package-info.java</include>
                         <!-- Internal classes used by the classes above -->
-                        <include>com/google/gson/internal/bind/JsonElementTypeAdapter.java</include>
-                        <include>com/google/gson/internal/bind/JsonTreeReader.java</include>
-                        <include>com/google/gson/internal/bind/JsonTreeWriter.java</include>
                         <include>com/google/gson/internal/JsonReaderInternalAccess.java</include>
                         <include>com/google/gson/internal/LazilyParsedNumber.java</include>
                         <include>com/google/gson/internal/LinkedTreeMap.java</include>
@@ -436,6 +441,9 @@
                         <include>com/google/gson/internal/NumberLimits.java</include>
                         <include>com/google/gson/internal/Streams.java</include>
                         <include>com/google/gson/internal/TroubleshootingGuide.java</include>
+                        <include>com/google/gson/internal/bind/JsonElementTypeAdapter.java</include>
+                        <include>com/google/gson/internal/bind/JsonTreeReader.java</include>
+                        <include>com/google/gson/internal/bind/JsonTreeWriter.java</include>
                       </includes>
                     </resource>
                   </resources>
@@ -485,7 +493,9 @@
                     <testInclude>com/google/gson/JsonObjectAsMapSuiteTest.java</testInclude>
                     <testInclude>com/google/gson/JsonObjectAsMapTest.java</testInclude>
                     <testInclude>com/google/gson/JsonObjectTest.java</testInclude>
+                    <testInclude>com/google/gson/JsonParserParameterizedTest.java</testInclude>
                     <testInclude>com/google/gson/JsonPrimitiveTest.java</testInclude>
+                    <testInclude>com/google/gson/JsonStreamParserTest.java</testInclude>
                     <testInclude>com/google/gson/SubsetTest.java</testInclude>
                     <testInclude>com/google/gson/TypeAdapterTest.java</testInclude>
                   </testIncludes>

--- a/gson/src/test/java/com/google/gson/JsonArrayTest.java
+++ b/gson/src/test/java/com/google/gson/JsonArrayTest.java
@@ -21,8 +21,6 @@ import static org.junit.Assert.assertThrows;
 
 import com.google.common.testing.EqualsTester;
 import com.google.gson.common.MoreAsserts;
-import com.google.gson.internal.bind.JsonElementTypeAdapter;
-import java.io.IOException;
 import java.math.BigInteger;
 import org.junit.Test;
 
@@ -130,10 +128,10 @@ public final class JsonArrayTest {
   }
 
   @Test
-  public void testFailedGetArrayValues() throws IOException {
+  public void testFailedGetArrayValues() {
     JsonArray jsonArray = new JsonArray();
     jsonArray.add(
-        JsonElementTypeAdapter.ADAPTER.fromJson(
+        JsonParser.parseString(
             "{"
                 + "\"key1\":\"value1\","
                 + "\"key2\":\"value2\","

--- a/gson/src/test/java/com/google/gson/JsonObjectTest.java
+++ b/gson/src/test/java/com/google/gson/JsonObjectTest.java
@@ -21,8 +21,6 @@ import static org.junit.Assert.assertThrows;
 
 import com.google.common.testing.EqualsTester;
 import com.google.gson.common.MoreAsserts;
-import com.google.gson.internal.bind.JsonElementTypeAdapter;
-import java.io.IOException;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -150,8 +148,8 @@ public class JsonObjectTest {
   }
 
   @Test
-  public void testReadPropertyWithEmptyStringName() throws IOException {
-    JsonObject jsonObj = JsonElementTypeAdapter.ADAPTER.fromJson("{\"\":true}").getAsJsonObject();
+  public void testReadPropertyWithEmptyStringName() {
+    JsonObject jsonObj = JsonParser.parseString("{\"\":true}").getAsJsonObject();
     assertThat(jsonObj.get("").getAsBoolean()).isTrue();
   }
 

--- a/gson/src/test/java/com/google/gson/SubsetTest.java
+++ b/gson/src/test/java/com/google/gson/SubsetTest.java
@@ -2,16 +2,14 @@ package com.google.gson;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.gson.internal.bind.JsonElementTypeAdapter;
-import java.io.IOException;
 import java.util.List;
 import org.junit.Test;
 
 /** Tests that we can parse and create JSON using the {@link JsonElement} subset. */
 public final class SubsetTest {
   @Test
-  public void read() throws IOException {
-    JsonElement json = JsonElementTypeAdapter.ADAPTER.fromJson("{\"a\":1,\"b\":[2.1, null]}");
+  public void read() {
+    JsonElement json = JsonParser.parseString("{\"a\":1,\"b\":[2.1, null]}");
     assertThat(json.isJsonObject()).isTrue();
     JsonObject jsonObject = json.getAsJsonObject();
     assertThat(jsonObject.get("a").getAsInt()).isEqualTo(1);


### PR DESCRIPTION
### Purpose
Follow-up for #2946

Adds a build config which builds the Gson API subset, so that any changes which break this can be directly noticed.

### Description
The Maven config is unfortunately a bit verbose because:
- it has to make sure only the explicitly listed source files are compiled
- it should not use the already compiled class files from `target/classes`

See also the comments in the changed code. Any hints on how this can be simplified are welcome.

As requested in https://github.com/google/gson/pull/2946#issuecomment-3566984829, the new GitHub workflow job will cause a workflow failure when building the Gson API subset fails.
