### PR TITLE
Preserve string-keyed map hardening for ConcurrentMap

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
+++ b/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
@@ -368,6 +368,10 @@ public final class ConstructorConstructor {
     else if (rawType.isAssignableFrom(TreeMap.class)) {
       return TreeMap::new;
     }
+    // Preserve string-key collision hardening for ConcurrentMap interfaces.
+    else if (rawType.isAssignableFrom(ConcurrentSkipListMap.class) && hasStringKeyType(type)) {
+      return ConcurrentSkipListMap::new;
+    }
     // Then try ConcurrentMap implementation
     else if (rawType.isAssignableFrom(ConcurrentHashMap.class)) {
       return ConcurrentHashMap::new;

--- a/gson/src/test/java/com/google/gson/functional/MapTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MapTest.java
@@ -279,11 +279,23 @@ public class MapTest {
   public void testConcurrentMap() {
     Type typeOfMap = new TypeToken<ConcurrentMap<Integer, String>>() {}.getType();
     ConcurrentMap<Integer, String> map = gson.fromJson("{\"123\":\"456\"}", typeOfMap);
+    assertThat(map).isInstanceOf(ConcurrentHashMap.class);
     assertThat(map).hasSize(1);
     assertThat(map).containsKey(123);
     assertThat(map.get(123)).isEqualTo("456");
     String json = gson.toJson(map);
     assertThat(json).isEqualTo("{\"123\":\"456\"}");
+  }
+
+  @Test
+  public void testConcurrentMapStringKeyDeserializationUsesSkipListMap() {
+    Type typeOfMap = new TypeToken<ConcurrentMap<String, Integer>>() {}.getType();
+    ConcurrentMap<String, Integer> map = gson.fromJson("{\"a\":1}", typeOfMap);
+
+    assertWithMessage("ConcurrentMap<String, ...> should avoid hash-table collision behavior")
+        .that(map)
+        .isInstanceOf(ConcurrentSkipListMap.class);
+    assertThat(map).isEqualTo(Collections.singletonMap("a", 1));
   }
 
   @Test


### PR DESCRIPTION
## Summary

This change preserves Gson's existing string-keyed map hardening behavior for
`ConcurrentMap<String, ...>` interface targets.

`Map<String, ...>` currently uses `LinkedTreeMap` to avoid hash-table collision
behavior on older runtimes. `ConcurrentMap<String, ...>` was instead resolved to
`ConcurrentHashMap`; this change resolves string-keyed concurrent map interface
targets to `ConcurrentSkipListMap` while preserving `ConcurrentHashMap` for
non-string keys and explicit `ConcurrentHashMap` targets.

## Tests

- `mise x java@temurin-17 maven@3.9.11 -- mvn -pl gson -Dtest=MapTest test`
- `mise x java@temurin-17 maven@3.9.11 -- mvn -pl gson spotless:check`
