### PR TITLE
Add convenience methods for creating `JsonElement` types from standar…

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonArray.java
+++ b/gson/src/main/java/com/google/gson/JsonArray.java
@@ -433,4 +433,34 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
   public int hashCode() {
     return elements.hashCode();
   }
+
+  /**
+   * Creates a {@link JsonArray} from an {@link Iterable}.
+   *
+   * @param iterable the iterable to convert to a {@link JsonArray}
+   * @return a {@link JsonArray} representing the iterable
+   * @since 2.11.0
+   */
+  public static JsonArray parse(Iterable<?> iterable) {
+    JsonArray jsonArray = new JsonArray();
+    for (Object element : iterable) {
+      jsonArray.add(JsonElement.parse(element));
+    }
+    return jsonArray;
+  }
+
+  /**
+   * Creates a {@link JsonArray} from an {@link Iterable} of {@link JsonElement}s.
+   *
+   * @param iterable the iterable to convert to a {@link JsonArray}
+   * @return a {@link JsonArray} representing the iterable
+   * @since 2.11.0
+   */
+  public static JsonArray of(Iterable<? extends JsonElement> iterable) {
+    JsonArray jsonArray = new JsonArray();
+    for (JsonElement element : iterable) {
+      jsonArray.add(element);
+    }
+    return jsonArray;
+  }
 }

--- a/gson/src/main/java/com/google/gson/JsonElement.java
+++ b/gson/src/main/java/com/google/gson/JsonElement.java
@@ -22,6 +22,7 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Map;
 
 /**
  * A class representing an element of JSON. It could either be a {@link JsonObject}, a {@link
@@ -100,7 +101,8 @@ public abstract class JsonElement {
    *     This constructor is only kept for backward compatibility.
    */
   @Deprecated
-  public JsonElement() {}
+  public JsonElement() {
+  }
 
   /**
    * Returns a deep copy of this element. Immutable elements like primitives and nulls are not
@@ -430,5 +432,44 @@ public abstract class JsonElement {
     } catch (IOException e) {
       throw new AssertionError(e);
     }
+  }
+
+  /**
+   * Convenience method to create a {@link JsonElement} from a Java object.
+   *
+   * <p>This method supports the following types:
+   *
+   * <ul>
+   *   <li>{@code null} (returns {@link JsonNull#INSTANCE})
+   *   <li>{@link JsonElement}
+   *   <li>{@link Map} (returns {@link JsonObject})
+   *   <li>{@link Iterable} (returns {@link JsonArray})
+   *   <li>{@link Boolean} (returns {@link JsonPrimitive})
+   *   <li>{@link Number} (returns {@link JsonPrimitive})
+   *   <li>{@link String} (returns {@link JsonPrimitive})
+   *   <li>{@link Character} (returns {@link JsonPrimitive})
+   * </ul>
+   *
+   * @param object the object to convert to a {@link JsonElement}
+   * @return a {@link JsonElement} representing the object
+   * @throws IllegalArgumentException if the object is not one of the supported types
+   * @since 2.11.0
+   */
+  public static JsonElement parse(Object object) {
+    if (object == null) {
+      return JsonNull.INSTANCE;
+    }
+    if (object instanceof JsonElement) {
+      return (JsonElement) object;
+    }
+    if (object instanceof Map) {
+      @SuppressWarnings("unchecked")
+      Map<String, ?> map = (Map<String, ?>) object;
+      return JsonObject.parse(map);
+    }
+    if (object instanceof Iterable) {
+      return JsonArray.parse((Iterable<?>) object);
+    }
+    return JsonPrimitive.parse(object);
   }
 }

--- a/gson/src/main/java/com/google/gson/JsonObject.java
+++ b/gson/src/main/java/com/google/gson/JsonObject.java
@@ -42,7 +42,8 @@ public final class JsonObject extends JsonElement {
 
   /** Creates an empty JsonObject. */
   @SuppressWarnings("deprecation") // superclass constructor
-  public JsonObject() {}
+  public JsonObject() {
+  }
 
   /**
    * Creates a deep copy of this element and all its children.
@@ -255,5 +256,35 @@ public final class JsonObject extends JsonElement {
   @Override
   public int hashCode() {
     return members.hashCode();
+  }
+
+  /**
+   * Creates a {@link JsonObject} from a {@link Map}.
+   *
+   * @param map the map to convert to a {@link JsonObject}
+   * @return a {@link JsonObject} representing the map
+   * @since 2.11.0
+   */
+  public static JsonObject parse(Map<String, ?> map) {
+    JsonObject jsonObject = new JsonObject();
+    for (Map.Entry<String, ?> entry : map.entrySet()) {
+      jsonObject.add(entry.getKey(), JsonElement.parse(entry.getValue()));
+    }
+    return jsonObject;
+  }
+
+  /**
+   * Creates a {@link JsonObject} from a {@link Map} of {@link JsonElement}s.
+   *
+   * @param map the map to convert to a {@link JsonObject}
+   * @return a {@link JsonObject} representing the map
+   * @since 2.11.0
+   */
+  public static JsonObject of(Map<String, ? extends JsonElement> map) {
+    JsonObject jsonObject = new JsonObject();
+    for (Map.Entry<String, ? extends JsonElement> entry : map.entrySet()) {
+      jsonObject.add(entry.getKey(), entry.getValue());
+    }
+    return jsonObject;
   }
 }

--- a/gson/src/main/java/com/google/gson/JsonPrimitive.java
+++ b/gson/src/main/java/com/google/gson/JsonPrimitive.java
@@ -44,7 +44,7 @@ public final class JsonPrimitive extends JsonElement {
   // "deprecation" suppression for superclass constructor
   // "UnnecessaryBoxedVariable" Error Prone warning is correct since method does not accept
   // null, but cannot be changed anymore since this is public API
-  @SuppressWarnings({"deprecation", "UnnecessaryBoxedVariable"})
+  @SuppressWarnings({ "deprecation", "UnnecessaryBoxedVariable" })
   public JsonPrimitive(Boolean bool) {
     value = Objects.requireNonNull(bool);
   }
@@ -78,7 +78,7 @@ public final class JsonPrimitive extends JsonElement {
   // "deprecation" suppression for superclass constructor
   // "UnnecessaryBoxedVariable" Error Prone warning is correct since method does not accept
   // null, but cannot be changed anymore since this is public API
-  @SuppressWarnings({"deprecation", "UnnecessaryBoxedVariable"})
+  @SuppressWarnings({ "deprecation", "UnnecessaryBoxedVariable" })
   public JsonPrimitive(Character c) {
     // convert characters to strings since in JSON, characters are represented as a single
     // character string
@@ -324,5 +324,35 @@ public final class JsonPrimitive extends JsonElement {
           || number instanceof Byte;
     }
     return false;
+  }
+
+  /**
+   * Convenience method to create a {@link JsonPrimitive} from a Java object.
+   *
+   * <p>This method supports the following types:
+   *
+   * <ul>
+   *   <li>{@link Boolean}
+   *   <li>{@link Number}
+   *   <li>{@link String}
+   *   <li>{@link Character}
+   * </ul>
+   *
+   * @param object the object to convert to a {@link JsonPrimitive}
+   * @return a {@link JsonPrimitive} representing the object
+   * @throws IllegalArgumentException if the object is not one of the supported types
+   */
+  public static JsonPrimitive parse(Object object) {
+    if (object instanceof Boolean) {
+      return new JsonPrimitive((Boolean) object);
+    } else if (object instanceof Number) {
+      return new JsonPrimitive((Number) object);
+    } else if (object instanceof String) {
+      return new JsonPrimitive((String) object);
+    } else if (object instanceof Character) {
+      return new JsonPrimitive((Character) object);
+    } else {
+      throw new IllegalArgumentException("Cannot parse " + object.getClass().getName() + " as a JsonPrimitive");
+    }
   }
 }

--- a/gson/src/test/java/com/google/gson/JsonArrayTest.java
+++ b/gson/src/test/java/com/google/gson/JsonArrayTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertThrows;
 import com.google.common.testing.EqualsTester;
 import com.google.gson.common.MoreAsserts;
 import java.math.BigInteger;
+import java.util.Arrays;
 import org.junit.Test;
 
 /**
@@ -353,5 +354,18 @@ public final class JsonArrayTest {
     nestedObject.addProperty("n\0", 1);
     array.add(nestedObject);
     assertThat(array.toString()).isEqualTo("[null,NaN,\"a\\u0000\",[\"\\\"\"],{\"n\\u0000\":1}]");
+  }
+
+  @Test
+  public void testParseIterable() {
+    JsonArray array = JsonArray.parse(Arrays.asList(1, "a"));
+    assertThat(array.get(0).getAsInt()).isEqualTo(1);
+    assertThat(array.get(1).getAsString()).isEqualTo("a");
+  }
+
+  @Test
+  public void testOfIterable() {
+    JsonArray array = JsonArray.of(Arrays.asList(new JsonPrimitive(1)));
+    assertThat(array.get(0).getAsInt()).isEqualTo(1);
   }
 }

--- a/gson/src/test/java/com/google/gson/JsonElementTest.java
+++ b/gson/src/test/java/com/google/gson/JsonElementTest.java
@@ -1,0 +1,51 @@
+package com.google.gson;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class JsonElementTest {
+    @Test
+    public void testParseNull() {
+        assertThat(JsonElement.parse(null)).isEqualTo(JsonNull.INSTANCE);
+    }
+
+    @Test
+    public void testParseJsonElement() {
+        JsonElement element = new JsonObject();
+        assertThat(JsonElement.parse(element)).isSameInstanceAs(element);
+    }
+
+    @Test
+    public void testParseMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("key", "value");
+        JsonElement element = JsonElement.parse(map);
+        assertThat(element.isJsonObject()).isTrue();
+        assertThat(element.getAsJsonObject().get("key").getAsString()).isEqualTo("value");
+    }
+
+    @Test
+    public void testParseIterable() {
+        JsonElement element = JsonElement.parse(Arrays.asList("a", "b"));
+        assertThat(element.isJsonArray()).isTrue();
+        assertThat(element.getAsJsonArray().get(0).getAsString()).isEqualTo("a");
+    }
+
+    @Test
+    public void testParsePrimitive() {
+        assertThat(JsonElement.parse("string").getAsString()).isEqualTo("string");
+        assertThat(JsonElement.parse(1).getAsInt()).isEqualTo(1);
+        assertThat(JsonElement.parse(true).getAsBoolean()).isTrue();
+        assertThat(JsonElement.parse('c').getAsString()).isEqualTo("c");
+    }
+
+    @Test
+    public void testParseUnsupported() {
+        assertThrows(IllegalArgumentException.class, () -> JsonElement.parse(new Object()));
+    }
+}

--- a/gson/src/test/java/com/google/gson/JsonObjectTest.java
+++ b/gson/src/test/java/com/google/gson/JsonObjectTest.java
@@ -27,8 +27,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import org.junit.Test;
@@ -284,10 +286,9 @@ public class JsonObjectTest {
 
     o.addProperty("a", false);
     // Insertion order should be preserved by entrySet()
-    List<?> expectedEntriesList =
-        Arrays.asList(
-            new SimpleEntry<>("b", new JsonPrimitive(true)),
-            new SimpleEntry<>("a", new JsonPrimitive(false)));
+    List<?> expectedEntriesList = Arrays.asList(
+        new SimpleEntry<>("b", new JsonPrimitive(true)),
+        new SimpleEntry<>("a", new JsonPrimitive(false)));
     assertThat(new ArrayList<>(o.entrySet())).isEqualTo(expectedEntriesList);
 
     Iterator<Entry<String, JsonElement>> iterator = o.entrySet().iterator();
@@ -299,10 +300,9 @@ public class JsonObjectTest {
       assertThat(entry.getValue()).isEqualTo(new JsonPrimitive(i));
     }
 
-    expectedEntriesList =
-        Arrays.asList(
-            new SimpleEntry<>("b", new JsonPrimitive(0)),
-            new SimpleEntry<>("a", new JsonPrimitive(1)));
+    expectedEntriesList = Arrays.asList(
+        new SimpleEntry<>("b", new JsonPrimitive(0)),
+        new SimpleEntry<>("a", new JsonPrimitive(1)));
     assertThat(new ArrayList<>(o.entrySet())).isEqualTo(expectedEntriesList);
 
     Entry<String, JsonElement> entry = o.entrySet().iterator().next();
@@ -316,13 +316,12 @@ public class JsonObjectTest {
     o.addProperty("key1", 1);
     o.addProperty("key2", 2);
 
-    Deque<?> expectedEntriesQueue =
-        new ArrayDeque<>(
-            Arrays.asList(
-                new SimpleEntry<>("b", new JsonPrimitive(0)),
-                new SimpleEntry<>("a", new JsonPrimitive(1)),
-                new SimpleEntry<>("key1", new JsonPrimitive(1)),
-                new SimpleEntry<>("key2", new JsonPrimitive(2))));
+    Deque<?> expectedEntriesQueue = new ArrayDeque<>(
+        Arrays.asList(
+            new SimpleEntry<>("b", new JsonPrimitive(0)),
+            new SimpleEntry<>("a", new JsonPrimitive(1)),
+            new SimpleEntry<>("key1", new JsonPrimitive(1)),
+            new SimpleEntry<>("key2", new JsonPrimitive(2))));
     // Note: Must wrap in ArrayList because Deque implementations do not implement `equals`
     assertThat(new ArrayList<>(o.entrySet())).isEqualTo(new ArrayList<>(expectedEntriesQueue));
     iterator = o.entrySet().iterator();
@@ -354,5 +353,25 @@ public class JsonObjectTest {
     object.add("d", nestedObject);
     assertThat(object.toString())
         .isEqualTo("{\"a\":null,\"b\\u0000\":NaN,\"c\":[\"\\\"\"],\"d\":{\"n\\u0000\":1}}");
+  }
+
+  @Test
+  public void testParseMap() {
+    Map<String, Object> map = new HashMap<>();
+    map.put("a", 1);
+    map.put("b", "string");
+
+    JsonObject jsonObject = JsonObject.parse(map);
+    assertThat(jsonObject.get("a").getAsInt()).isEqualTo(1);
+    assertThat(jsonObject.get("b").getAsString()).isEqualTo("string");
+  }
+
+  @Test
+  public void testOfMap() {
+    Map<String, JsonElement> map = new HashMap<>();
+    map.put("a", new JsonPrimitive(1));
+
+    JsonObject jsonObject = JsonObject.of(map);
+    assertThat(jsonObject.get("a").getAsInt()).isEqualTo(1);
   }
 }

--- a/gson/src/test/java/com/google/gson/JsonPrimitiveTest.java
+++ b/gson/src/test/java/com/google/gson/JsonPrimitiveTest.java
@@ -333,13 +333,13 @@ public class JsonPrimitiveTest {
   @Test
   public void testBigDecimalEqualsZero() {
     assertThat(
-            new JsonPrimitive(new BigDecimal("0.0"))
-                .equals(new JsonPrimitive(new BigDecimal("0.00"))))
+        new JsonPrimitive(new BigDecimal("0.0"))
+            .equals(new JsonPrimitive(new BigDecimal("0.00"))))
         .isTrue();
 
     assertThat(
-            new JsonPrimitive(new BigDecimal("0.00"))
-                .equals(new JsonPrimitive(Double.valueOf("0.00"))))
+        new JsonPrimitive(new BigDecimal("0.00"))
+            .equals(new JsonPrimitive(Double.valueOf("0.00"))))
         .isTrue();
   }
 
@@ -363,5 +363,14 @@ public class JsonPrimitiveTest {
   public void testEqualsDoubleNaNAndBigDecimal() {
     assertThat(new JsonPrimitive(Double.NaN).equals(new JsonPrimitive(new BigDecimal("1.0"))))
         .isFalse();
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  public void testParse() {
+    assertThat(JsonPrimitive.parse(1).getAsInt()).isEqualTo(1);
+    assertThat(JsonPrimitive.parse("a").getAsString()).isEqualTo("a");
+    assertThat(JsonPrimitive.parse(true).getAsBoolean()).isTrue();
+    assertThat(JsonPrimitive.parse('c').getAsCharacter()).isEqualTo('c');
   }
 }


### PR DESCRIPTION
Add convenience methods for creating `JsonElement` types from standad Java objects

Introduce new static `parse` and `of` methods to `JsonObject`, `JsonArray`, `JsonPrimitive`, and `JsonElement` for easier creation of Gson structures from Java collections and primitives.
* `JsonObject.parse(Map<String, ?>)`: Convert a `Map` into a `JsonObject`, auto-converting values to `JsonElement`.
* `JsonObject.of(Map<String, ? extends JsonElement>)`: Build a `JsonObject` from a map of `JsonElement`.
* `JsonArray.parse(Iterable<?>)`: Convert an `Iterable` into a `JsonArray`, auto-converting elements.
* `JsonArray.of(Iterable<? extends JsonElement>)`: Build a `JsonArray` from pre-converted elements.
* `JsonPrimitive.parse(Object)`: Create a `JsonPrimitive` from `Boolean`, `Number`, `String`, or `Character`.
* `JsonElement.parse(Object)`: Auto-detect input type and convert to the correct JSON type (`JsonObject`, `JsonArray`, `JsonPrimitive`, or `JsonNull`).

Includes complete unit tests for all added methods.