### PR TITLE
json pointers as local-only references

### DIFF
--- a/gson/src/main/java/com/google/gson/JRefTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/JRefTypeAdapter.java
@@ -1,0 +1,296 @@
+package com.google.gson;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.gson.internal.Streams;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import com.google.gson.stream.MalformedJsonException;
+
+public class JRefTypeAdapter extends TypeAdapter<Object> {
+
+	public static final String JREF_NAME = "$ref";
+	public static final String HASH = "#";
+
+	class JRefTokenStreamContext extends TokenStreamContext {
+
+		private JRefTokenStreamContext parent;
+		private String currentName;
+
+		// Arrays for serialization (known length)
+		JRefTokenStreamContext(JRefTokenStreamContext parent, int type, int index) {
+			this.parent = parent;
+			this._type = type;
+			this._index = index;
+		}
+
+		// Arrays
+		JRefTokenStreamContext(JRefTokenStreamContext parent, int index) {
+			this(parent, TYPE_ARRAY, index);
+		}
+
+		// Objects
+		JRefTokenStreamContext(JRefTokenStreamContext parent, String name) {
+			this(parent, TYPE_OBJECT, -1);
+			this.currentName = name;
+		}
+
+		boolean isKey = false;
+
+		// For map keys
+		JRefTokenStreamContext(JRefTokenStreamContext parent, String name, boolean isKey) {
+			this(parent, TYPE_OBJECT, -1);
+			this.currentName = name;
+			this.isKey = true;
+		}
+
+		boolean isKey() {
+			return isKey;
+		}
+
+		@Override
+		public TokenStreamContext getParent() {
+			return parent;
+		}
+
+		@Override
+		public String currentName() {
+			return currentName;
+		}
+
+		@Override
+		public void assignCurrentValue(Object v) {
+		}
+
+	}
+
+	public static ThreadLocal<Map<JsonPointer, Object>> ptrToValue = ThreadLocal.withInitial(() -> new HashMap<>());
+	public static ThreadLocal<Map<Object, JsonPointer>> valueToPtr = ThreadLocal.withInitial(() -> new HashMap<>());
+	public static ThreadLocal<JRefTokenStreamContext> readTSC = new ThreadLocal<>();
+	public static ThreadLocal<JRefTokenStreamContext> writeTSC = new ThreadLocal<>();
+
+	private final TypeToken<Object> type;
+	private final TypeAdapter<Object> delegate;
+
+	JRefTypeAdapter(TypeToken<Object> type, TypeAdapter<Object> delegateTypeAdapter) {
+		this.type = type;
+		this.delegate = delegateTypeAdapter;
+	}
+
+	JRefTokenStreamContext createTSC(JRefTokenStreamContext parent) {
+		if (type.getRawType().isArray() || Collection.class.isAssignableFrom(type.getRawType())) {
+			return new JRefTokenStreamContext(parent, TokenStreamContext.TYPE_ARRAY, 0);
+		} else {
+			return new JRefTokenStreamContext(parent, null);
+		}
+	}
+
+	@Override
+	public void write(JsonWriter out, Object value) throws IOException {
+		try {
+			// get previousTSC
+			JRefTokenStreamContext previousTSC = writeTSC.get();
+			String deferredName = out.getDeferredName();
+			if (previousTSC != null && deferredName != null) {
+				previousTSC = new JRefTokenStreamContext(previousTSC.parent, deferredName);
+			}
+			// Create our context using the (potentially modified) parent context from above
+			writeTSC.set(createTSC(previousTSC));
+			// check if value has a ptr already associated with it
+			JsonPointer valuePtr = valueToPtr.get().get(value);
+			if (valuePtr != null) {
+				// If found write jref and done
+				out.beginObject();
+				out.name(JREF_NAME);
+				out.value("#" + valuePtr.toString());
+				out.endObject();
+			} else {
+				// Call the delegate to do the actual serialization
+				this.delegate.write(out, value);
+			}
+			// get parent context
+			JRefTokenStreamContext parentTSC = writeTSC.get().parent;
+			// and get current valueToPtrMap
+			Map<Object, JsonPointer> valueToPtrMap = valueToPtr.get();
+			// parentTSC will be null for root
+			if (parentTSC != null) {
+				// Here is where the serialized value is assciated with a ptr
+				if (value != null && !valueToPtrMap.containsKey(value)) {
+					JsonPointer ptr = parentTSC.pathAsPointer();
+					valueToPtrMap.put(value, ptr);
+				}
+				// If an array element we just set, then increment index
+				if (parentTSC.inArray()) {
+					parentTSC = new JRefTokenStreamContext(parentTSC.parent, TokenStreamContext.TYPE_ARRAY,
+							++parentTSC._index);
+				}
+			} else {
+				// we are done so free up valueToPtrMap contents
+				valueToPtrMap.clear();
+			}
+			// Finished with this write, so set to parentTSC
+			writeTSC.set(parentTSC);
+		} catch (IOException e) {
+			// clear the static valueToPtr
+			valueToPtr.get().clear();
+			throw e;
+		}
+	}
+
+	@Override
+	public Object read(JsonReader in) throws IOException {
+		try {
+			JRefTokenStreamContext previousTSC = readTSC.get();
+			if (previousTSC != null) {
+				// Get ptr for previousTSC
+				JsonPointer parentPtr = JsonPointer.forPath(previousTSC, false);
+				// Convert jsonPath...e.g. '$..name[0] to jsonPointerPath...e.g. /name/0
+				String jsonPointerPath = "/" + getJsonPointerFromJsonPath(in.getPath());
+				// Use it to get ctxtPtr
+				JsonPointer ctxtPtr = JsonPointer.valueOf(jsonPointerPath);
+				String newParentName = null;
+				// If parentPtr is same as ctxtPtr, then no newParentName
+				if (parentPtr.equals(ctxtPtr)) {
+					// If parent and ctxt same, then no new parent name
+					newParentName = null;
+				} else {
+					String ctxtPtrStr = ctxtPtr.last().toString().substring(1);
+					// If parentPtr not set/empty then we set newParentName
+					if (parentPtr.equals(JsonPointer.EMPTY)) {
+						newParentName = ctxtPtrStr;
+					} else {
+						// If context is empty
+						if ("".equals(ctxtPtrStr)) {
+							// if we are not a key(
+							if (!previousTSC.isKey()) {
+								// newParentName is empty string
+								newParentName = "";
+							} else {
+								// No newParentName
+								newParentName = null;
+							}
+						} else {
+							// typical case for new parent name
+							newParentName = ctxtPtrStr;
+						}
+					}
+				}
+				if (newParentName != null) {
+					if (previousTSC.inArray()) {
+						// newParentName is array index
+						previousTSC = new JRefTokenStreamContext(previousTSC.parent, Integer.valueOf(newParentName));
+					} else {
+						// newParentName is object name
+						previousTSC = new JRefTokenStreamContext(previousTSC.parent, newParentName);
+					}
+				}
+			}
+			readTSC.set(createTSC(previousTSC));
+			// Here is where reading starts
+			Object result = null;
+			// Look for begin object
+			if (in.peek() == JsonToken.BEGIN_OBJECT) {
+				JsonElement e = Streams.parse(in);
+				JsonElement r = ((JsonObject) e).get(JREF_NAME);
+				if (r != null) {
+					// remove # (local only jrefs)
+					String jrefValue = r.getAsString().substring(1);
+					// create JsonPointer from jrefValue
+					JsonPointer ptr = JsonPointer.valueOf(jrefValue);
+					if (JsonPointer.EMPTY.equals(ptr)) {
+						throw new MalformedJsonException(
+								String.format("Empty JsonPointer for jrefValue=%s", jrefValue));
+					}
+					result = ptrToValue.get().get(ptr);
+					if (result == null) {
+						throw new MalformedJsonException(
+								String.format("Could not lookup value for JsonPointer=%s", ptr));
+					}
+				}
+				if (result == null) {
+					result = this.delegate.fromJsonTree(e);
+				}
+			}
+			if (result == null) {
+				result = this.delegate.read(in);
+			}
+			// unwinde tokenstreamcontext
+			JRefTokenStreamContext currTSC = readTSC.get();
+			JRefTokenStreamContext parentTSC = currTSC.parent;
+			Map<JsonPointer, Object> resultsMap = (Map<JsonPointer, Object>) ptrToValue.get();
+			if (parentTSC != null) {
+				// "" name means that we set the parentTSC with result (map key)
+				if ("".equals(parentTSC.currentName())) {
+					parentTSC = new JRefTokenStreamContext(parentTSC.parent, (String) result, true);
+				} else {
+					if (result != null) {
+						JsonPointer ptr = parentTSC.pathAsPointer();
+						// put ptr into map if not already there
+						if (!resultsMap.containsKey(ptr)) {
+							resultsMap.put(ptr, result);
+						}
+						// If this is a key that was just set, reset with name = ""
+						if (parentTSC.isKey()) {
+							parentTSC = new JRefTokenStreamContext(parentTSC.parent, "");
+						}
+					}
+				}
+			} else {
+				// no parentTSC, so we are done. Clear static map.
+				resultsMap.clear();
+			}
+			readTSC.set(parentTSC);
+			return result;
+		} catch (IOException e) {
+			// Clear out static map if exception
+			ptrToValue.get().clear();
+			// rethrow
+			throw e;
+		}
+	}
+
+	private String getJsonPointerFromJsonPath(String jsonPath) throws IOException {
+		if (jsonPath.startsWith("$") || jsonPath.startsWith(".")) {
+			// remove/return '$' and '.' from jsonPath
+			return getJsonPointerFromJsonPath(jsonPath.substring(1));
+		} else {
+			StringBuffer buf = new StringBuffer();
+			int leftBracketLoc = jsonPath.indexOf('[');
+			//
+			if (leftBracketLoc == -1) {
+				// no left bracket/arrays at all...simply return
+				return jsonPath;
+			} else if (leftBracketLoc > 0) {
+				// append name to buffer
+				buf.append(jsonPath.substring(0, leftBracketLoc));
+				// get remainder
+				jsonPath = jsonPath.substring(leftBracketLoc);
+				if (!jsonPath.isEmpty()) {
+					buf.append("/").append(getJsonPointerFromJsonPath(jsonPath));
+				}
+			} else {
+				// close bracket expected
+				int closeBracketLoc = jsonPath.indexOf(']');
+				if (closeBracketLoc > -1) {
+					buf.append(jsonPath.substring(leftBracketLoc + 1, closeBracketLoc)).toString();
+					jsonPath = jsonPath.substring(closeBracketLoc + 1);
+					if (!jsonPath.isEmpty()) {
+						buf.append("/");
+						buf.append(getJsonPointerFromJsonPath(jsonPath));
+					}
+				} else {
+					throw new IOException(
+							String.format("Bad index value starting with leftBracketLoc=%s in jsonPath=%s",
+									leftBracketLoc, jsonPath));
+				}
+			}
+			return buf.toString();
+		}
+	}
+
+}

--- a/gson/src/main/java/com/google/gson/JRefTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/JRefTypeAdapterFactory.java
@@ -1,0 +1,18 @@
+package com.google.gson;
+
+import com.google.gson.reflect.TypeToken;
+
+public class JRefTypeAdapterFactory implements TypeAdapterFactory {
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Override
+	public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+		TypeAdapter<Object> delegateTypeAdapter = (TypeAdapter<Object>) gson.getDelegateAdapter(this, type);
+		// We require a delegate type adapter. If none is present, then return null
+		if (delegateTypeAdapter == null) {
+			return null;
+		}
+		return (TypeAdapter) new JRefTypeAdapter((TypeToken<Object>) type, delegateTypeAdapter);
+	}
+
+}

--- a/gson/src/main/java/com/google/gson/JsonPointer.java
+++ b/gson/src/main/java/com/google/gson/JsonPointer.java
@@ -1,0 +1,966 @@
+package com.google.gson;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+import java.util.ArrayList;
+
+public class JsonPointer implements Serializable {
+	/**
+	 * Escape character {@value #ESC} per
+	 * <a href="https://datatracker.ietf.org/doc/html/rfc6901">RFC6901</a>.
+	 * 
+	 * <pre>
+	 * escaped         = "~" ( "0" / "1" )
+	 *  ; representing '~' and '/', respectively
+	 * </pre>
+	 *
+	 * @since 2.17
+	 */
+	public static final char ESC = '~';
+
+	/**
+	 * Escaped slash string {@value #ESC_TILDE} per
+	 * <a href="https://datatracker.ietf.org/doc/html/rfc6901">RFC6901</a>.
+	 * 
+	 * <pre>
+	 * escaped         = "~" ( "0" / "1" )
+	 *  ; representing '~' and '/', respectively
+	 * </pre>
+	 *
+	 * @since 2.17
+	 */
+	public static final String ESC_SLASH = "~1";
+
+	/**
+	 * Escaped tilde string {@value #ESC_TILDE} per
+	 * <a href="https://datatracker.ietf.org/doc/html/rfc6901">RFC6901</a>.
+	 * 
+	 * <pre>
+	 * escaped         = "~" ( "0" / "1" )
+	 *  ; representing '~' and '/', respectively
+	 * </pre>
+	 *
+	 * @since 2.17
+	 */
+	public static final String ESC_TILDE = "~0";
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Character used to separate segments.
+	 * 
+	 * <pre>
+	 * json-pointer    = *( "/" reference-token )
+	 * </pre>
+	 *
+	 * @since 2.9
+	 */
+	public final static char SEPARATOR = '/';
+
+	/**
+	 * Marker instance used to represent segment that matches current node or
+	 * position (that is, returns true for {@link #matches()}).
+	 */
+	protected final static JsonPointer EMPTY = new JsonPointer();
+
+	/**
+	 * Reference to rest of the pointer beyond currently matching segment (if any);
+	 * null if this pointer refers to the matching segment.
+	 */
+	protected final JsonPointer _nextSegment;
+
+	/**
+	 * Reference from currently matching segment (if any) to node before leaf.
+	 * Lazily constructed if/as needed.
+	 * <p>
+	 * NOTE: we'll use `volatile` here assuming that this is unlikely to become a
+	 * performance bottleneck. If it becomes one we can probably just drop it and
+	 * things still should work (despite warnings as per JMM regarding visibility
+	 * (and lack thereof) of unguarded changes).
+	 *
+	 * @since 2.5
+	 */
+	protected volatile JsonPointer _head;
+
+	/**
+	 * We will retain representation of the pointer, as a String, so that
+	 * {@link #toString} should be as efficient as possible.
+	 * <p>
+	 * NOTE: starting with 2.14, there is now accompanying {@link #_asStringOffset}
+	 * that MUST be considered with this String; this {@code String} may contain
+	 * preceding path, as it is now full path of parent pointer, except for the
+	 * outermost pointer instance.
+	 */
+	protected final String _asString;
+
+	/**
+	 * @since 2.14
+	 */
+	protected final int _asStringOffset;
+
+	protected final String _matchingPropertyName;
+
+	protected final int _matchingElementIndex;
+
+	/**
+	 * Lazily-calculated hash code: need to retain hash code now that we can no
+	 * longer rely on {@link #_asString} being the exact full representation (it is
+	 * often "more", including parent path).
+	 *
+	 * @since 2.14
+	 */
+	protected int _hashCode;
+
+	/*
+	 * /********************************************************** /* Construction
+	 * /**********************************************************
+	 */
+
+	/**
+	 * Constructor used for creating "empty" instance, used to represent state that
+	 * matches current node.
+	 */
+	protected JsonPointer() {
+		_nextSegment = null;
+		// [core#788]: must be `null` to distinguish from Property with "" as key
+		_matchingPropertyName = null;
+		_matchingElementIndex = -1;
+		_asString = "";
+		_asStringOffset = 0;
+	}
+
+	// Constructor used for creating non-empty Segments
+	protected JsonPointer(String fullString, int fullStringOffset, String segment, JsonPointer next) {
+		_asString = fullString;
+		_asStringOffset = fullStringOffset;
+		_nextSegment = next;
+		// Ok; may always be a property
+		_matchingPropertyName = segment;
+		// but could be an index, if parsable
+		_matchingElementIndex = _parseIndex(segment);
+	}
+
+	protected JsonPointer(String fullString, int fullStringOffset, String segment, int matchIndex, JsonPointer next) {
+		_asString = fullString;
+		_asStringOffset = fullStringOffset;
+		_nextSegment = next;
+		_matchingPropertyName = segment;
+		_matchingElementIndex = matchIndex;
+	}
+
+	/**
+	 * Copy-constructor used for creating transformed instances with re-linking
+	 * textual contents to new "next" pointer instance.
+	 *
+	 * @param src  Original pointer to copy "full String" from
+	 * @param next New "next" pointed to link to
+	 *
+	 * @since 2.19
+	 */
+	protected JsonPointer(JsonPointer src, JsonPointer next) {
+		_asString = src._asString;
+		_asStringOffset = src._asStringOffset;
+		_nextSegment = next;
+		_matchingPropertyName = src._matchingPropertyName;
+		_matchingElementIndex = src._matchingElementIndex;
+	}
+
+	/**
+	 * Copy-constructor used for creating transformed instances without "next"
+	 * linkage
+	 *
+	 * @param src                 Original pointer to copy "matchingXxx" fields from
+	 * @param newFullString       Full String to use
+	 * @param newFullStringOffset Offset for new full String to use
+	 *
+	 * @since 2.19
+	 */
+	protected JsonPointer(JsonPointer src, String newFullString, int newFullStringOffset) {
+		_asString = newFullString;
+		_asStringOffset = newFullStringOffset;
+		_nextSegment = null;
+		_matchingPropertyName = src._matchingPropertyName;
+		_matchingElementIndex = src._matchingElementIndex;
+	}
+
+	/*
+	 * /********************************************************** /* Factory
+	 * methods /**********************************************************
+	 */
+
+	/**
+	 * Factory method that parses given input and construct matching pointer
+	 * instance, if it represents a valid JSON Pointer: if not, a
+	 * {@link IllegalArgumentException} is thrown.
+	 *
+	 * @param expr Pointer expression to compile
+	 *
+	 * @return Compiled {@link JsonPointer} path expression
+	 *
+	 * @throws IllegalArgumentException Thrown if the input does not present a valid
+	 *                                  JSON Pointer expression: currently the only
+	 *                                  such expression is one that does NOT start
+	 *                                  with a slash ('/').
+	 */
+	public static JsonPointer compile(String expr) throws IllegalArgumentException {
+		// First quick checks for well-known 'empty' pointer
+		if ((expr == null) || expr.length() == 0) {
+			return EMPTY;
+		}
+		// And then quick validity check:
+		if (expr.charAt(0) != SEPARATOR) {
+			throw new IllegalArgumentException(
+					"Invalid input: JSON Pointer expression must start with '/': " + "\"" + expr + "\"");
+		}
+		return _parseTail(expr);
+	}
+
+	/**
+	 * Alias for {@link #compile}; added to make instances automatically
+	 * deserializable by Jackson databind.
+	 *
+	 * @param expr Pointer expression to compile
+	 *
+	 * @return Compiled {@link JsonPointer} path expression
+	 */
+	public static JsonPointer valueOf(String expr) {
+		return compile(expr);
+	}
+
+	/**
+	 * Accessor for an "empty" expression, that is, one you can get by calling
+	 * {@link #compile} with "" (empty String).
+	 * <p>
+	 * NOTE: this is different from expression for {@code "/"} which would instead
+	 * match Object node property with empty String ("") as name.
+	 *
+	 * @return "Empty" pointer expression instance that matches given root value
+	 *
+	 * @since 2.10
+	 */
+	public static JsonPointer empty() {
+		return EMPTY;
+	}
+
+	private static void _appendEscaped(StringBuilder sb, String segment) {
+		for (int i = 0, end = segment.length(); i < end; ++i) {
+			char c = segment.charAt(i);
+			if (c == SEPARATOR) {
+				sb.append(ESC_SLASH);
+				continue;
+			}
+			if (c == ESC) {
+				sb.append(ESC_TILDE);
+				continue;
+			}
+			sb.append(c);
+		}
+	}
+
+	/*
+	 * /********************************************************** /* Public API
+	 * /**********************************************************
+	 */
+
+	/**
+	 * Functionally same as: <code>
+	 *  toString().length()
+	 *</code> but more efficient as it avoids likely String allocation.
+	 *
+	 * @return Length of String representation of this pointer instance
+	 *
+	 * @since 2.14
+	 */
+	public int length() {
+		return _asString.length() - _asStringOffset;
+	}
+
+	public boolean matches() {
+		return _nextSegment == null;
+	}
+
+	public String getMatchingProperty() {
+		return _matchingPropertyName;
+	}
+
+	public int getMatchingIndex() {
+		return _matchingElementIndex;
+	}
+
+	/**
+	 * @return True if the root selector matches property name (that is, could match
+	 *         field value of JSON Object node)
+	 */
+	public boolean mayMatchProperty() {
+		return _matchingPropertyName != null;
+	}
+
+	/**
+	 * @return True if the root selector matches element index (that is, could match
+	 *         an element of JSON Array node)
+	 */
+	public boolean mayMatchElement() {
+		return _matchingElementIndex >= 0;
+	}
+
+	/**
+	 * @return the leaf of current JSON Pointer expression: leaf is the last
+	 *         non-null segment of current JSON Pointer.
+	 *
+	 * @since 2.5
+	 */
+	public JsonPointer last() {
+		JsonPointer current = this;
+		if (current == EMPTY) {
+			return null;
+		}
+		JsonPointer next;
+		while ((next = current._nextSegment) != JsonPointer.EMPTY) {
+			current = next;
+		}
+		return current;
+	}
+
+	/**
+	 * Mutant factory method that will return
+	 * <ul>
+	 * <li>`tail` if `this` instance is "empty" pointer, OR</li>
+	 * <li>`this` instance if `tail` is "empty" pointer, OR</li>
+	 * <li>Newly constructed {@link JsonPointer} instance that starts with all
+	 * segments of `this`, followed by all segments of `tail`.</li>
+	 * </ul>
+	 *
+	 * @param tail {@link JsonPointer} instance to append to this one, to create a
+	 *             new pointer instance
+	 *
+	 * @return Either `this` instance, `tail`, or a newly created combination, as
+	 *         per description above.
+	 */
+	public JsonPointer append(JsonPointer tail) {
+		if (this == EMPTY) {
+			return tail;
+		}
+		if (tail == EMPTY) {
+			return this;
+		}
+		// 21-Mar-2017, tatu: Not superbly efficient; could probably improve by not
+		// concatenating,
+		// re-decoding -- by stitching together segments -- but for now should be fine.
+
+		String currentJsonPointer = toString();
+
+		// 14-Dec-2023, tatu: Pre-2.17 had special handling which makes no sense:
+		/*
+		 * if (currentJsonPointer.endsWith("/")) { //removes final slash
+		 * currentJsonPointer = currentJsonPointer.substring(0,
+		 * currentJsonPointer.length()-1); }
+		 */
+		return compile(currentJsonPointer + tail.toString());
+	}
+
+	/**
+	 * ATTENTION! {@link JsonPointer} is head-centric, tail appending is much
+	 * costlier than head appending. It is recommended that this method is used
+	 * sparingly due to possible sub-par performance.
+	 *
+	 * Mutant factory method that will return:
+	 * <ul>
+	 * <li>`this` instance if `property` is null, OR</li>
+	 * <li>Newly constructed {@link JsonPointer} instance that starts with all
+	 * segments of `this`, followed by new segment of 'property' name.</li>
+	 * </ul>
+	 * 'property' is name to match: value is escaped as necessary (for any contained
+	 * slashes or tildes).
+	 * <p>
+	 * NOTE! Before Jackson 2.17, no escaping was performed, and leading slash was
+	 * dropped if passed. This was incorrect implementation. Empty {@code property}
+	 * was also ignored (similar to {@code null}).
+	 *
+	 * @param property new segment property name
+	 *
+	 * @return Either `this` instance, or a newly created combination, as per
+	 *         description above.
+	 */
+	public JsonPointer appendProperty(String property) {
+		if (property == null) {
+			return this;
+		}
+		// 14-Dec-2023, tatu: [core#1145] Must escape `property`; accept empty String
+		// as valid segment to match as well
+		StringBuilder sb = toStringBuilder(property.length() + 2).append(SEPARATOR);
+		_appendEscaped(sb, property);
+		return compile(sb.toString());
+	}
+
+	/**
+	 * ATTENTION! {@link JsonPointer} is head-centric, tail appending is much
+	 * costlier than head appending. It is recommended that this method is used
+	 * sparingly due to possible sub-par performance.
+	 *
+	 * Mutant factory method that will return newly constructed {@link JsonPointer}
+	 * instance that starts with all segments of `this`, followed by new segment of
+	 * element 'index'. Element 'index' should be non-negative.
+	 *
+	 * @param index new segment element index
+	 *
+	 * @return Newly created combination, as per description above.
+	 * @throws IllegalArgumentException if element index is negative
+	 */
+	public JsonPointer appendIndex(int index) {
+		if (index < 0) {
+			throw new IllegalArgumentException("Negative index cannot be appended");
+		}
+		// 14-Dec-2024, tatu: Used to have odd logic for removing "trailing" slash;
+		// removed from 2.17
+		return compile(toStringBuilder(8).append(SEPARATOR).append(index).toString());
+	}
+
+	/**
+	 * Method that may be called to see if the pointer head (first segment) would
+	 * match property (of a JSON Object) with given name.
+	 *
+	 * @param name Name of Object property to match
+	 *
+	 * @return {@code True} if the pointer head matches specified property name
+	 *
+	 * @since 2.5
+	 */
+	public boolean matchesProperty(String name) {
+		return (_nextSegment != null) && _matchingPropertyName.equals(name);
+	}
+
+	/**
+	 * Method that may be called to check whether the pointer head (first segment)
+	 * matches specified Object property (by name) and if so, return
+	 * {@link JsonPointer} that represents rest of the path after match. If there is
+	 * no match, {@code null} is returned.
+	 *
+	 * @param name Name of Object property to match
+	 *
+	 * @return Remaining path after matching specified property, if there is match;
+	 *         {@code null} otherwise
+	 */
+	public JsonPointer matchProperty(String name) {
+		if ((_nextSegment != null) && _matchingPropertyName.equals(name)) {
+			return _nextSegment;
+		}
+		return null;
+	}
+
+	/**
+	 * Method that may be called to see if the pointer would match Array element (of
+	 * a JSON Array) with given index.
+	 *
+	 * @param index Index of Array element to match
+	 *
+	 * @return {@code True} if the pointer head matches specified Array index
+	 *
+	 * @since 2.5
+	 */
+	public boolean matchesElement(int index) {
+		return (index == _matchingElementIndex) && (index >= 0);
+	}
+
+	/**
+	 * Method that may be called to check whether the pointer head (first segment)
+	 * matches specified Array index and if so, return {@link JsonPointer} that
+	 * represents rest of the path after match. If there is no match, {@code null}
+	 * is returned.
+	 *
+	 * @param index Index of Array element to match
+	 *
+	 * @return Remaining path after matching specified index, if there is match;
+	 *         {@code null} otherwise
+	 *
+	 * @since 2.6
+	 */
+	public JsonPointer matchElement(int index) {
+		if ((index != _matchingElementIndex) || (index < 0)) {
+			return null;
+		}
+		return _nextSegment;
+	}
+
+	/**
+	 * Accessor for getting a "sub-pointer" (or sub-path), instance where current
+	 * segment has been removed and pointer includes rest of the segments. For
+	 * example, for JSON Pointer "/root/branch/leaf", this method would return
+	 * pointer "/branch/leaf". For matching state (last segment), will return
+	 * {@code null}.
+	 * <p>
+	 * Note that this is a very cheap method to call as it simply returns "next"
+	 * segment (which has been constructed when pointer instance was constructed).
+	 *
+	 * @return Tail of this pointer, if it has any; {@code null} if this pointer
+	 *         only has the current segment
+	 */
+	public JsonPointer tail() {
+		return _nextSegment;
+	}
+
+	/**
+	 * Accessor for getting a pointer instance that is identical to this instance
+	 * except that the last segment has been dropped. For example, for JSON Pointer
+	 * "/root/branch/leaf", this method would return pointer "/root/branch"
+	 * (compared to {@link #tail()} that would return "/branch/leaf").
+	 * <p>
+	 * Note that whereas {@link #tail} is a very cheap operation to call (as "tail"
+	 * already exists for single-linked forward direction), this method has to fully
+	 * construct a new instance by traversing the chain of segments.
+	 *
+	 * @return Pointer expression that contains same segments as this one, except
+	 *         for the last segment.
+	 *
+	 * @since 2.5
+	 */
+	public JsonPointer head() {
+		JsonPointer h = _head;
+		if (h == null) {
+			if (this != EMPTY) {
+				h = _constructHead();
+			}
+			_head = h;
+		}
+		return h;
+	}
+
+	/*
+	 * /********************************************************** /* Standard
+	 * method overrides (since 2.14)
+	 * /**********************************************************
+	 */
+
+	@Override
+	public String toString() {
+		if (_asStringOffset <= 0) {
+			return _asString;
+		}
+		return _asString.substring(_asStringOffset);
+	}
+
+	/**
+	 * Functionally equivalent to:
+	 * 
+	 * <pre>
+	 * new StringBuilder(toString());
+	 * </pre>
+	 * 
+	 * but possibly more efficient
+	 *
+	 * @param slack Number of characters to reserve in StringBuilder beyond minimum
+	 *              copied
+	 * @return a new StringBuilder
+	 *
+	 * @since 2.17
+	 */
+	protected StringBuilder toStringBuilder(int slack) {
+		if (_asStringOffset <= 0) {
+			return new StringBuilder(_asString);
+		}
+		final int len = _asString.length();
+		StringBuilder sb = new StringBuilder(len - _asStringOffset + slack);
+		sb.append(_asString, _asStringOffset, len);
+		return sb;
+	}
+
+	@Override
+	public int hashCode() {
+		int h = _hashCode;
+		if (h == 0) {
+			// Alas, this is bit wasteful, creating temporary String, but
+			// without JDK exposing hash code calculation for a sub-string
+			// can't do much
+			h = toString().hashCode();
+			if (h == 0) {
+				h = -1;
+			}
+			_hashCode = h;
+		}
+		return h;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (o == this)
+			return true;
+		if (o == null)
+			return false;
+		if (!(o instanceof JsonPointer))
+			return false;
+		JsonPointer other = (JsonPointer) o;
+		// 07-Oct-2022, tatu: Ugh.... this gets way more complicated as we MUST
+		// compare logical representation so cannot simply compare offset
+		// and String
+		return _compare(_asString, _asStringOffset, other._asString, other._asStringOffset);
+	}
+
+	private final boolean _compare(String str1, int offset1, String str2, int offset2) {
+		final int end1 = str1.length();
+
+		// Different lengths? Not equal
+		if ((end1 - offset1) != (str2.length() - offset2)) {
+			return false;
+		}
+
+		for (; offset1 < end1;) {
+			if (str1.charAt(offset1++) != str2.charAt(offset2++)) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/*
+	 * /********************************************************** /* Internal
+	 * methods /**********************************************************
+	 */
+
+	private final static int _parseIndex(String str) {
+		final int len = str.length();
+		// [core#133]: beware of super long indexes; assume we never
+		// have arrays over 2 billion entries so ints are fine.
+		if (len == 0 || len > 10) {
+			return -1;
+		}
+		// [core#176]: no leading zeroes allowed
+		char c = str.charAt(0);
+		if (c <= '0') {
+			return (len == 1 && c == '0') ? 0 : -1;
+		}
+		if (c > '9') {
+			return -1;
+		}
+		for (int i = 1; i < len; ++i) {
+			c = str.charAt(i);
+			if (c > '9' || c < '0') {
+				return -1;
+			}
+		}
+		if (len == 10) {
+			long l = Long.parseLong(str);
+			if (l > Integer.MAX_VALUE) {
+				return -1;
+			}
+			return (int) l;
+		}
+		return Integer.parseInt(str);
+	}
+
+	protected static JsonPointer _parseTail(final String fullPath) {
+		PointerParent parent = null;
+
+		// first char is the contextual slash, skip
+		int i = 1;
+		final int end = fullPath.length();
+		int startOffset = 0;
+
+		while (i < end) {
+			char c = fullPath.charAt(i);
+			if (c == SEPARATOR) { // common case, got a segment
+				parent = new PointerParent(parent, startOffset, fullPath.substring(startOffset + 1, i));
+				startOffset = i;
+				++i;
+				continue;
+			}
+			++i;
+			// quoting is different; offline this case
+			if (c == ESC && i < end) { // possibly, quote
+				// 04-Oct-2022, tatu: Let's decode escaped segment
+				// instead of recursive call
+				StringBuilder sb = new StringBuilder(32);
+				i = _extractEscapedSegment(fullPath, startOffset + 1, i, sb);
+				final String segment = sb.toString();
+				if (i < 0) { // end!
+					return _buildPath(fullPath, startOffset, segment, parent);
+				}
+				parent = new PointerParent(parent, startOffset, segment);
+				startOffset = i;
+				++i;
+				continue;
+			}
+			// otherwise, loop on
+		}
+		// end of the road, no escapes
+		return _buildPath(fullPath, startOffset, fullPath.substring(startOffset + 1), parent);
+	}
+
+	private static JsonPointer _buildPath(final String fullPath, int fullPathOffset, String segment,
+			PointerParent parent) {
+		JsonPointer curr = new JsonPointer(fullPath, fullPathOffset, segment, EMPTY);
+		for (; parent != null; parent = parent.parent) {
+			curr = new JsonPointer(fullPath, parent.fullPathOffset, parent.segment, curr);
+		}
+		return curr;
+	}
+
+	/**
+	 * Method called to extract the next segment of the path, in case where we seem
+	 * to have encountered a (tilde-)escaped character within segment.
+	 *
+	 * @param input           Full input for the tail being parsed
+	 * @param firstCharOffset Offset of the first character of segment (one after
+	 *                        slash)
+	 * @param i               Offset to character after tilde
+	 * @param sb              StringBuilder into which unquoted segment is added
+	 *
+	 * @return Offset at which slash was encountered, if any, or -1 if expression
+	 *         ended without seeing unescaped slash
+	 */
+	protected static int _extractEscapedSegment(String input, int firstCharOffset, int i, StringBuilder sb) {
+		final int end = input.length();
+		final int toCopy = i - 1 - firstCharOffset;
+		if (toCopy > 0) {
+			sb.append(input, firstCharOffset, i - 1);
+		}
+		i += _appendEscape(sb, input.charAt(i));
+		while (i < end) {
+			char c = input.charAt(i);
+			if (c == SEPARATOR) { // end is nigh!
+				return i;
+			}
+			++i;
+			if (c == ESC && i < end) {
+				i += _appendEscape(sb, input.charAt(i));
+				continue;
+			}
+			sb.append(c);
+		}
+		// end of the road, last segment
+		return -1;
+	}
+
+	private static int _appendEscape(StringBuilder sb, char c) {
+		if (c == '0') {
+			sb.append(ESC);
+			return 1;
+		}
+		if (c == '1') {
+			sb.append(SEPARATOR);
+			return 1;
+		}
+		// Not a valid escape; just output tilde, do not advance past following char
+		sb.append(ESC);
+		return 0;
+	}
+
+	protected JsonPointer _constructHead() {
+		// ok; find out the segment we are to drop
+		JsonPointer last = last();
+		if (last == this) {
+			return EMPTY;
+		}
+
+		// Initialize a list to store intermediate JsonPointers in reverse
+		ArrayList<JsonPointer> pointers = new ArrayList<>();
+
+		JsonPointer current = this;
+		String origFullString = toString();
+		// Make sure to share the new full string for path segments
+		String fullString = origFullString.substring(0, origFullString.length() - last.length());
+
+		// Also: if there was an offset, must compensate (new String starts at 0)
+		final int offsetDiff = -_asStringOffset;
+
+		while (current != last) {
+			// NOTE: since we drop from the end we can simply reuse offset (w/ possible
+			// modification)
+			JsonPointer nextSegment = new JsonPointer(current, fullString, current._asStringOffset + offsetDiff);
+			pointers.add(nextSegment);
+			current = current._nextSegment;
+		}
+
+		// Iteratively build the JsonPointer chain from the list in reverse
+		JsonPointer head = EMPTY;
+		for (int i = pointers.size() - 1; i >= 0; i--) {
+			head = new JsonPointer(pointers.get(i), head);
+		}
+
+		return head;
+	}
+
+	/*
+	 * /********************************************************** /* Helper class
+	 * used to replace call stack (2.14+)
+	 * /**********************************************************
+	 */
+
+	/**
+	 * Helper class used to replace call stack when parsing JsonPointer expressions.
+	 */
+	private static class PointerParent {
+		public final PointerParent parent;
+		public final int fullPathOffset;
+		public final String segment;
+
+		PointerParent(PointerParent pp, int fpo, String sgm) {
+			parent = pp;
+			fullPathOffset = fpo;
+			segment = sgm;
+		}
+	}
+
+	/**
+	 * Helper class used to contain a single segment when constructing JsonPointer
+	 * from context.
+	 */
+	private static class PointerSegment {
+		public final PointerSegment next;
+		public final String property;
+		public final int index;
+
+		// Offset within external buffer, updated when constructing
+		public int pathOffset;
+
+		// And we actually need 2-way traversal, it turns out so:
+		public PointerSegment prev;
+
+		public PointerSegment(PointerSegment next, String pn, int ix) {
+			this.next = next;
+			property = pn;
+			index = ix;
+			// Ok not the cleanest thing but...
+			if (next != null) {
+				next.prev = this;
+			}
+		}
+	}
+
+	/*
+	 * /********************************************************** /* Support for
+	 * JDK serialization (2.14+)
+	 * /**********************************************************
+	 */
+
+	// Since 2.14: needed for efficient JDK serializability
+	private Object writeReplace() {
+		// 11-Oct-2022, tatu: very important, must serialize just contents!
+		return new Serialization(toString());
+	}
+
+	/**
+	 * This must only exist to allow both final properties and implementation of
+	 * Externalizable/Serializable for JsonPointer. Note that here we do not store
+	 * offset but simply use (and expect use) full path, from which we need to
+	 * decode actual structure.
+	 *
+	 * @since 2.14
+	 */
+	static class Serialization implements Externalizable {
+		private String _fullPath;
+
+		public Serialization() {
+		}
+
+		Serialization(String fullPath) {
+			_fullPath = fullPath;
+		}
+
+		@Override
+		public void writeExternal(ObjectOutput out) throws IOException {
+			out.writeUTF(_fullPath);
+		}
+
+		@Override
+		public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+			_fullPath = in.readUTF();
+		}
+
+		private Object readResolve() throws ObjectStreamException {
+			// NOTE: method handles canonicalization of "empty", as well as other
+			// aspects of decoding.
+			return compile(_fullPath);
+		}
+	}
+
+	/**
+	 * Factory method that will construct a pointer instance that describes path to
+	 * location given {@link JsonStreamContext} points to.
+	 *
+	 * @param context     Context to build pointer expression for
+	 * @param includeRoot Whether to include number offset for virtual "root
+	 *                    context" or not.
+	 *
+	 * @return {@link JsonPointer} path to location of given context
+	 *
+	 * @since 2.9
+	 */
+	public static JsonPointer forPath(TokenStreamContext context, boolean includeRoot) {
+		// First things first: last segment may be for START_ARRAY/START_OBJECT,
+		// in which case it does not yet point to anything, and should be skipped
+		if (context == null) {
+			return EMPTY;
+		}
+		// Otherwise if context was just created but is not advanced -- like,
+		// opening START_ARRAY/START_OBJECT returned -- drop the empty context.
+		if (!context.hasPathSegment()) {
+			// Except one special case: do not prune root if we need it
+			if (!(includeRoot && context.inRoot() && context.hasCurrentIndex())) {
+				context = context.getParent();
+			}
+		}
+
+		PointerSegment next = null;
+		int approxLength = 0;
+
+		for (; context != null; context = context.getParent()) {
+			if (context.inObject()) {
+				String propName = context.currentName();
+				if (propName == null) { // is this legal?
+					propName = "";
+				}
+				approxLength += 2 + propName.length();
+				next = new PointerSegment(next, propName, -1);
+			} else if (context.inArray() || includeRoot) {
+				int ix = context.getCurrentIndex();
+				approxLength += 6;
+				next = new PointerSegment(next, null, ix);
+			}
+			// NOTE: this effectively drops ROOT node(s); should have 1 such node,
+			// as the last one, but we don't have to care (probably some paths have
+			// no root, for example)
+		}
+		if (next == null) {
+			return EMPTY;
+		}
+
+		// And here the fun starts! We have the head, need to traverse
+		// to compose full path String
+		StringBuilder pathBuilder = new StringBuilder(approxLength);
+		PointerSegment last = null;
+
+		for (; next != null; next = next.next) {
+			// Let's find the last segment as well, for reverse traversal
+			last = next;
+			next.pathOffset = pathBuilder.length();
+			pathBuilder.append(SEPARATOR);
+			if (next.property != null) {
+				_appendEscaped(pathBuilder, next.property);
+			} else {
+				pathBuilder.append(next.index);
+			}
+		}
+		final String fullPath = pathBuilder.toString();
+
+		// and then iteratively construct JsonPointer chain in reverse direction
+		// (from innermost back to outermost)
+		PointerSegment currSegment = last;
+		JsonPointer currPtr = EMPTY;
+
+		for (; currSegment != null; currSegment = currSegment.prev) {
+			if (currSegment.property != null) {
+				currPtr = new JsonPointer(fullPath, currSegment.pathOffset, currSegment.property, currPtr);
+			} else {
+				int index = currSegment.index;
+				currPtr = new JsonPointer(fullPath, currSegment.pathOffset, String.valueOf(index), index, currPtr);
+			}
+		}
+
+		return currPtr;
+	}
+
+}

--- a/gson/src/main/java/com/google/gson/TokenStreamContext.java
+++ b/gson/src/main/java/com/google/gson/TokenStreamContext.java
@@ -1,0 +1,376 @@
+package com.google.gson;
+
+import java.util.Arrays;
+
+import com.google.gson.JsonParser;
+
+/**
+ * Shared base class for streaming processing contexts used during reading and
+ * writing of token streams using Streaming API. This context is also exposed to
+ * applications: context object can be used by applications to get an idea of
+ * relative position of the parser/generator within content being processed.
+ * This allows for some contextual processing: for example, output within Array
+ * context can differ from that of Object context. Perhaps more importantly
+ * context is hierarchic so that enclosing contexts can be inspected as well.
+ * All levels also include information about current property name (for Objects)
+ * and element index (for Arrays).
+ * <p>
+ * NOTE: in Jackson 2.x this class was named {@code JsonStreamContext}
+ */
+public abstract class TokenStreamContext {
+	// // // Type constants used internally
+	// // // (but exposed publicly as of 2.12 as possibly needed)
+
+	/**
+	 * Indicator for "Root Value" context (has not parent)
+	 */
+	public final static int TYPE_ROOT = 0;
+
+	/**
+	 * Indicator for "Array" context.
+	 */
+	public final static int TYPE_ARRAY = 1;
+
+	/**
+	 * Indicator for "Object" context.
+	 */
+	public final static int TYPE_OBJECT = 2;
+
+	/**
+	 * Indicates logical type of context as one of {@code TYPE_xxx} constants.
+	 */
+	protected int _type;
+
+	/**
+	 * Index of the currently processed entry. Starts with -1 to signal that no
+	 * entries have been started, and gets advanced each time a new entry is
+	 * started, either by encountering an expected separator, or with new values if
+	 * no separators are expected (the case for root context).
+	 */
+	protected int _index;
+
+	/**
+	 * The nesting depth is a count of objects and arrays that have not been closed,
+	 * `{` and `[` respectively.
+	 *
+	 * @since 2.15
+	 */
+	protected int _nestingDepth;
+
+	/*
+	 * /********************************************************************** /*
+	 * Life-cycle
+	 * /**********************************************************************
+	 */
+
+	protected TokenStreamContext() {
+	}
+
+	/**
+	 * Copy constructor used by sub-classes for creating copies for buffering.
+	 *
+	 * @param base Context instance to copy type and index from
+	 */
+	protected TokenStreamContext(TokenStreamContext base) {
+		_type = base._type;
+		_index = base._index;
+	}
+
+	protected TokenStreamContext(int type, int index) {
+		_type = type;
+		_index = index;
+	}
+
+	/*
+	 * /********************************************************************** /*
+	 * Public API, accessors
+	 * /**********************************************************************
+	 */
+
+	/**
+	 * Accessor for finding parent context of this context; will return null for
+	 * root context.
+	 *
+	 * @return Parent context of this context, if any; {@code null} for Root
+	 *         contexts
+	 */
+	public abstract TokenStreamContext getParent();
+
+	/**
+	 * Method that returns true if this context is an Array context; that is,
+	 * content is being read from or written to a JSON Array.
+	 *
+	 * @return {@code True} if this context represents an Array; {@code false}
+	 *         otherwise
+	 */
+	public final boolean inArray() {
+		return _type == TYPE_ARRAY;
+	}
+
+	/**
+	 * Method that returns true if this context is a Root context; that is, content
+	 * is being read from or written to without enclosing array or object structure.
+	 *
+	 * @return {@code True} if this context represents a sequence of Root values;
+	 *         {@code false} otherwise
+	 */
+	public final boolean inRoot() {
+		return _type == TYPE_ROOT;
+	}
+
+	/**
+	 * Method that returns true if this context is an Object context; that is,
+	 * content is being read from or written to a JSON Object.
+	 *
+	 * @return {@code True} if this context represents an Object; {@code false}
+	 *         otherwise
+	 */
+	public final boolean inObject() {
+		return _type == TYPE_OBJECT;
+	}
+
+	/**
+	 * The nesting depth is a count of objects and arrays that have not been closed,
+	 * `{` and `[` respectively.
+	 *
+	 * @return Nesting depth
+	 *
+	 * @since 2.15
+	 */
+	public final int getNestingDepth() {
+		return _nestingDepth;
+	}
+
+	/**
+	 * Method for accessing simple type description of current context; either ROOT
+	 * (for root-level values), OBJECT (for Object property names and values) or
+	 * ARRAY (for elements of JSON Arrays)
+	 *
+	 * @return Type description String
+	 */
+	public String typeDesc() {
+		switch (_type) {
+		case TYPE_ROOT:
+			return "root";
+		case TYPE_ARRAY:
+			return "Array";
+		case TYPE_OBJECT:
+			return "Object";
+		}
+		return "?";
+	}
+
+	/**
+	 * @return Number of entries that are complete and started.
+	 */
+	public final int getEntryCount() {
+		return _index + 1;
+	}
+
+	/**
+	 * @return Index of the currently processed entry, if any
+	 */
+	public final int getCurrentIndex() {
+		return (_index < 0) ? 0 : _index;
+	}
+
+	/**
+	 * Method that may be called to verify whether this context has valid index:
+	 * will return `false` before the first entry of Object context or before first
+	 * element of Array context; otherwise returns `true`.
+	 *
+	 * @return {@code True} if this context has value index to access, {@code false}
+	 *         otherwise
+	 */
+	public boolean hasCurrentIndex() {
+		return _index >= 0;
+	}
+
+	/**
+	 * Method that may be called to check if this context is either:
+	 * <ul>
+	 * <li>Object, with at least one entry written (partially or completely)</li>
+	 * <li>Array, with at least one entry written (partially or completely)</li>
+	 * </ul>
+	 * and if so, return `true`; otherwise return `false`. Latter case includes Root
+	 * context (always), and Object/Array contexts before any entries/elements have
+	 * been read or written.
+	 * <p>
+	 * Method is mostly used to determine whether this context should be used for
+	 * constructing {@link JsonPointer}
+	 *
+	 * @return {@code True} if this context has value path segment to access,
+	 *         {@code false} otherwise
+	 */
+	public boolean hasPathSegment() {
+		if (_type == TYPE_OBJECT) {
+			return hasCurrentName();
+		} else if (_type == TYPE_ARRAY) {
+			return hasCurrentIndex();
+		}
+		return false;
+	}
+
+	/**
+	 * Method for accessing name associated with the current location. Non-null for
+	 * <code>PROPERTY_NAME</code> and value events that directly follow Property
+	 * names; null for root level and array values.
+	 *
+	 * @return Current property name within context, if any; {@code null} if none
+	 */
+	public abstract String currentName();
+
+	public boolean hasCurrentName() {
+		return currentName() != null;
+	}
+
+	/**
+	 * Method for accessing currently active value being used by data-binding (as
+	 * the source of streaming data to write, or destination of data being read), at
+	 * this level in hierarchy.
+	 * <p>
+	 * Note that "current value" is NOT populated (or used) by Streaming parser or
+	 * generator; it is only used by higher-level data-binding functionality. The
+	 * reason it is included here is that it can be stored and accessed
+	 * hierarchically, and gets passed through data-binding.
+	 *
+	 * @return Currently active value, if one has been assigned.
+	 */
+	public Object currentValue() {
+		return null;
+	}
+
+	/**
+	 * Method to call to pass value to be returned via {@link #currentValue};
+	 * typically called indirectly through {@link JsonParser#assignCurrentValue} or
+	 * {@link JsonGenerator#assignCurrentValue}).
+	 *
+	 * @param v Current value to assign to this context
+	 */
+	public void assignCurrentValue(Object v) {
+	}
+
+	/**
+	 * Factory method for constructing a {@link JsonPointer} that points to the
+	 * current location within the stream that this context is for, excluding
+	 * information about "root context" (only relevant for multi-root-value cases)
+	 *
+	 * @return Pointer instance constructed
+	 */
+	public JsonPointer pathAsPointer() {
+		return JsonPointer.forPath(this, false);
+	}
+
+	/**
+	 * Factory method for constructing a {@link JsonPointer} that points to the
+	 * current location within the stream that this context is for, optionally
+	 * including "root value index"
+	 *
+	 * @param includeRoot Whether root-value offset is included as the first segment
+	 *                    or not
+	 *
+	 * @return Pointer instance constructed
+	 */
+	public JsonPointer pathAsPointer(boolean includeRoot) {
+		return JsonPointer.forPath(this, includeRoot);
+	}
+
+	/**
+	 * Overridden to provide developer readable "JsonPath" representation of the
+	 * context.
+	 *
+	 * @return Simple developer-readable description this context layer (note: NOT
+	 *         constructed with parents, unlike {@link #pathAsPointer})
+	 */
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder(64);
+		switch (_type) {
+		case TYPE_ROOT:
+			sb.append("/");
+			break;
+		case TYPE_ARRAY:
+			sb.append('[');
+			sb.append(getCurrentIndex());
+			sb.append(']');
+			break;
+		case TYPE_OBJECT:
+		default:
+			sb.append('{');
+			String currentName = currentName();
+			if (currentName != null) {
+				sb.append('"');
+				appendQuoted(sb, currentName);
+				sb.append('"');
+			} else {
+				sb.append('?');
+			}
+			sb.append('}');
+			break;
+		}
+		return sb.toString();
+	}
+
+	protected final static char[] HC = "0123456789ABCDEF".toCharArray();
+
+	public final static int ESCAPE_STANDARD = -1;
+
+	protected final static int[] sOutputEscapes128NoSlash;
+	static {
+		int[] table = new int[128];
+		// Control chars need generic escape sequence
+		for (int i = 0; i < 32; ++i) {
+			// 04-Mar-2011, tatu: Used to use "-(i + 1)", replaced with constant
+			table[i] = ESCAPE_STANDARD;
+		}
+		// Others (and some within that range too) have explicit shorter sequences
+		table['"'] = '"';
+		table['\\'] = '\\';
+		// Escaping of slash is optional, so let's not add it
+		table[0x08] = 'b';
+		table[0x09] = 't';
+		table[0x0C] = 'f';
+		table[0x0A] = 'n';
+		table[0x0D] = 'r';
+		sOutputEscapes128NoSlash = table;
+	}
+
+	protected final static int[] sOutputEscapes128WithSlash;
+	static {
+		sOutputEscapes128WithSlash = Arrays.copyOf(sOutputEscapes128NoSlash, sOutputEscapes128NoSlash.length);
+		sOutputEscapes128WithSlash['/'] = '/';
+	}
+
+	public static void appendQuoted(StringBuilder sb, String content) {
+		final int[] escCodes = sOutputEscapes128WithSlash;
+		final int escLen = escCodes.length;
+		for (int i = 0, len = content.length(); i < len; ++i) {
+			char c = content.charAt(i);
+			if (c >= escLen || escCodes[c] == 0) {
+				sb.append(c);
+				continue;
+			}
+			sb.append('\\');
+			int escCode = escCodes[c];
+			if (escCode < 0) { // generic quoting (hex value)
+				// The only negative value sOutputEscapes128 returns
+				// is CharacterEscapes.ESCAPE_STANDARD, which mean
+				// appendQuotes should encode using the Unicode encoding;
+				// not sure if this is the right way to encode for
+				// CharacterEscapes.ESCAPE_CUSTOM or other (future)
+				// CharacterEscapes.ESCAPE_XXX values.
+
+				// We know that it has to fit in just 2 hex chars
+				sb.append('u');
+				sb.append('0');
+				sb.append('0');
+				int value = c; // widening
+				sb.append(HC[value >> 4]);
+				sb.append(HC[value & 0xF]);
+			} else { // "named", i.e. prepend with slash
+				sb.append((char) escCode);
+			}
+		}
+	}
+
+}

--- a/gson/src/main/java/com/google/gson/stream/JsonWriter.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonWriter.java
@@ -699,6 +699,10 @@ public class JsonWriter implements Closeable, Flushable {
     return this;
   }
 
+  public String getDeferredName() {
+	  return this.deferredName;
+  }
+  
   /**
    * Ensures all buffered data is written to the underlying {@link Writer} and flushes that writer.
    */

--- a/gson/src/test/java/com/google/gson/jref/JRefAbstractTest.java
+++ b/gson/src/test/java/com/google/gson/jref/JRefAbstractTest.java
@@ -1,0 +1,57 @@
+package com.google.gson.jref;
+
+import java.util.regex.Pattern;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JRefTypeAdapter;
+import com.google.gson.JRefTypeAdapterFactory;
+
+import org.junit.After;
+import org.junit.Assert;
+
+public class JRefAbstractTest {
+
+	public static boolean TRACE = true;
+
+	@After
+	public void tearDown() {
+		JRefTypeAdapter.ptrToValue.remove();
+		JRefTypeAdapter.readTSC.remove();
+		JRefTypeAdapter.writeTSC.remove();
+		JRefTypeAdapter.valueToPtr.remove();
+	}
+
+	public static GsonBuilder jsonMapperBuilder() {
+		return new GsonBuilder();
+	}
+
+	protected Gson buildGsonJRef() {
+		GsonBuilder builder = jsonMapperBuilder();
+		builder.registerTypeAdapterFactory(new JRefTypeAdapterFactory());
+		return builder.create();
+	}
+
+	protected Gson buildGsonNoJRef() {
+		GsonBuilder builder = jsonMapperBuilder();
+		return builder.create();
+	}
+
+	static long countMatches(String text, String target) {
+		if (text == null || target == null || target.isEmpty())
+			return 0;
+		String quotedTarget = Pattern.quote(target);
+
+		return Pattern.compile(quotedTarget).matcher(text).results().count();
+	}
+
+	protected void assertJRefCount(String input, long expectedJRefs) {
+		Assert.assertEquals(expectedJRefs, countMatches(input, "$ref"));
+	}
+
+	void trace(String method, String s) {
+		if (TRACE) {
+			System.out.println(method + "." + s);
+		}
+	}
+}

--- a/gson/src/test/java/com/google/gson/jref/JRefArrayTest.java
+++ b/gson/src/test/java/com/google/gson/jref/JRefArrayTest.java
@@ -1,0 +1,162 @@
+package com.google.gson.jref;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.google.gson.Gson;
+
+public class JRefArrayTest extends JRefAbstractTest {
+
+	@Test
+	public void testStringArrayRef() throws Exception {
+		Gson mapper = buildGsonJRef();
+		String o1 = new String("one");
+		String o2 = o1;
+		String[] arr = new String[] { o1, o2 };
+		String out = mapper.toJson(arr);
+		assertJRefCount(out, 1);
+		trace("testStringArrayRef jrefserialized=", out);
+		String[] oa = mapper.fromJson(out, String[].class);
+		assertTrue(oa[0] instanceof String);
+		assertTrue(oa[1] instanceof String);
+		assertEquals(oa[0], oa[1]);
+	}
+
+	@Test
+	public void test2DStringArrayRef() throws Exception {
+		Gson mapper = buildGsonJRef();
+		String o1 = new String("one");
+		String o2 = o1;
+		String[] arr1 = new String[] { o1, o2 };
+		String[] arr2 = arr1;
+		String out = mapper.toJson(new String[][] { arr1, arr2 });
+		assertJRefCount(out, 2);
+		trace("test2DStringArrayRef jrefserialized=", out);
+		String[][] oa = mapper.fromJson(out, String[][].class);
+		assertTrue(oa[0][0] instanceof String);
+		assertTrue(oa[0][1] instanceof String);
+		assertArrayEquals(oa[0], oa[1]);
+		assertArrayEquals(oa[0], oa[1]);
+	}
+
+	@Test
+	public void testIntegerArrayRef() throws Exception {
+		Gson mapper = buildGsonJRef();
+		Integer o1 = Integer.valueOf(100);
+		Integer o2 = o1;
+		Integer[] arr = new Integer[] { o1, o2 };
+		String out = mapper.toJson(arr);
+		assertJRefCount(out, 1);
+		trace("testIntegerArrayRef jrefserialized=", out);
+		Integer[] oa = mapper.fromJson(out, Integer[].class);
+		assertTrue(oa[0] instanceof Integer);
+		assertTrue(oa[1] instanceof Integer);
+		assertEquals(oa[0], oa[1]);
+	}
+
+	@Test
+	public void test2DIntegerArrayRef() throws Exception {
+		Gson mapper = buildGsonJRef();
+		Integer o1 = Integer.valueOf(5);
+		Integer o2 = o1;
+		Integer[] arr1 = new Integer[] { o1, o2 };
+		Integer[] arr2 = arr1;
+		String out = mapper.toJson(new Integer[][] { arr1, arr2 });
+		assertJRefCount(out, 2);
+		trace("test2DStringArrayRef jrefserialized=", out);
+		Integer[][] oa = mapper.fromJson(out, Integer[][].class);
+		assertTrue(oa[0][0] instanceof Integer);
+		assertTrue(oa[0][1] instanceof Integer);
+		assertArrayEquals(oa[0], oa[1]);
+		assertArrayEquals(oa[0], oa[1]);
+	}
+
+	@Test
+	public void test3DObjectArrayRef() throws Exception {
+		Gson mapper = buildGsonJRef();
+		Object o1 = Integer.valueOf(0);
+		Object o2 = Integer.valueOf(1);
+		Object[] arr1 = new Object[] { o1, o2 };
+		Object[][] arr2d = new Object[][] { arr1, arr1 };
+		Object[][][] arr3d = new Object[][][] { arr2d, arr2d };
+
+		String out = mapper.toJson(arr3d);
+		trace("test3DObjectArrayRef jrefserialized=", out);
+		assertJRefCount(out, 2);
+
+		Object[][][] oa = mapper.fromJson(out, Object[][][].class);
+		assertArrayEquals(oa[0], oa[1]);
+		assertArrayEquals(oa[0][0], oa[0][1]);
+	}
+
+	@Test
+	public void test3DStringArrayRef() throws Exception {
+		Gson mapper = buildGsonJRef();
+		String s1 = new String("test");
+		String[] arr1 = new String[] { s1, s1 };
+		String[][] arr2d = new String[][] { arr1, arr1 };
+		String[][][] arr3d = new String[][][] { arr2d, arr2d };
+
+		String out = mapper.toJson(arr3d);
+		assertJRefCount(out, 3);
+		trace("test3DStringArrayRef jrefserialized=", out);
+
+		String[][][] oa = mapper.fromJson(out, String[][][].class);
+		assertArrayEquals(oa[0], oa[1]);
+		assertArrayEquals(oa[0][0], oa[0][1]);
+		assertEquals(oa[0][0][0], oa[0][0][1]);
+		assertTrue(oa[0][0][0] instanceof String);
+	}
+
+	@Test
+	public void test4DObjectArrayRef() throws Exception {
+		Gson mapper = buildGsonJRef();
+		Object o1 = new Object();
+		Object[] arr1 = new Object[] { o1 };
+		Object[][] arr2 = new Object[][] { arr1 };
+		Object[][][] arr3 = new Object[][][] { arr2 };
+		Object[][][][] arr4 = new Object[][][][] { arr3, arr3 };
+
+		String out = mapper.toJson(arr4);
+		assertJRefCount(out, 1);
+		trace("test4DObjectArrayRef jrefserialized=", out);
+
+		Object[][][][] oa = mapper.fromJson(out, Object[][][][].class);
+		assertArrayEquals(oa[0], oa[1]);
+		assertArrayEquals(oa[0][0], oa[1][0]);
+		assertArrayEquals(oa[0][0][0], oa[1][0][0]);
+		assertTrue(oa[0][0][0][0] instanceof Map);
+	}
+
+	@Test
+	public void test4DStringArrayRef() throws Exception {
+		Gson mapper = buildGsonJRef();
+		String s1 = new String("deep");
+		String s2 = new String("thoughts");
+		String[] arr1 = new String[] { s1, s2, s2 };
+		String[] arr1a = arr1;
+		String[][] arr2 = new String[][] { arr1, arr1a };
+		String[][] arr2a = arr2;
+		String[][][] arr3 = new String[][][] { arr2, arr2a };
+		String[][][] arr3a = arr3;
+		String[][][][] arr4 = new String[][][][] { arr3, arr3a, arr3 };
+
+		String out = mapper.toJson(arr4);
+		assertJRefCount(out, 5);
+		trace("test4DStringArrayRef jrefserialized=", out);
+
+		String[][][][] oa = mapper.fromJson(out, String[][][][].class);
+		assertArrayEquals(oa[0], oa[1]);
+		assertArrayEquals(oa[0], oa[2]);
+		assertArrayEquals(oa[0][0], oa[0][1]);
+		assertArrayEquals(oa[0][0][0], oa[0][0][1]);
+		assertEquals(oa[0][0][0][0], "deep");
+		assertEquals(oa[0][0][0][1], "thoughts");
+
+	}
+}

--- a/gson/src/test/java/com/google/gson/jref/JRefBeanPublicMemberDeserializerTest.java
+++ b/gson/src/test/java/com/google/gson/jref/JRefBeanPublicMemberDeserializerTest.java
@@ -1,0 +1,144 @@
+package com.google.gson.jref;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.google.gson.Gson;
+
+public class JRefBeanPublicMemberDeserializerTest extends JRefAbstractTest {
+
+	static class StringItems {
+		public List<String> items;
+		public String second;
+	}
+
+	@Test
+	public void testStringItems() throws Exception {
+		Gson mapper = buildGsonJRef();
+		String input = "{\"items\":[\"hello\", { \"$ref\": \"#/items/0\" }], \"second\": { \"$ref\": \"#/items/0\" }}";
+		StringItems result = mapper.fromJson(input, StringItems.class);
+		assertEquals(result.items.get(0), result.items.get(1));
+		assertEquals(result.items.get(0), result.second);
+	}
+
+	static class IntegerItems {
+		public List<Integer> items;
+	}
+
+	@Test
+	public void testIntegerItems() throws Exception {
+		Gson mapper = buildGsonJRef();
+		String input = "{\"items\":[5, { \"$ref\": \"#/items/0\" }]}";
+		IntegerItems result = mapper.fromJson(input, IntegerItems.class);
+		assertEquals(result.items.get(0), result.items.get(1));
+	}
+
+	static class DoubleItems {
+		public List<Double> items;
+	}
+
+	@Test
+	public void testDoubleItems() throws Exception {
+		Gson mapper = buildGsonJRef();
+		String input = "{\"items\":[5.0, { \"$ref\": \"#/items/0\" }]}";
+		DoubleItems result = mapper.fromJson(input, DoubleItems.class);
+		assertEquals(result.items.get(0), result.items.get(1));
+	}
+
+	static class FloatItems {
+		public List<Float> items;
+	}
+
+	@Test
+	public void testFloatItems() throws Exception {
+		Gson mapper = buildGsonJRef();
+		String input = "{\"items\":[5.0, { \"$ref\": \"#/items/0\" }]}";
+		FloatItems result = mapper.fromJson(input, FloatItems.class);
+		assertEquals(result.items.get(0), result.items.get(1));
+	}
+
+	static class BooleanItems {
+		public List<Boolean> items;
+	}
+
+	@Test
+	public void testBooleanItems() throws Exception {
+		Gson mapper = buildGsonJRef();
+		String input = "{\"items\":[true, { \"$ref\": \"#/items/0\" }]}";
+		BooleanItems result = mapper.fromJson(input, BooleanItems.class);
+		assertEquals(result.items.get(0), result.items.get(1));
+	}
+
+	static class Human {
+		public String name;
+		public Human parent;
+		public Map<String, Object> props;
+		public Human o;
+		public String otherName;
+		public Map<Object, Object> moreProps;
+
+		public Human() {
+		}
+
+		@Override
+		public String toString() {
+			return "Human[name=" + name + ", parent=" + parent + ", props=" + props + ", o=" + this.o + "]";
+		}
+
+	}
+
+	static class Message {
+		public List<Human> items;
+
+		public Message() {
+
+		}
+
+		public Message(List<Human> items) {
+			this.items = items;
+		}
+
+		@Override
+		public String toString() {
+			return "Message[items=" + items + "]";
+		}
+	}
+
+	@Test
+	public void testStringItemPath() throws Exception {
+		Gson mapper = buildGsonJRef();
+		// Input has first item in Message.items list fully defined, and second item
+		// jrefs to first item
+		String message = "{\"items\": [{ \"name\": \"sam\", \"parent\": null, \"props\": { \"p\": 1 }, \"otherName\": { \"$ref\": \"#/items/0/name\" } }]}";
+
+		Message msg = mapper.fromJson(message, Message.class);
+		assertEquals(msg.items.get(0).name, msg.items.get(0).otherName);
+	}
+
+	@Test
+	public void testCollectionStringKeyItemPath() throws Exception {
+		Gson mapper = buildGsonJRef();
+		// Input has first item in Message.items list fully defined, and second item
+		// jrefs to first item
+		String message = "{\"items\": [{ \"name\": \"sam\", \"parent\": null, \"props\": { \"p\": 1 } }, { \"$ref\": \"#/items/0\" }]}";
+
+		Message msg = mapper.fromJson(message, Message.class);
+		assertEquals(msg.items.get(0), msg.items.get(1));
+	}
+
+	@Test
+	public void testCollectionObjectKeyItemPath() throws Exception {
+		Gson mapper = buildGsonJRef();
+		// Input has first item in Message.items list fully defined, and second item
+		// jrefs to first item
+		String message = "{\"items\": [{ \"name\": \"sam\", \"parent\": null, \"props\": { \"p\": 1 } }, { \"name\": \"wendy\", \"parent\": null, \"moreProps\": { \"$ref\": \"#/items/0/props\" }}]}";
+
+		Message msg = mapper.fromJson(message, Message.class);
+		assertEquals(msg.items.get(0).props, msg.items.get(1).moreProps);
+	}
+
+}

--- a/gson/src/test/java/com/google/gson/jref/JRefCircularReferenceTests.java
+++ b/gson/src/test/java/com/google/gson/jref/JRefCircularReferenceTests.java
@@ -1,0 +1,112 @@
+package com.google.gson.jref;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.google.gson.Gson;
+
+public class JRefCircularReferenceTests extends JRefAbstractTest {
+
+	public static class Node {
+		public String name;
+		public Node child;
+		public Node sibling;
+		public List<Node> neighbors = new ArrayList<>();
+
+		public Node() {
+		}
+
+		public Node(String name) {
+			this.name = name;
+		}
+	}
+
+	public static class Graph {
+		public Node root;
+		public List<Node> allNodes = new ArrayList<>();
+	}
+
+	@Test
+	public void testNestedCircularDeserialization() throws Exception {
+		Gson mapper = buildGsonJRef();
+
+		// JSON representing a circular structure: root -> child -> child (ref to root)
+		String json = "{" + "  \"root\": {" + "    \"name\": \"parent\"," + "    \"child\": {"
+				+ "      \"name\": \"child\"," + "      \"child\": { \"$ref\": \"#/root\" }" + "    }" + "  }" + "}";
+
+		try {
+			mapper.fromJson(json, Graph.class);
+			fail();
+		} catch (Exception e) {
+			// this should be thrown by deserialization
+			// so we pass
+		}
+
+	}
+
+	@Test
+	public void testSiblingAndNeighborDeserialization() throws Exception {
+		Gson mapper = buildGsonJRef();
+
+		// JSON representing nodes where neighbors refer back to previous nodes in a
+		// list
+		String json = "{" + "  \"allNodes\": [" + "    { \"name\": \"node0\" },"
+				+ "    { \"name\": \"node1\", \"sibling\": { \"$ref\": \"#/allNodes/0\" } },"
+				+ "    { \"name\": \"node2\", \"neighbors\": [ { \"$ref\": \"#/allNodes/0\" }, { \"$ref\": \"#/allNodes/1\" } ] }"
+				+ "  ]" + "}";
+
+		Graph graph = mapper.fromJson(json, Graph.class);
+
+		assertEquals(3, graph.allNodes.size());
+		Node n0 = graph.allNodes.get(0);
+		Node n1 = graph.allNodes.get(1);
+		Node n2 = graph.allNodes.get(2);
+
+		assertEquals("node0", n0.name);
+		assertEquals("node1", n1.name);
+		assertEquals("node2", n2.name);
+
+		assertSame(n0, n1.sibling);
+		assertEquals(2, n2.neighbors.size());
+		assertSame(n0, n2.neighbors.get(0));
+		assertSame(n1, n2.neighbors.get(1));
+	}
+
+	/*
+	 * @Test public void testCircularStructureSerialization() throws Exception {
+	 * Gson mapper = buildGsonJRef();
+	 * 
+	 * Node root = new Node("root"); Node child = new Node("child"); root.child =
+	 * child; child.child = root; // Circular
+	 * 
+	 * Graph graph = new Graph(); graph.root = root; graph.allNodes.add(root);
+	 * graph.allNodes.add(child);
+	 * 
+	 * try { mapper.toJson(graph); fail(); } catch (Exception e) { // this should be
+	 * thrown by serialization // so we pass } }
+	 */
+	@Test
+	public void testNestedPathDeserialization() throws Exception {
+		Gson mapper = buildGsonJRef();
+
+		// Test resolving a path that goes through multiple levels of objects and arrays
+		String json = "{" + "  \"root\": {" + "    \"neighbors\": ["
+				+ "      { \"name\": \"neighbor0\", \"child\": { \"name\": \"inner\" } }" + "    ]" + "  },"
+				+ "  \"allNodes\": [" + "    { \"$ref\": \"#/root/neighbors/name/child/name\" }" + "  ]" + "}";
+
+		try {
+			mapper.fromJson(json, Graph.class);
+			fail();
+		} catch (Exception e) {
+			// this should be thrown by deserialization
+			// so we pass
+			System.out.println(e);
+		}
+	}
+}

--- a/gson/src/test/java/com/google/gson/jref/JRefNestedTypeTest.java
+++ b/gson/src/test/java/com/google/gson/jref/JRefNestedTypeTest.java
@@ -1,0 +1,242 @@
+package com.google.gson.jref;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.google.gson.Gson;
+
+public class JRefNestedTypeTest extends JRefAbstractTest {
+
+	public record TreeNode(TreeNode parent, String name, String data) {
+	}
+
+	private static final String ADDRESS = "Four score and seven years ago our fathers brought forth on this continent, a new nation, conceived in Liberty, and dedicated to the proposition that all men are created equal.\r\n"
+			+ "\r\n"
+			+ "Now we are engaged in a great civil war, testing whether that nation, or any nation so conceived and so dedicated, can long endure. We are met on a great battle-field of that war. We have come to dedicate a portion of that field, as a final resting place for those who here gave their lives that that nation might live. It is altogether fitting and proper that we should do this.\r\n"
+			+ "\r\n"
+			+ "But, in a larger sense, we can not dedicate -- we can not consecrate -- we can not hallow -- this ground. The brave men, living and dead, who struggled here, have consecrated it, far above our poor power to add or detract. The world will little note, nor long remember what we say here, but it can never forget what they did here. It is for us the living, rather, to be dedicated here to the unfinished work which they who fought here have thus far so nobly advanced. It is rather for us to be here dedicated to the great task remaining before us -- that from these honored dead we take increased devotion to that cause for which they gave the last full measure of devotion -- that we here highly resolve that these dead shall not have died in vain -- that this nation, under God, shall have a new birth of freedom -- and that government of the people, by the people, for the people, shall not perish from the earth.";
+
+	TreeNode[] buildTwoLevelTopArray() {
+		TreeNode topNode = new TreeNode(null, "top", ADDRESS);
+		// Create three children
+		TreeNode firstChild = new TreeNode(topNode, "child1", "data1");
+		TreeNode secondChild = new TreeNode(topNode, "child2", "data2");
+		TreeNode thirdChild = new TreeNode(topNode, "child3", "data3");
+		// Put top and all nodes in array
+		return new TreeNode[] { topNode, firstChild, secondChild, thirdChild };
+	}
+
+	TreeNode[] buildTwoLevelNoTopArray() {
+		TreeNode topNode = new TreeNode(null, "top", ADDRESS);
+		// Create three children
+		TreeNode firstChild = new TreeNode(topNode, "child1", "data1");
+		TreeNode secondChild = new TreeNode(topNode, "child2", "data2");
+		TreeNode thirdChild = new TreeNode(topNode, "child3", "data3");
+		// Put child nodes in array
+		return new TreeNode[] { firstChild, secondChild, thirdChild };
+	}
+
+	static String JREF_JSON = "[ {\r\n" + "  \"parent\" : null,\r\n" + "  \"name\" : \"top\",\r\n"
+			+ "  \"data\" : \"Four score and seven years ago our fathers brought forth on this continent, a new nation, conceived in Liberty, and dedicated to the proposition that all men are created equal.\\r\\n\\r\\nNow we are engaged in a great civil war, testing whether that nation, or any nation so conceived and so dedicated, can long endure. We are met on a great battle-field of that war. We have come to dedicate a portion of that field, as a final resting place for those who here gave their lives that that nation might live. It is altogether fitting and proper that we should do this.\\r\\n\\r\\nBut, in a larger sense, we can not dedicate -- we can not consecrate -- we can not hallow -- this ground. The brave men, living and dead, who struggled here, have consecrated it, far above our poor power to add or detract. The world will little note, nor long remember what we say here, but it can never forget what they did here. It is for us the living, rather, to be dedicated here to the unfinished work which they who fought here have thus far so nobly advanced. It is rather for us to be here dedicated to the great task remaining before us -- that from these honored dead we take increased devotion to that cause for which they gave the last full measure of devotion -- that we here highly resolve that these dead shall not have died in vain -- that this nation, under God, shall have a new birth of freedom -- and that government of the people, by the people, for the people, shall not perish from the earth.\"\r\n"
+			+ "}, {\r\n" + "  \"parent\" : {\r\n" + "    \"$ref\" : \"#/0\"\r\n" + "  },\r\n"
+			+ "  \"name\" : \"child1\",\r\n" + "  \"data\" : \"data1\"\r\n" + "}, {\r\n" + "  \"parent\" : {\r\n"
+			+ "    \"$ref\" : \"#/0\"\r\n" + "  },\r\n" + "  \"name\" : \"child2\",\r\n" + "  \"data\" : \"data2\"\r\n"
+			+ "}, {\r\n" + "  \"parent\" : {\r\n" + "    \"$ref\" : \"#/0\"\r\n" + "  },\r\n"
+			+ "  \"name\" : \"child3\",\r\n" + "  \"data\" : \"data3\"\r\n" + "} ]";
+
+	@Test
+	public void testDeerializeTwoLevelTreeThreeChildrenJRef() {
+		Gson mapper = buildGsonJRef();
+		TreeNode[] nodes = mapper.fromJson(JREF_JSON, TreeNode[].class);
+		assertEquals(nodes[0], nodes[1].parent);
+		assertEquals(nodes[0], nodes[2].parent);
+		assertEquals(nodes[0], nodes[3].parent);
+	}
+
+	@Test
+	public void testTwoLevelTreeNoJRefNoTop() {
+		TreeNode[] nodes = buildTwoLevelNoTopArray();
+		Gson mapper = buildGsonNoJRef();
+		String json = mapper.toJson(nodes);
+		// two jrefs
+		assertJRefCount(json, 0);
+		trace("testTwoLevelTreeNoJRefNoTop json=", json);
+		TreeNode[] out = mapper.fromJson(json, TreeNode[].class);
+		assertTrue(out.length == 3);
+		assertEquals(out[0].parent, out[1].parent);
+		assertEquals(out[0].parent, out[2].parent);
+	}
+
+	@Test
+	public void testTwoLevelTreeNoJRefWithTop() {
+		TreeNode[] nodes = buildTwoLevelTopArray();
+		// Object mapper without JRefModule
+		Gson mapper = buildGsonNoJRef();
+		String json = mapper.toJson(nodes);
+		// No jrefs
+		assertJRefCount(json, 0);
+		trace("testTwoLevelTreeNoJRef json=", json);
+		TreeNode[] out = mapper.fromJson(json, TreeNode[].class);
+		assertEquals(out.length, 4);
+		assertEquals(out[0], out[1].parent);
+		assertEquals(out[0], out[2].parent);
+		assertEquals(out[0], out[3].parent);
+	}
+
+	@Test
+	public void testTwoLevelTreeJRefNoTop() {
+		TreeNode[] nodes = buildTwoLevelNoTopArray();
+		Gson mapper = buildGsonJRef();
+		String json = mapper.toJson(nodes);
+		// two jrefs
+		assertJRefCount(json, 2);
+		trace("testTwoLevelTreeNoJRefNoTop json=", json);
+		TreeNode[] out = mapper.fromJson(json, TreeNode[].class);
+		assertTrue(out.length == 3);
+		assertEquals(out[0].parent, out[1].parent);
+		assertEquals(out[0].parent, out[2].parent);
+	}
+
+	@Test
+	public void testTwoLevelTreeJRefWithTop() {
+		TreeNode[] nodes = buildTwoLevelTopArray();
+		// Object mapper without JRefModule
+		Gson mapper = buildGsonJRef();
+		String json = mapper.toJson(nodes);
+		// No jrefs
+		assertJRefCount(json, 3);
+		trace("testTwoLevelTreeNoJRef json=", json);
+		TreeNode[] out = mapper.fromJson(json, TreeNode[].class);
+		assertEquals(out.length, 4);
+		assertEquals(out[0], out[1].parent);
+		assertEquals(out[0], out[2].parent);
+		assertEquals(out[0], out[3].parent);
+	}
+
+	TreeNode[] buildThreeLevelArray() {
+		TreeNode topNode = new TreeNode(null, "top", ADDRESS);
+		// Create three children
+		TreeNode firstChild = new TreeNode(topNode, "child1", "data1");
+		TreeNode firstGChild = new TreeNode(firstChild, "gchild1", "data1g");
+		TreeNode secondChild = new TreeNode(topNode, "child2", "data2");
+		TreeNode secondGChild = new TreeNode(secondChild, "gchild2", "data2g");
+		TreeNode thirdChild = new TreeNode(topNode, "child3", "data3");
+		TreeNode thirdGChild = new TreeNode(thirdChild, "child", "data3g");
+
+		// Put grandchildren nodes in array
+		return new TreeNode[] { firstGChild, secondGChild, thirdGChild };
+	}
+
+	@Test
+	public void testThreeLevelTree() {
+		TreeNode[] nodes = buildThreeLevelArray();
+		Gson mapper = buildGsonJRef();
+		String json = mapper.toJson(nodes);
+		// two jrefs
+		assertJRefCount(json, 2);
+		trace("testThreeLevelTree json=", json);
+		TreeNode[] out = mapper.fromJson(json, TreeNode[].class);
+		assertTrue(out.length == 3);
+		assertEquals(out[0].parent.parent, out[1].parent.parent);
+		assertEquals(out[0].parent.parent, out[2].parent.parent);
+	}
+
+	List<TreeNode> buildThreeLevelArrayAsList() {
+		TreeNode topNode = new TreeNode(null, "top", ADDRESS);
+		// Create three children
+		TreeNode firstChild = new TreeNode(topNode, "child1", "data1");
+		TreeNode firstGChild = new TreeNode(firstChild, "gchild1", "data1g");
+		TreeNode secondChild = new TreeNode(topNode, "child2", "data2");
+		TreeNode secondGChild = new TreeNode(secondChild, "gchild2", "data2g");
+		TreeNode thirdChild = new TreeNode(topNode, "child3", "data3");
+		TreeNode thirdGChild = new TreeNode(thirdChild, "child", "data3g");
+
+		// Put grandchildren nodes in List
+		return List.of(firstGChild, secondGChild, thirdGChild);
+	}
+
+	public record TreeNodeList(List<TreeNode> nodes) {
+	}
+
+	@Test
+	public void testThreeLevelTreeNodeListRecord() {
+		List<TreeNode> nodes = buildThreeLevelArrayAsList();
+		TreeNodeList tnl = new TreeNodeList(nodes);
+		Gson mapper = buildGsonJRef();
+		String json = mapper.toJson(tnl);
+		// two jrefs
+		assertJRefCount(json, 2);
+		trace("testThreeLevelTreeNodeListRecord json=", json);
+		TreeNodeList out = mapper.fromJson(json, TreeNodeList.class);
+		assertTrue(out.nodes().size() == 3);
+		assertEquals(out.nodes().get(0).parent.parent, out.nodes().get(1).parent.parent);
+		assertEquals(out.nodes().get(0).parent.parent, out.nodes().get(2).parent.parent);
+	}
+
+	static class TreeNodeListClass {
+
+		public List<TreeNode> nodes;
+
+	}
+
+	@Test
+	public void testThreeLevelTreeNodeListClass() {
+		TreeNodeListClass tnlc = new TreeNodeListClass();
+		tnlc.nodes = buildThreeLevelArrayAsList();
+		Gson mapper = buildGsonJRef();
+		String json = mapper.toJson(tnlc);
+		// two jrefs
+		assertJRefCount(json, 2);
+		trace("testThreeLevelTreeNodeListClass json=", json);
+		TreeNodeListClass out = mapper.fromJson(json, TreeNodeListClass.class);
+		assertTrue(out.nodes.size() == 3);
+		assertEquals(out.nodes.get(0).parent.parent, out.nodes.get(1).parent.parent);
+		assertEquals(out.nodes.get(0).parent.parent, out.nodes.get(2).parent.parent);
+	}
+
+	Map<String, TreeNode> buildThreeLevelArrayAsMap() {
+		TreeNode topNode = new TreeNode(null, "top", ADDRESS);
+		// Create three children
+		TreeNode firstChild = new TreeNode(topNode, "child1", "data1");
+		TreeNode firstGChild = new TreeNode(firstChild, "gchild1", "data1g");
+		TreeNode secondChild = new TreeNode(topNode, "child2", "data2");
+		TreeNode secondGChild = new TreeNode(secondChild, "gchild2", "data2g");
+		TreeNode thirdChild = new TreeNode(topNode, "child3", "data3");
+		TreeNode thirdGChild = new TreeNode(thirdChild, "child", "data3g");
+
+		// Put grandchildren nodes in Map
+		return Map.of(firstGChild.name, firstGChild, secondGChild.name, secondGChild, thirdGChild.name, thirdGChild);
+	}
+
+	public record TreeNodeMapRecord(Map<String, TreeNode> nodes) {
+	}
+
+	@Test
+	public void testThreeLevelTreeNodeMapRecord() {
+		TreeNodeMapRecord tnmr = new TreeNodeMapRecord(buildThreeLevelArrayAsMap());
+		Gson mapper = buildGsonJRef();
+		String json = mapper.toJson(tnmr);
+		// two jrefs
+		assertJRefCount(json, 2);
+		trace("testThreeLevelTreeNodeMapRecord json=", json);
+		TreeNodeMapRecord out = mapper.fromJson(json, TreeNodeMapRecord.class);
+		assertTrue(out.nodes.size() == 3);
+		out.nodes().forEach((k, v) -> {
+			assertEquals(k, v.name);
+		});
+		TreeNode first = null;
+		for (Map.Entry<String, TreeNode> entry : out.nodes().entrySet()) {
+			if (first == null) {
+				first = entry.getValue();
+			} else {
+				assertEquals(first.parent.parent, entry.getValue().parent.parent);
+			}
+		}
+	}
+
+}

--- a/gson/src/test/java/com/google/gson/jref/JRefRecordBeanTest.java
+++ b/gson/src/test/java/com/google/gson/jref/JRefRecordBeanTest.java
@@ -1,0 +1,94 @@
+package com.google.gson.jref;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.google.gson.Gson;
+
+public class JRefRecordBeanTest extends JRefAbstractTest {
+
+	static record IntBean(Integer j) {
+	}
+
+	@Test
+	public void testIntBeanArray() throws Exception {
+		Gson mapper = buildGsonJRef();
+		IntBean i1 = new IntBean(10);
+		IntBean i2 = new IntBean(20);
+		IntBean[] beans = new IntBean[] { i1, i2, i1, i2 };
+		String out = mapper.toJson(beans);
+		trace("testIntBeanArray", out);
+		IntBean[] result = mapper.fromJson(out, IntBean[].class);
+		assertEquals(result[0], result[2]);
+		assertEquals(result[1], result[3]);
+	}
+
+	/*
+	 * @Test public void testIntBeanList() throws Exception { Gson mapper =
+	 * buildGsonJRef(); IntBean i1 = new IntBean(10); IntBean i2 = new IntBean(20);
+	 * List<IntBean> beans = List.of(i1, i2, i1, i2); String out =
+	 * mapper.toJson(beans); trace("testIntBeanList", out);
+	 * 
+	 * @SuppressWarnings("unchecked") List<IntBean> result = (List<IntBean>)
+	 * mapper.fromJson(out, List.class); assertEquals(result.get(0), result.get(2));
+	 * assertEquals(result.get(1), result.get(3)); }
+	 */
+	record StringKeyBeanMap(Map<String, IntBean> items) {
+	}
+
+	@Test
+	public void testStringKeyMap() throws Exception {
+		Gson mapper = buildGsonJRef();
+		IntBean i1 = new IntBean(10);
+		IntBean i2 = new IntBean(20);
+		StringKeyBeanMap beanMap = new StringKeyBeanMap(Map.of("one", i1, "two", i2, "three", i1, "four", i2));
+		String out = mapper.toJson(beanMap);
+		trace("testIntBeanStringKeyMap", out);
+		StringKeyBeanMap result = mapper.fromJson(out, StringKeyBeanMap.class);
+		assertEquals(result.items().get("one"), result.items().get("three"));
+		assertEquals(result.items().get("two"), result.items().get("four"));
+	}
+
+	record Node(Node parent, String name) {
+	}
+
+	record NodeList(List<Node> nodes) {
+
+	}
+
+	@Test
+	public void testNodeTree() throws Exception {
+		Gson mapper = buildGsonJRef();
+		Node root = new Node(null, "root");
+		String[] nodeNames = new String[] { "child1", "child2", "child3" };
+		List<Node> nodeList = new ArrayList<>();
+		for (int i = 0; i < nodeNames.length; i++) {
+			nodeList.add(new Node(root, nodeNames[i]));
+		}
+		// Add references to previously added nodes in reverse order
+		nodeList.add(nodeList.get(2));
+		nodeList.add(nodeList.get(1));
+		nodeList.add(nodeList.get(0));
+		String out = mapper.toJson(new NodeList(nodeList));
+		trace("testNodeTree", out);
+		NodeList result = mapper.fromJson(out, NodeList.class);
+		List<Node> nodes = result.nodes();
+		// assert nodes list same as input
+		assertEquals(nodeList.size(), nodes.size());
+		for (int firstIndex = 0; firstIndex < nodeList.size() / 2; firstIndex++) {
+			int secondIndex = (nodeList.size() - 1) - firstIndex;
+			Node n1 = result.nodes().get(firstIndex);
+			assertEquals(root.name(), n1.parent().name());
+			Node n2 = result.nodes().get(secondIndex);
+			assertEquals(root.name(), n2.parent().name());
+			assertEquals(n1, n2);
+
+		}
+	}
+
+}


### PR DESCRIPTION
The purpose of this pull request is to add support for the enhancement #1443.

The pr implements the [JRef 'local-only' specification](https://github.com/hyperjump-io/json-reference/blob/main/spec.md). Local-pnly means that only json pointers starting with '#' (local to the document) are supported.

The main two classes for the implementation are JRefTypeAdapter and JRefTypeAdapterFactory.  The JRefTypeAdapterFactory implements the Gson TypeAdapterFactory and creates instances of JRefTypeAdapter.

JRefTypeAdapter implements Gson TypeAdapter and so implements the write (serialization) and read (deserialization) with JRef support.

Two support classes from the [Jackson 3.0 databind project](https://github.com/FasterXML/jackson-databind) have been included as part of this contribution, with permission from the Jackson maintainer: @cowtowncoder.  [Please see this dialog](https://github.com/FasterXML/jackson-databind/pull/6027#issuecomment-4763834920) about these two classes.  The two classes from Jackson are:
JsonPointer (implementation of the rfc-6901 json pointer specification for local-only json pointers).  Also includes parent/child ptr creation/validation/compare code.

TokenStreamContext - Allows the creation of a context for parsers (like Jackson and Gson) that treat the wirting and reading of json as a sequentially processed stream of tokens.  This class is used within JsonPointer to go back and forth between JsonPointers as strings (e.g. /foo/bar/0) and JsonPointers as parent and child contexts (e.g. /foo parent for bar parent for /0 container element 0).

The JRefTypeAdapter. uses the JsonReader.getPath() (json path syntax...e.g. $foo, $bar[0]) in order to  get a contextual name from the token stream, and contruct JsonPointer instances during deserialization.  See JRefTypeAdapter.read(JsonReader) and JRefTypeAdapter.getJsonPointerFromJsonPath methods.

The only modification to an existing Gson class, other than new classes described above is the addition of a single method to JsonWriter class

```java
  public String getDeferredName() {
	  return this.deferredName;
  }
 ```
This method is used in the JRefTypeAdapter.write method to get the deferred name in serialization context where required (e.g. objects, and containers).

Also included in this pr are test classes, in the test src tree in new package named com.google.gson.jref package.

All tests are passing using junit 4.

I'm happy to break this up into multiple prs (e.g. gson changes, jref impl, tests) if desired.  Or to refactor.