### PR TITLE
Fix outdated comment

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
+++ b/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
@@ -443,7 +443,7 @@ public final class ConstructorConstructor {
       // New exception is created every time to avoid keeping a reference to an exception with
       // potentially long stack trace, causing a memory leak
       // (which would happen if the exception was already created when the
-      // `ExceptionObjectConstructor` is created)
+      // `ThrowingObjectConstructor` is created)
       throw new JsonIOException(exceptionMessage);
     }
   }


### PR DESCRIPTION
Follow-up for #2950

The comment still used the old class name, before the class was renamed, see https://github.com/google/gson/pull/2950#discussion_r2561033074.

(Sorry for the confusion the separate review comments on that previous PR might have caused.)