### PR TITLE
Use Double and Long hashCode functions

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonPrimitive.java
+++ b/gson/src/main/java/com/google/gson/JsonPrimitive.java
@@ -262,14 +262,11 @@ public final class JsonPrimitive extends JsonElement {
     if (value == null) {
       return 31;
     }
-    // Using recommended hashing algorithm from Effective Java for longs and doubles
     if (isIntegral(this)) {
-      long value = getAsNumber().longValue();
-      return (int) (value ^ (value >>> 32));
+      return Long.hashCode(getAsNumber().longValue());
     }
     if (value instanceof Number) {
-      long value = Double.doubleToLongBits(getAsNumber().doubleValue());
-      return (int) (value ^ (value >>> 32));
+      return Double.hashCode(getAsNumber().doubleValue());
     }
     return value.hashCode();
   }


### PR DESCRIPTION
### Purpose

`JsonPrimitive.hashCode` currently contains a comment and the hashCode bitwise computation itself. This can be simplified using the hashCode functions that JDK 1.8+ provides through Long and Double. This PR aims to improve the readability of the function by using those Long and Double hashCode functions.

### Description

Java 1.8 introduced [Double.hashCode](https://docs.oracle.com/javase/8/docs/api/java/lang/Double.html#hashCode-double-) and [Long.hashCode](https://docs.oracle.com/javase/8/docs/api/java/lang/Long.html#hashCode-long-).

[`Double.hashCode`](https://github.com/keerath/openjdk-8-source/blob/master/jdk/src/share/classes/java/lang/Double.java):

```java
/**
 * Returns a hash code for a {@code double} value; compatible with
 * {@code Double.hashCode()}.
 *
 * @param value the value to hash
 * @return a hash code value for a {@code double} value.
 * @since 1.8
 */
public static int hashCode(double value) {
    long bits = doubleToLongBits(value);
    return (int)(bits ^ (bits >>> 32));
}
```

[`Long.hashCode`](https://github.com/keerath/openjdk-8-source/blob/master/jdk/src/share/classes/java/lang/Long.java):

```java
/**
 * Returns a hash code for a {@code long} value; compatible with
 * {@code Long.hashCode()}.
 *
 * @param value the value to hash
 * @return a hash code value for a {@code long} value.
 * @since 1.8
 */
public static int hashCode(long value) {
    return (int)(value ^ (value >>> 32));
}
```

Currently, GSON performs the same operations by essentially inlining these functions. By using the JDK provided hashCode functions and not inlining them, this PR improves the readability of the `JsonPrimitive.hashCode` function. Thanks for considering!

### Checklist

- [X] New code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)\
  This is automatically checked by `mvn verify`, but can also be checked on its own using `mvn spotless:check`.\
  Style violations can be fixed using `mvn spotless:apply`; this can be done in a separate commit to verify that it did not cause undesired changes.
- [X] `mvn clean verify javadoc:jar` passes without errors
