### PR TITLE
Throw JsonSyntaxException instead of NullPointerException for a null AtomicLongArray element

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -378,8 +378,11 @@ public final class TypeAdapters {
         List<Long> list = new ArrayList<>();
         in.beginArray();
         while (in.hasNext()) {
-          long value = longAdapter.read(in).longValue();
-          list.add(value);
+          Number value = longAdapter.read(in);
+          if (value == null) {
+            throw new JsonSyntaxException("null is not a valid AtomicLongArray element");
+          }
+          list.add(value.longValue());
         }
         in.endArray();
         int length = list.size();

--- a/gson/src/test/java/com/google/gson/functional/JavaUtilConcurrentAtomicTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JavaUtilConcurrentAtomicTest.java
@@ -17,9 +17,11 @@
 package com.google.gson.functional;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
 import com.google.gson.LongSerializationPolicy;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -112,5 +114,13 @@ public class JavaUtilConcurrentAtomicTest {
 
   private static class AtomicLongHolder {
     AtomicLong value;
+  }
+
+  @Test
+  public void testAtomicLongArrayWithNullElement() {
+    JsonSyntaxException e =
+        assertThrows(
+            JsonSyntaxException.class, () -> gson.fromJson("[1,null,3]", AtomicLongArray.class));
+    assertThat(e).hasMessageThat().isEqualTo("null is not a valid AtomicLongArray element");
   }
 }


### PR DESCRIPTION
Deserializing a JSON array that contains a `null` element into an `AtomicLongArray` throws a raw `NullPointerException`:

```java
new Gson().fromJson("[1,null,3]", AtomicLongArray.class); // NullPointerException
```

The array adapter calls `longAdapter.read(in).longValue()`, and the element adapter returns `null` for a JSON `null`, so `longValue()` is invoked on `null`.

This throws a `JsonSyntaxException` for the null element instead, consistent with how the `Long` adapter already reports malformed numbers. Includes a regression test.
