### PR TITLE
fix: Correct Multiset example in TypeAdapterFactory Javadoc

### DIFF
--- a/gson/src/main/java/com/google/gson/TypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/TypeAdapterFactory.java
@@ -106,7 +106,7 @@ import com.google.gson.reflect.TypeToken;
  * public class MultisetTypeAdapterFactory implements TypeAdapterFactory {
  *   public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
  *     Type type = typeToken.getType();
- *     if (typeToken.getRawType() != Multiset.class
+ *     if (!Multiset.class.isAssignableFrom(typeToken.getRawType())
  *         || !(type instanceof ParameterizedType)) {
  *       return null;
  *     }


### PR DESCRIPTION
## Problem

The `TypeAdapterFactory` Javadoc contains a `MultisetTypeAdapterFactory` code sample that does not work in practice. The factory uses `typeToken.getRawType() != Multiset.class` to check whether the type is a Multiset, but this identity check only matches the exact `Multiset` interface, not concrete implementations like `HashMultiset` or `LinkedHashMultiset`. As a result, the factory always returns null and Gson's built-in `CollectionTypeAdapterFactory` handles the type instead.

## Root Cause

The raw type check uses `!=` (reference equality) instead of `isAssignableFrom`, so it fails for all Multiset subtypes.

## Fix

Change `typeToken.getRawType() != Multiset.class` to `!Multiset.class.isAssignableFrom(typeToken.getRawType())`, which correctly matches all Multiset implementations.

## Impact

Documentation-only change. No runtime behavior affected.

Fixes #1335