### PR TITLE
Throw JsonSyntaxException for null map keys in array form

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
@@ -187,6 +187,9 @@ public final class MapTypeAdapterFactory implements TypeAdapterFactory {
         while (in.hasNext()) {
           in.beginArray(); // entry array
           K key = keyTypeAdapter.read(in);
+          if (key == null) {
+            throw new JsonSyntaxException("Map key is null");
+          }
           V value = valueTypeAdapter.read(in);
           if (map.containsKey(key)) {
             throw new JsonSyntaxException("duplicate key: " + key);
@@ -200,6 +203,9 @@ public final class MapTypeAdapterFactory implements TypeAdapterFactory {
         while (in.hasNext()) {
           JsonReaderInternalAccess.INSTANCE.promoteNameToValue(in);
           K key = keyTypeAdapter.read(in);
+          if (key == null) {
+            throw new JsonSyntaxException("Map key is null");
+          }
           V value = valueTypeAdapter.read(in);
           if (map.containsKey(key)) {
             throw new JsonSyntaxException("duplicate key: " + key);

--- a/gson/src/test/java/com/google/gson/functional/MapAsArrayTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MapAsArrayTypeAdapterTest.java
@@ -91,6 +91,15 @@ public class MapAsArrayTypeAdapterTest {
   }
 
   @Test
+  public void testNullKeyArrayForm() {
+    Gson gson = new Gson();
+    Type type = new TypeToken<Map<String, Object>>() {}.getType();
+    JsonSyntaxException e =
+        assertThrows(JsonSyntaxException.class, () -> gson.fromJson("[[null,1]]", type));
+    assertThat(e).hasMessageThat().isEqualTo("Map key is null");
+  }
+
+  @Test
   public void testMultipleEnableComplexKeyRegistrationHasNoEffect() {
     Type type = new TypeToken<Map<Point, String>>() {}.getType();
     Gson gson =


### PR DESCRIPTION
Fixes #3037

## Summary
- Reject `null` map keys in `MapTypeAdapterFactory.Adapter.read` before insertion
- Throw `JsonSyntaxException` instead of letting `LinkedTreeMap.put` surface an unchecked `NullPointerException`

## Root cause
Array-encoded map entries (`[[key, value], ...]`) decode a JSON `null` key to Java `null` and pass it straight to the backing map. `LinkedTreeMap` rejects that with `NullPointerException: key == null`, which escapes Gson's documented `JsonParseException` error contract.

## Test plan
- [x] `mvn -pl gson -Dtest=MapAsArrayTypeAdapterTest test`
- [x] `mvn -pl gson -Dtest=MapTest,MapAsArrayTypeAdapterTest test`