### PR TITLE
Bump Error Prone to 2.50.0

### DIFF
--- a/extras/src/test/java/com/google/gson/interceptors/InterceptorTest.java
+++ b/extras/src/test/java/com/google/gson/interceptors/InterceptorTest.java
@@ -163,6 +163,7 @@ public final class InterceptorTest {
     }
   }
 
+  @SuppressWarnings("ExposedPrivateType")
   public static final class UserValidator implements JsonPostDeserializer<User> {
     @Override
     public void postDeserialize(User user) {
@@ -186,6 +187,7 @@ public final class InterceptorTest {
     String zip;
   }
 
+  @SuppressWarnings("ExposedPrivateType")
   public static final class AddressValidator implements JsonPostDeserializer<Address> {
     @Override
     public void postDeserialize(Address address) {

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_annotations</artifactId>
-      <version>2.49.0</version>
+      <version>2.50.0</version>
     </dependency>
 
     <dependency>

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -480,7 +480,9 @@ public final class Gson {
     boolean skipPastFound = false;
     for (TypeAdapterFactory factory : factories) {
       if (!skipPastFound) {
-        if (factory == skipPast) {
+        @SuppressWarnings("ReferenceEquality")
+        boolean isSkipPast = factory == skipPast;
+        if (isSkipPast) {
           skipPastFound = true;
         }
         continue;

--- a/gson/src/main/java/com/google/gson/internal/GsonTypes.java
+++ b/gson/src/main/java/com/google/gson/internal/GsonTypes.java
@@ -169,7 +169,9 @@ public final class GsonTypes {
 
   /** Returns true if {@code a} and {@code b} are equal. */
   public static boolean equals(Type a, Type b) {
-    if (a == b) {
+    @SuppressWarnings("ReferenceEquality")
+    boolean areSame = a == b;
+    if (areSame) {
       // also handles (a == null && b == null)
       return true;
 
@@ -366,7 +368,9 @@ public final class GsonTypes {
         }
 
         toResolve = resolveTypeVariable(context, contextRawType, typeVariable);
-        if (toResolve == typeVariable) {
+        @SuppressWarnings("ReferenceEquality")
+        boolean areSame = toResolve == typeVariable;
+        if (areSame) {
           break;
         }
 
@@ -421,14 +425,14 @@ public final class GsonTypes {
         if (originalLowerBound.length == 1) {
           Type lowerBound =
               resolve(context, contextRawType, originalLowerBound[0], visitedTypeVariables);
-          if (lowerBound != originalLowerBound[0]) {
+          if (!equal(lowerBound, originalLowerBound[0])) {
             toResolve = supertypeOf(lowerBound);
             break;
           }
         } else if (originalUpperBound.length == 1) {
           Type upperBound =
               resolve(context, contextRawType, originalUpperBound[0], visitedTypeVariables);
-          if (upperBound != originalUpperBound[0]) {
+          if (!equal(upperBound, originalUpperBound[0])) {
             toResolve = subtypeOf(upperBound);
             break;
           }

--- a/gson/src/main/java/com/google/gson/internal/bind/JsonAdapterAnnotationTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonAdapterAnnotationTypeAdapterFactory.java
@@ -35,7 +35,7 @@ import java.util.concurrent.ConcurrentMap;
  * @since 2.3
  */
 public final class JsonAdapterAnnotationTypeAdapterFactory implements TypeAdapterFactory {
-  private static class DummyTypeAdapterFactory implements TypeAdapterFactory {
+  private static final class DummyTypeAdapterFactory implements TypeAdapterFactory {
     @Override
     public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
       throw new AssertionError("Factory should not be used");
@@ -43,11 +43,11 @@ public final class JsonAdapterAnnotationTypeAdapterFactory implements TypeAdapte
   }
 
   /** Factory used for {@link TreeTypeAdapter}s created for {@code @JsonAdapter} on a class. */
-  private static final TypeAdapterFactory TREE_TYPE_CLASS_DUMMY_FACTORY =
+  private static final DummyTypeAdapterFactory TREE_TYPE_CLASS_DUMMY_FACTORY =
       new DummyTypeAdapterFactory();
 
   /** Factory used for {@link TreeTypeAdapter}s created for {@code @JsonAdapter} on a field. */
-  private static final TypeAdapterFactory TREE_TYPE_FIELD_DUMMY_FACTORY =
+  private static final DummyTypeAdapterFactory TREE_TYPE_FIELD_DUMMY_FACTORY =
       new DummyTypeAdapterFactory();
 
   private final ConstructorConstructor constructorConstructor;
@@ -161,6 +161,12 @@ public final class JsonAdapterAnnotationTypeAdapterFactory implements TypeAdapte
     return typeAdapter;
   }
 
+  @SuppressWarnings("ReferenceEquality")
+  private static boolean areSameFactories(TypeAdapterFactory a, TypeAdapterFactory b) {
+    // Checks for reference equality, like it is done by `Gson.getDelegateAdapter`
+    return a == b;
+  }
+
   /**
    * Returns whether {@code factory} is a type adapter factory created for {@code @JsonAdapter}
    * placed on {@code type}.
@@ -178,8 +184,7 @@ public final class JsonAdapterAnnotationTypeAdapterFactory implements TypeAdapte
 
     TypeAdapterFactory existingFactory = adapterFactoryMap.get(rawType);
     if (existingFactory != null) {
-      // Checks for reference equality, like it is done by `Gson.getDelegateAdapter`
-      return existingFactory == factory;
+      return areSameFactories(existingFactory, factory);
     }
 
     // If no factory has been created for the type yet check manually for a @JsonAdapter annotation
@@ -198,7 +203,8 @@ public final class JsonAdapterAnnotationTypeAdapterFactory implements TypeAdapte
 
     Object adapter = createAdapter(constructorConstructor, adapterClass);
     TypeAdapterFactory newFactory = (TypeAdapterFactory) adapter;
+    newFactory = putFactoryAndGetCurrent(rawType, newFactory);
 
-    return putFactoryAndGetCurrent(rawType, newFactory) == factory;
+    return areSameFactories(newFactory, factory);
   }
 }

--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
@@ -122,6 +122,9 @@ public final class JsonTreeReader extends JsonReader {
         && token != JsonToken.END_DOCUMENT;
   }
 
+  // TODO: Suppression is likely redundant once https://github.com/google/error-prone/pull/5895
+  //   is released
+  @SuppressWarnings("ReferenceEquality")
   @Override
   public JsonToken peek() throws IOException {
     if (stackSize == 0) {

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -243,7 +243,10 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
         } else {
           fieldValue = field.get(source);
         }
-        if (fieldValue == source) {
+
+        @SuppressWarnings("ReferenceEquality")
+        boolean isSameObject = fieldValue == source;
+        if (isSameObject) {
           // avoid direct recursion
           return;
         }
@@ -474,7 +477,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
   public abstract static class Adapter<T, A> extends TypeAdapter<T> {
     private final FieldsData fieldsData;
 
-    Adapter(FieldsData fieldsData) {
+    private Adapter(FieldsData fieldsData) {
       this.fieldsData = fieldsData;
     }
 

--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapterRuntimeTypeWrapper.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapterRuntimeTypeWrapper.java
@@ -51,7 +51,10 @@ final class TypeAdapterRuntimeTypeWrapper<T> extends TypeAdapter<T> {
 
     TypeAdapter<T> chosen = delegate;
     Type runtimeType = getRuntimeTypeIfMoreSpecific(type, value);
-    if (runtimeType != type) {
+
+    @SuppressWarnings("ReferenceEquality")
+    boolean isDifferentType = runtimeType != type;
+    if (isDifferentType) {
       @SuppressWarnings("unchecked")
       TypeAdapter<T> runtimeTypeAdapter =
           (TypeAdapter<T>) context.getAdapter(TypeToken.get(runtimeType));
@@ -83,8 +86,10 @@ final class TypeAdapterRuntimeTypeWrapper<T> extends TypeAdapter<T> {
     while (typeAdapter instanceof SerializationDelegatingTypeAdapter) {
       TypeAdapter<?> delegate =
           ((SerializationDelegatingTypeAdapter<?>) typeAdapter).getSerializationDelegate();
-      // Break if adapter does not delegate serialization
-      if (delegate == typeAdapter) {
+
+      @SuppressWarnings("ReferenceEquality")
+      boolean hasNoDelegate = delegate == typeAdapter;
+      if (hasNoDelegate) {
         break;
       }
       typeAdapter = delegate;

--- a/gson/src/test/java/com/google/gson/functional/ParameterizedTypesTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ParameterizedTypesTest.java
@@ -481,7 +481,7 @@ public class ParameterizedTypesTest {
 
   private interface Immutable {}
 
-  public static final class Amount<Q extends Quantity>
+  private static final class Amount<Q extends Quantity>
       implements Measurable<Q>, Field<Amount<?>>, Serializable, Immutable {
     private static final long serialVersionUID = -7560491093120970437L;
 

--- a/metrics/src/main/java/com/google/gson/metrics/ParseBenchmark.java
+++ b/metrics/src/main/java/com/google/gson/metrics/ParseBenchmark.java
@@ -55,6 +55,7 @@ import java.util.zip.ZipFile;
  * <p>This benchmark requires that ParseBenchmarkData.zip is on the classpath. That file contains
  * Twitter feed data, which is representative of what applications will be parsing.
  */
+@SuppressWarnings("ExposedPrivateType")
 public final class ParseBenchmark {
   @Param Document document;
   @Param Api api;

--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
               <path>
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_core</artifactId>
-                <version>2.49.0</version>
+                <version>2.50.0</version>
               </path>
             </annotationProcessorPaths>
           </configuration>


### PR DESCRIPTION
### Purpose
Bumps Error Prone to 2.50.0 and fixes new warnings
Unblocks #3051

### Description
The change to the Error Prone check `ReferenceEquality` and the new check `ExposedPrivateType` required some code changes.