### PR TITLE
Remove obsolete native-maven-plugin JUnit workaround

### DIFF
--- a/test-graal-native-image/pom.xml
+++ b/test-graal-native-image/pom.xml
@@ -150,7 +150,6 @@
                   <buildArgs>
                     <!-- Show stack traces to make troubleshooting build issues easier -->
                     <buildArg>-H:+ReportExceptionStackTraces</buildArg>
-                    <buildArg>--initialize-at-build-time=org.junit.jupiter.engine.discovery.MethodSegmentResolver</buildArg>
                   </buildArgs>
                 </configuration>
               </execution>


### PR DESCRIPTION
[Version 1.1.0](https://github.com/graalvm/native-build-tools/releases/tag/1.1.0) (which is used since #3032) added the missing built-in configuration for `--initialize-at-build-time=...MethodSegmentResolver` which was added as workaround in #2969; therefore I have removed that workaround again.
