### PR TITLE
Fix JsonPrimitive.hashCode to honor the equals/hashCode contract (#992)

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonPrimitive.java
+++ b/gson/src/main/java/com/google/gson/JsonPrimitive.java
@@ -262,14 +262,24 @@ public final class JsonPrimitive extends JsonElement {
     if (value == null) {
       return 31;
     }
-    // Using recommended hashing algorithm from Effective Java for longs and doubles
-    if (isIntegral(this)) {
-      long value = getAsNumber().longValue();
-      return (int) (value ^ (value >>> 32));
-    }
     if (value instanceof Number) {
-      long value = Double.doubleToLongBits(getAsNumber().doubleValue());
-      return (int) (value ^ (value >>> 32));
+      // equals(Object) can consider primitives backed by different Number classes equal (for
+      // example Integer 42, a lazily parsed number 42 and Double 42.0), and every case in which
+      // equals(Object) considers two numbers equal implies that they have the same `double` value.
+      // Therefore the hash code must be derived only from the `double` value, otherwise equal
+      // primitives could have different hash codes, see https://github.com/google/gson/issues/992
+      double doubleValue = getAsNumber().doubleValue();
+      long longValue = (long) doubleValue;
+      if (doubleValue == longValue) {
+        // Mathematically integral values within `long` range use the hashing algorithm recommended
+        // by Effective Java for longs; this keeps the hash code unchanged for the common integral
+        // types and also normalizes -0.0 to 0.0 (which equals(Object) considers equal)
+        return (int) (longValue ^ (longValue >>> 32));
+      }
+      // doubleToLongBits (unlike doubleToRawLongBits) collapses all NaN bit patterns to a single
+      // canonical value, matching equals(Object) which considers all NaN values equal
+      long bits = Double.doubleToLongBits(doubleValue);
+      return (int) (bits ^ (bits >>> 32));
     }
     return value.hashCode();
   }

--- a/gson/src/main/java/com/google/gson/JsonPrimitive.java
+++ b/gson/src/main/java/com/google/gson/JsonPrimitive.java
@@ -262,26 +262,45 @@ public final class JsonPrimitive extends JsonElement {
     if (value == null) {
       return 31;
     }
+    // The conditions below parallel the structure of equals(Object). Unlike in equals, every
+    // numeric branch must delegate to the same double-based hash: equals can consider primitives
+    // from *different* branches equal (for example Integer 42 equals Double 42.0 and a lazily
+    // parsed number 42 through the floating-point comparison), so a branch hashing anything other
+    // than the double value would give equal primitives different hash codes, see
+    // https://github.com/google/gson/issues/992
+    if (isIntegral(this)) {
+      // equals compares two integral primitives by their BigInteger values or long values;
+      // primitives equal under either comparison also have the same double value, so the
+      // double-based hash is consistent with this branch of equals. It is also consistent with
+      // the mixed comparisons handled below, such as Integer 42 vs Double 42.0.
+      return hashOfDoubleValue(getAsNumber().doubleValue());
+    }
     if (value instanceof Number) {
-      // equals(Object) can consider primitives backed by different Number classes equal (for
-      // example Integer 42, a lazily parsed number 42 and Double 42.0), and every case in which
-      // equals(Object) considers two numbers equal implies that they have the same `double` value.
-      // Therefore the hash code must be derived only from the `double` value, otherwise equal
-      // primitives could have different hash codes, see https://github.com/google/gson/issues/992
-      double doubleValue = getAsNumber().doubleValue();
-      long longValue = (long) doubleValue;
-      if (doubleValue == longValue) {
-        // Mathematically integral values within `long` range use the hashing algorithm recommended
-        // by Effective Java for longs; this keeps the hash code unchanged for the common integral
-        // types and also normalizes -0.0 to 0.0 (which equals(Object) considers equal)
-        return (int) (longValue ^ (longValue >>> 32));
-      }
-      // doubleToLongBits (unlike doubleToRawLongBits) collapses all NaN bit patterns to a single
-      // canonical value, matching equals(Object) which considers all NaN values equal
-      long bits = Double.doubleToLongBits(doubleValue);
-      return (int) (bits ^ (bits >>> 32));
+      // equals compares the remaining numbers by their double values. (For two BigDecimals it
+      // uses compareTo, which only considers values equal that also have the same double value.)
+      return hashOfDoubleValue(getAsNumber().doubleValue());
     }
     return value.hashCode();
+  }
+
+  /**
+   * Hash code derived from the {@code double} value which {@link #equals(Object)} ultimately
+   * compares numbers by.
+   *
+   * <p>Mathematically integral values within {@code long} range use the hashing algorithm
+   * recommended by Effective Java for longs; this keeps the hash code unchanged for the common
+   * integral types and also normalizes {@code -0.0} to {@code 0.0} (which {@code equals} considers
+   * equal to {@code 0}). All other values hash their {@link Double#doubleToLongBits} bits, which
+   * collapses all NaN bit patterns to a single canonical value, matching {@code equals} which
+   * considers all NaN values equal.
+   */
+  private static int hashOfDoubleValue(double doubleValue) {
+    long longValue = (long) doubleValue;
+    if (doubleValue == longValue) {
+      return (int) (longValue ^ (longValue >>> 32));
+    }
+    long bits = Double.doubleToLongBits(doubleValue);
+    return (int) (bits ^ (bits >>> 32));
   }
 
   /**

--- a/gson/src/test/java/com/google/gson/JsonPrimitiveTest.java
+++ b/gson/src/test/java/com/google/gson/JsonPrimitiveTest.java
@@ -21,6 +21,7 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.Assert.assertThrows;
 
 import com.google.gson.common.MoreAsserts;
+import com.google.gson.internal.LazilyParsedNumber;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import org.junit.Test;
@@ -296,6 +297,34 @@ public class JsonPrimitiveTest {
         new JsonPrimitive(new BigDecimal("0")), new JsonPrimitive(0));
     MoreAsserts.assertEqualsAndHashCode(
         new JsonPrimitive(Float.NaN), new JsonPrimitive(Double.NaN));
+  }
+
+  /**
+   * Regression test for <a href="https://github.com/google/gson/issues/992">issue 992</a>: numbers
+   * which {@link JsonPrimitive#equals(Object)} considers equal must have the same hash code, even
+   * when they are backed by different {@link Number} classes.
+   */
+  @Test
+  public void testEqualsAndHashCodeAcrossNumberTypes() {
+    // The case from issue 992: an integer compared with the corresponding lazily parsed number
+    MoreAsserts.assertEqualsAndHashCode(
+        new JsonPrimitive(42), new JsonPrimitive(new LazilyParsedNumber("42")));
+    // Round-trip through JSON string representation produces a lazily parsed number
+    JsonPrimitive integer = new JsonPrimitive(42);
+    JsonPrimitive parsedBack = JsonParser.parseString(integer.toString()).getAsJsonPrimitive();
+    MoreAsserts.assertEqualsAndHashCode(integer, parsedBack);
+
+    // Integral and floating point Number classes with the same numeric value
+    MoreAsserts.assertEqualsAndHashCode(new JsonPrimitive(42), new JsonPrimitive(42.0));
+    MoreAsserts.assertEqualsAndHashCode(
+        new JsonPrimitive(new BigDecimal("42")), new JsonPrimitive(42));
+    MoreAsserts.assertEqualsAndHashCode(
+        new JsonPrimitive(new BigInteger("42")), new JsonPrimitive(new LazilyParsedNumber("42")));
+    // equals considers -0.0 and 0 equal
+    MoreAsserts.assertEqualsAndHashCode(new JsonPrimitive(-0.0), new JsonPrimitive(0));
+    // equals considers a large long equal to the double it loses precision to
+    MoreAsserts.assertEqualsAndHashCode(
+        new JsonPrimitive(9007199254740993L), new JsonPrimitive(9007199254740992.0));
   }
 
   @Test


### PR DESCRIPTION
Fixes #992.

### Problem

`JsonPrimitive.equals` considers numbers with the same value but different `Number` backing types equal — e.g. `new JsonPrimitive(42)`, a lazily-parsed `"42"` (the type produced by round-tripping a number through JSON), and `new JsonPrimitive(42.0)` are all equal to one another. But `hashCode` branched on `isIntegral(this)`:

```java
if (isIntegral(this)) {
  long value = getAsNumber().longValue();
  return (int) (value ^ (value >>> 32));
}
if (value instanceof Number) {
  long value = Double.doubleToLongBits(getAsNumber().doubleValue());
  return (int) (value ^ (value >>> 32));
}
```

An integral primitive (`42`, hashed as a `long`) and an equal non-integral one (lazily-parsed `"42"`, hashed via `doubleToLongBits`) therefore get different hash codes, violating the `Object.hashCode` contract. In practice this breaks `HashMap`/`HashSet`: a value stored under `new JsonPrimitive(42)` can't be found using the equal primitive you get back after parsing the same number from JSON.

### Fix

Derive the hash code solely from the `double` value that every branch of `equals` ultimately compares:

- Mathematically-integral values within `long` range are hashed as the `long` (this keeps the hash unchanged for the common integral types, and normalizes `-0.0` to `0`, which `equals` treats as equal to `0`).
- Everything else is hashed via `doubleToLongBits(doubleValue)` (which canonicalizes NaN, matching `equals`).

`equals` is left untouched.

### Scope / disclosure

- **Some hash codes change — by design.** The old `hashCode` used two different algorithms (integral → hash the `long`; otherwise → hash `doubleToLongBits`), which is the root cause of the bug. Now anything integral-valued and in `long` range hashes as the `long`. Concretely: an integral-valued floating primitive like `42.0` now hashes like `42`; `-0.0` now hashes like `0`; and an integral value with magnitude `> 2^53` (a `Long`/`BigInteger` a `double` can't represent exactly) now hashes by its `double` value, so `9007199254740993L` matches `9007199254740992.0`. In every one of those cases the new hash agrees with another primitive that `equals` already considers equal. Purely fractional `Double`/`Float`/`BigDecimal` values are unchanged. Hash codes aren't part of gson's serialized contract, but I'm flagging the change explicitly.
- **Pre-existing, out of scope:** `equals` itself is non-transitive around the `2^53` boundary (two distinct `long`s that both round to the same `double` are each "equal" to that `double`, but not to each other). This PR does not touch `equals` and does not try to fix that; it only makes `hashCode` consistent with `equals` as currently defined. Happy to file a separate issue if that's useful.

### Testing

- New `testEqualsAndHashCodeAcrossNumberTypes` asserts equal-implies-equal-hashcode across `Integer`/`LazilyParsedNumber`/`Double`/`BigDecimal`/`BigInteger`, the JSON round-trip case from the issue, `-0.0` vs `0`, and the `> 2^53` long/double case.
- Full `gson` module test suite passes (`mvn test`); Spotless clean.

<sub>Authored with AI assistance; the change was independently reviewed and verified before submission (including a fuzz check confirming no `equals`-equal pair produces differing hash codes). I'll sign the Google CLA.</sub>
