### PR TITLE
Wrap IllegalStateException at the AtomicIntegerArray adapter level, consistent with AtomicLongArray

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -344,7 +344,7 @@ public final class TypeAdapters {
             try {
               int integer = in.nextInt();
               list.add(integer);
-            } catch (NumberFormatException e) {
+            } catch (NumberFormatException | IllegalStateException e) {
               throw new JsonSyntaxException(e);
             }
           }

--- a/gson/src/test/java/com/google/gson/functional/JavaUtilConcurrentAtomicTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JavaUtilConcurrentAtomicTest.java
@@ -89,6 +89,22 @@ public class JavaUtilConcurrentAtomicTest {
   }
 
   @Test
+  public void testAtomicIntegerArrayWithNullElement() {
+    JsonSyntaxException e =
+        assertThrows(
+            JsonSyntaxException.class, () -> gson.fromJson("[1,null,3]", AtomicIntegerArray.class));
+    assertThat(e).hasCauseThat().isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void testAtomicIntegerArrayWithNonNumericElement() {
+    JsonSyntaxException e =
+        assertThrows(
+            JsonSyntaxException.class, () -> gson.fromJson("[1,true,3]", AtomicIntegerArray.class));
+    assertThat(e).hasCauseThat().isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
   public void testAtomicLongArray() {
     AtomicLongArray target = gson.fromJson("[10, 13, 14]", AtomicLongArray.class);
     assertThat(target.length()).isEqualTo(3);


### PR DESCRIPTION
This PR was written primarily by Claude Code; I reviewed the change and ran the test suite before submitting.

## Background

I originally opened this PR believing it fixed a crash described in #3047 (a non-numeric `AtomicIntegerArray` element causing a raw, uncaught `IllegalStateException`). On closer testing, I confirmed that crash does not actually reproduce via the public `Gson.fromJson()` API, since `Gson.fromJson(Reader, TypeToken)` already catches `IllegalStateException` generically and wraps it as `JsonSyntaxException` before it reaches the caller (Gson.java around line 1123). See the discussion on the issue and on this PR for the full back-and-forth - my apologies for initially missing that contradiction.

## What this PR actually does

- `ATOMIC_INTEGER_ARRAY.read()` now catches `IllegalStateException` (in addition to the existing `NumberFormatException`) and wraps it at the adapter level, the same way `AtomicLongArray`'s adapter already handles its null check (see #3038) rather than relying on the caller (`Gson.fromJson`) to do the wrapping.
- This only matters if the adapter's `read(JsonReader)` is invoked directly, bypassing `Gson.fromJson`. Through the normal `fromJson` path, the only visible effect is a more specific exception message/cause at the point of failure instead of the generic message from the outer catch.

This is a minor consistency/message-quality change, not a crash fix. I'm leaving it open in case the consistency improvement is still wanted, but I understand if maintainers would rather close it given the original premise doesn't hold.

## Testing

Added `testAtomicIntegerArrayWithNullElement` and `testAtomicIntegerArrayWithNonNumericElement`. `mvn spotless:check` and the full `gson` module test suite pass.