### PR TITLE
Avoid a potential CheckReturnValue issue.

### DIFF
--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -638,7 +638,7 @@ public final class GsonBuilder {
   public GsonBuilder setDateFormat(String pattern) {
     if (pattern != null) {
       try {
-        new SimpleDateFormat(pattern);
+        SimpleDateFormat unused = new SimpleDateFormat(pattern);
       } catch (IllegalArgumentException e) {
         // Throw exception if it is an invalid date format
         throw new IllegalArgumentException("The date pattern '" + pattern + "' is not valid", e);


### PR DESCRIPTION
Assign the result of `new SimpleDateFormat(pattern)` to a variable `unused`. We're only calling the constructor to validate `pattern`.
