### PR TITLE
Use LinkedHashMap as the default Map.

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
+++ b/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
@@ -304,7 +304,7 @@ public final class ConstructorConstructor {
 
     if (Map.class.isAssignableFrom(rawType)) {
       @SuppressWarnings("unchecked")
-      ObjectConstructor<T> constructor = (ObjectConstructor<T>) newMapConstructor(type, rawType);
+      ObjectConstructor<T> constructor = (ObjectConstructor<T>) newMapConstructor(rawType);
       return constructor;
     }
 
@@ -336,21 +336,7 @@ public final class ConstructorConstructor {
     return null;
   }
 
-  private static boolean hasStringKeyType(Type mapType) {
-    // If mapType is not parameterized, assume it might have String as key type
-    if (!(mapType instanceof ParameterizedType)) {
-      return true;
-    }
-
-    Type[] typeArguments = ((ParameterizedType) mapType).getActualTypeArguments();
-    if (typeArguments.length == 0) {
-      return false;
-    }
-    return GsonTypes.getRawType(typeArguments[0]) == String.class;
-  }
-
-  private static ObjectConstructor<? extends Map<?, Object>> newMapConstructor(
-      Type type, Class<?> rawType) {
+  private static ObjectConstructor<? extends Map<?, Object>> newMapConstructor(Class<?> rawType) {
     // First try Map implementation
     if (rawType.isAssignableFrom(LinkedHashMap.class)) {
       return LinkedHashMap::new;

--- a/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
+++ b/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
@@ -352,16 +352,7 @@ public final class ConstructorConstructor {
   private static ObjectConstructor<? extends Map<?, Object>> newMapConstructor(
       Type type, Class<?> rawType) {
     // First try Map implementation
-    /*
-     * Legacy special casing for Map<String, ...> to avoid DoS from colliding String hashCode
-     * values for older JDKs; use own LinkedTreeMap<String, Object> instead
-     */
-    if (rawType.isAssignableFrom(LinkedTreeMap.class) && hasStringKeyType(type)) {
-      // Must use lambda instead of method reference (`LinkedTreeMap::new`) here, otherwise this
-      // causes an exception when Gson is used by a custom system class loader, see
-      // https://github.com/google/gson/pull/2864#issuecomment-3528623716
-      return () -> new LinkedTreeMap<>();
-    } else if (rawType.isAssignableFrom(LinkedHashMap.class)) {
+    if (rawType.isAssignableFrom(LinkedHashMap.class)) {
       return LinkedHashMap::new;
     }
     // Then try SortedMap / NavigableMap implementation

--- a/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
+++ b/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java
@@ -134,7 +134,7 @@ public final class ConstructorConstructor {
       return defaultConstructor;
     }
 
-    ObjectConstructor<T> defaultImplementation = newDefaultImplementationConstructor(type, rawType);
+    ObjectConstructor<T> defaultImplementation = newDefaultImplementationConstructor(rawType);
     if (defaultImplementation != null) {
       return defaultImplementation;
     }
@@ -286,7 +286,7 @@ public final class ConstructorConstructor {
 
   /** Constructors for common interface types like Map and List and their subtypes. */
   private static <T> ObjectConstructor<T> newDefaultImplementationConstructor(
-      Type type, Class<? super T> rawType) {
+      Class<? super T> rawType) {
 
     /*
      * IMPORTANT: Must only create instances for classes with public no-args constructor.

--- a/gson/src/main/java/com/google/gson/internal/bind/ObjectTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ObjectTypeAdapter.java
@@ -21,7 +21,6 @@ import com.google.gson.ToNumberPolicy;
 import com.google.gson.ToNumberStrategy;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
-import com.google.gson.internal.LinkedTreeMap;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
@@ -30,6 +29,7 @@ import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -81,7 +81,7 @@ public final class ObjectTypeAdapter extends TypeAdapter<Object> {
         return new ArrayList<>();
       case BEGIN_OBJECT:
         in.beginObject();
-        return new LinkedTreeMap<>();
+        return new LinkedHashMap<>();
       default:
         return null;
     }

--- a/gson/src/test/java/com/google/gson/functional/MapTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MapTest.java
@@ -166,6 +166,14 @@ public class MapTest {
   }
 
   @Test
+  public void testMapDeserializationWithNullKeyAndListOfEntries() {
+    Type typeOfMap = new TypeToken<Map<String, Integer>>() {}.getType();
+    Map<String, Integer> map = gson.fromJson("[[null,123]]", typeOfMap);
+    assertThat(map).hasSize(1);
+    assertThat(map.get(null)).isEqualTo(123);
+  }
+
+  @Test
   public void testMapSerializationWithIntegerKeys() {
     Map<Integer, String> map = new LinkedHashMap<>();
     map.put(123, "456");

--- a/gson/src/test/java/com/google/gson/functional/MapTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MapTest.java
@@ -233,33 +233,6 @@ public class MapTest {
   }
 
   @Test
-  public void testMapStringSupertypeKeyDeserialization() {
-    // Should only use Gson's LinkedTreeMap for String as key, but not for supertypes (e.g. Object)
-    Type typeOfMap = new TypeToken<Map<Object, Integer>>() {}.getType();
-    Map<?, ?> map = gson.fromJson("{\"a\":1}", typeOfMap);
-
-    assertWithMessage("Map<Object, ...> should not use Gson Map implementation")
-        .that(map)
-        .isNotInstanceOf(LinkedTreeMap.class);
-
-    Map<?, ?> expectedMap = Collections.singletonMap("a", 1);
-    assertThat(map).isEqualTo(expectedMap);
-  }
-
-  @Test
-  public void testMapNonStringKeyDeserialization() {
-    Type typeOfMap = new TypeToken<Map<Integer, Integer>>() {}.getType();
-    Map<?, ?> map = gson.fromJson("{\"1\":1}", typeOfMap);
-
-    assertWithMessage("Map<Integer, ...> should not use Gson Map implementation")
-        .that(map)
-        .isNotInstanceOf(LinkedTreeMap.class);
-
-    Map<?, ?> expectedMap = Collections.singletonMap(1, 1);
-    assertThat(map).isEqualTo(expectedMap);
-  }
-
-  @Test
   public void testHashMapDeserialization() {
     Type typeOfMap = new TypeToken<HashMap<Integer, String>>() {}.getType();
     HashMap<Integer, String> map = gson.fromJson("{\"123\":\"456\"}", typeOfMap);

--- a/gson/src/test/java/com/google/gson/functional/MapTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MapTest.java
@@ -220,12 +220,6 @@ public class MapTest {
     Type typeOfMap = new TypeToken<Map<String, Integer>>() {}.getType();
     Map<?, ?> map = gson.fromJson("{\"a\":1}", typeOfMap);
 
-    assertWithMessage(
-            "Map<String, ...> should use LinkedTreeMap to protect against DoS in older JDK"
-                + " versions")
-        .that(map)
-        .isInstanceOf(LinkedTreeMap.class);
-
     Map<?, ?> expectedMap = Collections.singletonMap("a", 1);
     assertThat(map).isEqualTo(expectedMap);
   }

--- a/gson/src/test/java/com/google/gson/functional/MapTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MapTest.java
@@ -17,7 +17,6 @@
 package com.google.gson.functional;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.Assert.assertThrows;
 
 import com.google.gson.Gson;
@@ -33,7 +32,6 @@ import com.google.gson.JsonSerializer;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.common.TestTypes;
 import com.google.gson.internal.GsonTypes;
-import com.google.gson.internal.LinkedTreeMap;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
 import java.util.AbstractMap;

--- a/gson/src/test/java/com/google/gson/internal/ConstructorConstructorTest.java
+++ b/gson/src/test/java/com/google/gson/internal/ConstructorConstructorTest.java
@@ -158,15 +158,12 @@ public class ConstructorConstructorTest {
 
   @Test
   public void testStringMapCreation() {
-    // When creating raw Map should use Gson's LinkedTreeMap, assuming keys could be String
     Object actual = constructorConstructor.get(TypeToken.get(Map.class)).construct();
-    assertThat(actual).isInstanceOf(LinkedTreeMap.class);
+    assertThat(actual).isInstanceOf(LinkedHashMap.class);
 
-    // When creating a `Map<String, ...>` should use Gson's LinkedTreeMap
     actual = constructorConstructor.get(new TypeToken<Map<String, Integer>>() {}).construct();
-    assertThat(actual).isInstanceOf(LinkedTreeMap.class);
+    assertThat(actual).isInstanceOf(LinkedHashMap.class);
 
-    // But when explicitly requesting a JDK `LinkedHashMap<String, ...>` should use LinkedHashMap
     actual =
         constructorConstructor.get(new TypeToken<LinkedHashMap<String, Integer>>() {}).construct();
     assertThat(actual).isInstanceOf(LinkedHashMap.class);

--- a/gson/src/test/java/com/google/gson/internal/ConstructorConstructorTest.java
+++ b/gson/src/test/java/com/google/gson/internal/ConstructorConstructorTest.java
@@ -157,7 +157,7 @@ public class ConstructorConstructorTest {
   }
 
   @Test
-  public void testStringMapCreation() {
+  public void testMapCreation() {
     Object actual = constructorConstructor.get(TypeToken.get(Map.class)).construct();
     assertThat(actual).isInstanceOf(LinkedHashMap.class);
 
@@ -169,8 +169,6 @@ public class ConstructorConstructorTest {
     assertThat(actual).isInstanceOf(LinkedHashMap.class);
 
     // For all Map types with non-String key, should use JDK LinkedHashMap by default
-    // This is also done to avoid ClassCastException later, because Gson's LinkedTreeMap requires
-    // that keys are Comparable
     Class<?>[] nonStringTypes = {Integer.class, CharSequence.class, Object.class};
     for (Class<?> keyType : nonStringTypes) {
       actual =


### PR DESCRIPTION
The JDK and Android have had DoS protection at least as good as LinkedTreeMap for over a decade now.

Fixes #3037. Fixes #2737. Fixes #1247.
