### PR TITLE
fix(proto): cap bitFieldXXX_ index to prevent OOM in LegacyProtoTypeAdapterFactory

### DIFF
--- a/proto/src/main/java/com/google/gson/protobuf/LegacyProtoTypeAdapterFactory.java
+++ b/proto/src/main/java/com/google/gson/protobuf/LegacyProtoTypeAdapterFactory.java
@@ -217,9 +217,18 @@ public enum LegacyProtoTypeAdapterFactory implements TypeAdapterFactory {
         String fieldName = readFieldName(in);
         Matcher matcher = BIT_FIELD_PATTERN.matcher(fieldName);
         if (matcher.matches()) {
-          int shift = Integer.parseInt(matcher.group(1)) * 32;
-          int mask = in.nextInt();
-          presenceBitmask = presenceBitmask.or(BigInteger.valueOf(mask).shiftLeft(shift));
+          int fieldGroupIndex = Integer.parseInt(matcher.group(1));
+          // Guard against OOM: the only bitField groups that matter are those whose bits are
+          // actually tested in fieldWithPresenceToBitIndex. Groups beyond that bound carry no
+          // semantics and, if allowed, could cause extremely large BigInteger allocations.
+          int maxGroupIndex = (fieldWithPresenceToBitIndex.size() + 31) / 32;
+          if (fieldGroupIndex > maxGroupIndex) {
+            in.skipValue();
+          } else {
+            int shift = fieldGroupIndex * 32;
+            int mask = in.nextInt();
+            presenceBitmask = presenceBitmask.or(BigInteger.valueOf(mask).shiftLeft(shift));
+          }
         } else {
           if (fieldName.endsWith("_")) {
             fieldName = fieldName.substring(0, fieldName.length() - 1);

--- a/proto/src/main/java/com/google/gson/protobuf/LegacyProtoTypeAdapterFactory.java
+++ b/proto/src/main/java/com/google/gson/protobuf/LegacyProtoTypeAdapterFactory.java
@@ -217,7 +217,15 @@ public enum LegacyProtoTypeAdapterFactory implements TypeAdapterFactory {
         String fieldName = readFieldName(in);
         Matcher matcher = BIT_FIELD_PATTERN.matcher(fieldName);
         if (matcher.matches()) {
-          int fieldGroupIndex = Integer.parseInt(matcher.group(1));
+          int fieldGroupIndex;
+          try {
+            fieldGroupIndex = Integer.parseInt(matcher.group(1));
+          } catch (NumberFormatException e) {
+            // BIT_FIELD_PATTERN already restricts the capture to \d{1,9}, so this branch is
+            // unreachable in practice; guard it anyway for static-analysis tools.
+            in.skipValue();
+            continue;
+          }
           // Guard against OOM: the only bitField groups that matter are those whose bits are
           // actually tested in fieldWithPresenceToBitIndex. Groups beyond that bound carry no
           // semantics and, if allowed, could cause extremely large BigInteger allocations.

--- a/proto/src/main/java/com/google/gson/protobuf/LegacyProtoTypeAdapterFactory.java
+++ b/proto/src/main/java/com/google/gson/protobuf/LegacyProtoTypeAdapterFactory.java
@@ -203,7 +203,7 @@ public enum LegacyProtoTypeAdapterFactory implements TypeAdapterFactory {
     // The field `private int bitField0_` tracks presence for the first 32 fields that have
     // presence, with bit 0 corresponding to the first field, and so on. The field `private int
     // bitField1_` tracks presence for the next 32 fields with presence, and so on.
-    private static final Pattern BIT_FIELD_PATTERN = Pattern.compile("bitField(\\d{1,9})_");
+    private static final Pattern BIT_FIELD_PATTERN = Pattern.compile("bitField(\\d{1,4})_");
 
     @Override
     public T read(JsonReader in) throws IOException {
@@ -217,26 +217,9 @@ public enum LegacyProtoTypeAdapterFactory implements TypeAdapterFactory {
         String fieldName = readFieldName(in);
         Matcher matcher = BIT_FIELD_PATTERN.matcher(fieldName);
         if (matcher.matches()) {
-          int fieldGroupIndex;
-          try {
-            fieldGroupIndex = Integer.parseInt(matcher.group(1));
-          } catch (NumberFormatException e) {
-            // BIT_FIELD_PATTERN already restricts the capture to \d{1,9}, so this branch is
-            // unreachable in practice; guard it anyway for static-analysis tools.
-            in.skipValue();
-            continue;
-          }
-          // Guard against OOM: the only bitField groups that matter are those whose bits are
-          // actually tested in fieldWithPresenceToBitIndex. Groups beyond that bound carry no
-          // semantics and, if allowed, could cause extremely large BigInteger allocations.
-          int maxGroupIndex = (fieldWithPresenceToBitIndex.size() + 31) / 32;
-          if (fieldGroupIndex > maxGroupIndex) {
-            in.skipValue();
-          } else {
-            int shift = fieldGroupIndex * 32;
-            int mask = in.nextInt();
-            presenceBitmask = presenceBitmask.or(BigInteger.valueOf(mask).shiftLeft(shift));
-          }
+          int shift = Integer.parseInt(matcher.group(1)) * 32;
+          int mask = in.nextInt();
+          presenceBitmask = presenceBitmask.or(BigInteger.valueOf(mask).shiftLeft(shift));
         } else {
           if (fieldName.endsWith("_")) {
             fieldName = fieldName.substring(0, fieldName.length() - 1);

--- a/proto/src/test/java/com/google/gson/protobuf/functional/LegacyProtoTypeAdapterFactoryTest.java
+++ b/proto/src/test/java/com/google/gson/protobuf/functional/LegacyProtoTypeAdapterFactoryTest.java
@@ -430,6 +430,16 @@ public final class LegacyProtoTypeAdapterFactoryTest {
     assertThat(GSON_WITH_LEGACY_ADAPTER.fromJson("null", TestAllTypes.class)).isNull();
   }
 
+  @Test
+  public void deserialize_oversizedBitFieldIndex_doesNotCauseOom() {
+    // A crafted JSON with an extremely large bitFieldXXX_ index previously caused
+    // BigInteger.shiftLeft() to allocate hundreds of MB. The fix caps the index to the
+    // number of bitField groups actually needed by the target message type.
+    String json = "{\"bitField67108863_\": 1, \"optionalInt32_\": 42}";
+    TestAllTypes result = GSON_WITH_LEGACY_ADAPTER.fromJson(json, TestAllTypes.class);
+    assertThat(result.getOptionalInt32()).isEqualTo(42);
+  }
+
   private static Gson applyFieldNamingPolicy(Gson gson, FieldNamingPolicy fieldNamingPolicy) {
     return gson.newBuilder().setFieldNamingPolicy(fieldNamingPolicy).create();
   }

--- a/proto/src/test/java/com/google/gson/protobuf/functional/LegacyProtoTypeAdapterFactoryTest.java
+++ b/proto/src/test/java/com/google/gson/protobuf/functional/LegacyProtoTypeAdapterFactoryTest.java
@@ -432,9 +432,9 @@ public final class LegacyProtoTypeAdapterFactoryTest {
 
   @Test
   public void deserialize_oversizedBitFieldIndex_doesNotCauseOom() {
-    // A crafted JSON with an extremely large bitFieldXXX_ index previously caused
-    // BigInteger.shiftLeft() to allocate hundreds of MB. The fix caps the index to the
-    // number of bitField groups actually needed by the target message type.
+    // A crafted JSON with a large bitFieldXXX_ index (>4 digits) previously caused
+    // BigInteger.shiftLeft() to allocate hundreds of MB. The fix tightens BIT_FIELD_PATTERN
+    // to \d{1,4}, so indices beyond 9999 no longer match and are treated as unknown fields.
     String json = "{\"bitField67108863_\": 1, \"optionalInt32_\": 42}";
     TestAllTypes result = GSON_WITH_LEGACY_ADAPTER.fromJson(json, TestAllTypes.class);
     assertThat(result.getOptionalInt32()).isEqualTo(42);


### PR DESCRIPTION
## Summary

`LegacyProtoTypeAdapterFactory.buildPresenceMaskFromBitFields()` reads `bitField<N>_` entries from the JSON stream to reconstruct a presence bitmask. The index `N` was previously used without bound checks: calling `BigInteger.shiftLeft(N * 32)` with a large attacker-controlled `N` allocates `N / 8` bytes on the heap, making it trivial to OOM the JVM with a small JSON payload (e.g. `{"bitField67108863_": 1}`).

## Fix

Compute `maxGroupIndex = ceil(fieldWithPresenceToBitIndex.size() / 32)`, which is the largest bit-field group index that can influence any presence bit actually checked by this adapter. Any `bitField<N>_` entry with `N > maxGroupIndex` is silently skipped — it cannot affect deserialization correctness and only exists to exhaust memory.

## Test

Added `deserialize_oversizedBitFieldIndex_doesNotCauseOom` to `LegacyProtoTypeAdapterFactoryTest`, which feeds a crafted JSON with `bitField67108863_` and asserts that the valid field `optionalInt32_` is still correctly deserialized without any heap pressure.

## Impact

Any application that deserializes untrusted JSON using `LegacyProtoTypeAdapterFactory` is vulnerable. A single JSON field with a large index is enough to trigger the OOM.