### PR TITLE
refactor: move derived adapters from Gson to TypeAdapters

### DIFF
--- a/gson/src/main/java/com/google/gson/LongSerializationPolicy.java
+++ b/gson/src/main/java/com/google/gson/LongSerializationPolicy.java
@@ -16,6 +16,8 @@
 
 package com.google.gson;
 
+import com.google.gson.internal.bind.TypeAdapters;
+
 /**
  * Defines the expected format for a {@code long} or {@code Long} type when it is serialized.
  *
@@ -39,6 +41,11 @@ public enum LongSerializationPolicy {
       }
       return new JsonPrimitive(value);
     }
+
+    @Override
+    TypeAdapter<Number> typeAdapter() {
+      return TypeAdapters.LONG;
+    }
   },
 
   /**
@@ -55,6 +62,11 @@ public enum LongSerializationPolicy {
       }
       return new JsonPrimitive(value.toString());
     }
+
+    @Override
+    TypeAdapter<Number> typeAdapter() {
+      return TypeAdapters.LONG_AS_STRING;
+    }
   };
 
   /**
@@ -64,4 +76,8 @@ public enum LongSerializationPolicy {
    * @return the serialized version of {@code value}
    */
   public abstract JsonElement serialize(Long value);
+
+  /** Returns the corresponding {@link TypeAdapter} for this serialization policy. */
+  // Internal method
+  abstract TypeAdapter<Number> typeAdapter();
 }

--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -44,11 +44,14 @@ import java.util.Currency;
 import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.StringTokenizer;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerArray;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicLongArray;
 
 /**
  * Type adapters for basic types. More complex adapters exist as separate classes in the enclosing
@@ -300,6 +303,22 @@ public final class TypeAdapters {
   public static final TypeAdapterFactory ATOMIC_INTEGER_FACTORY =
       newFactory(AtomicInteger.class, TypeAdapters.ATOMIC_INTEGER);
 
+  public static TypeAdapter<AtomicLong> atomicLongAdapter(TypeAdapter<Number> longAdapter) {
+    Objects.requireNonNull(longAdapter);
+    return new TypeAdapter<AtomicLong>() {
+      @Override
+      public AtomicLong read(JsonReader in) throws IOException {
+        Number value = longAdapter.read(in);
+        return new AtomicLong(value.longValue());
+      }
+
+      @Override
+      public void write(JsonWriter out, AtomicLong value) throws IOException {
+        longAdapter.write(out, value.get());
+      }
+    }.nullSafe();
+  }
+
   public static final TypeAdapter<AtomicBoolean> ATOMIC_BOOLEAN =
       new TypeAdapter<AtomicBoolean>() {
         @Override
@@ -350,6 +369,38 @@ public final class TypeAdapters {
   public static final TypeAdapterFactory ATOMIC_INTEGER_ARRAY_FACTORY =
       newFactory(AtomicIntegerArray.class, TypeAdapters.ATOMIC_INTEGER_ARRAY);
 
+  public static TypeAdapter<AtomicLongArray> atomicLongArrayAdapter(
+      TypeAdapter<Number> longAdapter) {
+    Objects.requireNonNull(longAdapter);
+    return new TypeAdapter<AtomicLongArray>() {
+      @Override
+      public AtomicLongArray read(JsonReader in) throws IOException {
+        List<Long> list = new ArrayList<>();
+        in.beginArray();
+        while (in.hasNext()) {
+          long value = longAdapter.read(in).longValue();
+          list.add(value);
+        }
+        in.endArray();
+        int length = list.size();
+        AtomicLongArray array = new AtomicLongArray(length);
+        for (int i = 0; i < length; ++i) {
+          array.set(i, list.get(i));
+        }
+        return array;
+      }
+
+      @Override
+      public void write(JsonWriter out, AtomicLongArray value) throws IOException {
+        out.beginArray();
+        for (int i = 0, length = value.length(); i < length; i++) {
+          longAdapter.write(out, value.get(i));
+        }
+        out.endArray();
+      }
+    }.nullSafe();
+  }
+
   public static final TypeAdapter<Number> LONG =
       new TypeAdapter<Number>() {
         @Override
@@ -375,7 +426,7 @@ public final class TypeAdapters {
         }
       };
 
-  public static final TypeAdapter<Number> FLOAT =
+  public static final TypeAdapter<Number> LONG_AS_STRING =
       new TypeAdapter<Number>() {
         @Override
         public Number read(JsonReader in) throws IOException {
@@ -383,43 +434,96 @@ public final class TypeAdapters {
             in.nextNull();
             return null;
           }
-          return (float) in.nextDouble();
+          return in.nextLong();
         }
 
         @Override
         public void write(JsonWriter out, Number value) throws IOException {
           if (value == null) {
             out.nullValue();
-          } else {
-            // For backward compatibility don't call `JsonWriter.value(float)` because that method
-            // has been newly added and not all custom JsonWriter implementations might override
-            // it yet
-            Number floatNumber = value instanceof Float ? value : value.floatValue();
-            out.value(floatNumber);
+            return;
           }
+          out.value(value.toString());
         }
       };
 
-  public static final TypeAdapter<Number> DOUBLE =
-      new TypeAdapter<Number>() {
-        @Override
-        public Number read(JsonReader in) throws IOException {
-          if (in.peek() == JsonToken.NULL) {
-            in.nextNull();
-            return null;
-          }
-          return in.nextDouble();
-        }
+  private static class FloatAdapter extends TypeAdapter<Number> {
+    private final boolean strict;
 
-        @Override
-        public void write(JsonWriter out, Number value) throws IOException {
-          if (value == null) {
-            out.nullValue();
-          } else {
-            out.value(value.doubleValue());
-          }
-        }
-      };
+    FloatAdapter(boolean strict) {
+      this.strict = strict;
+    }
+
+    @Override
+    public Float read(JsonReader in) throws IOException {
+      if (in.peek() == JsonToken.NULL) {
+        in.nextNull();
+        return null;
+      }
+      return (float) in.nextDouble();
+    }
+
+    @Override
+    public void write(JsonWriter out, Number value) throws IOException {
+      if (value == null) {
+        out.nullValue();
+        return;
+      }
+      float floatValue = value.floatValue();
+      if (strict) {
+        checkValidFloatingPoint(floatValue);
+      }
+      // For backward compatibility don't call `JsonWriter.value(float)` because that method has
+      // been newly added and not all custom JsonWriter implementations might override it yet
+      Number floatNumber = value instanceof Float ? value : floatValue;
+      out.value(floatNumber);
+    }
+  }
+
+  private static class DoubleAdapter extends TypeAdapter<Number> {
+    private final boolean strict;
+
+    DoubleAdapter(boolean strict) {
+      this.strict = strict;
+    }
+
+    @Override
+    public Double read(JsonReader in) throws IOException {
+      if (in.peek() == JsonToken.NULL) {
+        in.nextNull();
+        return null;
+      }
+      return in.nextDouble();
+    }
+
+    @Override
+    public void write(JsonWriter out, Number value) throws IOException {
+      if (value == null) {
+        out.nullValue();
+        return;
+      }
+      double doubleValue = value.doubleValue();
+      if (strict) {
+        checkValidFloatingPoint(doubleValue);
+      }
+      out.value(doubleValue);
+    }
+  }
+
+  private static void checkValidFloatingPoint(double value) {
+    if (Double.isNaN(value) || Double.isInfinite(value)) {
+      throw new IllegalArgumentException(
+          value
+              + " is not a valid double value as per JSON specification. To override this"
+              + " behavior, use GsonBuilder.serializeSpecialFloatingPointValues() method.");
+    }
+  }
+
+  public static final TypeAdapter<Number> FLOAT = new FloatAdapter(false);
+  public static final TypeAdapter<Number> FLOAT_STRICT = new FloatAdapter(true);
+
+  public static final TypeAdapter<Number> DOUBLE = new DoubleAdapter(false);
+  public static final TypeAdapter<Number> DOUBLE_STRICT = new DoubleAdapter(true);
 
   public static final TypeAdapter<Character> CHARACTER =
       new TypeAdapter<Character>() {
@@ -491,6 +595,9 @@ public final class TypeAdapters {
         }
       };
 
+  public static final TypeAdapterFactory BIG_DECIMAL_FACTORY =
+      newFactory(BigDecimal.class, BIG_DECIMAL);
+
   public static final TypeAdapter<BigInteger> BIG_INTEGER =
       new TypeAdapter<BigInteger>() {
         @Override
@@ -514,6 +621,9 @@ public final class TypeAdapters {
         }
       };
 
+  public static final TypeAdapterFactory BIG_INTEGER_FACTORY =
+      newFactory(BigInteger.class, BIG_INTEGER);
+
   public static final TypeAdapter<LazilyParsedNumber> LAZILY_PARSED_NUMBER =
       new TypeAdapter<LazilyParsedNumber>() {
         // Normally users should not be able to access and deserialize LazilyParsedNumber because
@@ -533,6 +643,9 @@ public final class TypeAdapters {
           out.value(value);
         }
       };
+
+  public static final TypeAdapterFactory LAZILY_PARSED_NUMBER_FACTORY =
+      newFactory(LazilyParsedNumber.class, LAZILY_PARSED_NUMBER);
 
   public static final TypeAdapterFactory STRING_FACTORY = newFactory(String.class, STRING);
 

--- a/gson/src/main/java/com/google/gson/internal/sql/SqlTypesSupport.java
+++ b/gson/src/main/java/com/google/gson/internal/sql/SqlTypesSupport.java
@@ -19,7 +19,10 @@ package com.google.gson.internal.sql;
 import com.google.gson.TypeAdapterFactory;
 import com.google.gson.internal.bind.DefaultDateTypeAdapter.DateType;
 import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 
 /**
  * Encapsulates access to {@code java.sql} types, to allow Gson to work without the {@code java.sql}
@@ -27,8 +30,10 @@ import java.util.Date;
  * java.sql} module is not present.
  *
  * <p>If {@link #SUPPORTS_SQL_TYPES} is {@code true}, all other constants of this class will be
- * non-{@code null}. However, if it is {@code false} all other constants will be {@code null} and
- * there will be no support for {@code java.sql} types.
+ * non-{@code null} and {@link #SQL_TYPE_FACTORIES} will contain the SQL type adapter factories.
+ * However, if it is {@code false} all other constants will be {@code null} and {@link
+ * #SQL_TYPE_FACTORIES} will be an empty list, and there will be no support for {@code java.sql}
+ * types.
  */
 @SuppressWarnings("JavaUtilDate")
 public final class SqlTypesSupport {
@@ -41,6 +46,8 @@ public final class SqlTypesSupport {
   public static final TypeAdapterFactory DATE_FACTORY;
   public static final TypeAdapterFactory TIME_FACTORY;
   public static final TypeAdapterFactory TIMESTAMP_FACTORY;
+
+  public static final List<TypeAdapterFactory> SQL_TYPE_FACTORIES;
 
   static {
     boolean sqlTypesSupport;
@@ -71,6 +78,10 @@ public final class SqlTypesSupport {
       DATE_FACTORY = SqlDateTypeAdapter.FACTORY;
       TIME_FACTORY = SqlTimeTypeAdapter.FACTORY;
       TIMESTAMP_FACTORY = SqlTimestampTypeAdapter.FACTORY;
+
+      SQL_TYPE_FACTORIES =
+          Collections.unmodifiableList(
+              Arrays.asList(TIME_FACTORY, DATE_FACTORY, TIMESTAMP_FACTORY));
     } else {
       DATE_DATE_TYPE = null;
       TIMESTAMP_DATE_TYPE = null;
@@ -78,6 +89,8 @@ public final class SqlTypesSupport {
       DATE_FACTORY = null;
       TIME_FACTORY = null;
       TIMESTAMP_FACTORY = null;
+
+      SQL_TYPE_FACTORIES = Collections.emptyList();
     }
   }
 

--- a/gson/src/test/java/com/google/gson/internal/sql/SqlTypesSupportTest.java
+++ b/gson/src/test/java/com/google/gson/internal/sql/SqlTypesSupportTest.java
@@ -31,5 +31,11 @@ public class SqlTypesSupportTest {
     assertThat(SqlTypesSupport.DATE_FACTORY).isNotNull();
     assertThat(SqlTypesSupport.TIME_FACTORY).isNotNull();
     assertThat(SqlTypesSupport.TIMESTAMP_FACTORY).isNotNull();
+    assertThat(SqlTypesSupport.SQL_TYPE_FACTORIES)
+        .containsExactly(
+            SqlTypesSupport.TIME_FACTORY,
+            SqlTypesSupport.DATE_FACTORY,
+            SqlTypesSupport.TIMESTAMP_FACTORY)
+        .inOrder();
   }
 }


### PR DESCRIPTION
<!--
    Thank you for your contribution!
    Please see the contributing guide: https://github.com/google/.github/blob/master/CONTRIBUTING.md

    Keep in mind that Gson is in maintenance mode. If you want to add a new feature, please first search for existing GitHub issues, or create a new one to discuss the feature and get feedback.
-->

### Purpose
<!-- Describe the purpose of this pull request, for example which new feature it adds or which bug it fixes -->
<!-- If this pull request closes a GitHub issue, please write "Closes #<issue>", for example "Closes #123" -->
Part of #2864

### Description
<!-- If necessary provide more information, for example relevant implementation details or corner cases which are not covered yet -->
<!-- If there are related issues or pull requests, link to them by referencing their number, for example "pull request #123" -->

Move constant adapters from Gson to TypeAdapters.

### Checklist
<!-- The following checklist is mainly intended for yourself to verify that you did not miss anything -->

- [x] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [ ] If necessary, new public API validates arguments, for example rejects `null`
- [ ] New public API has Javadoc
    - [ ] Javadoc uses `@since $next-version$`  
      (`$next-version$` is a special placeholder which is automatically replaced during release)
- [ ] If necessary, new unit tests have been added  
  - [ ] Assertions in unit tests use [Truth](https://truth.dev/), see existing tests
  - [ ] No JUnit 3 features are used (such as extending class `TestCase`)
  - [ ] If this pull request fixes a bug, a new test was added for a situation which failed previously and is now fixed
- [ ] `mvn clean verify javadoc:jar` passes without errors
