### PR TITLE
Bump Error Prone to 2.49.0 and fix new warnings

### DIFF
--- a/extras/src/test/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactoryTest.java
+++ b/extras/src/test/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactoryTest.java
@@ -164,10 +164,9 @@ public final class RuntimeTypeAdapterFactoryTest {
     TypeAdapterFactory billingAdapter =
         RuntimeTypeAdapterFactory.of(BillingInstrument.class).registerSubtype(BankTransfer.class);
     Gson gson = new GsonBuilder().registerTypeAdapterFactory(billingAdapter).create();
+    CreditCard value = new CreditCard("Jesse", 456);
     var e =
-        assertThrows(
-            JsonParseException.class,
-            () -> gson.toJson(new CreditCard("Jesse", 456), BillingInstrument.class));
+        assertThrows(JsonParseException.class, () -> gson.toJson(value, BillingInstrument.class));
     assertThat(e)
         .hasMessageThat()
         .isEqualTo(
@@ -182,10 +181,9 @@ public final class RuntimeTypeAdapterFactoryTest {
         RuntimeTypeAdapterFactory.of(BillingInstrument.class, "cvv")
             .registerSubtype(CreditCard.class);
     Gson gson = new GsonBuilder().registerTypeAdapterFactory(billingAdapter).create();
+    CreditCard value = new CreditCard("Jesse", 456);
     var e =
-        assertThrows(
-            JsonParseException.class,
-            () -> gson.toJson(new CreditCard("Jesse", 456), BillingInstrument.class));
+        assertThrows(JsonParseException.class, () -> gson.toJson(value, BillingInstrument.class));
     assertThat(e)
         .hasMessageThat()
         .isEqualTo(

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_annotations</artifactId>
-      <version>2.48.0</version>
+      <version>2.49.0</version>
     </dependency>
 
     <dependency>

--- a/gson/src/main/java/com/google/gson/internal/LinkedTreeMap.java
+++ b/gson/src/main/java/com/google/gson/internal/LinkedTreeMap.java
@@ -42,16 +42,11 @@ import java.util.Set;
  */
 @SuppressWarnings("serial") // ignore warning about missing serialVersionUID
 public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Serializable {
-  @SuppressWarnings({"unchecked", "rawtypes"}) // to avoid Comparable<Comparable<Comparable<...>>>
-  private static final Comparator<Comparable> NATURAL_ORDER =
-      new Comparator<Comparable>() {
-        @Override
-        public int compare(Comparable a, Comparable b) {
-          return a.compareTo(b);
-        }
-      };
-
+  /** Comparator for comparing keys; {@code null} if 'natural order' should be used. */
+  // Uses null for 'natural order' instead of `java.util.Comparator#naturalOrder()` as potential
+  // performance optimization by directly calling `compareTo` on the key objects
   private final Comparator<? super K> comparator;
+
   private final boolean allowNullValues;
   Node<K, V> root;
   int size = 0;
@@ -64,9 +59,8 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
    * Create a natural order, empty tree map whose keys must be mutually comparable and non-null, and
    * whose values can be {@code null}.
    */
-  @SuppressWarnings("unchecked") // unsafe! this assumes K is comparable
   public LinkedTreeMap() {
-    this((Comparator<? super K>) NATURAL_ORDER, true);
+    this(null, true);
   }
 
   /**
@@ -74,9 +68,8 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
    *
    * @param allowNullValues whether {@code null} is allowed as entry value
    */
-  @SuppressWarnings("unchecked") // unsafe! this assumes K is comparable
   public LinkedTreeMap(boolean allowNullValues) {
-    this((Comparator<? super K>) NATURAL_ORDER, allowNullValues);
+    this(null, allowNullValues);
   }
 
   /**
@@ -87,10 +80,8 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
    *     ordering.
    * @param allowNullValues whether {@code null} is allowed as entry value
    */
-  // unsafe! if comparator is null, this assumes K is comparable
-  @SuppressWarnings({"unchecked", "rawtypes"})
   public LinkedTreeMap(Comparator<? super K> comparator, boolean allowNullValues) {
-    this.comparator = comparator != null ? comparator : (Comparator) NATURAL_ORDER;
+    this.comparator = comparator;
     this.allowNullValues = allowNullValues;
     this.header = new Node<>(allowNullValues);
   }
@@ -156,8 +147,7 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
     if (nearest != null) {
       // Micro-optimization: avoid polymorphic calls to Comparator.compare().
       @SuppressWarnings("unchecked") // Throws a ClassCastException below if there's trouble.
-      Comparable<Object> comparableKey =
-          (comparator == NATURAL_ORDER) ? (Comparable<Object>) key : null;
+      Comparable<Object> comparableKey = comparator == null ? (Comparable<Object>) key : null;
 
       while (true) {
         comparison =
@@ -190,7 +180,7 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
     Node<K, V> created;
     if (nearest == null) {
       // Check that the value is comparable if we didn't do any comparisons.
-      if (comparator == NATURAL_ORDER && !(key instanceof Comparable)) {
+      if (comparator == null && !(key instanceof Comparable)) {
         throw new ClassCastException(key.getClass().getName() + " is not Comparable");
       }
       created = new Node<>(allowNullValues, nearest, key, header, header.prev);

--- a/gson/src/main/java/com/google/gson/internal/ReflectionAccessFilterHelper.java
+++ b/gson/src/main/java/com/google/gson/internal/ReflectionAccessFilterHelper.java
@@ -73,6 +73,7 @@ public class ReflectionAccessFilterHelper {
   }
 
   /** See {@link AccessibleObject#canAccess(Object)} (Java >= 9) */
+  @SuppressWarnings("InvalidLink") // suppress Error Prone warning about link to Java 9 method
   public static boolean canAccess(AccessibleObject accessibleObject, Object object) {
     return AccessChecker.INSTANCE.canAccess(accessibleObject, object);
   }

--- a/gson/src/test/java/com/google/gson/GsonTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/GsonTypeAdapterTest.java
@@ -51,7 +51,8 @@ public class GsonTypeAdapterTest {
 
   @Test
   public void testTypeAdapterThrowsException() {
-    Exception e = assertThrows(IllegalStateException.class, () -> gson.toJson(new AtomicLong(0)));
+    AtomicLong value = new AtomicLong(0);
+    Exception e = assertThrows(IllegalStateException.class, () -> gson.toJson(value));
     assertThat(e).isSameInstanceAs(ExceptionTypeAdapter.thrownException);
 
     // Verify that serializer is made null-safe, i.e. it is not called for null
@@ -66,13 +67,13 @@ public class GsonTypeAdapterTest {
 
   @Test
   public void testTypeAdapterProperlyConvertsTypes() {
-    int intialValue = 1;
-    AtomicInteger atomicInt = new AtomicInteger(intialValue);
+    int initialValue = 1;
+    AtomicInteger atomicInt = new AtomicInteger(initialValue);
     String json = gson.toJson(atomicInt);
-    assertThat(Integer.parseInt(json)).isEqualTo(intialValue + 1);
+    assertThat(Integer.parseInt(json)).isEqualTo(initialValue + 1);
 
     atomicInt = gson.fromJson(json, AtomicInteger.class);
-    assertThat(atomicInt.get()).isEqualTo(intialValue);
+    assertThat(atomicInt.get()).isEqualTo(initialValue);
   }
 
   @Test

--- a/gson/src/test/java/com/google/gson/JsonArrayAsListTest.java
+++ b/gson/src/test/java/com/google/gson/JsonArrayAsListTest.java
@@ -68,8 +68,9 @@ public class JsonArrayAsListTest {
     assertThat(list.get(0)).isEqualTo(new JsonPrimitive(2));
     assertThat(a.get(0)).isEqualTo(new JsonPrimitive(2));
 
-    assertThrows(IndexOutOfBoundsException.class, () -> list.set(-1, new JsonPrimitive(1)));
-    assertThrows(IndexOutOfBoundsException.class, () -> list.set(2, new JsonPrimitive(1)));
+    JsonPrimitive value = new JsonPrimitive(1);
+    assertThrows(IndexOutOfBoundsException.class, () -> list.set(-1, value));
+    assertThrows(IndexOutOfBoundsException.class, () -> list.set(2, value));
 
     NullPointerException e = assertThrows(NullPointerException.class, () -> list.set(0, null));
     assertThat(e).hasMessageThat().isEqualTo("Element must be non-null");
@@ -95,9 +96,10 @@ public class JsonArrayAsListTest {
             JsonNull.INSTANCE);
     assertThat(list).isEqualTo(expectedList);
 
-    assertThrows(IndexOutOfBoundsException.class, () -> list.set(-1, new JsonPrimitive(1)));
-    assertThrows(
-        IndexOutOfBoundsException.class, () -> list.set(list.size(), new JsonPrimitive(1)));
+    JsonPrimitive value = new JsonPrimitive(1);
+    assertThrows(IndexOutOfBoundsException.class, () -> list.set(-1, value));
+    int listSize = list.size();
+    assertThrows(IndexOutOfBoundsException.class, () -> list.set(listSize, value));
 
     NullPointerException e = assertThrows(NullPointerException.class, () -> list.add(0, null));
     assertThat(e).hasMessageThat().isEqualTo("Element must be non-null");
@@ -118,14 +120,12 @@ public class JsonArrayAsListTest {
         Arrays.asList(new JsonPrimitive(1), new JsonPrimitive(2), new JsonPrimitive(3));
     assertThat(list).isEqualTo(expectedList);
 
+    List<JsonElement> nullElementList = Collections.singletonList(null);
     NullPointerException e =
-        assertThrows(
-            NullPointerException.class, () -> list.addAll(0, Collections.singletonList(null)));
+        assertThrows(NullPointerException.class, () -> list.addAll(0, nullElementList));
     assertThat(e).hasMessageThat().isEqualTo("Element must be non-null");
 
-    e =
-        assertThrows(
-            NullPointerException.class, () -> list.addAll(Collections.singletonList(null)));
+    e = assertThrows(NullPointerException.class, () -> list.addAll(nullElementList));
     assertThat(e).hasMessageThat().isEqualTo("Element must be non-null");
   }
 

--- a/gson/src/test/java/com/google/gson/JsonArrayTest.java
+++ b/gson/src/test/java/com/google/gson/JsonArrayTest.java
@@ -78,7 +78,8 @@ public final class JsonArrayTest {
   @Test
   public void testSet() {
     JsonArray array = new JsonArray();
-    assertThrows(IndexOutOfBoundsException.class, () -> array.set(0, new JsonPrimitive(1)));
+    JsonPrimitive value = new JsonPrimitive(1);
+    assertThrows(IndexOutOfBoundsException.class, () -> array.set(0, value));
 
     JsonPrimitive a = new JsonPrimitive("a");
     array.add(a);

--- a/gson/src/test/java/com/google/gson/JsonObjectAsMapTest.java
+++ b/gson/src/test/java/com/google/gson/JsonObjectAsMapTest.java
@@ -103,7 +103,8 @@ public class JsonObjectAsMapTest {
     assertThat(map.put("b", JsonNull.INSTANCE)).isNull();
     assertThat(map.get("b")).isEqualTo(JsonNull.INSTANCE);
 
-    var e = assertThrows(NullPointerException.class, () -> map.put(null, new JsonPrimitive(1)));
+    JsonPrimitive value = new JsonPrimitive(1);
+    var e = assertThrows(NullPointerException.class, () -> map.put(null, value));
     assertThat(e).hasMessageThat().isEqualTo("key == null");
 
     e = assertThrows(NullPointerException.class, () -> map.put("a", null));
@@ -145,15 +146,12 @@ public class JsonObjectAsMapTest {
     assertThat(map.get("a")).isEqualTo(new JsonPrimitive(2));
     assertThat(map.get("b")).isEqualTo(new JsonPrimitive(3));
 
-    var e =
-        assertThrows(
-            NullPointerException.class,
-            () -> map.putAll(Collections.singletonMap(null, new JsonPrimitive(1))));
+    Map<String, JsonElement> nullKeyMap = Collections.singletonMap(null, new JsonPrimitive(1));
+    var e = assertThrows(NullPointerException.class, () -> map.putAll(nullKeyMap));
     assertThat(e).hasMessageThat().isEqualTo("key == null");
 
-    e =
-        assertThrows(
-            NullPointerException.class, () -> map.putAll(Collections.singletonMap("a", null)));
+    Map<String, JsonElement> nullValueMap = Collections.singletonMap("a", null);
+    e = assertThrows(NullPointerException.class, () -> map.putAll(nullValueMap));
     assertThat(e).hasMessageThat().isEqualTo("value == null");
   }
 
@@ -198,8 +196,9 @@ public class JsonObjectAsMapTest {
     // Should contain values in same order
     assertThat(values).containsExactly(new JsonPrimitive(2), new JsonPrimitive(1)).inOrder();
 
+    JsonPrimitive value = new JsonPrimitive(3);
     // Values collection doesn't support insertions
-    assertThrows(UnsupportedOperationException.class, () -> values.add(new JsonPrimitive(3)));
+    assertThrows(UnsupportedOperationException.class, () -> values.add(value));
 
     assertThat(values.remove(new JsonPrimitive(2))).isTrue();
     assertThat(new ArrayList<>(map.values()))
@@ -224,10 +223,9 @@ public class JsonObjectAsMapTest {
     // Should contain entries in same order
     assertThat(new ArrayList<>(entrySet)).isEqualTo(expectedEntrySet);
 
+    Map.Entry<String, JsonElement> dummyEntry = new SimpleEntry<>("c", new JsonPrimitive(3));
     // Entry set doesn't support insertions
-    assertThrows(
-        UnsupportedOperationException.class,
-        () -> entrySet.add(new SimpleEntry<>("c", new JsonPrimitive(3))));
+    assertThrows(UnsupportedOperationException.class, () -> entrySet.add(dummyEntry));
 
     assertThat(entrySet.remove(new SimpleEntry<>("a", new JsonPrimitive(1)))).isTrue();
     assertThat(map.entrySet())

--- a/gson/src/test/java/com/google/gson/MixedStreamTest.java
+++ b/gson/src/test/java/com/google/gson/MixedStreamTest.java
@@ -132,10 +132,8 @@ public final class MixedStreamTest {
     Gson gson = new Gson();
     JsonReader jsonReader = new JsonReader(new StringReader(CARS_JSON));
     jsonReader.close();
-    var e =
-        assertThrows(
-            JsonParseException.class,
-            () -> gson.fromJson(jsonReader, new TypeToken<List<Car>>() {}.getType()));
+    Type type = new TypeToken<List<Car>>() {}.getType();
+    var e = assertThrows(JsonParseException.class, () -> gson.fromJson(jsonReader, type));
     assertThat(e).hasCauseThat().hasMessageThat().isEqualTo("JsonReader is closed");
   }
 
@@ -166,9 +164,8 @@ public final class MixedStreamTest {
   @Test
   public void testWriteNulls() {
     Gson gson = new Gson();
-    assertThrows(
-        NullPointerException.class,
-        () -> gson.toJson(new JsonPrimitive("hello"), (JsonWriter) null));
+    JsonPrimitive value = new JsonPrimitive("hello");
+    assertThrows(NullPointerException.class, () -> gson.toJson(value, (JsonWriter) null));
 
     StringWriter stringWriter = new StringWriter();
     gson.toJson(null, new JsonWriter(stringWriter));
@@ -179,9 +176,9 @@ public final class MixedStreamTest {
   public void testReadNulls() {
     Gson gson = new Gson();
     assertThrows(NullPointerException.class, () -> gson.fromJson((JsonReader) null, Integer.class));
-    assertThrows(
-        NullPointerException.class,
-        () -> gson.fromJson(new JsonReader(new StringReader("true")), (Type) null));
+
+    JsonReader jsonReader = new JsonReader(new StringReader("true"));
+    assertThrows(NullPointerException.class, () -> gson.fromJson(jsonReader, (Type) null));
   }
 
   @Test
@@ -220,10 +217,10 @@ public final class MixedStreamTest {
         .toJson(doubles, type, jsonWriter);
     assertThat(writer.toString()).isEqualTo("[NaN,-Infinity,Infinity,-0.0,0.5,0.0]");
 
+    Gson gson = new Gson();
+    JsonWriter jsonWriter2 = new JsonWriter(new StringWriter());
     var e =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> new Gson().toJson(doubles, type, new JsonWriter(new StringWriter())));
+        assertThrows(IllegalArgumentException.class, () -> gson.toJson(doubles, type, jsonWriter2));
     assertThat(e)
         .hasMessageThat()
         .isEqualTo(

--- a/gson/src/test/java/com/google/gson/ToNumberPolicyTest.java
+++ b/gson/src/test/java/com/google/gson/ToNumberPolicyTest.java
@@ -43,8 +43,8 @@ public class ToNumberPolicyTest {
             "JSON forbids NaN and infinities: Infinity at line 1 column 6 path $\n"
                 + "See https://github.com/google/gson/blob/main/Troubleshooting.md#malformed-json");
 
-    assertThrows(
-        NumberFormatException.class, () -> strategy.readNumber(fromString("\"not-a-number\"")));
+    JsonReader jsonReader = fromString("\"not-a-number\"");
+    assertThrows(NumberFormatException.class, () -> strategy.readNumber(jsonReader));
   }
 
   @Test
@@ -118,18 +118,18 @@ public class ToNumberPolicyTest {
         .isEqualTo(new BigDecimal("3.141592653589793238462643383279"));
     assertThat(strategy.readNumber(fromString("1e400"))).isEqualTo(new BigDecimal("1e400"));
 
+    JsonReader jsonReader = fromString("\"not-a-number\"");
     JsonParseException e =
-        assertThrows(
-            JsonParseException.class, () -> strategy.readNumber(fromString("\"not-a-number\"")));
+        assertThrows(JsonParseException.class, () -> strategy.readNumber(jsonReader));
     assertThat(e).hasMessageThat().isEqualTo("Cannot parse not-a-number; at path $");
   }
 
   @Test
-  public void testNullsAreNeverExpected() throws IOException {
+  public void testNullsAreNeverExpected() {
+    JsonReader jsonReader = fromString("null");
     IllegalStateException e =
         assertThrows(
-            IllegalStateException.class,
-            () -> ToNumberPolicy.DOUBLE.readNumber(fromString("null")));
+            IllegalStateException.class, () -> ToNumberPolicy.DOUBLE.readNumber(jsonReader));
     assertThat(e)
         .hasMessageThat()
         .isEqualTo(

--- a/gson/src/test/java/com/google/gson/functional/GsonVersionDiagnosticsTest.java
+++ b/gson/src/test/java/com/google/gson/functional/GsonVersionDiagnosticsTest.java
@@ -67,7 +67,8 @@ public class GsonVersionDiagnosticsTest {
 
   @Test
   public void testAssertionErrorInSerializationPrintsVersion() {
-    AssertionError e = assertThrows(AssertionError.class, () -> gson.toJson(new TestType()));
+    TestType value = new TestType();
+    AssertionError e = assertThrows(AssertionError.class, () -> gson.toJson(value));
     ensureAssertionErrorPrintsGsonVersion(e);
   }
 

--- a/gson/src/test/java/com/google/gson/functional/Java17RecordTest.java
+++ b/gson/src/test/java/com/google/gson/functional/Java17RecordTest.java
@@ -196,7 +196,8 @@ public final class Java17RecordTest {
       }
     }
 
-    var e = assertThrows(JsonIOException.class, () -> gson.toJson(new LocalRecord("a")));
+    LocalRecord value = new LocalRecord("a");
+    var e = assertThrows(JsonIOException.class, () -> gson.toJson(value));
     assertThat(e)
         .hasMessageThat()
         .isEqualTo("Accessor method '" + LocalRecord.class.getName() + "#s()' threw exception");
@@ -420,7 +421,8 @@ public final class Java17RecordTest {
     String json = gson.toJson(new Allowed(1));
     assertThat(json).isEqualTo("{\"a\":1}");
 
-    var exception = assertThrows(JsonIOException.class, () -> gson.toJson(new Blocked(1)));
+    Blocked value = new Blocked(1);
+    var exception = assertThrows(JsonIOException.class, () -> gson.toJson(value));
     assertThat(exception)
         .hasMessageThat()
         .isEqualTo(
@@ -434,7 +436,8 @@ public final class Java17RecordTest {
     Gson gson =
         new GsonBuilder().addReflectionAccessFilter(c -> FilterResult.BLOCK_INACCESSIBLE).create();
 
-    var exception = assertThrows(JsonIOException.class, () -> gson.toJson(new PrivateRecord(1)));
+    PrivateRecord value = new PrivateRecord(1);
+    var exception = assertThrows(JsonIOException.class, () -> gson.toJson(value));
     assertThat(exception)
         .hasMessageThat()
         .isEqualTo(

--- a/gson/src/test/java/com/google/gson/functional/NamingPolicyTest.java
+++ b/gson/src/test/java/com/google/gson/functional/NamingPolicyTest.java
@@ -159,8 +159,8 @@ public class NamingPolicyTest {
   public void testGsonDuplicateNameDueToBadNamingPolicy() {
     Gson gson = builder.setFieldNamingStrategy(f -> "x").create();
 
-    var e =
-        assertThrows(IllegalArgumentException.class, () -> gson.toJson(new ClassWithTwoFields()));
+    ClassWithTwoFields value = new ClassWithTwoFields();
+    var e = assertThrows(IllegalArgumentException.class, () -> gson.toJson(value));
     assertThat(e)
         .hasMessageThat()
         .isEqualTo(

--- a/gson/src/test/java/com/google/gson/functional/NumberLimitsTest.java
+++ b/gson/src/test/java/com/google/gson/functional/NumberLimitsTest.java
@@ -84,31 +84,26 @@ public class NumberLimitsTest {
     assertThat(new JsonPrimitive("1e9999").getAsBigDecimal()).isEqualTo(new BigDecimal("1e9999"));
     assertThat(new JsonPrimitive("1e-9999").getAsBigDecimal()).isEqualTo(new BigDecimal("1e-9999"));
 
+    JsonPrimitive number1 = new JsonPrimitive("1".repeat(MAX_LENGTH + 1));
     NumberFormatException e =
-        assertThrows(
-            NumberFormatException.class,
-            () -> new JsonPrimitive("1".repeat(MAX_LENGTH + 1)).getAsBigDecimal());
+        assertThrows(NumberFormatException.class, () -> number1.getAsBigDecimal());
     assertThat(e)
         .hasMessageThat()
         .isEqualTo("Number string too large: 111111111111111111111111111111...");
 
-    e =
-        assertThrows(
-            NumberFormatException.class, () -> new JsonPrimitive("1e10000").getAsBigDecimal());
+    JsonPrimitive number2 = new JsonPrimitive("1e10000");
+    e = assertThrows(NumberFormatException.class, () -> number2.getAsBigDecimal());
     assertThat(e).hasMessageThat().isEqualTo("Number has unsupported scale: 1e10000");
 
-    e =
-        assertThrows(
-            NumberFormatException.class, () -> new JsonPrimitive("1e-10000").getAsBigDecimal());
+    JsonPrimitive number3 = new JsonPrimitive("1e-10000");
+    e = assertThrows(NumberFormatException.class, () -> number3.getAsBigDecimal());
     assertThat(e).hasMessageThat().isEqualTo("Number has unsupported scale: 1e-10000");
 
     assertThat(new JsonPrimitive("1".repeat(MAX_LENGTH)).getAsBigInteger())
         .isEqualTo(new BigInteger("1".repeat(MAX_LENGTH)));
 
-    e =
-        assertThrows(
-            NumberFormatException.class,
-            () -> new JsonPrimitive("1".repeat(MAX_LENGTH + 1)).getAsBigInteger());
+    JsonPrimitive number4 = new JsonPrimitive("1".repeat(MAX_LENGTH + 1));
+    e = assertThrows(NumberFormatException.class, () -> number4.getAsBigInteger());
     assertThat(e)
         .hasMessageThat()
         .isEqualTo("Number string too large: 111111111111111111111111111111...");
@@ -122,10 +117,9 @@ public class NumberLimitsTest {
         .isEqualTo(new BigDecimal("1".repeat(MAX_LENGTH)));
     assertThat(strategy.readNumber(jsonReader("1e9999"))).isEqualTo(new BigDecimal("1e9999"));
 
+    JsonReader jsonReader1 = jsonReader("\"" + "1".repeat(MAX_LENGTH + 1) + "\"");
     JsonParseException e =
-        assertThrows(
-            JsonParseException.class,
-            () -> strategy.readNumber(jsonReader("\"" + "1".repeat(MAX_LENGTH + 1) + "\"")));
+        assertThrows(JsonParseException.class, () -> strategy.readNumber(jsonReader1));
     assertThat(e)
         .hasMessageThat()
         .isEqualTo("Cannot parse " + "1".repeat(MAX_LENGTH + 1) + "; at path $");
@@ -134,9 +128,8 @@ public class NumberLimitsTest {
         .hasMessageThat()
         .isEqualTo("Number string too large: 111111111111111111111111111111...");
 
-    e =
-        assertThrows(
-            JsonParseException.class, () -> strategy.readNumber(jsonReader("\"1e10000\"")));
+    JsonReader jsonReader2 = jsonReader("\"1e10000\"");
+    e = assertThrows(JsonParseException.class, () -> strategy.readNumber(jsonReader2));
     assertThat(e).hasMessageThat().isEqualTo("Cannot parse 1e10000; at path $");
     assertThat(e)
         .hasCauseThat()
@@ -151,22 +144,18 @@ public class NumberLimitsTest {
     assertThat(new LazilyParsedNumber("1e9999").intValue())
         .isEqualTo(new BigDecimal("1e9999").intValue());
 
-    NumberFormatException e =
-        assertThrows(
-            NumberFormatException.class,
-            () -> new LazilyParsedNumber("1".repeat(MAX_LENGTH + 1)).intValue());
+    LazilyParsedNumber number1 = new LazilyParsedNumber("1".repeat(MAX_LENGTH + 1));
+    NumberFormatException e = assertThrows(NumberFormatException.class, () -> number1.intValue());
     assertThat(e)
         .hasMessageThat()
         .isEqualTo("Number string too large: 111111111111111111111111111111...");
 
-    e =
-        assertThrows(
-            NumberFormatException.class, () -> new LazilyParsedNumber("1e10000").intValue());
+    LazilyParsedNumber number2 = new LazilyParsedNumber("1e10000");
+    e = assertThrows(NumberFormatException.class, () -> number2.intValue());
     assertThat(e).hasMessageThat().isEqualTo("Number has unsupported scale: 1e10000");
 
-    e =
-        assertThrows(
-            NumberFormatException.class, () -> new LazilyParsedNumber("1e10000").longValue());
+    LazilyParsedNumber number3 = new LazilyParsedNumber("1e10000");
+    e = assertThrows(NumberFormatException.class, () -> number3.longValue());
     assertThat(e).hasMessageThat().isEqualTo("Number has unsupported scale: 1e10000");
 
     ObjectOutputStream objOut = new ObjectOutputStream(OutputStream.nullOutputStream());
@@ -186,10 +175,8 @@ public class NumberLimitsTest {
         .isEqualTo(new BigDecimal("1".repeat(MAX_LENGTH)));
     assertThat(adapter.fromJson("\"1e9999\"")).isEqualTo(new BigDecimal("1e9999"));
 
-    JsonSyntaxException e =
-        assertThrows(
-            JsonSyntaxException.class,
-            () -> adapter.fromJson("\"" + "1".repeat(MAX_LENGTH + 1) + "\""));
+    String json = "\"" + "1".repeat(MAX_LENGTH + 1) + "\"";
+    JsonSyntaxException e = assertThrows(JsonSyntaxException.class, () -> adapter.fromJson(json));
     assertThat(e)
         .hasMessageThat()
         .isEqualTo("Failed parsing '" + "1".repeat(MAX_LENGTH + 1) + "' as BigDecimal; at path $");
@@ -213,10 +200,8 @@ public class NumberLimitsTest {
     assertThat(adapter.fromJson("\"" + "1".repeat(MAX_LENGTH) + "\""))
         .isEqualTo(new BigInteger("1".repeat(MAX_LENGTH)));
 
-    JsonSyntaxException e =
-        assertThrows(
-            JsonSyntaxException.class,
-            () -> adapter.fromJson("\"" + "1".repeat(MAX_LENGTH + 1) + "\""));
+    String json = "\"" + "1".repeat(MAX_LENGTH + 1) + "\"";
+    JsonSyntaxException e = assertThrows(JsonSyntaxException.class, () -> adapter.fromJson(json));
     assertThat(e)
         .hasMessageThat()
         .isEqualTo("Failed parsing '" + "1".repeat(MAX_LENGTH + 1) + "' as BigInteger; at path $");

--- a/gson/src/test/java/com/google/gson/functional/ReadersWritersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ReadersWritersTest.java
@@ -142,9 +142,8 @@ public class ReadersWritersTest {
   @Test
   public void testTypeMismatchThrowsJsonSyntaxExceptionForReaders() {
     Type type = new TypeToken<Map<String, String>>() {}.getType();
-    var e =
-        assertThrows(
-            JsonSyntaxException.class, () -> gson.fromJson(new StringReader("true"), type));
+    StringReader reader = new StringReader("true");
+    var e = assertThrows(JsonSyntaxException.class, () -> gson.fromJson(reader, type));
     assertThat(e)
         .hasCauseThat()
         .hasMessageThat()

--- a/gson/src/test/java/com/google/gson/functional/ReflectionAccessFilterTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ReflectionAccessFilterTest.java
@@ -128,8 +128,9 @@ public class ReflectionAccessFilterTest {
     Gson gson =
         new GsonBuilder().addReflectionAccessFilter(ReflectionAccessFilter.BLOCK_ALL_JAVA).create();
 
+    Thread value = Thread.currentThread();
     // Serialization should fail for any Java class without custom adapter
-    var e = assertThrows(JsonIOException.class, () -> gson.toJson(Thread.currentThread()));
+    var e = assertThrows(JsonIOException.class, () -> gson.toJson(value));
     assertThat(e)
         .hasMessageThat()
         .isEqualTo(
@@ -142,7 +143,8 @@ public class ReflectionAccessFilterTest {
     Gson gson =
         new GsonBuilder().addReflectionAccessFilter(ReflectionAccessFilter.BLOCK_ALL_JAVA).create();
 
-    var e = assertThrows(JsonIOException.class, () -> gson.toJson(new ClassExtendingJdkClass()));
+    ClassExtendingJdkClass value = new ClassExtendingJdkClass();
+    var e = assertThrows(JsonIOException.class, () -> gson.toJson(value));
     assertThat(e)
         .hasMessageThat()
         .isEqualTo(
@@ -224,8 +226,9 @@ public class ReflectionAccessFilterTest {
                 })
             .create();
 
+    SuperTestClass value = new SuperTestClass();
     // Filter disallows SuperTestClass
-    var e = assertThrows(JsonIOException.class, () -> gson.toJson(new SuperTestClass()));
+    var e = assertThrows(JsonIOException.class, () -> gson.toJson(value));
     assertThat(e)
         .hasMessageThat()
         .isEqualTo(

--- a/gson/src/test/java/com/google/gson/functional/ToNumberPolicyFunctionalTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ToNumberPolicyFunctionalTest.java
@@ -133,16 +133,16 @@ public class ToNumberPolicyFunctionalTest {
         gson.fromJson("[null, 10, 20, 30]", new TypeToken<List<Byte>>() {}.getType());
     assertThat(numbers).containsExactly(null, (byte) 10, (byte) 20, (byte) 30).inOrder();
 
+    Type type1 = new TypeToken<List<Object>>() {}.getType();
     var e =
         assertThrows(
-            UnsupportedOperationException.class,
-            () -> gson.fromJson("[null, 10, 20, 30]", new TypeToken<List<Object>>() {}.getType()));
+            UnsupportedOperationException.class, () -> gson.fromJson("[null, 10, 20, 30]", type1));
     assertThat(e).isSameInstanceAs(customException);
 
+    Type type2 = new TypeToken<List<Number>>() {}.getType();
     e =
         assertThrows(
-            UnsupportedOperationException.class,
-            () -> gson.fromJson("[null, 10, 20, 30]", new TypeToken<List<Number>>() {}.getType()));
+            UnsupportedOperationException.class, () -> gson.fromJson("[null, 10, 20, 30]", type2));
     assertThat(e).isSameInstanceAs(customException);
   }
 }

--- a/gson/src/test/java/com/google/gson/internal/LinkedTreeMapTest.java
+++ b/gson/src/test/java/com/google/gson/internal/LinkedTreeMapTest.java
@@ -71,7 +71,8 @@ public final class LinkedTreeMapTest {
   @SuppressWarnings("ModifiedButNotUsed")
   public void testPutNonComparableKeyFails() {
     LinkedTreeMap<Object, String> map = new LinkedTreeMap<>();
-    assertThrows(ClassCastException.class, () -> map.put(new Object(), "android"));
+    Object value = new Object();
+    assertThrows(ClassCastException.class, () -> map.put(value, "android"));
   }
 
   @Test

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeWriterTest.java
@@ -23,6 +23,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.Strictness;
 import com.google.gson.common.MoreAsserts;
+import com.google.gson.internal.LazilyParsedNumber;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.io.Writer;
@@ -233,23 +234,36 @@ public final class JsonTreeWriterTest {
     assertThrows(IllegalArgumentException.class, () -> writer.value(Double.POSITIVE_INFINITY));
   }
 
+  // Suppress Error Prone warning; extracting `(Number) ...` into separate var is redundant
+  @SuppressWarnings("AssertThrowsMinimizer")
   @Test
   public void testStrictBoxedNansAndInfinities() throws IOException {
     JsonTreeWriter writer = new JsonTreeWriter();
     writer.setStrictness(Strictness.LEGACY_STRICT);
     writer.beginArray();
-    assertThrows(IllegalArgumentException.class, () -> writer.value(Float.valueOf(Float.NaN)));
+    assertThrows(IllegalArgumentException.class, () -> writer.value((Number) Float.NaN));
     assertThrows(
-        IllegalArgumentException.class, () -> writer.value(Float.valueOf(Float.NEGATIVE_INFINITY)));
+        IllegalArgumentException.class, () -> writer.value((Number) Float.NEGATIVE_INFINITY));
     assertThrows(
-        IllegalArgumentException.class, () -> writer.value(Float.valueOf(Float.POSITIVE_INFINITY)));
-    assertThrows(IllegalArgumentException.class, () -> writer.value(Double.valueOf(Double.NaN)));
+        IllegalArgumentException.class, () -> writer.value((Number) Float.POSITIVE_INFINITY));
+    assertThrows(IllegalArgumentException.class, () -> writer.value((Number) Double.NaN));
     assertThrows(
-        IllegalArgumentException.class,
-        () -> writer.value(Double.valueOf(Double.NEGATIVE_INFINITY)));
+        IllegalArgumentException.class, () -> writer.value((Number) Double.NEGATIVE_INFINITY));
     assertThrows(
-        IllegalArgumentException.class,
-        () -> writer.value(Double.valueOf(Double.POSITIVE_INFINITY)));
+        IllegalArgumentException.class, () -> writer.value((Number) Double.POSITIVE_INFINITY));
+  }
+
+  @Test
+  public void testStrictLazyNansAndInfinities() throws IOException {
+    JsonTreeWriter writer = new JsonTreeWriter();
+    writer.setStrictness(Strictness.LEGACY_STRICT);
+    writer.beginArray();
+
+    Number lazyNumberNaN = new LazilyParsedNumber(Double.toString(Double.NaN));
+    assertThrows(IllegalArgumentException.class, () -> writer.value(lazyNumberNaN));
+
+    Number lazyNumberInfinity = new LazilyParsedNumber(Double.toString(Double.POSITIVE_INFINITY));
+    assertThrows(IllegalArgumentException.class, () -> writer.value(lazyNumberInfinity));
   }
 
   @Test

--- a/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
@@ -335,18 +335,19 @@ public final class JsonWriterTest {
     assertNonFiniteDoublesExceptions(jsonWriter);
   }
 
+  // Suppress Error Prone warning; extracting `(Number) ...` into separate var is redundant
+  @SuppressWarnings("AssertThrowsMinimizer")
   private static void assertNonFiniteNumbersExceptions(JsonWriter jsonWriter) throws IOException {
     jsonWriter.beginArray();
 
     IllegalArgumentException expected =
-        assertThrows(
-            IllegalArgumentException.class, () -> jsonWriter.value(Double.valueOf(Double.NaN)));
+        assertThrows(IllegalArgumentException.class, () -> jsonWriter.value((Number) Double.NaN));
     assertThat(expected).hasMessageThat().isEqualTo("Numeric values must be finite, but was NaN");
 
     expected =
         assertThrows(
             IllegalArgumentException.class,
-            () -> jsonWriter.value(Double.valueOf(Double.NEGATIVE_INFINITY)));
+            () -> jsonWriter.value((Number) Double.NEGATIVE_INFINITY));
     assertThat(expected)
         .hasMessageThat()
         .isEqualTo("Numeric values must be finite, but was -Infinity");
@@ -354,15 +355,18 @@ public final class JsonWriterTest {
     expected =
         assertThrows(
             IllegalArgumentException.class,
-            () -> jsonWriter.value(Double.valueOf(Double.POSITIVE_INFINITY)));
+            () -> jsonWriter.value((Number) Double.POSITIVE_INFINITY));
     assertThat(expected)
         .hasMessageThat()
         .isEqualTo("Numeric values must be finite, but was Infinity");
 
+    Number lazyNumberNaN = new LazilyParsedNumber(Double.toString(Double.NaN));
+    expected = assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(lazyNumberNaN));
+    assertThat(expected).hasMessageThat().isEqualTo("Numeric values must be finite, but was NaN");
+
+    Number lazyNumberInfinity = new LazilyParsedNumber(Double.toString(Double.POSITIVE_INFINITY));
     expected =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> jsonWriter.value(new LazilyParsedNumber("Infinity")));
+        assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(lazyNumberInfinity));
     assertThat(expected)
         .hasMessageThat()
         .isEqualTo("Numeric values must be finite, but was Infinity");
@@ -554,7 +558,7 @@ public final class JsonWriterTest {
   }
 
   @Test
-  public void testMalformedNumbers() throws IOException {
+  public void testMalformedNumbers() {
     String[] malformedNumbers = {
       "some text",
       "",
@@ -584,10 +588,8 @@ public final class JsonWriterTest {
 
     for (String malformedNumber : malformedNumbers) {
       JsonWriter jsonWriter = new JsonWriter(new StringWriter());
-      var e =
-          assertThrows(
-              IllegalArgumentException.class,
-              () -> jsonWriter.value(new LazilyParsedNumber(malformedNumber)));
+      Number number = new LazilyParsedNumber(malformedNumber);
+      var e = assertThrows(IllegalArgumentException.class, () -> jsonWriter.value(number));
       assertThat(e)
           .hasMessageThat()
           .isEqualTo(

--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
               <path>
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_core</artifactId>
-                <version>2.48.0</version>
+                <version>2.49.0</version>
               </path>
             </annotationProcessorPaths>
           </configuration>

--- a/test-shrinker/src/test/java/com/google/gson/it/ShrinkingIT.java
+++ b/test-shrinker/src/test/java/com/google/gson/it/ShrinkingIT.java
@@ -306,7 +306,7 @@ public class ShrinkingIT {
   }
 
   @Test
-  public void testUnusedClassRemoved() throws Exception {
+  public void testUnusedClassRemoved() {
     // For some reason this test only works for R8 but not for ProGuard; ProGuard keeps the unused
     // class
     assumeFalse(isTestingProGuard());
@@ -315,13 +315,9 @@ public class ShrinkingIT {
     ClassNotFoundException e =
         assertThrows(
             ClassNotFoundException.class,
-            () -> {
-              runTest(
-                  className,
-                  c -> {
-                    fail("Class should have been removed during shrinking: " + c);
-                  });
-            });
+            () ->
+                runTest(
+                    className, c -> fail("Class should have been removed during shrinking: " + c)));
     assertThat(e).hasMessageThat().contains(className);
   }
 }


### PR DESCRIPTION
Bumps Error Prone to 2.49.0 and fixes the new warnings it reports.

This should fix the build error of #3022.

The largest changes are:
- Refactoring `LinkedTreeMap` to remove `NATURAL_ORDER` and related reference equality checks (first commit)
- Extracting code out of `assertThrows(...)` calls
Please let me know if you would prefer other local variable names (currently I mostly used "`value`" for the object to be serialized) or if you have any suggestions for changes.