### PR TITLE
docs: fix incomplete Gson examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Maven:
 </dependency>
 ```
 
-[Gson jar downloads](https://maven-badges.herokuapp.com/maven-central/com.google.code.gson/gson) are available from Maven Central.
+[Gson jar downloads](https://central.sonatype.com/artifact/com.google.code.gson/gson) are available from Maven Central.
 
 ![Build Status](https://github.com/google/gson/actions/workflows/build.yml/badge.svg)
 

--- a/gson/src/main/java/com/google/gson/JsonElement.java
+++ b/gson/src/main/java/com/google/gson/JsonElement.java
@@ -47,6 +47,7 @@ import java.math.BigInteger;
  *   <li>{@link Gson#fromJson(java.io.Reader, Class) Gson.fromJson(..., JsonElement.class)}<br>
  *       It is possible to directly specify a {@code JsonElement} subclass, for example:
  *       <pre>
+ * Gson gson = new Gson();
  * JsonObject jsonObject = gson.fromJson("{}", JsonObject.class);
  * </pre>
  * </ul>
@@ -58,6 +59,7 @@ import java.math.BigInteger;
  * Gson} instance and then use it for conversion from and to JSON:
  *
  * <pre>{@code
+ * Gson gson = new Gson();
  * TypeAdapter<JsonElement> adapter = gson.getAdapter(JsonElement.class);
  *
  * JsonElement value = adapter.fromJson("{}");
@@ -73,11 +75,13 @@ import java.math.BigInteger;
  * <ul>
  *   <li>{@link Gson#fromJson(JsonElement, Class) Gson.fromJson(JsonElement, ...)}, for example:
  *       <pre>
+ * Gson gson = new Gson();
  * JsonObject jsonObject = ...;
  * MyClass myObj = gson.fromJson(jsonObject, MyClass.class);
  * </pre>
  *   <li>{@link Gson#toJsonTree(Object)}, for example:
  *       <pre>
+ * Gson gson = new Gson();
  * MyClass myObj = ...;
  * JsonElement json = gson.toJsonTree(myObj);
  * </pre>

--- a/gson/src/main/java/com/google/gson/annotations/SerializedName.java
+++ b/gson/src/main/java/com/google/gson/annotations/SerializedName.java
@@ -66,6 +66,7 @@ import java.lang.annotation.Target;
  * example:
  *
  * <pre>
+ *   Gson gson = new Gson();
  *   MyClass target = gson.fromJson("{'name1':'v1'}", MyClass.class);
  *   assertEquals("v1", target.b);
  *   target = gson.fromJson("{'name2':'v2'}", MyClass.class);


### PR DESCRIPTION

**Repo:** google/gson (⭐ 23000)
**Type:** docs
**Files changed:** 3
**Lines:** +6/-1

## What
Updated public-facing documentation examples so they are copy-pasteable and point at the right destination. The patch adds missing `Gson gson = new Gson();` setup lines to `JsonElement` and `SerializedName` Javadocs where example code referenced an undeclared `gson` variable, and replaces the README download link from an external badge service with the direct Maven Central artifact page.

## Why
These are small but concrete documentation defects in surfaces users are likely to copy from. Undeclared variables in Javadocs make the examples incomplete, and the README download link currently routes through a badge URL instead of the canonical artifact page. Tightening those examples reduces friction for first-time users without changing runtime behavior.

## Testing
Verified the patch shape with `git diff --check` and reviewed the resulting committed diff. No unit tests were run because the change is documentation-only.

## Risk
Low - docs-only change with no production code or build logic impact.
