### PR TITLE
Remove deprecated `overwrite` parameter from maven-resources-plugin

### DIFF
--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -256,7 +256,6 @@
             <configuration>
               <skip>${maven.test.skip}</skip>
               <outputDirectory>${project.build.directory}/test-classes-obfuscated-injar/com/google/gson/functional</outputDirectory>
-              <overwrite>true</overwrite>
               <resources>
                 <resource>
                   <directory>${project.build.directory}/test-classes/com/google/gson/functional</directory>
@@ -277,7 +276,6 @@
             <configuration>
               <skip>${maven.test.skip}</skip>
               <outputDirectory>${project.build.directory}/test-classes/com/google/gson/functional</outputDirectory>
-              <overwrite>true</overwrite>
               <resources>
                 <resource>
                   <directory>${project.build.directory}/test-classes-obfuscated-outjar/com/google/gson/functional</directory>
@@ -408,7 +406,6 @@
                 </goals>
                 <configuration>
                   <outputDirectory>${gsonSubsetSrcDir}</outputDirectory>
-                  <overwrite>true</overwrite>
                   <resources>
                     <resource>
                       <directory>${project.build.sourceDirectory}</directory>


### PR DESCRIPTION
### Purpose
Removes a deprecated Maven plugin parameter, which is causing a warning. For example:
> [INFO] --- resources:3.5.0:copy-resources (pre-obfuscate-class) @ gson ---
> [WARNING]  Parameter 'overwrite' is deprecated: Use changeDetection instead.

### Description
In version 3.5.0 of the maven-resources-plugin the parameter was deprecated and replaced with the new `changeDetection` parameter. However, the default of that new parameter is "content" which replaces the file if the contents changed, which is the desired behavior here, so that default can be omitted.
See also https://maven.apache.org/plugins/maven-resources-plugin/copy-resources-mojo.html#changeDetection
