### PR TITLE
Fix #3008: reject trailing data after top-level null

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -1195,7 +1195,7 @@ public final class Gson {
 
   private static void assertFullConsumption(Object obj, JsonReader reader) {
     try {
-      if (obj != null && reader.peek() != JsonToken.END_DOCUMENT) {
+      if (reader.peek() != JsonToken.END_DOCUMENT) {
         throw new JsonSyntaxException("JSON document was not fully consumed.");
       }
     } catch (MalformedJsonException e) {

--- a/gson/src/main/java/com/google/gson/JsonParser.java
+++ b/gson/src/main/java/com/google/gson/JsonParser.java
@@ -108,7 +108,7 @@ public final class JsonParser {
     try {
       JsonReader jsonReader = new JsonReader(reader);
       JsonElement element = parseReader(jsonReader);
-      if (!element.isJsonNull() && jsonReader.peek() != JsonToken.END_DOCUMENT) {
+      if (jsonReader.peek() != JsonToken.END_DOCUMENT) {
         throw new JsonSyntaxException("Did not consume the entire document.");
       }
       return element;


### PR DESCRIPTION
Fixes google/gson#3008.

Both `Gson.fromJson` and `JsonParser.parseReader` accepted trailing data after a top-level null because the trailing-data check was skipped when the parsed element was null.

## Changes

- **Gson.java** `assertFullConsumption()`: Removed the `obj != null` guard so trailing-data validation runs even when the parsed object is null.
- **JsonParser.java** `parseReader()`: Removed the `!element.isJsonNull()` guard so trailing-data validation runs unconditionally.

Now `null  extra` correctly throws `JsonSyntaxException: Did not consume the entire document` (or the equivalent from `Gson.fromJson`).