### PR TITLE
Don't rely on Android desugaring.

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -16,8 +16,6 @@
 
 package com.google.gson.internal.bind;
 
-import static java.lang.Math.toIntExact;
-
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonIOException;
@@ -773,6 +771,15 @@ public final class TypeAdapters {
         }
       };
 
+  // TODO: update this when we are on at least Android API Level 24.
+  private static int toIntExact(long x) {
+    int i = (int) x;
+    if (i != x) {
+      throw new IllegalArgumentException("Too big for an int: " + x);
+    }
+    return i;
+  }
+
   public static final TypeAdapterFactory CALENDAR_FACTORY =
       newFactoryForMultipleTypes(Calendar.class, GregorianCalendar.class, CALENDAR);
 
@@ -833,7 +840,7 @@ public final class TypeAdapters {
       FactorySupplier supplier =
           (FactorySupplier) javaTimeTypeAdapterFactoryClass.getDeclaredConstructor().newInstance();
       return supplier.get();
-    } catch (ReflectiveOperationException e) {
+    } catch (ReflectiveOperationException | LinkageError e) {
       return null;
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -522,9 +522,10 @@
               <configuration>
                 <skip>${gson.isTestModule}</skip>
                 <signature>
-                  <groupId>com.toasttab.android</groupId>
-                  <artifactId>gummy-bears-api-23</artifactId>
-                  <version>0.8.0</version>
+                  <!-- Google's internal use currently requires API Level 23 without desugaring. -->
+                  <groupId>net.sf.androidscents.signature</groupId>
+                  <artifactId>android-api-level-23</artifactId>
+                  <version>6.0_r3</version>
                 </signature>
                 <annotations>
                   <annotation>com.google.gson.internal.bind.IgnoreJRERequirement</annotation>


### PR DESCRIPTION
Some Google libraries that rely on Gson require Android 23 *without* desugaring, because otherwise their clients would be forced to enable desugaring too. So revert to the standard animal-sniffer configuration, and reinstate the local `toIntExact` implementation.

Also, catch `LinkageError` in addition to `ReflectiveOperationException` when trying to load the new `JavaTimeTypeAdapters` class.
