### PR TITLE
Fix: reject trailing data after top-level JSON null

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -1195,7 +1195,7 @@ public final class Gson {
 
   private static void assertFullConsumption(Object obj, JsonReader reader) {
     try {
-      if (obj != null && reader.peek() != JsonToken.END_DOCUMENT) {
+      if (obj == null || reader.peek() != JsonToken.END_DOCUMENT) {
         throw new JsonSyntaxException("JSON document was not fully consumed.");
       }
     } catch (MalformedJsonException e) {

--- a/gson/src/main/java/com/google/gson/JsonParser.java
+++ b/gson/src/main/java/com/google/gson/JsonParser.java
@@ -108,7 +108,7 @@ public final class JsonParser {
     try {
       JsonReader jsonReader = new JsonReader(reader);
       JsonElement element = parseReader(jsonReader);
-      if (!element.isJsonNull() && jsonReader.peek() != JsonToken.END_DOCUMENT) {
+      if (jsonReader.peek() != JsonToken.END_DOCUMENT) {
         throw new JsonSyntaxException("Did not consume the entire document.");
       }
       return element;

--- a/gson/src/test/java/com/google/gson/JsonParserTest.java
+++ b/gson/src/test/java/com/google/gson/JsonParserTest.java
@@ -195,4 +195,19 @@ public class JsonParserTest {
     // Original strictness was kept
     assertThat(reader.getStrictness()).isEqualTo(strictness);
   }
+
+  // Tests for https://github.com/google/gson/issues/3008 - trailing data after top-level null
+  @Test
+  public void testParseTrailingDataAfterNull() {
+    assertThrows(JsonSyntaxException.class, () -> JsonParser.parseString("null trailing"));
+    assertThrows(JsonSyntaxException.class, () -> JsonParser.parseString("nulltrailing"));
+    assertThrows(JsonSyntaxException.class, () -> JsonParser.parseString(" null  extra"));
+  }
+
+  @Test
+  public void testFromJsonTrailingDataAfterNull() {
+    Gson gson = new Gson();
+    StringReader reader = new StringReader("null trailing");
+    assertThrows(JsonSyntaxException.class, () -> gson.fromJson(reader, String.class));
+  }
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/google/gson/issues/3008

`Gson.fromJson(String/Reader, ...)` and `JsonParser.parseReader(Reader)` documentedly reject trailing data, but both made an exception when the parsed top-level value was JSON `null`.

For non-null values, trailing data already causes a `JsonSyntaxException`. For top-level `null`, the trailing-data check was skipped.

## Changes

### Gson.java
```java
// Before:
if (obj != null && reader.peek() != JsonToken.END_DOCUMENT) {

// After:
if (obj == null || reader.peek() != JsonToken.END_DOCUMENT) {
```

### JsonParser.java
```java
// Before:
if (!element.isJsonNull() && jsonReader.peek() != JsonToken.END_DOCUMENT) {

// After:
if (jsonReader.peek() != JsonToken.END_DOCUMENT) {
```

## Tests

Added `testParseTrailingDataAfterNull()` and `testFromJsonTrailingDataAfterNull()` in `JsonParserTest.java` to verify trailing data is rejected after parsing top-level null.