### PR TITLE
Cache reflective accessibility check result per BoundField

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -183,11 +183,11 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
 
   /**
    * Caches the result of {@link ReflectionAccessFilterHelper#canAccess} for a single (non-static)
-   * member, so the reflective check only has to run once per {@code BoundField} instead of on
-   * every {@link BoundField#write} or {@link BoundField#readIntoField} call. The result only
-   * depends on the member itself and the {@code ReflectionAccessFilter}s configured for the
-   * enclosing {@code Gson} instance, not on the specific object instance being serialized or
-   * deserialized, so it is safe to compute it lazily on the first check and reuse it afterwards.
+   * member, so the reflective check only has to run once per {@code BoundField} instead of on every
+   * {@link BoundField#write} or {@link BoundField#readIntoField} call. The result only depends on
+   * the member itself and the {@code ReflectionAccessFilter}s configured for the enclosing {@code
+   * Gson} instance, not on the specific object instance being serialized or deserialized, so it is
+   * safe to compute it lazily on the first check and reuse it afterwards.
    */
   private static final class AccessibleCache<M extends AccessibleObject & Member> {
     private static final String ACCESSIBLE = "";

--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -169,12 +169,49 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
       Object object, M member) {
     if (!ReflectionAccessFilterHelper.canAccess(
         member, Modifier.isStatic(member.getModifiers()) ? null : object)) {
-      String memberDescription = ReflectionHelper.getAccessibleObjectDescription(member, true);
-      throw new JsonIOException(
-          memberDescription
-              + " is not accessible and ReflectionAccessFilter does not permit making it"
-              + " accessible. Register a TypeAdapter for the declaring type, adjust the access"
-              + " filter or increase the visibility of the element and its declaring type.");
+      throw new JsonIOException(getInaccessibleMessage(member));
+    }
+  }
+
+  private static <M extends AccessibleObject & Member> String getInaccessibleMessage(M member) {
+    String memberDescription = ReflectionHelper.getAccessibleObjectDescription(member, true);
+    return memberDescription
+        + " is not accessible and ReflectionAccessFilter does not permit making it"
+        + " accessible. Register a TypeAdapter for the declaring type, adjust the access"
+        + " filter or increase the visibility of the element and its declaring type.";
+  }
+
+  /**
+   * Caches the result of {@link ReflectionAccessFilterHelper#canAccess} for a single (non-static)
+   * member, so the reflective check only has to run once per {@code BoundField} instead of on
+   * every {@link BoundField#write} or {@link BoundField#readIntoField} call. The result only
+   * depends on the member itself and the {@code ReflectionAccessFilter}s configured for the
+   * enclosing {@code Gson} instance, not on the specific object instance being serialized or
+   * deserialized, so it is safe to compute it lazily on the first check and reuse it afterwards.
+   */
+  private static final class AccessibleCache<M extends AccessibleObject & Member> {
+    private static final String ACCESSIBLE = "";
+
+    private final M member;
+    // null until first check; ACCESSIBLE represents 'member is accessible'
+    private volatile String inaccessibleMessage;
+
+    AccessibleCache(M member) {
+      this.member = member;
+    }
+
+    void check(Object object) {
+      String message = inaccessibleMessage;
+      if (message == null) {
+        boolean accessible =
+            ReflectionAccessFilterHelper.canAccess(
+                member, Modifier.isStatic(member.getModifiers()) ? null : object);
+        message = accessible ? ACCESSIBLE : getInaccessibleMessage(member);
+        inaccessibleMessage = message;
+      }
+      if (!message.isEmpty()) {
+        throw new JsonIOException(message);
+      }
     }
   }
 
@@ -217,16 +254,23 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
       // Will never actually be used, but we set it to avoid confusing nullness-analysis tools
       writeTypeAdapter = typeAdapter;
     }
+    // Only used when blockInaccessible is true; created once per field/accessor here instead of
+    // performing the (identical) reflective accessibility check on every write()/readIntoField()
+    // call.
+    AccessibleCache<Field> fieldAccessCache =
+        blockInaccessible ? new AccessibleCache<>(field) : null;
+    AccessibleCache<Method> accessorAccessCache =
+        blockInaccessible && accessor != null ? new AccessibleCache<>(accessor) : null;
     return new BoundField(serializedName, field) {
       @Override
       void write(JsonWriter writer, Object source) throws IOException, IllegalAccessException {
         if (blockInaccessible) {
           if (accessor == null) {
-            checkAccessible(source, field);
+            fieldAccessCache.check(source);
           } else {
             // Note: This check might actually be redundant because access check for canonical
             // constructor should have failed already
-            checkAccessible(source, accessor);
+            accessorAccessCache.check(source);
           }
         }
 
@@ -271,7 +315,7 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
         Object fieldValue = typeAdapter.read(reader);
         if (fieldValue != null || !isPrimitive) {
           if (blockInaccessible) {
-            checkAccessible(target, field);
+            fieldAccessCache.check(target);
           } else if (isStaticFinalField) {
             // Reflection does not permit setting value of `static final` field, even after calling
             // `setAccessible`


### PR DESCRIPTION
Closes #2202

`checkAccessible` calls `ReflectionAccessFilterHelper.canAccess` reflectively on every single `write()` and `readIntoField()` call when `blockInaccessible` is true, even though the result only depends on the field/accessor and the `ReflectionAccessFilter`s configured on the `Gson` instance, not on the specific object being serialized or deserialized. So for repeated (de)serialization of many instances of the same type, the exact same reflective check gets redone for every single object.

This adds a small `AccessibleCache` per `BoundField` that runs the check lazily on the first `write()`/`readIntoField()` call and caches the result (accessible, or the inaccessible message) for reuse afterwards, so the reflective check effectively runs once per field/accessor instead of once per object.

The constructor accessibility check for records (`RecordAdapter`) already only runs once at adapter creation time, so it did not need this change.

### Testing

I don't have a maven setup in the environment I worked in, so I could not run `mvn clean verify`. To still verify correctness I compiled the `gson` module's main sources directly with `javac` (stubbing out the generated `GsonBuildConfig` and pulling `error_prone_annotations` from Maven Central), then compiled and ran the existing `ReflectionAccessFilterTest` and `ReflectionAccessTest` against it with JUnit + Truth pulled from Maven Central:

- `ReflectionAccessFilterTest`: all 15 tests pass.
- `ReflectionAccessTest`: 2/3 pass; the third (`testRestrictiveSecurityManager`) fails both with and without my change, with a `BootstrapMethodError` coming from `Truth`'s lambda metafactory colliding with a custom `SecurityManager` under JDK 17, so it's a pre-existing environment issue unrelated to this change, not a regression.

I also wrote a small standalone repro exercising a `Gson` configured with a `BLOCK_INACCESSIBLE` filter: a public field serializes/deserializes correctly across repeated calls (the cached "accessible" result gets reused), and a private field consistently throws `JsonIOException` on every call (the cached "inaccessible" result doesn't get lost or silently become a false positive after the first check).

Would appreciate someone running the full `mvn clean verify` on CI to double check, since I couldn't do that locally.