### PR TITLE
Fix: peekNumber rejects some numerals like 2^64 + "0"

### DIFF
--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -853,7 +853,7 @@ public class JsonReader implements Closeable {
             value = -(c - '0');
             last = NUMBER_CHAR_DIGIT;
           } else if (last == NUMBER_CHAR_DIGIT) {
-            if (value == 0) {
+            if (fitsInLong && value == 0) {
               return PEEKED_NONE; // Leading '0' prefix is not allowed (since it could be octal).
             }
             long newValue = value * 10 - (c - '0');

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -829,6 +829,7 @@ public final class JsonReaderTest {
   public void testNumberLongAccumulatorOverflowsToZero() throws IOException {
     String number = "184467440737095516160";
     JsonReader reader = new JsonReader(reader(number));
+    reader.setStrictness(Strictness.STRICT);
     assertThat(reader.peek()).isEqualTo(NUMBER);
     assertThat(reader.nextString()).isEqualTo(number);
   }

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -820,6 +820,19 @@ public final class JsonReaderTest {
     assertStrictError(e, expectedLocation);
   }
 
+  /**
+   * Regression test for a bug where {@code peekNumber} rejected a valid numeric literal whose
+   * prefix happened to be a multiple of 2<sup>64</sup>. The {@code long} accumulator wraps to
+   * exactly zero in that case, which the old "leading zero" guard misread as an octal prefix.
+   */
+  @Test
+  public void testNumberLongAccumulatorOverflowsToZero() throws IOException {
+    String number = "184467440737095516160";
+    JsonReader reader = new JsonReader(reader(number));
+    assertThat(reader.peek()).isEqualTo(NUMBER);
+    assertThat(reader.nextString()).isEqualTo(number);
+  }
+
   @Test
   public void testBooleans() throws IOException {
     JsonReader reader = new JsonReader(reader("[true,false]"));


### PR DESCRIPTION
Issue: the "leading zero" logic in `peekNumber`, which tries to reject octal representations, does not account for long overflows. This results in valid numeric literals like "184467440737095516160" (2^64 + "0") being rejected in `STRICT` parsing mode.

The easiest way to reproduce this is to serialize and deserialize a `BigInteger` with the value above.

This is a minimal fix which adds an overflow check to the leading zero condition.