### PR TITLE
docs: update Gson jar download link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Maven:
 </dependency>
 ```
 
-[Gson jar downloads](https://maven-badges.herokuapp.com/maven-central/com.google.code.gson/gson) are available from Maven Central.
+[Gson jar downloads](https://central.sonatype.com/artifact/com.google.code.gson/gson) are available from Maven Central.
 
 ![Build Status](https://github.com/google/gson/actions/workflows/build.yml/badge.svg)
 


### PR DESCRIPTION
**Purpose:-**

Fixes an outdated and potentially misleading link in the README for Gson JAR downloads.

**Description:-**

The current README includes a link to:

```
https://maven-badges.herokuapp.com/maven-central/com.google.code.gson/gson
```

This is a third-party badge service and not an official Maven Central page, which may confuse users looking for reliable dependency or download information.

This pull request updates the link to the official Maven Central page maintained by Sonatype:

```
https://central.sonatype.com/artifact/com.google.code.gson/gson
```

This ensures users are directed to up-to-date source for Gson artifacts.