### PR TITLE
docs: Fix copy-paste @return in JsonArray.getAsCharacter javadoc

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonArray.java
+++ b/gson/src/main/java/com/google/gson/JsonArray.java
@@ -364,7 +364,7 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
    * method calls {@link JsonElement#getAsCharacter()} on the element, therefore any of the
    * exceptions declared by that method can occur.
    *
-   * @return this element as a primitive short if it is single element array.
+   * @return this element as a character if it is single element array.
    * @throws IllegalStateException if the array is empty or has more than one element.
    * @deprecated This method is misleading, as it does not get this element as a char but rather as
    *     a string's first character.


### PR DESCRIPTION
## Problem

The `@return` tag on `JsonArray.getAsCharacter()` reads:

```
@return this element as a primitive short if it is single element array.
```

This is a copy-paste from `getAsShort()` and is wrong. The method returns a `char`, not a primitive short, and every other line of the same javadoc block (the description, the `@deprecated` note, and the method signature) talks about a character.

## Root Cause

When the per-method getters were templated, the `getAsCharacter` block reused the `@return` text from `getAsShort` without updating the type description.

## Fix

Replace `primitive short` with `character` in the `@return` tag of `JsonArray.getAsCharacter`. No behavior change; javadoc only.

## Tests

No new tests are required because this is a documentation-only fix. The full test suite still passes:

```
mvn -pl gson test
...
Tests run: 4592, Failures: 0, Errors: 0, Skipped: 19
BUILD SUCCESS
```