### PR TITLE
fix: Preserve integral Number type in toJsonTree for byte/short/int

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -214,7 +214,7 @@ public final class TypeAdapters {
           if (value == null) {
             out.nullValue();
           } else {
-            out.value(value.byteValue());
+            out.value((Number) value.byteValue());
           }
         }
       };
@@ -249,7 +249,7 @@ public final class TypeAdapters {
           if (value == null) {
             out.nullValue();
           } else {
-            out.value(value.shortValue());
+            out.value((Number) value.shortValue());
           }
         }
       };
@@ -277,7 +277,7 @@ public final class TypeAdapters {
           if (value == null) {
             out.nullValue();
           } else {
-            out.value(value.intValue());
+            out.value((Number) value.intValue());
           }
         }
       };

--- a/gson/src/test/java/com/google/gson/functional/PrimitiveTest.java
+++ b/gson/src/test/java/com/google/gson/functional/PrimitiveTest.java
@@ -161,6 +161,33 @@ public class PrimitiveTest {
     assertThat(gson.toJson(1.5, Integer.class)).isEqualTo("1");
   }
 
+  /** Regression test for https://github.com/google/gson/issues/2680 */
+  @Test
+  public void testToJsonTreePreservesIntegralType() {
+    // toJsonTree should preserve the Number type, not widen byte/short/int to Long
+    assertThat(gson.toJsonTree((byte) 1, byte.class).getAsNumber().getClass())
+        .isEqualTo(Byte.class);
+    assertThat(gson.toJsonTree((byte) 1, Byte.class).getAsNumber().getClass())
+        .isEqualTo(Byte.class);
+
+    assertThat(gson.toJsonTree((short) 1, short.class).getAsNumber().getClass())
+        .isEqualTo(Short.class);
+    assertThat(gson.toJsonTree((short) 1, Short.class).getAsNumber().getClass())
+        .isEqualTo(Short.class);
+
+    assertThat(gson.toJsonTree(1, int.class).getAsNumber().getClass()).isEqualTo(Integer.class);
+    assertThat(gson.toJsonTree(1, Integer.class).getAsNumber().getClass()).isEqualTo(Integer.class);
+
+    // Long should remain Long
+    assertThat(gson.toJsonTree(1L, long.class).getAsNumber().getClass()).isEqualTo(Long.class);
+    assertThat(gson.toJsonTree(1L, Long.class).getAsNumber().getClass()).isEqualTo(Long.class);
+
+    // Narrowing conversion should produce the target type
+    assertThat(gson.toJsonTree(1.5, Integer.class).getAsNumber().getClass())
+        .isEqualTo(Integer.class);
+    assertThat(gson.toJsonTree(1L, Byte.class).getAsNumber().getClass()).isEqualTo(Byte.class);
+  }
+
   @Test
   public void testLongSerialization() {
     assertThat(gson.toJson(1L, long.class)).isEqualTo("1");


### PR DESCRIPTION
## Problem

When using `toJsonTree` with `byte`, `short`, or `int` types, the resulting `JsonPrimitive` stores a `Long` instead of the expected `Byte`, `Short`, or `Integer`. This is a regression introduced by commit 3e3266cf.

## Root Cause

The `BYTE`, `SHORT`, and `INTEGER` type adapters call `out.value(value.byteValue())`, `out.value(value.shortValue())`, and `out.value(value.intValue())` respectively. Since `JsonWriter` only has `value(long)` (no `value(int)`), Java auto-widens the primitive to `long`. In `JsonTreeWriter`, `value(long)` creates `new JsonPrimitive(long)`, storing a `Long` regardless of the original type.

## Fix

Cast the narrowed primitive to `Number` before passing to `value()`. This triggers autoboxing to `Byte`/`Short`/`Integer` and causes Java to resolve `value(Number)` instead of `value(long)`. `JsonTreeWriter.value(Number)` preserves the actual Number type in the `JsonPrimitive`. For regular `JsonWriter`, `value(Number)` produces identical text output.

## Tests Added

- `testToJsonTreePreservesIntegralType` — verifies that `toJsonTree` preserves:
  - `Byte` type for `byte`/`Byte.class`
  - `Short` type for `short`/`Short.class`
  - `Integer` type for `int`/`Integer.class`
  - `Long` type for `long`/`Long.class` (unchanged, regression guard)
  - Correct target type after narrowing conversion (e.g., `Double` → `Integer`, `Long` → `Byte`)

## Impact

Only affects code paths using `JsonTreeWriter` (i.e., `toJsonTree`). Regular JSON string serialization via `toJson` is unaffected since `value(Number)` and `value(long)` produce the same text output. All 4587 existing tests pass.

Fixes #2680