### PR TITLE
Rethrow Error from @PostConstruct method instead of wrapping it in RuntimeException

### DIFF
--- a/extras/src/main/java/com/google/gson/typeadapters/PostConstructAdapterFactory.java
+++ b/extras/src/main/java/com/google/gson/typeadapters/PostConstructAdapterFactory.java
@@ -65,6 +65,8 @@ public class PostConstructAdapterFactory implements TypeAdapterFactory {
         } catch (InvocationTargetException e) {
           if (e.getCause() instanceof RuntimeException) {
             throw (RuntimeException) e.getCause();
+          } else if (e.getCause() instanceof Error) {
+            throw (Error) e.getCause();
           }
           throw new RuntimeException(e.getCause());
         }

--- a/extras/src/test/java/com/google/gson/typeadapters/PostConstructAdapterFactoryTest.java
+++ b/extras/src/test/java/com/google/gson/typeadapters/PostConstructAdapterFactoryTest.java
@@ -95,6 +95,37 @@ public class PostConstructAdapterFactoryTest {
     }
   }
 
+  @Test
+  public void testErrorFromPostConstructPropagatesAsError() {
+    Gson gson =
+        new GsonBuilder().registerTypeAdapterFactory(new PostConstructAdapterFactory()).create();
+
+    CustomTestError thrown =
+        assertThrows(
+            CustomTestError.class, () -> gson.fromJson("{\"value\": 1}", ErrorThrowingClass.class));
+
+    assertThat(thrown).hasMessageThat().isEqualTo("error from post-construct");
+  }
+
+  static class ErrorThrowingClass {
+    public int value;
+
+    @PostConstruct
+    private void init() {
+      throw new CustomTestError("error from post-construct");
+    }
+  }
+
+  // A dedicated Error subclass so the test does not rely on a JDK Error type (e.g. AssertionError,
+  // which Gson re-tags with a version prefix) and is not confused with a meaningful JVM error.
+  private static final class CustomTestError extends Error {
+    private static final long serialVersionUID = 1L;
+
+    CustomTestError(String message) {
+      super(message);
+    }
+  }
+
   @SuppressWarnings({"overrides", "EqualsHashCode"}) // for missing hashCode() override
   static class MultipleSandwiches {
     public List<Sandwich> sandwiches;


### PR DESCRIPTION
`PostConstructAdapterFactory` rethrows a `RuntimeException` cause as-is, but wraps everything else (`throw new RuntimeException(e.getCause())`). An `Error` thrown by the `@PostConstruct` method — `AssertionError`, `OutOfMemoryError`, `NoClassDefFoundError`, … — is unchecked like `RuntimeException` and should propagate **unchanged**, not be wrapped in a `RuntimeException` (where a `catch (RuntimeException)` could swallow what is meant to be unrecoverable).

This adds the symmetric `else if (e.getCause() instanceof Error) throw (Error) e.getCause();`, matching how the same block already treats `RuntimeException`. The `new RuntimeException(...)` fallback stays for genuinely checked causes. Includes a regression test.
