### PR TITLE
Add `LegacyProtoTypeAdapterFactory`.

### DIFF
--- a/.github/workflows/check-android-compatibility.yml
+++ b/.github/workflows/check-android-compatibility.yml
@@ -35,4 +35,4 @@ jobs:
 
       - name: Check Android compatibility
         run: |
-          mvn compile animal-sniffer:check@check-android-compatibility -Dmaven.test.skip --projects '!metrics,!test-graal-native-image,!test-jpms,!test-shrinker'
+          mvn compile animal-sniffer:check@check-android-compatibility -Dmaven.test.skip --projects '!metrics,!proto,!test-graal-native-image,!test-jpms,!test-shrinker'

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -70,6 +70,18 @@
       <artifactId>truth</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.truth.extensions</groupId>
+      <artifactId>truth-proto-extension</artifactId>
+      <version>1.4.5</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.testparameterinjector</groupId>
+      <artifactId>test-parameter-injector</artifactId>
+      <version>1.22</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/proto/src/main/java/com/google/gson/protobuf/LegacyProtoTypeAdapterFactory.java
+++ b/proto/src/main/java/com/google/gson/protobuf/LegacyProtoTypeAdapterFactory.java
@@ -203,7 +203,7 @@ public enum LegacyProtoTypeAdapterFactory implements TypeAdapterFactory {
     // The field `private int bitField0_` tracks presence for the first 32 fields that have
     // presence, with bit 0 corresponding to the first field, and so on. The field `private int
     // bitField1_` tracks presence for the next 32 fields with presence, and so on.
-    private static final Pattern BIT_FIELD_PATTERN = Pattern.compile("bitField(\\d+)_");
+    private static final Pattern BIT_FIELD_PATTERN = Pattern.compile("bitField(\\d{1,9})_");
 
     @Override
     public T read(JsonReader in) throws IOException {

--- a/proto/src/main/java/com/google/gson/protobuf/LegacyProtoTypeAdapterFactory.java
+++ b/proto/src/main/java/com/google/gson/protobuf/LegacyProtoTypeAdapterFactory.java
@@ -1,0 +1,677 @@
+package com.google.gson.protobuf;
+
+import com.google.common.base.CaseFormat;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.EnumValueDescriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.Descriptors.OneofDescriptor;
+import com.google.protobuf.Message;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.IntStream;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A {@link TypeAdapterFactory} that supports the broken JSON mapping that Gson users get for
+ * protobuf messages if they forget to register a proper handler such as {@link
+ * ProtoTypeAdapter}. <b>This class is a migration aid.</b> If your project currently
+ * uses it, you should consider migrating to {@link ProtoTypeAdapter} or similar. That does
+ * <i>change</i> the JSON encoding, though, so there can be compatibility concerns.
+ *
+ * <p>The default JSON mapping for protobuf messages is derived by examining the private fields of
+ * the generated protobuf classes. That's obviously very fragile, and leads to ugly JSON that is not
+ * what people would reasonably expect. For example, here is what a serialized {@code
+ * .google.protobuf.Duration} might look like:
+ *
+ * <pre>
+ * {
+ *   "seconds_": 10,
+ *   "nanos_": 20,
+ *   "bitField0_": 3
+ * }
+ * </pre>
+ *
+ * <p>Notice the underscore at the end of each field name and the extra field {@code bitField0_}
+ * whose meaning is unlikely to be obvious to typical observers.
+ *
+ * <p>This class does not support Java Proto Lite.
+ */
+public enum LegacyProtoTypeAdapterFactory implements TypeAdapterFactory {
+  INSTANCE;
+
+  private LegacyProtoTypeAdapterFactory() {}
+
+  @Override
+  public <T> @Nullable TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+    Class<?> rawType = type.getRawType();
+    if (!Message.class.isAssignableFrom(rawType)) {
+      return null;
+    }
+    if (rawType == Message.class) {
+      @SuppressWarnings("unchecked")
+      TypeAdapter<T> dynamicAdapter = (TypeAdapter<T>) new DynamicAdapter(gson).nullSafe();
+      return dynamicAdapter;
+    }
+    @SuppressWarnings("unchecked")
+    TypeAdapter<T> adapter = (TypeAdapter<T>) new Adapter<>(gson, type).nullSafe();
+    return adapter;
+  }
+
+  // In what follows, RTAF means ReflectiveTypeAdapterFactory, which is the fallback that Gson
+  // uses for classes that don't have an explicit TypeAdapter. When serializing or deserializing
+  // a Java object, RTAF reflects on the instance fields of the object's class to determine
+  // its JSON representation. To output JSON, it outputs a JSON object with one key-value
+  // pair for each instance field. The keys are the field names and the values are the JSON
+  // representations of the field contents. To read JSON, it creates a new instance of the class
+  // using its private no-arg constructor then reflectively sets each of the instance fields based
+  // on the key-value pairs in the JSON object. Our Adapter here mimics both of these things
+  // without depending on the private implementation details of generated proto message classes.
+  // Specifically, it attempts to behave the same as RTAF would when reflecting on the version of
+  // proto generated code that was current in early 2026.
+
+  private static final class Adapter<T extends Message> extends TypeAdapter<T> {
+    private final Gson gson;
+    private final FieldNamingPolicy fieldNamingPolicy;
+    private final Class<T> messageClass;
+
+    private static final ClassValue<Message> DEFAULT_INSTANCE_CACHE =
+        new ClassValue<Message>() {
+          @Override
+          protected Message computeValue(Class<?> type) {
+            try {
+              return (Message) type.getMethod("getDefaultInstance").invoke(null);
+            } catch (Exception e) {
+              throw new IllegalArgumentException(e);
+            }
+          }
+        };
+
+    private final ImmutableMap<String, FieldDescriptor> javaNameToFieldDescriptor;
+    private final ImmutableMap<String, OneofDescriptor> oneofNameToOneofDescriptor;
+    private final ImmutableMap<FieldDescriptor, Integer> fieldWithPresenceToBitIndex;
+
+    // We use this to write or read string-valued fields. We don't bother using a TypeAdapter for
+    // the other kinds of fields, because no google3 code needs that.
+    private final TypeAdapter<String> stringAdapter;
+
+    // We could support the other cases, but they don't have immediate CaseFormat equivalents and
+    // are not actually used in conjunction with RTAF, so it's not worth it.
+    private static final ImmutableSet<FieldNamingPolicy> SUPPORTED_FIELD_NAMING_POLICIES =
+        ImmutableSet.of(
+            FieldNamingPolicy.IDENTITY,
+            FieldNamingPolicy.UPPER_CAMEL_CASE,
+            FieldNamingPolicy.UPPER_CASE_WITH_UNDERSCORES,
+            FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES,
+            FieldNamingPolicy.LOWER_CASE_WITH_DASHES);
+
+    Adapter(Gson gson, TypeToken<?> type) {
+      this.gson = gson;
+      if (gson.fieldNamingStrategy() instanceof FieldNamingPolicy) {
+        FieldNamingPolicy fieldNamingPolicy = (FieldNamingPolicy) gson.fieldNamingStrategy();
+        if (!SUPPORTED_FIELD_NAMING_POLICIES.contains(fieldNamingPolicy)) {
+          throw new IllegalArgumentException(
+              "Gson instance has FieldNamingPolicy that is not supported by"
+                  + " LegacyProtoTypeAdapterFactory: "
+                  + fieldNamingPolicy);
+        }
+        this.fieldNamingPolicy = fieldNamingPolicy;
+      } else {
+        throw new IllegalArgumentException(
+            "Gson instance has a custom FieldNamingStrategy, which is not supported by"
+                + " LegacyProtoTypeAdapterFactory: "
+                + gson.fieldNamingStrategy());
+      }
+      @SuppressWarnings("unchecked") // we're inventing T here to track types
+      Class<T> messageClass = (Class<T>) type.getRawType().asSubclass(Message.class);
+      this.messageClass = messageClass;
+      Descriptor descriptor = DEFAULT_INSTANCE_CACHE.get(messageClass).getDescriptorForType();
+      this.javaNameToFieldDescriptor = makeJavaNameToFieldDescriptor(descriptor);
+      this.oneofNameToOneofDescriptor = makeOneofNameToOneofDescriptor(descriptor);
+      this.fieldWithPresenceToBitIndex = makeFieldWithPresenceToBitIndex(descriptor);
+      this.stringAdapter = gson.getAdapter(String.class);
+    }
+
+    private static ImmutableMap<String, FieldDescriptor> makeJavaNameToFieldDescriptor(
+        Descriptor descriptor) {
+      ImmutableMap.Builder<String, FieldDescriptor> builder = ImmutableMap.builder();
+      for (FieldDescriptor fieldDescriptor : descriptor.getFields()) {
+        builder.put(javaName(fieldDescriptor.getName()), fieldDescriptor);
+      }
+      return builder.buildOrThrow();
+    }
+
+    private static ImmutableMap<String, OneofDescriptor> makeOneofNameToOneofDescriptor(
+        Descriptor descriptor) {
+      ImmutableMap.Builder<String, OneofDescriptor> builder = ImmutableMap.builder();
+      for (OneofDescriptor oneofDescriptor : descriptor.getOneofs()) {
+        builder.put(javaName(oneofDescriptor.getName()), oneofDescriptor);
+      }
+      return builder.buildOrThrow();
+    }
+
+    private static ImmutableMap<FieldDescriptor, Integer> makeFieldWithPresenceToBitIndex(
+        Descriptor descriptor) {
+      ImmutableMap.Builder<FieldDescriptor, Integer> builder = ImmutableMap.builder();
+      int bitIndex = 0;
+      for (FieldDescriptor fieldDescriptor : descriptor.getFields()) {
+        if (fieldDescriptor.hasPresence() && fieldDescriptor.getRealContainingOneof() == null) {
+          builder.put(fieldDescriptor, bitIndex++);
+        }
+      }
+      return builder.buildOrThrow();
+    }
+
+    private static String javaName(String name) {
+      return CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, name);
+    }
+
+    // The field `private int bitField0_` tracks presence for the first 32 fields that have
+    // presence, with bit 0 corresponding to the first field, and so on. The field `private int
+    // bitField1_` tracks presence for the next 32 fields with presence, and so on.
+    private static final Pattern BIT_FIELD_PATTERN = Pattern.compile("bitField(\\d+)_");
+
+    @Override
+    public T read(JsonReader in) throws IOException {
+      Message defaultInstance = DEFAULT_INSTANCE_CACHE.get(messageClass);
+      Message.Builder builder = defaultInstance.newBuilderForType();
+      in.beginObject();
+      BigInteger presenceBitmask = BigInteger.ZERO;
+      Map<String, Integer> oneofNameToCaseNumber = new LinkedHashMap<>();
+      Map<String, String> oneofNameToValue = new LinkedHashMap<>();
+      while (in.hasNext()) {
+        String fieldName = readFieldName(in);
+        Matcher matcher = BIT_FIELD_PATTERN.matcher(fieldName);
+        if (matcher.matches()) {
+          int shift = Integer.parseInt(matcher.group(1)) * 32;
+          int mask = in.nextInt();
+          presenceBitmask = presenceBitmask.or(BigInteger.valueOf(mask).shiftLeft(shift));
+        } else {
+          if (fieldName.endsWith("_")) {
+            fieldName = fieldName.substring(0, fieldName.length() - 1);
+          }
+          FieldDescriptor fieldDescriptor = javaNameToFieldDescriptor.get(fieldName);
+          if (fieldDescriptor != null) {
+            builder.setField(fieldDescriptor, readField(in, builder, fieldDescriptor));
+          } else if (!readOneofField(fieldName, oneofNameToCaseNumber, oneofNameToValue, in)) {
+            in.skipValue();
+          }
+        }
+      }
+      in.endObject();
+      // Now use the presence bitmask to determine whether to keep each value read from the JSON. If
+      // a field with presence does not have a 1 bit in the bitmask, then we clear it, but only if
+      // its value is the same as the default value. Its Java field in the source message will have
+      // been copied into the JSON by RTAF regardless of "presence", so if it really is absent then
+      // that value should be the same as the default. Doing this avoids a problem where the set of
+      // fields with presence might have changed between the time the proto was converted to JSON
+      // and now. If that happens, the bits in the bitmask may be completely bogus, but at worst we
+      // will mark a field as absent when it should be present but with the default value. That is
+      // actually a much better failure mode than RTAF. If the meaning of the bits in the bitmask
+      // has changed then RTAF can mark a field as absent even though a non-default value has been
+      // read into the corresponding Java field.
+      // We do have another failure mode that RTAF doesn't have: if the default value of a field has
+      // changed, then we might set that field to the old default value when it should have been
+      // absent.
+      for (Map.Entry<FieldDescriptor, Integer> entry : fieldWithPresenceToBitIndex.entrySet()) {
+        FieldDescriptor fieldDescriptor = entry.getKey();
+        Integer presenceBitIndex = entry.getValue();
+        if (!presenceBitmask.testBit(presenceBitIndex)
+            && builder
+                .getField(fieldDescriptor)
+                .equals(defaultInstance.getField(fieldDescriptor))) {
+          builder.clearField(fieldDescriptor);
+        }
+      }
+      // Finally, set any string-valued oneof fields.
+      oneofNameToValue.forEach(
+          (oneofName, value) -> {
+            Integer caseNumber = oneofNameToCaseNumber.get(oneofName);
+            if (caseNumber != null && caseNumber > 0) {
+              OneofDescriptor oneofDescriptor = oneofNameToOneofDescriptor.get(oneofName);
+              FieldDescriptor fieldDescriptor =
+                  oneofDescriptor.getContainingType().findFieldByNumber(caseNumber);
+              if (fieldDescriptor != null
+                  && fieldDescriptor.getRealContainingOneof() == oneofDescriptor) {
+                builder.setField(fieldDescriptor, value);
+              }
+            }
+          });
+      @SuppressWarnings("unchecked")
+      T result = (T) builder.build();
+      return result;
+    }
+
+    // A oneof `foo` is represented as two fields in the generated proto class: `int fooCase` and
+    // `Object foo`. RTAF can deserialize this, but except in special cases it will produce a
+    // corrupt message where getting the set oneof field will throw a `ClassCastException`.
+    // The most important of those special cases is when the oneof field is of type `string`. We
+    // handle that here: if the JSON has `"fooCase":2,"foo":"hello"` then the oneof case is a
+    // string and we will set it. Because of the way the JSON is read from a stream, we have to
+    // record the "fooCase" and "foo" fields separately, and join the read values from the two maps
+    // here at the end.
+    private boolean readOneofField(
+        String fieldName,
+        Map<String, Integer> oneofNameToCaseNumber,
+        Map<String, String> oneofNameToValue,
+        JsonReader in)
+        throws IOException {
+      for (String oneofName : oneofNameToOneofDescriptor.keySet()) {
+        if (fieldName.equals(oneofName) && in.peek() == JsonToken.STRING) {
+          oneofNameToValue.put(oneofName, stringAdapter.read(in));
+          return true;
+        } else if (fieldName.equals(oneofName + "Case") && in.peek() == JsonToken.NUMBER) {
+          oneofNameToCaseNumber.put(oneofName, in.nextInt());
+          return true;
+        }
+      }
+      return false;
+    }
+
+    private Object readField(
+        JsonReader in, Message.Builder builder, FieldDescriptor fieldDescriptor)
+        throws IOException {
+      if (fieldDescriptor.getType() == FieldDescriptor.Type.MESSAGE) {
+        Class<? extends Message> nestedMessageClass =
+            builder
+                .newBuilderForField(fieldDescriptor)
+                .getClass()
+                .getEnclosingClass()
+                .asSubclass(Message.class);
+        return readMessageField(in, nestedMessageClass, fieldDescriptor);
+      } else if (fieldDescriptor.isRepeated()) {
+        return readRepeatedField(in, fieldDescriptor);
+      } else {
+        return readSingleFieldValue(in, fieldDescriptor);
+      }
+    }
+
+    private Object readSingleFieldValue(JsonReader in, FieldDescriptor fieldDescriptor)
+        throws IOException {
+      switch (fieldDescriptor.getType()) {
+        case INT32:
+        case SINT32:
+        case UINT32:
+        case FIXED32:
+        case SFIXED32:
+          return in.nextInt();
+        case INT64:
+        case SINT64:
+        case UINT64:
+        case FIXED64:
+        case SFIXED64:
+          return in.nextLong();
+        case BOOL:
+          return in.nextBoolean();
+        case FLOAT:
+          return (float) in.nextDouble();
+        case DOUBLE:
+          return in.nextDouble();
+        case STRING:
+          return stringAdapter.read(in);
+        case BYTES:
+          return readByteString(in);
+        case ENUM:
+          return fieldDescriptor.getEnumType().findValueByNumber(in.nextInt());
+        case MESSAGE:
+          throw new AssertionError("Should not happen");
+        case GROUP:
+          throw new JsonSyntaxException("Groups are not supported");
+        default:
+          throw new AssertionError("Unexpected type: " + fieldDescriptor.getType());
+      }
+    }
+
+    private List<?> readRepeatedField(JsonReader in, FieldDescriptor fieldDescriptor)
+        throws IOException {
+      List<Object> result = new ArrayList<>();
+      in.beginArray();
+      while (in.hasNext()) {
+        result.add(readSingleFieldValue(in, fieldDescriptor));
+      }
+      in.endArray();
+      return result;
+    }
+
+    private Object readMessageField(
+        JsonReader in, Class<? extends Message> messageClass, FieldDescriptor fieldDescriptor)
+        throws IOException {
+      TypeAdapter<?> nestedAdapter = gson.getAdapter(messageClass);
+      if (fieldDescriptor.isRepeated()) {
+        List<Message> result = new ArrayList<>();
+        in.beginArray();
+        while (in.hasNext()) {
+          result.add(messageClass.cast(nestedAdapter.read(in)));
+        }
+        in.endArray();
+        return result;
+      } else {
+        return nestedAdapter.read(in);
+      }
+    }
+
+    private ByteString readByteString(JsonReader in) throws IOException {
+      // Since RTAF doesn't know any better, it will serialize a ByteString as a JSON object with
+      // two fields:
+      // - "bytes": the actual byte contents of the ByteString, a JSON array of integers;
+      // - "hash": an integer hash code of the ByteString.
+      ByteString byteString = null;
+      in.beginObject();
+      while (in.hasNext()) {
+        String fieldName = readFieldName(in);
+        switch (fieldName) {
+          case "bytes":
+            byteString = ByteString.copyFrom((byte[]) gson.fromJson(in, byte[].class));
+            break;
+          case "hash":
+            in.skipValue();
+            break;
+          default:
+            throw new IllegalArgumentException("Unrecognized ByteString field: " + fieldName);
+        }
+      }
+      in.endObject();
+      if (byteString == null) {
+        throw new IllegalArgumentException("Missing bytes field");
+      }
+      return byteString;
+    }
+
+    private String readFieldName(JsonReader in) throws IOException {
+      String fieldName = in.nextName();
+      String translatedName;
+      switch (fieldNamingPolicy) {
+        case IDENTITY:
+          translatedName = fieldName;
+          break;
+        case UPPER_CAMEL_CASE:
+          translatedName = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, fieldName);
+          break;
+        case UPPER_CASE_WITH_UNDERSCORES:
+          translatedName = CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, fieldName);
+          break;
+        case LOWER_CASE_WITH_UNDERSCORES:
+          translatedName = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, fieldName);
+          break;
+        case LOWER_CASE_WITH_DASHES:
+          translatedName = CaseFormat.LOWER_HYPHEN.to(CaseFormat.LOWER_CAMEL, fieldName);
+          break;
+        default:
+          throw new AssertionError(fieldNamingPolicy);
+      }
+      if (fieldName.endsWith("_") && !translatedName.endsWith("_")) {
+        translatedName += "_";
+      }
+      return translatedName;
+    }
+
+    @Override
+    public void write(JsonWriter out, T message) throws IOException {
+      int bitFieldCount = (fieldWithPresenceToBitIndex.size() + 31) / 32;
+      int[] bitFields = new int[bitFieldCount];
+      fieldWithPresenceToBitIndex.forEach(
+          (fieldDescriptor, bitIndex) -> {
+            if (message.hasField(fieldDescriptor)) {
+              bitFields[bitIndex / 32] |= 1 << bitIndex; // `<<` automatically mods with 32
+            }
+          });
+      out.beginObject();
+      for (int i = 0; i < bitFieldCount; i++) {
+        writeFieldName(out, "bitField" + i + "_").value(bitFields[i]);
+      }
+      // Consistently with RTAF, we write all fields, regardless of presence.
+      List<FieldDescriptor> fields = message.getDescriptorForType().getFields();
+      for (int i = 0; i < fields.size(); i++) {
+        FieldDescriptor fieldDescriptor = fields.get(i);
+        OneofDescriptor containingOneof = fieldDescriptor.getRealContainingOneof();
+        if (containingOneof != null) {
+          i = writeOneofFields(out, message, fields, i, containingOneof);
+          continue;
+        }
+        writeFieldName(out, javaName(fieldDescriptor.getName()) + "_");
+        if (fieldDescriptor.getType() == FieldDescriptor.Type.MESSAGE
+            && fieldDescriptor.hasPresence()
+            && !message.hasField(fieldDescriptor)) {
+          // Writing null is consistent with what RTAF does, and avoids the infinite recursion we
+          // could otherwise get for a recursive message.
+          out.nullValue();
+        } else {
+          writeField(out, message.getField(fieldDescriptor), fieldDescriptor);
+        }
+      }
+      out.endObject();
+    }
+
+    private void writeField(JsonWriter out, Object value, FieldDescriptor fieldDescriptor)
+        throws IOException {
+      if (fieldDescriptor.isMapField()) {
+        writeMapField(out, value, fieldDescriptor);
+      } else if (fieldDescriptor.isRepeated()) {
+        writeRepeatedField(out, value, fieldDescriptor);
+      } else {
+        writeSingleFieldValue(out, value, fieldDescriptor);
+      }
+    }
+
+    private void writeRepeatedField(JsonWriter out, Object value, FieldDescriptor fieldDescriptor)
+        throws IOException {
+      out.beginArray();
+      for (Object element : (List<?>) value) {
+        writeSingleFieldValue(out, element, fieldDescriptor);
+      }
+      out.endArray();
+    }
+
+    private void writeSingleFieldValue(
+        JsonWriter out, Object value, FieldDescriptor fieldDescriptor) throws IOException {
+      switch (fieldDescriptor.getType()) {
+        case INT32:
+        case SINT32:
+        case UINT32:
+        case FIXED32:
+        case SFIXED32:
+          out.value((int) value);
+          break;
+        case INT64:
+        case SINT64:
+        case UINT64:
+        case FIXED64:
+        case SFIXED64:
+          out.value((long) value);
+          break;
+        case BOOL:
+          out.value((boolean) value);
+          break;
+        case FLOAT:
+          out.value((float) value);
+          break;
+        case DOUBLE:
+          out.value((double) value);
+          break;
+        case STRING:
+          stringAdapter.write(out, (String) value);
+          break;
+        case BYTES:
+          writeByteString(out, (ByteString) value);
+          break;
+        case ENUM:
+          out.value(((EnumValueDescriptor) value).getNumber());
+          break;
+        case MESSAGE:
+          writeMessageField(out, (Message) value);
+          break;
+        case GROUP:
+          throw new JsonSyntaxException("Groups are not supported");
+      }
+    }
+
+    private void writeMessageField(JsonWriter out, Message value) throws IOException {
+      @SuppressWarnings("unchecked") // remove `? extends` to allow the write call
+      TypeAdapter<Message> nestedAdapter = (TypeAdapter<Message>) gson.getAdapter(value.getClass());
+      nestedAdapter.write(out, value);
+    }
+
+    private void writeMapField(JsonWriter out, Object value, FieldDescriptor fieldDescriptor)
+        throws IOException {
+      // At the proto level, a map field is a repeated field of MapEntry instances, each with fields
+      // "key" and "value". That's what the FieldDescriptor will tell us, and in particular it will
+      // tell us what the type of the value field is. (We always serialize the key as a string
+      // because that's how Gson serializes Java Map objects.)
+      // In the generated code (in the version we are emulating), a map field my_map is a Java field
+      // `com.google.protobuf.MapField<...> myMap_`. The field is null if the map is empty.
+      @SuppressWarnings("unchecked") // we know it's a list of MapEntry, which is a Message.
+      List<? extends Message> mapEntries = (List<? extends Message>) value;
+      if (mapEntries.isEmpty()) {
+        out.nullValue();
+        return;
+      }
+      Descriptor mapEntryDescriptor = fieldDescriptor.getMessageType();
+      FieldDescriptor keyFieldDescriptor = mapEntryDescriptor.findFieldByName("key");
+      FieldDescriptor valueFieldDescriptor = mapEntryDescriptor.findFieldByName("value");
+      // MapField can represent maps in two ways, as a Java Map or as a List of MapEntry objects.
+      // We'll emulate just the Map version here. So we'll emulate the fields `boolean isMutable`,
+      // `StorageMode mode`, `MutabilityAwareMapData mapData` and `Converter<K, V> converter`, and
+      // leave the field `List<Message> listData` null (which by default means Gson will output
+      // nothing for it).
+      out.beginObject();
+      writeFieldName(out, "isMutable").value(false);
+      writeFieldName(out, "mode").value("MAP");
+      // MutabilityAwareMapData inherits from Map, so Gson serializes it as a Map, not using RTAF.
+      writeFieldName(out, "mapData");
+      out.beginObject();
+      for (Message entry : mapEntries) {
+        writeFieldName(out, entry.getField(keyFieldDescriptor).toString());
+        Object entryValue = entry.getField(valueFieldDescriptor);
+        gson.toJson(entryValue, entryValue.getClass(), out);
+      }
+      out.endObject();
+      writeFieldName(out, "listData").nullValue();
+      writeFieldName(out, "converter");
+      out.beginObject();
+      out.endObject();
+      out.endObject();
+    }
+
+    private int writeOneofFields(
+        JsonWriter out,
+        Message message,
+        List<FieldDescriptor> messageFields,
+        int firstOneofIndex,
+        OneofDescriptor containingOneof)
+        throws IOException {
+      // gather all fields that are in the same oneof
+      int i;
+      for (i = firstOneofIndex;
+          i < messageFields.size()
+              && messageFields.get(i).getRealContainingOneof() == containingOneof;
+          i++) {}
+      int lastOneofIndex = i - 1;
+      // Determine which of the oneof fields is set, if any.
+      FieldDescriptor presentField =
+          IntStream.rangeClosed(firstOneofIndex, lastOneofIndex)
+              .mapToObj(messageFields::get)
+              .filter(field -> message.hasField(field))
+              .findFirst()
+              .orElse(null);
+      // For a oneof `foo_bar`, a legacy proto class has two fields: `int fooBarCase_` and `Object
+      // fooBar_`. Write these based on `presentField`.
+      String javaName = javaName(containingOneof.getName());
+      writeFieldName(out, javaName + "Case_")
+          .value(presentField == null ? 0 : presentField.getNumber());
+      writeFieldName(out, javaName + "_");
+      if (presentField == null) {
+        out.nullValue();
+      } else {
+        writeField(out, message.getField(presentField), presentField);
+      }
+      return lastOneofIndex;
+    }
+
+    private void writeByteString(JsonWriter out, ByteString byteString) throws IOException {
+      out.beginObject();
+      writeFieldName(out, "bytes");
+      gson.toJson(byteString.toByteArray(), byte[].class, out);
+      // A value for the `hash` field of 0 means that the hashCode has not been computed because
+      // hashCode() has never been called on this ByteString. We could also just not output `hash`
+      // at all and still be compatible with RTAF, but we would be more likely to fail tests that
+      // textually compare expected JSON output.
+      // For ByteString.EMPTY, chances are that something has already called hashCode() on it. So to
+      // make tests pass that compare JSON output, we do call its hashCode().
+      writeFieldName(out, "hash").value(byteString.isEmpty() ? byteString.hashCode() : 0);
+      out.endObject();
+      // If you are later deserializing with RTAF, and you don't have a specific TypeAdapter for
+      // ByteString, the default will be to use RTAF for that too. It won't be able to make a
+      // ByteString because that is an abstract class. But LegacyProtoTypeAdapterFactory does know
+      // how to deserialize, because it is using the type in FieldDescriptor.getType(), not the Java
+      // declared type of the field.
+    }
+
+    @CanIgnoreReturnValue
+    private JsonWriter writeFieldName(JsonWriter out, String name) throws IOException {
+      String translatedName;
+      switch (fieldNamingPolicy) {
+        case IDENTITY:
+          translatedName = name;
+          break;
+        case UPPER_CAMEL_CASE:
+          translatedName = CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_CAMEL, name);
+          break;
+        case UPPER_CASE_WITH_UNDERSCORES:
+          translatedName = CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, name);
+          break;
+        case LOWER_CASE_WITH_UNDERSCORES:
+          translatedName = CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, name);
+          break;
+        case LOWER_CASE_WITH_DASHES:
+          translatedName = CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_HYPHEN, name);
+          break;
+        default:
+          throw new AssertionError(fieldNamingPolicy);
+      }
+      return out.name(translatedName);
+    }
+  }
+
+  private static class DynamicAdapter extends TypeAdapter<Message> {
+    private final Gson gson;
+
+    DynamicAdapter(Gson gson) {
+      this.gson = gson;
+    }
+
+    @Override
+    public void write(JsonWriter out, Message value) throws IOException {
+      writeSubclass(out, value, value.getClass());
+    }
+
+    private <T extends Message> void writeSubclass(
+        JsonWriter out, Message value, Class<T> valueClass) throws IOException {
+      TypeAdapter<T> adapter = gson.getAdapter(valueClass);
+      adapter.write(out, valueClass.cast(value));
+    }
+
+    @Override
+    public Message read(JsonReader in) throws IOException {
+      throw new JsonParseException("Cannot deserialize a generic Message");
+    }
+  }
+}

--- a/proto/src/main/java/com/google/gson/protobuf/LegacyProtoTypeAdapterFactory.java
+++ b/proto/src/main/java/com/google/gson/protobuf/LegacyProtoTypeAdapterFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.gson.protobuf;
 
 import com.google.common.base.CaseFormat;

--- a/proto/src/main/java/com/google/gson/protobuf/LegacyProtoTypeAdapterFactory.java
+++ b/proto/src/main/java/com/google/gson/protobuf/LegacyProtoTypeAdapterFactory.java
@@ -48,10 +48,10 @@ import org.jspecify.annotations.Nullable;
 
 /**
  * A {@link TypeAdapterFactory} that supports the broken JSON mapping that Gson users get for
- * protobuf messages if they forget to register a proper handler such as {@link
- * ProtoTypeAdapter}. <b>This class is a migration aid.</b> If your project currently
- * uses it, you should consider migrating to {@link ProtoTypeAdapter} or similar. That does
- * <i>change</i> the JSON encoding, though, so there can be compatibility concerns.
+ * protobuf messages if they forget to register a proper handler such as {@link ProtoTypeAdapter}.
+ * <b>This class is a migration aid.</b> If your project currently uses it, you should consider
+ * migrating to {@link ProtoTypeAdapter} or similar. That does <i>change</i> the JSON encoding,
+ * though, so there can be compatibility concerns.
  *
  * <p>The default JSON mapping for protobuf messages is derived by examining the private fields of
  * the generated protobuf classes. That's obviously very fragile, and leads to ugly JSON that is not

--- a/proto/src/main/java/com/google/gson/protobuf/LegacyProtoTypeAdapterFactory.java
+++ b/proto/src/main/java/com/google/gson/protobuf/LegacyProtoTypeAdapterFactory.java
@@ -351,9 +351,8 @@ public enum LegacyProtoTypeAdapterFactory implements TypeAdapterFactory {
           throw new AssertionError("Should not happen");
         case GROUP:
           throw new JsonSyntaxException("Groups are not supported");
-        default:
-          throw new AssertionError("Unexpected type: " + fieldDescriptor.getType());
       }
+      throw new AssertionError("Unexpected type: " + fieldDescriptor.getType());
     }
 
     private List<?> readRepeatedField(JsonReader in, FieldDescriptor fieldDescriptor)

--- a/proto/src/test/java/com/google/gson/protobuf/functional/LegacyProtoTypeAdapterFactoryTest.java
+++ b/proto/src/test/java/com/google/gson/protobuf/functional/LegacyProtoTypeAdapterFactoryTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.gson.protobuf.functional;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;

--- a/proto/src/test/java/com/google/gson/protobuf/functional/LegacyProtoTypeAdapterFactoryTest.java
+++ b/proto/src/test/java/com/google/gson/protobuf/functional/LegacyProtoTypeAdapterFactoryTest.java
@@ -43,6 +43,7 @@ import com.google.gson.protobuf2.TestAllTypesProto2;
 import com.google.gson.protobuf2.TestManyOptionals;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import com.google.protobuf.Duration;
 import com.google.protobuf.Message;
 import com.google.protobuf.NullValue;
 import com.google.testing.junit.testparameterinjector.TestParameter;
@@ -69,16 +70,12 @@ public final class LegacyProtoTypeAdapterFactoryTest {
           .put("TestDuration with no Duration", TestDuration.newBuilder().build())
           .put(
               "TestDuration with empty Duration",
-              TestDuration.newBuilder()
-                  .setDurationValue(com.google.protobuf.Duration.getDefaultInstance())
-                  .build())
+              TestDuration.newBuilder().setDurationValue(Duration.getDefaultInstance()).build())
           .put(
               "TestDuration with large Duration",
               TestDuration.newBuilder()
                   .setDurationValue(
-                      com.google.protobuf.Duration.newBuilder()
-                          .setSeconds(300_000_000_000L)
-                          .setNanos(67890))
+                      Duration.newBuilder().setSeconds(300_000_000_000L).setNanos(67890))
                   .build())
           .put("ManyOptionals with nothing set", TestManyOptionals.getDefaultInstance())
           .put(

--- a/proto/src/test/java/com/google/gson/protobuf/functional/LegacyProtoTypeAdapterFactoryTest.java
+++ b/proto/src/test/java/com/google/gson/protobuf/functional/LegacyProtoTypeAdapterFactoryTest.java
@@ -1,0 +1,457 @@
+package com.google.gson.protobuf.functional;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.base.Ascii;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.protobuf.LegacyProtoTypeAdapterFactory;
+import com.google.gson.protobuf.TestAllTypes;
+import com.google.gson.protobuf.TestAllTypes.NestedMessage;
+import com.google.gson.protobuf.TestDuration;
+import com.google.gson.protobuf.TestMap;
+import com.google.gson.protobuf.TestOneof;
+import com.google.gson.protobuf2.TestAllTypesProto2;
+import com.google.gson.protobuf2.TestManyOptionals;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import com.google.protobuf.Message;
+import com.google.protobuf.NullValue;
+import com.google.testing.junit.testparameterinjector.TestParameter;
+import com.google.testing.junit.testparameterinjector.TestParameterInjector;
+import com.google.testing.junit.testparameterinjector.TestParameterValue;
+import com.google.testing.junit.testparameterinjector.TestParameterValuesProvider;
+import java.io.IOException;
+import java.util.regex.Pattern;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(TestParameterInjector.class)
+public final class LegacyProtoTypeAdapterFactoryTest {
+  // A reminder that RTAF means "ReflectiveTypeAdapterFactory", which is the fallback that Gson
+  // uses for classes that don't have an explicit TypeAdapter. See the comments in
+  // LegacyProtoTypeAdapterFactory.java for more details.
+
+  private static final Gson RTAF_GSON = new Gson();
+  private static final Gson GSON_WITH_LEGACY_ADAPTER =
+      new GsonBuilder().registerTypeAdapterFactory(LegacyProtoTypeAdapterFactory.INSTANCE).create();
+
+  private static final ImmutableMap<String, Message> SHARED_TEST_MESSAGES =
+      ImmutableMap.<String, Message>builder()
+          .put("TestDuration with no Duration", TestDuration.newBuilder().build())
+          .put(
+              "TestDuration with empty Duration",
+              TestDuration.newBuilder()
+                  .setDurationValue(com.google.protobuf.Duration.getDefaultInstance())
+                  .build())
+          .put(
+              "TestDuration with large Duration",
+              TestDuration.newBuilder()
+                  .setDurationValue(
+                      com.google.protobuf.Duration.newBuilder()
+                          .setSeconds(300_000_000_000L)
+                          .setNanos(67890))
+                  .build())
+          .put("ManyOptionals with nothing set", TestManyOptionals.getDefaultInstance())
+          .put(
+              "ManyOptionals with some fields set to their defaults",
+              TestManyOptionals.newBuilder()
+                  .setOptionalX1(0)
+                  .setOptionalX8(0)
+                  .setOptionalX40(0)
+                  .setOptionalX41(41) // not default
+                  .build())
+          .put("Oneof with string", TestOneof.newBuilder().setOneofString("hello").build())
+          .buildOrThrow();
+
+  private static final ImmutableMap<String, Message> SERIALIZED_WITH_RTAF =
+      ImmutableMap.<String, Message>builder()
+          .putAll(SHARED_TEST_MESSAGES)
+          .put("TestAllTypes with nothing set", TestAllTypes.getDefaultInstance())
+          .put("TestAllTypes with everything set", TestMessages.testAllTypes())
+          .put(
+              "TestAllTypesProto2",
+              TestAllTypesProto2.newBuilder()
+                  .setOptionalInt32(1234)
+                  .setOptionalString("hello")
+                  .setOptionalNestedEnum(TestAllTypesProto2.NestedEnum.BAR)
+                  .addRepeatedString("hello")
+                  .addRepeatedString("world")
+                  .addRepeatedInt32(1234)
+                  .build())
+          .buildOrThrow();
+
+  private static final ImmutableMap<String, Message> DESERIALIZED_WITH_RTAF =
+      ImmutableMap.<String, Message>builder().putAll(SHARED_TEST_MESSAGES).buildOrThrow();
+
+  private static final ImmutableMap<String, Message> ONEOF_MESSAGES =
+      ImmutableMap.<String, Message>builder()
+          .put("Oneof with nothing set", TestOneof.getDefaultInstance())
+          .put("Oneof with int32", TestOneof.newBuilder().setOneofInt32(123).build())
+          .put(
+              "Oneof with nested message",
+              TestOneof.newBuilder()
+                  .setOneofNestedMessage(NestedMessage.newBuilder().setValue(123))
+                  .build())
+          .put(
+              "Oneof with NullValue",
+              TestOneof.newBuilder().setOneofNullValue(NullValue.NULL_VALUE).build())
+          .put("Oneof with string", TestOneof.newBuilder().setOneofString("hello").build())
+          .buildOrThrow();
+
+  /**
+   * Tests that messages can be serialized by the RTAF logic and then deserialized by a Gson
+   * instance with {@link LegacyProtoTypeAdapterFactory} registered.
+   */
+  @Test
+  public void rtafToLegacyCompat(
+      @TestParameter(valuesProvider = RtafToLegacyCompatProvider.class) Message message,
+      @TestParameter({
+            "IDENTITY",
+            "UPPER_CAMEL_CASE",
+            "UPPER_CASE_WITH_UNDERSCORES",
+            "LOWER_CASE_WITH_UNDERSCORES",
+            "LOWER_CASE_WITH_DASHES"
+          })
+          FieldNamingPolicy fieldNamingPolicy) {
+    String json = applyFieldNamingPolicy(RTAF_GSON, fieldNamingPolicy).toJson(message);
+    Message compatMessage =
+        applyFieldNamingPolicy(GSON_WITH_LEGACY_ADAPTER, fieldNamingPolicy)
+            .fromJson(json, message.getClass());
+    assertThat(compatMessage).isEqualTo(message);
+    assertThat(compatMessage.getSerializedSize()).isEqualTo(message.getSerializedSize());
+  }
+
+  /**
+   * Tests that {@link LegacyProtoTypeAdapterFactory} produces JSON that is equivalent to what RTAF
+   * produces.
+   */
+  @Test
+  public void legacyCompatOutputsSameJsonAsRtaf(
+      @TestParameter(valuesProvider = RtafToLegacyCompatProvider.class) Message message,
+      @TestParameter({
+            "IDENTITY",
+            "UPPER_CAMEL_CASE",
+            "UPPER_CASE_WITH_UNDERSCORES",
+            "LOWER_CASE_WITH_UNDERSCORES",
+            "LOWER_CASE_WITH_DASHES"
+          })
+          FieldNamingPolicy fieldNamingPolicy) {
+    JsonObject rtafJson =
+        applyFieldNamingPolicy(RTAF_GSON, fieldNamingPolicy).toJsonTree(message).getAsJsonObject();
+    JsonObject legacyJson =
+        applyFieldNamingPolicy(GSON_WITH_LEGACY_ADAPTER, fieldNamingPolicy)
+            .toJsonTree(message)
+            .getAsJsonObject();
+    // Rewrite both JSONs to remove fields that may harmlessly differ between the two.
+    rewriteJsonObject(rtafJson);
+    rewriteJsonObject(legacyJson);
+    assertThat(legacyJson).isEqualTo(rtafJson);
+
+    // If the following assertion failed, it would mostly be harmless, but it would mean that some
+    // golden-file tests in google3 might have to be updated after migrating to
+    // LegacyProtoTypeAdapterFactory. (It's actually a bit surprising that the order of JSON object
+    // members is the same in both cases, for all our tests. They're not sorted or anything.)
+    assertThat(legacyJson.toString()).isEqualTo(rtafJson.toString());
+  }
+
+  private static void rewriteJsonElement(JsonElement json) {
+    if (json.isJsonObject()) {
+      rewriteJsonObject(json.getAsJsonObject());
+    } else if (json.isJsonArray()) {
+      rewriteJsonArray(json.getAsJsonArray());
+    }
+  }
+
+  private static void rewriteJsonObject(JsonObject json) {
+    // The RTAF JSON includes a field `fooMemoizedSerializedSize` for every `foo` that is a a
+    // repeated non-message field. Not including it means that it gets its default value of -1,
+    // which implies that it will be computed on demand. We verify `getSerializedSize()` in
+    // `legacyCompatToRtaf`, which would fail if the absence of `fooMemoizedSerializedSize` were a
+    // problem.
+    // There are a number of fields that are transient in Google's internal version but not yet in
+    // the open-source version (for compatibility reasons). So we rewrite those ones too.
+    Pattern pattern =
+        Pattern.compile(
+            "^(memoized.?(Hash.?Code|Is.?Initialized|Size))|unknown.?Fields"
+                + "|.*Memoized.?Serialized.?Size$",
+            Pattern.CASE_INSENSITIVE);
+    var keysToRemove =
+        json.keySet().stream()
+            .filter(key -> pattern.matcher(key).find())
+            .collect(toImmutableList());
+    json.keySet().removeAll(keysToRemove);
+    json.keySet().removeAll(TRANSIENT_FIELDS);
+
+    // Similarly, the RTAF JSON for a ByteString can include a `hash` field that is either 0
+    // (meaning the hash has not been computed) or a non-zero hash value. We rewrite it to 0 always.
+    var lowerCaseToOriginalCase =
+        json.keySet().stream().collect(toImmutableMap(s -> Ascii.toLowerCase(s), s -> s));
+    if (lowerCaseToOriginalCase.keySet().equals(BYTE_STRING_FIELDS)) {
+      json.addProperty(lowerCaseToOriginalCase.get("hash"), 0);
+    }
+
+    for (var element : json.asMap().values()) {
+      rewriteJsonElement(element);
+    }
+  }
+
+  private static void rewriteJsonArray(JsonArray json) {
+    for (var element : json) {
+      rewriteJsonElement(element);
+    }
+  }
+
+  /**
+   * Fields that are transient in Google's internal version but, for compatibility reasons, not yet
+   * in open-source protos. We remove them before comparing expected and actual.
+   */
+  private static final ImmutableSet<String> TRANSIENT_FIELDS =
+      ImmutableSet.of("memoizedHashCode", "memoizedIsInitialized", "memoizedSize", "unknownFields");
+
+  private static final ImmutableSet<String> BYTE_STRING_FIELDS = ImmutableSet.of("bytes", "hash");
+
+  // "memoizedIsInitialized":1,"memoizedSize":-1,"memoizedHashCode":0}
+
+  /**
+   * Tests that messages with oneof fields can be serialized by a Gson instance with {@link
+   * LegacyProtoTypeAdapterFactory} registered, and the result will be the same as with RTAF. Doing
+   * this is really only useful for logging and golden-file tests, because neither RTAF nor {@link
+   * LegacyProtoTypeAdapterFactory} can deserialize these messages correctly.
+   */
+  @Test
+  public void legacyCompat_serializeOneof(
+      @TestParameter(valuesProvider = OneofProvider.class) TestOneof message) {
+    JsonElement rtafJson = RTAF_GSON.toJsonTree(message);
+    rewriteJsonElement(rtafJson);
+    JsonElement legacyJson = GSON_WITH_LEGACY_ADAPTER.toJsonTree(message);
+    rewriteJsonElement(legacyJson);
+    assertThat(legacyJson).isEqualTo(rtafJson);
+  }
+
+  /**
+   * Verifies that RTAF cannot in general deserialize a message with a oneof field correctly.
+   *
+   * <p>For most messages with a oneof field that is set, serializing with RTAF and then
+   * deserializing leads to an object where fetching the oneof field value causes a {@code
+   * ClassCastException}. That's because the oneof value is stored in a field of type {@code
+   * Object}. Gson will usually guess the wrong type, since all it has to go on is the shape of the
+   * JSON: it will deserialize a {@code double} if the JSON value is a number (with or without
+   * decimal point), and it will deserialize a {@code Map} if the JSON value is a JSON object.
+   */
+  @Test
+  public void rtaf_cannotDeserializeOneof(
+      @TestParameter(valuesProvider = OneofProvider.class) TestOneof message) {
+    String json = RTAF_GSON.toJson(message);
+    TestOneof possiblyCorruptMessage = RTAF_GSON.fromJson(json, TestOneof.class);
+
+    switch (message.getOneofFieldCase()) {
+      case ONEOFFIELD_NOT_SET:
+        assertThat(possiblyCorruptMessage.getOneofFieldCase())
+            .isEqualTo(TestOneof.OneofFieldCase.ONEOFFIELD_NOT_SET);
+        break;
+      case ONEOF_INT32:
+        assertThrows(ClassCastException.class, possiblyCorruptMessage::getOneofInt32);
+        break;
+      case ONEOF_NESTED_MESSAGE:
+        assertThrows(ClassCastException.class, possiblyCorruptMessage::getOneofNestedMessage);
+        break;
+      case ONEOF_NULL_VALUE:
+        assertThrows(ClassCastException.class, possiblyCorruptMessage::getOneofNullValue);
+        break;
+      case ONEOF_STRING:
+        assertThat(possiblyCorruptMessage.getOneofString()).isEqualTo(message.getOneofString());
+        break;
+    }
+  }
+
+  /**
+   * Verifies that {@link LegacyProtoTypeAdapterFactory} drops oneof fields on deserialization.
+   * That's probably better than producing a message that throws a {@code ClassCastException} when
+   * the oneof field is accessed. We do retain oneof fields with string values, because that one
+   * situation works.
+   */
+  @Test
+  public void legacyCompat_canOnlyDeserializeStringOneof(
+      @TestParameter(valuesProvider = OneofProvider.class) TestOneof message) {
+    String json = GSON_WITH_LEGACY_ADAPTER.toJson(message);
+    TestOneof deserialized = GSON_WITH_LEGACY_ADAPTER.fromJson(json, TestOneof.class);
+
+    switch (message.getOneofFieldCase()) {
+      case ONEOF_STRING:
+        assertThat(deserialized.getOneofString()).isEqualTo(message.getOneofString());
+        break;
+      default:
+        assertThat(deserialized.getOneofFieldCase())
+            .isEqualTo(TestOneof.OneofFieldCase.ONEOFFIELD_NOT_SET);
+    }
+  }
+
+  /**
+   * Tests that messages can be serialized by a Gson instance with {@link
+   * LegacyProtoTypeAdapterFactory} registered and then deserialized by the RTAF logic.
+   *
+   * <p>There are fewer test messages for this case than for {@link #rtafToLegacyCompat} because
+   * RTAF can handle fewer kinds of proto fields when deserializing than when serializing. When
+   * serializing an instance field in the message implementation class, it can use the actual
+   * runtime type of the field contents. But when deserializing a field, it has to construct an
+   * instance of some type, and the only information it has is the declared type of the field. If
+   * that type is an abstract class or an interface, it will generally not be able to construct an
+   * instance. That applies for example to fields of type {@code Object} or {@code ByteString} or
+   * {@code Internal.IntList}.
+   */
+  @Test
+  public void legacyCompatToRtaf(
+      @TestParameter(valuesProvider = LegacyCompatToRtafProvider.class) Message message) {
+    String rtafJson = RTAF_GSON.toJson(message);
+    assertThat(RTAF_GSON.fromJson(rtafJson, message.getClass())).isEqualTo(message);
+    String json = GSON_WITH_LEGACY_ADAPTER.toJson(message);
+    Message reflectionMessage = RTAF_GSON.fromJson(json, message.getClass());
+    assertThat(reflectionMessage).isEqualTo(message);
+    assertThat(reflectionMessage.getSerializedSize()).isEqualTo(message.getSerializedSize());
+  }
+
+  /**
+   * Tests that messages can be serialized by a Gson instance with {@link
+   * LegacyProtoTypeAdapterFactory} registered, even if given only {@code Message.class} as the
+   * target type. For serialization, it's possible to use the actual runtime type to get the right
+   * results. (This is better than RTAF, which just produces an empty JSON object.)
+   */
+  @Test
+  public void legacyCompatToRtafWithTargetTypeMessage(
+      @TestParameter(valuesProvider = LegacyCompatToRtafProvider.class) Message message) {
+    String json = GSON_WITH_LEGACY_ADAPTER.toJson(message, Message.class);
+    Message reflectionMessage = RTAF_GSON.fromJson(json, message.getClass());
+    assertThat(reflectionMessage).isEqualTo(message);
+    assertThat(reflectionMessage.getSerializedSize()).isEqualTo(message.getSerializedSize());
+  }
+
+  /**
+   * Tests that messages cannot be deserialized by a Gson instance with {@link
+   * LegacyProtoTypeAdapterFactory} registered, if given only {@code Message.class} as the target
+   * type.
+   */
+  @Test
+  public void rtafToLegacyCompatWithTargetTypeMessage(
+      @TestParameter(valuesProvider = LegacyCompatToRtafProvider.class) Message message) {
+    String json = RTAF_GSON.toJson(message);
+    var exception =
+        assertThrows(
+            JsonParseException.class, () -> GSON_WITH_LEGACY_ADAPTER.fromJson(json, Message.class));
+    assertThat(exception).hasMessageThat().contains("Cannot deserialize a generic Message");
+  }
+
+  /**
+   * Neither RTAF nor {@link LegacyProtoTypeAdapterFactory} can deserialize maps. We test only that
+   * they both serialize maps in the same way.
+   */
+  @Test
+  public void serializeMap() {
+    TestMap map =
+        TestMap.newBuilder()
+            .putInt32ToInt32Map(1, 2)
+            .putInt32ToInt32Map(3, 4)
+            .putStringToInt32Map("a", 1)
+            .putInt32ToMessageMap(1, NestedMessage.newBuilder().setValue(100).build())
+            .build();
+    JsonElement rtafJson = RTAF_GSON.toJsonTree(map);
+    rewriteJsonElement(rtafJson);
+    JsonElement json = GSON_WITH_LEGACY_ADAPTER.toJsonTree(map);
+    rewriteJsonElement(json);
+    assertThat(json).isEqualTo(rtafJson);
+
+    assertThrows(JsonParseException.class, () -> RTAF_GSON.fromJson(json, TestMap.class));
+  }
+
+  private static final class StringAdapter extends TypeAdapter<String> {
+    @Override
+    public void write(JsonWriter out, String value) throws IOException {
+      out.value("«" + value + "»");
+    }
+
+    @Override
+    public String read(JsonReader in) throws IOException {
+      String s = in.nextString();
+      if (!s.startsWith("«") || !s.endsWith("»")) {
+        throw new JsonParseException("Unexpected string: " + s);
+      }
+      return s.substring(1, s.length() - 1);
+    }
+  }
+
+  @Test
+  public void customStringAdapter() {
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapterFactory(LegacyProtoTypeAdapterFactory.INSTANCE)
+            .registerTypeAdapter(String.class, new StringAdapter())
+            .create();
+    TestAllTypes message = TestMessages.testAllTypes();
+    String json = gson.toJson(message);
+    assertThat(json).contains("\"optionalString_\":\"«" + message.getOptionalString() + "»");
+    TestAllTypes message2 = gson.fromJson(json, TestAllTypes.class);
+    assertThat(message2).isEqualTo(message);
+  }
+
+  @Test
+  public void serializeNull() {
+    assertThat(RTAF_GSON.toJson(null, TestAllTypes.class)).isEqualTo("null");
+    assertThat(GSON_WITH_LEGACY_ADAPTER.toJson(null, TestAllTypes.class)).isEqualTo("null");
+  }
+
+  @Test
+  public void deserializeNull() {
+    assertThat(RTAF_GSON.fromJson("null", TestAllTypes.class)).isNull();
+    assertThat(GSON_WITH_LEGACY_ADAPTER.fromJson("null", TestAllTypes.class)).isNull();
+  }
+
+  private static Gson applyFieldNamingPolicy(Gson gson, FieldNamingPolicy fieldNamingPolicy) {
+    return gson.newBuilder().setFieldNamingPolicy(fieldNamingPolicy).create();
+  }
+
+  private abstract static class TestMessagesProvider extends TestParameterValuesProvider {
+    private final ImmutableMap<String, Message> testMessages;
+
+    TestMessagesProvider(ImmutableMap<String, Message> testMessages) {
+      this.testMessages = testMessages;
+    }
+
+    @Override
+    public ImmutableList<TestParameterValue> provideValues(Context context) {
+      return testMessages.entrySet().stream()
+          .map(entry -> value(entry.getValue()).withName(entry.getKey()))
+          .collect(toImmutableList());
+    }
+  }
+
+  private static final class RtafToLegacyCompatProvider extends TestMessagesProvider {
+    RtafToLegacyCompatProvider() {
+      super(SERIALIZED_WITH_RTAF);
+    }
+  }
+
+  private static final class LegacyCompatToRtafProvider extends TestMessagesProvider {
+    LegacyCompatToRtafProvider() {
+      super(DESERIALIZED_WITH_RTAF);
+    }
+  }
+
+  private static final class OneofProvider extends TestMessagesProvider {
+    OneofProvider() {
+      super(ONEOF_MESSAGES);
+    }
+  }
+}

--- a/proto/src/test/java/com/google/gson/protobuf/functional/TestMessages.java
+++ b/proto/src/test/java/com/google/gson/protobuf/functional/TestMessages.java
@@ -1,0 +1,76 @@
+package com.google.gson.protobuf.functional;
+
+import com.google.gson.protobuf.TestAllTypes;
+import com.google.gson.protobuf.TestAllTypes.NestedEnum;
+import com.google.gson.protobuf.TestRecursive;
+import com.google.protobuf.ByteString;
+
+/** Helper class for creating test messages. */
+final class TestMessages {
+
+  static TestAllTypes testAllTypes() {
+    TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+    builder.setOptionalInt32(1234);
+    builder.setOptionalInt64(1234567890123456789L);
+    builder.setOptionalUint32(-1);
+    builder.setOptionalUint64(-1L);
+    builder.setOptionalSint32(9012);
+    builder.setOptionalSint64(3456789012345678901L);
+    builder.setOptionalFixed32(3456);
+    builder.setOptionalFixed64(4567890123456789012L);
+    builder.setOptionalSfixed32(7890);
+    builder.setOptionalSfixed64(5678901234567890123L);
+    builder.setOptionalFloat(1.5f);
+    builder.setOptionalDouble(1.25);
+    builder.setOptionalBool(true);
+    builder.setOptionalString("Hello world!");
+    builder.setOptionalBytes(ByteString.copyFrom(new byte[] {0, 1, -2}));
+    builder.setOptionalNestedEnum(NestedEnum.BAR);
+    builder.setOptionalRecursive(
+        TestRecursive.newBuilder()
+            .setValue(100)
+            .setNested(TestRecursive.newBuilder().setValue(200)));
+    builder.getOptionalNestedMessageBuilder().setValue(100);
+
+    builder.addRepeatedInt32(1234);
+    builder.addRepeatedInt64(1234567890123456789L);
+    builder.addRepeatedUint32(5678);
+    builder.addRepeatedUint64(2345678901234567890L);
+    builder.addRepeatedSint32(9012);
+    builder.addRepeatedSint64(3456789012345678901L);
+    builder.addRepeatedFixed32(3456);
+    builder.addRepeatedFixed64(4567890123456789012L);
+    builder.addRepeatedSfixed32(7890);
+    builder.addRepeatedSfixed64(5678901234567890123L);
+    builder.addRepeatedFloat(1.5f);
+    builder.addRepeatedDouble(1.25);
+    builder.addRepeatedBool(true);
+    builder.addRepeatedString("Hello world!");
+    builder.addRepeatedBytes(ByteString.copyFrom(new byte[] {0, 1, 2}));
+    builder.addRepeatedNestedEnum(NestedEnum.BAR);
+    builder.addRepeatedNestedMessageBuilder().setValue(100);
+
+    builder.addRepeatedInt32(234);
+    builder.addRepeatedInt64(234567890123456789L);
+    builder.addRepeatedUint32(678);
+    builder.addRepeatedUint64(345678901234567890L);
+    builder.addRepeatedSint32(012);
+    builder.addRepeatedSint64(456789012345678901L);
+    builder.addRepeatedFixed32(456);
+    builder.addRepeatedFixed64(567890123456789012L);
+    builder.addRepeatedSfixed32(890);
+    builder.addRepeatedSfixed64(678901234567890123L);
+    builder.addRepeatedFloat(11.5f);
+    builder.addRepeatedDouble(11.25);
+    builder.addRepeatedBool(true);
+    builder.addRepeatedString("ello world!");
+    builder.addRepeatedBytes(ByteString.copyFrom(new byte[] {1, 2}));
+    builder.addRepeatedNestedEnum(NestedEnum.BAZ);
+    builder.addRepeatedNestedMessageBuilder().setValue(200);
+
+    return builder.build();
+  }
+
+  private TestMessages() {
+  }
+}

--- a/proto/src/test/java/com/google/gson/protobuf/functional/TestMessages.java
+++ b/proto/src/test/java/com/google/gson/protobuf/functional/TestMessages.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.gson.protobuf.functional;
 
 import com.google.gson.protobuf.TestAllTypes;

--- a/proto/src/test/java/com/google/gson/protobuf/functional/TestMessages.java
+++ b/proto/src/test/java/com/google/gson/protobuf/functional/TestMessages.java
@@ -86,6 +86,5 @@ final class TestMessages {
     return builder.build();
   }
 
-  private TestMessages() {
-  }
+  private TestMessages() {}
 }

--- a/proto/src/test/protobuf/json_test.proto
+++ b/proto/src/test/protobuf/json_test.proto
@@ -1,0 +1,175 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+// LINT: LEGACY_NAMES
+
+syntax = "proto3";
+
+package com.google.gson.protobuf;
+
+import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/field_mask.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
+
+option java_package = "com.google.gson.protobuf";
+option java_outer_classname = "JsonTestProto";
+option java_multiple_files = true;
+
+message TestAllTypes {
+  enum NestedEnum {
+    FOO = 0;
+    BAR = 1;
+    BAZ = 2;
+  }
+
+  enum AliasedEnum {
+    option allow_alias = true;
+
+    ALIAS_FOO = 0;
+    ALIAS_BAR = 1;
+    ALIAS_BAZ = 2;
+    QUX = 2;
+    qux = 2;
+    bAz = 2;
+  }
+  message NestedMessage {
+    int32 value = 1;
+  }
+
+  int32 optional_int32 = 1;
+  int64 optional_int64 = 2;
+  uint32 optional_uint32 = 3;
+  uint64 optional_uint64 = 4;
+  sint32 optional_sint32 = 5;
+  sint64 optional_sint64 = 6;
+  fixed32 optional_fixed32 = 7;
+  fixed64 optional_fixed64 = 8;
+  sfixed32 optional_sfixed32 = 9;
+  sfixed64 optional_sfixed64 = 10;
+  float optional_float = 11;
+  double optional_double = 12;
+  bool optional_bool = 13;
+  string optional_string = 14;
+  bytes optional_bytes = 15;
+  NestedMessage optional_nested_message = 18;
+  NestedEnum optional_nested_enum = 21;
+  AliasedEnum optional_aliased_enum = 52;
+  TestRecursive optional_recursive = 53;
+
+  optional int32 explicit_presence_int32 = 54;
+
+  // Repeated
+  repeated int32 repeated_int32 = 31;
+  repeated int64 repeated_int64 = 32;
+  repeated uint32 repeated_uint32 = 33;
+  repeated uint64 repeated_uint64 = 34;
+  repeated sint32 repeated_sint32 = 35;
+  repeated sint64 repeated_sint64 = 36;
+  repeated fixed32 repeated_fixed32 = 37;
+  repeated fixed64 repeated_fixed64 = 38;
+  repeated sfixed32 repeated_sfixed32 = 39;
+  repeated sfixed64 repeated_sfixed64 = 40;
+  repeated float repeated_float = 41;
+  repeated double repeated_double = 42;
+  repeated bool repeated_bool = 43;
+  repeated string repeated_string = 44;
+  repeated bytes repeated_bytes = 45;
+  repeated NestedMessage repeated_nested_message = 48;
+  repeated NestedEnum repeated_nested_enum = 51;
+  repeated TestRecursive repeated_recursive = 55;
+}
+
+message TestOneof {
+  oneof oneof_field {
+    int32 oneof_int32 = 1;
+    TestAllTypes.NestedMessage oneof_nested_message = 2;
+    .google.protobuf.NullValue oneof_null_value = 3;
+    string oneof_string = 4;
+  }
+}
+
+message TestMap {
+  // Instead of testing all combinations (too many), we only make sure all
+  // valid types have been used at least in one field as key and in one
+  // field as value.
+  map<int32, int32> int32_to_int32_map = 1;
+  map<int64, int32> int64_to_int32_map = 2;
+  map<uint32, int32> uint32_to_int32_map = 3;
+  map<uint64, int32> uint64_to_int32_map = 4;
+  map<sint32, int32> sint32_to_int32_map = 5;
+  map<sint64, int32> sint64_to_int32_map = 6;
+  map<fixed32, int32> fixed32_to_int32_map = 7;
+  map<fixed64, int32> fixed64_to_int32_map = 8;
+  map<sfixed32, int32> sfixed32_to_int32_map = 9;
+  map<sfixed64, int32> sfixed64_to_int32_map = 10;
+  map<bool, int32> bool_to_int32_map = 11;
+  map<string, int32> string_to_int32_map = 12;
+
+  map<int32, int64> int32_to_int64_map = 101;
+  map<int32, uint32> int32_to_uint32_map = 102;
+  map<int32, uint64> int32_to_uint64_map = 103;
+  map<int32, sint32> int32_to_sint32_map = 104;
+  map<int32, sint64> int32_to_sint64_map = 105;
+  map<int32, fixed32> int32_to_fixed32_map = 106;
+  map<int32, fixed64> int32_to_fixed64_map = 107;
+  map<int32, sfixed32> int32_to_sfixed32_map = 108;
+  map<int32, sfixed64> int32_to_sfixed64_map = 109;
+  map<int32, float> int32_to_float_map = 110;
+  map<int32, double> int32_to_double_map = 111;
+  map<int32, bool> int32_to_bool_map = 112;
+  map<int32, string> int32_to_string_map = 113;
+  map<int32, bytes> int32_to_bytes_map = 114;
+  map<int32, TestAllTypes.NestedMessage> int32_to_message_map = 115;
+  map<int32, TestAllTypes.NestedEnum> int32_to_enum_map = 116;
+}
+
+message TestWrappers {
+  .google.protobuf.Int32Value int32_value = 1;
+  .google.protobuf.UInt32Value uint32_value = 2;
+  .google.protobuf.Int64Value int64_value = 3;
+  .google.protobuf.UInt64Value uint64_value = 4;
+  .google.protobuf.FloatValue float_value = 5;
+  .google.protobuf.DoubleValue double_value = 6;
+  .google.protobuf.BoolValue bool_value = 7;
+  .google.protobuf.StringValue string_value = 8;
+  .google.protobuf.BytesValue bytes_value = 9;
+}
+
+message TestTimestamp {
+  .google.protobuf.Timestamp timestamp_value = 1;
+}
+
+message TestDuration {
+  .google.protobuf.Duration duration_value = 1;
+}
+
+message TestFieldMask {
+  .google.protobuf.FieldMask field_mask_value = 1;
+}
+
+message TestStruct {
+  .google.protobuf.Struct struct_value = 1;
+  .google.protobuf.Value value = 2;
+  .google.protobuf.ListValue list_value = 3;
+}
+
+message TestAny {
+  .google.protobuf.Any any_value = 1;
+  map<string, .google.protobuf.Any> any_map = 2;
+}
+
+message TestCustomJsonName {
+  int32 value = 1 [json_name = "@value"];
+}
+
+message TestRecursive {
+  int32 value = 1;
+  TestRecursive nested = 2;
+}

--- a/proto/src/test/protobuf/json_test.proto
+++ b/proto/src/test/protobuf/json_test.proto
@@ -1,11 +1,18 @@
-// Protocol Buffers - Google's data interchange format
-// Copyright 2008 Google Inc.  All rights reserved.
-//
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file or at
-// https://developers.google.com/open-source/licenses/bsd
-
-// LINT: LEGACY_NAMES
+/*
+ * Copyright (C) 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 syntax = "proto3";
 

--- a/proto/src/test/protobuf/json_test_proto2.proto
+++ b/proto/src/test/protobuf/json_test_proto2.proto
@@ -1,0 +1,133 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+// LINT: LEGACY_NAMES
+
+syntax = "proto2";
+
+package com.google.gson.protobuf2;
+
+option java_package = "com.google.gson.protobuf2";
+option java_outer_classname = "JsonTestProto2";
+option java_multiple_files = true;
+
+message TestAllTypesProto2 {
+  enum NestedEnum {
+    FOO = 0;
+    BAR = 1;
+    BAZ = 2;
+  }
+
+  enum AliasedEnum {
+    option allow_alias = true;
+
+    ALIAS_FOO = 0;
+    ALIAS_BAR = 1;
+    ALIAS_BAZ = 2;
+    QUX = 2;
+    qux = 2;
+    bAz = 2;
+  }
+  message NestedMessage {
+    optional int32 value = 1;
+  }
+
+  optional int32 optional_int32 = 1;
+  optional int64 optional_int64 = 2;
+  optional uint32 optional_uint32 = 3;
+  optional uint64 optional_uint64 = 4;
+  optional sint32 optional_sint32 = 5;
+  optional sint64 optional_sint64 = 6;
+  optional fixed32 optional_fixed32 = 7;
+  optional fixed64 optional_fixed64 = 8;
+  optional sfixed32 optional_sfixed32 = 9;
+  optional sfixed64 optional_sfixed64 = 10;
+  optional float optional_float = 11;
+  optional double optional_double = 12;
+  optional bool optional_bool = 13;
+  optional string optional_string = 14;
+  optional bytes optional_bytes = 15;
+  optional NestedMessage optional_nested_message = 18;
+  optional NestedEnum optional_nested_enum = 21;
+  optional AliasedEnum optional_aliased_enum = 52;
+  optional TestRecursive optional_recursive = 53;
+
+  // Repeated
+  repeated int32 repeated_int32 = 31;
+  repeated int64 repeated_int64 = 32;
+  repeated uint32 repeated_uint32 = 33;
+  repeated uint64 repeated_uint64 = 34;
+  repeated sint32 repeated_sint32 = 35;
+  repeated sint64 repeated_sint64 = 36;
+  repeated fixed32 repeated_fixed32 = 37;
+  repeated fixed64 repeated_fixed64 = 38;
+  repeated sfixed32 repeated_sfixed32 = 39;
+  repeated sfixed64 repeated_sfixed64 = 40;
+  repeated float repeated_float = 41;
+  repeated double repeated_double = 42;
+  repeated bool repeated_bool = 43;
+  repeated string repeated_string = 44;
+  repeated bytes repeated_bytes = 45;
+  repeated NestedMessage repeated_nested_message = 48;
+  repeated NestedEnum repeated_nested_enum = 51;
+  repeated TestRecursive repeated_recursive = 55;
+}
+
+message TestRecursive {
+  optional int32 value = 1;
+  optional TestRecursive nested = 2;
+}
+
+// There are enough optional fields in this message to require more than one
+// int bitmask to record their presence.
+message TestManyOptionals {
+  optional int32 optional_x1 = 1;
+  optional int32 optional_x2 = 2;
+  optional int32 optional_x3 = 3;
+  optional int32 optional_x4 = 4;
+  optional int32 optional_x5 = 5;
+  optional int32 optional_x6 = 6;
+  optional int32 optional_x7 = 7;
+  optional int32 optional_x8 = 8;
+  optional int32 optional_x9 = 9;
+  optional int32 optional_x10 = 10;
+  optional int32 optional_x11 = 11;
+  optional int32 optional_x12 = 12;
+  optional int32 optional_x13 = 13;
+  optional int32 optional_x14 = 14;
+  optional int32 optional_x15 = 15;
+  optional int32 optional_x16 = 16;
+  optional int32 optional_x17 = 17;
+  optional int32 optional_x18 = 18;
+  optional int32 optional_x19 = 19;
+  optional int32 optional_x20 = 20;
+  optional int32 optional_x21 = 21;
+  optional int32 optional_x22 = 22;
+  optional int32 optional_x23 = 23;
+  optional int32 optional_x24 = 24;
+  optional int32 optional_x25 = 25;
+  optional int32 optional_x26 = 26;
+  optional int32 optional_x27 = 27;
+  optional int32 optional_x28 = 28;
+  optional int32 optional_x29 = 29;
+  optional int32 optional_x30 = 30;
+  optional int32 optional_x31 = 31;
+  optional int32 optional_x32 = 32;
+  optional int32 optional_x33 = 33;
+  optional int32 optional_x34 = 34;
+  optional int32 optional_x35 = 35;
+  optional int32 optional_x36 = 36;
+  optional int32 optional_x37 = 37;
+  optional int32 optional_x38 = 38;
+  optional int32 optional_x39 = 39;
+  optional int32 optional_x40 = 40;
+  optional int32 optional_x41 = 41;
+  optional int32 optional_x42 = 42;
+  optional int32 optional_x43 = 43;
+  optional int32 optional_x44 = 44;
+  optional int32 optional_x45 = 45;
+}

--- a/proto/src/test/protobuf/json_test_proto2.proto
+++ b/proto/src/test/protobuf/json_test_proto2.proto
@@ -1,11 +1,18 @@
-// Protocol Buffers - Google's data interchange format
-// Copyright 2008 Google Inc.  All rights reserved.
-//
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file or at
-// https://developers.google.com/open-source/licenses/bsd
-
-// LINT: LEGACY_NAMES
+/*
+ * Copyright (C) 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 syntax = "proto2";
 


### PR DESCRIPTION
This is a migration aid for code that is currently accidentally relying
on `ReflectiveTypeAdapterFactory` to serialize and/or deserialize
protobuf messages. Such code depends on the internal details of how
protobuf messages are represented as Java objects, and can break if
those details change. This adapter freezes a particular representation
and allows code to become independent of future changes.

We do not recommend this for anything other than managing legacy code
that may have come to rely on a particular JSON format.

This code is not currently part of any released artifact.
