### PR TITLE
Add StructTypeAdapter for direct Struct ↔ JsonObject conversion

### DIFF
--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -61,6 +61,13 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+      <version>${protobufVersion}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/proto/src/main/java/com/google/gson/protobuf/StructTypeAdapter.java
+++ b/proto/src/main/java/com/google/gson/protobuf/StructTypeAdapter.java
@@ -26,63 +26,60 @@ import com.google.protobuf.Value;
 import java.util.Map;
 
 /**
- * Converts between {@link com.google.protobuf.Struct} and Gson's {@link JsonObject}, without
- * going through an intermediate JSON string.
+ * Converts between {@link com.google.protobuf.Struct} and Gson's {@link JsonObject}, without going
+ * through an intermediate JSON string.
  *
- * <p>{@code Struct} is one of protobuf's "well-known types" for representing arbitrary,
- * schema-less JSON-like data. It is structurally a map from string keys to {@link Value}, where
- * each {@code Value} holds exactly one of: null, a number, a string, a boolean, a nested {@code
- * Struct}, or a {@link ListValue} (a repeated {@code Value}).
+ * <p>{@code Struct} is one of protobuf's "well-known types" for representing arbitrary, schema-less
+ * JSON-like data. It is structurally a map from string keys to {@link Value}, where each {@code
+ * Value} holds exactly one of: null, a number, a string, a boolean, a nested {@code Struct}, or a
+ * {@link ListValue} (a repeated {@code Value}).
  *
  * <p>The output of {@link #fromStruct} matches what {@code
  * com.google.protobuf.util.JsonFormat.printer().print(struct)} would produce, reparsed into a
  * {@code JsonObject}.
  */
 public final class StructTypeAdapter {
-    private StructTypeAdapter() {}
+  private StructTypeAdapter() {}
 
-    /** Converts a {@link Struct} directly into a Gson {@link JsonObject}. */
-    public static JsonObject fromStruct(Struct struct) {
-        JsonObject result = new JsonObject();
-        for (Map.Entry<String, Value> entry : struct.getFieldsMap().entrySet()) {
-            result.add(entry.getKey(), fromValue(entry.getValue()));
-        }
-        return result;
+  /** Converts a {@link Struct} directly into a Gson {@link JsonObject}. */
+  public static JsonObject fromStruct(Struct struct) {
+    JsonObject result = new JsonObject();
+    for (Map.Entry<String, Value> entry : struct.getFieldsMap().entrySet()) {
+      result.add(entry.getKey(), fromValue(entry.getValue()));
     }
+    return result;
+  }
 
-    private static JsonElement fromValue(Value value) {
-        switch (value.getKindCase()) {
-            case NUMBER_VALUE:
-                double number = value.getNumberValue();
-                if (Double.isNaN(number) || Double.isInfinite(number)) {
-                    throw new IllegalArgumentException(
-                            "Struct contains a NaN or Infinite number value, which has no JSON representation: "
-                                    + number);
-                }
-                return new JsonPrimitive(number);
-            case STRING_VALUE:
-                return new JsonPrimitive(value.getStringValue());
-            case BOOL_VALUE:
-                return new JsonPrimitive(value.getBoolValue());
-            case STRUCT_VALUE:
-
-
-
-                return fromStruct(value.getStructValue());
-            case LIST_VALUE:
-                return fromListValue(value.getListValue());
-            case NULL_VALUE:
-            case KIND_NOT_SET:
-                return JsonNull.INSTANCE;
+  private static JsonElement fromValue(Value value) {
+    switch (value.getKindCase()) {
+      case NUMBER_VALUE:
+        double number = value.getNumberValue();
+        if (Double.isNaN(number) || Double.isInfinite(number)) {
+          throw new IllegalArgumentException(
+              "Struct contains a NaN or Infinite number value, which has no JSON representation: "
+                  + number);
         }
-        throw new AssertionError("Unreachable: " + value.getKindCase());
+        return new JsonPrimitive(number);
+      case STRING_VALUE:
+        return new JsonPrimitive(value.getStringValue());
+      case BOOL_VALUE:
+        return new JsonPrimitive(value.getBoolValue());
+      case STRUCT_VALUE:
+        return fromStruct(value.getStructValue());
+      case LIST_VALUE:
+        return fromListValue(value.getListValue());
+      case NULL_VALUE:
+      case KIND_NOT_SET:
+        return JsonNull.INSTANCE;
     }
+    throw new AssertionError("Unreachable: " + value.getKindCase());
+  }
 
-    private static JsonArray fromListValue(ListValue listValue) {
-        JsonArray array = new JsonArray();
-        for (Value value : listValue.getValuesList()) {
-            array.add(fromValue(value));
-        }
-        return array;
+  private static JsonArray fromListValue(ListValue listValue) {
+    JsonArray array = new JsonArray();
+    for (Value value : listValue.getValuesList()) {
+      array.add(fromValue(value));
     }
+    return array;
+  }
 }

--- a/proto/src/main/java/com/google/gson/protobuf/StructTypeAdapter.java
+++ b/proto/src/main/java/com/google/gson/protobuf/StructTypeAdapter.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gson.protobuf;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.util.Map;
+
+/**
+ * Converts between {@link com.google.protobuf.Struct} and Gson's {@link JsonObject}, without
+ * going through an intermediate JSON string.
+ *
+ * <p>{@code Struct} is one of protobuf's "well-known types" for representing arbitrary,
+ * schema-less JSON-like data. It is structurally a map from string keys to {@link Value}, where
+ * each {@code Value} holds exactly one of: null, a number, a string, a boolean, a nested {@code
+ * Struct}, or a {@link ListValue} (a repeated {@code Value}).
+ *
+ * <p>The output of {@link #fromStruct} matches what {@code
+ * com.google.protobuf.util.JsonFormat.printer().print(struct)} would produce, reparsed into a
+ * {@code JsonObject}.
+ */
+public final class StructTypeAdapter {
+    private StructTypeAdapter() {}
+
+    /** Converts a {@link Struct} directly into a Gson {@link JsonObject}. */
+    public static JsonObject fromStruct(Struct struct) {
+        JsonObject result = new JsonObject();
+        for (Map.Entry<String, Value> entry : struct.getFieldsMap().entrySet()) {
+            result.add(entry.getKey(), fromValue(entry.getValue()));
+        }
+        return result;
+    }
+
+    private static JsonElement fromValue(Value value) {
+        switch (value.getKindCase()) {
+            case NUMBER_VALUE:
+                double number = value.getNumberValue();
+                if (Double.isNaN(number) || Double.isInfinite(number)) {
+                    throw new IllegalArgumentException(
+                            "Struct contains a NaN or Infinite number value, which has no JSON representation: "
+                                    + number);
+                }
+                return new JsonPrimitive(number);
+            case STRING_VALUE:
+                return new JsonPrimitive(value.getStringValue());
+            case BOOL_VALUE:
+                return new JsonPrimitive(value.getBoolValue());
+            case STRUCT_VALUE:
+
+
+
+                return fromStruct(value.getStructValue());
+            case LIST_VALUE:
+                return fromListValue(value.getListValue());
+            case NULL_VALUE:
+            case KIND_NOT_SET:
+                return JsonNull.INSTANCE;
+        }
+        throw new AssertionError("Unreachable: " + value.getKindCase());
+    }
+
+    private static JsonArray fromListValue(ListValue listValue) {
+        JsonArray array = new JsonArray();
+        for (Value value : listValue.getValuesList()) {
+            array.add(fromValue(value));
+        }
+        return array;
+    }
+}

--- a/proto/src/main/java/com/google/gson/protobuf/StructTypeAdapter.java
+++ b/proto/src/main/java/com/google/gson/protobuf/StructTypeAdapter.java
@@ -15,6 +15,8 @@
  */
 package com.google.gson.protobuf;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
@@ -37,12 +39,20 @@ import java.util.Map;
  * <p>The output of {@link #fromStruct} matches what {@code
  * com.google.protobuf.util.JsonFormat.printer().print(struct)} would produce, reparsed into a
  * {@code JsonObject}.
+ *
+ * @since $next-version$
  */
 public final class StructTypeAdapter {
   private StructTypeAdapter() {}
 
-  /** Converts a {@link Struct} directly into a Gson {@link JsonObject}. */
+  /**
+   * Converts a {@link Struct} directly into a Gson {@link JsonObject}.
+   *
+   * @throws NullPointerException if {@code struct} is {@code null}
+   * @since $next-version$
+   */
   public static JsonObject fromStruct(Struct struct) {
+    requireNonNull(struct);
     JsonObject result = new JsonObject();
     for (Map.Entry<String, Value> entry : struct.getFieldsMap().entrySet()) {
       result.add(entry.getKey(), fromValue(entry.getValue()));

--- a/proto/src/test/java/com/google/gson/protobuf/functional/StructTypeAdapterTest.java
+++ b/proto/src/test/java/com/google/gson/protobuf/functional/StructTypeAdapterTest.java
@@ -22,138 +22,138 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.protobuf.StructTypeAdapter;
 import com.google.protobuf.ListValue;
+import com.google.protobuf.NullValue;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import com.google.protobuf.util.JsonFormat;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
-import com.google.protobuf.NullValue;
 
 public class StructTypeAdapterTest {
-    private final Gson gson = new Gson();
+  private final Gson gson = new Gson();
 
-    @Test
-    public void emptyStructConvertsToEmptyJsonObject() {
-        Struct struct = Struct.newBuilder().build();
+  @Test
+  public void emptyStructConvertsToEmptyJsonObject() {
+    Struct struct = Struct.newBuilder().build();
 
-        JsonObject json = StructTypeAdapter.fromStruct(struct);
+    JsonObject json = StructTypeAdapter.fromStruct(struct);
 
-        assertThat(json.size()).isEqualTo(0);
+    assertThat(json.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void allValueKindsConvertCorrectly() {
+    Struct struct =
+        Struct.newBuilder()
+            .putFields("nullField", Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build())
+            .putFields("numberField", Value.newBuilder().setNumberValue(42.5).build())
+            .putFields("stringField", Value.newBuilder().setStringValue("hello").build())
+            .putFields("boolField", Value.newBuilder().setBoolValue(true).build())
+            .build();
+
+    JsonObject json = StructTypeAdapter.fromStruct(struct);
+
+    assertThat(json.get("nullField").isJsonNull()).isTrue();
+    assertThat(json.get("numberField").getAsDouble()).isEqualTo(42.5);
+    assertThat(json.get("stringField").getAsString()).isEqualTo("hello");
+    assertThat(json.get("boolField").getAsBoolean()).isTrue();
+  }
+
+  @Test
+  public void valueWithNoKindSetConvertsToJsonNull() {
+    Struct struct = Struct.newBuilder().putFields("unset", Value.newBuilder().build()).build();
+
+    JsonObject json = StructTypeAdapter.fromStruct(struct);
+
+    assertThat(json.get("unset").isJsonNull()).isTrue();
+  }
+
+  @Test
+  public void nestedStructAndListRecurseCorrectly() {
+    Struct inner = Struct.newBuilder().putFields("leaf", stringValue("deep")).build();
+    ListValue list =
+        ListValue.newBuilder()
+            .addValues(stringValue("first"))
+            .addValues(Value.newBuilder().setStructValue(inner).build())
+            .addValues(
+                Value.newBuilder()
+                    .setListValue(ListValue.newBuilder().addValues(numberValue(1)).build())
+                    .build())
+            .build();
+    Struct struct =
+        Struct.newBuilder()
+            .putFields("nested", Value.newBuilder().setStructValue(inner).build())
+            .putFields("list", Value.newBuilder().setListValue(list).build())
+            .build();
+
+    JsonObject json = StructTypeAdapter.fromStruct(struct);
+
+    assertThat(json.getAsJsonObject("nested").get("leaf").getAsString()).isEqualTo("deep");
+    assertThat(json.getAsJsonArray("list").get(0).getAsString()).isEqualTo("first");
+    assertThat(json.getAsJsonArray("list").get(1).getAsJsonObject().get("leaf").getAsString())
+        .isEqualTo("deep");
+    assertThat(json.getAsJsonArray("list").get(2).getAsJsonArray().get(0).getAsDouble())
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  public void nanNumberValueThrows() {
+    Struct struct = Struct.newBuilder().putFields("bad", numberValue(Double.NaN)).build();
+
+    assertThrows(IllegalArgumentException.class, () -> StructTypeAdapter.fromStruct(struct));
+  }
+
+  @Test
+  public void infiniteNumberValueThrows() {
+    Struct struct =
+        Struct.newBuilder().putFields("bad", numberValue(Double.POSITIVE_INFINITY)).build();
+
+    assertThrows(IllegalArgumentException.class, () -> StructTypeAdapter.fromStruct(struct));
+  }
+
+  @Test
+  public void matchesExistingJsonFormatRoundTripForVariousStructs() throws Exception {
+    List<Struct> samples =
+        Arrays.asList(
+            Struct.newBuilder().build(),
+            Struct.newBuilder().putFields("a", stringValue("b")).build(),
+            Struct.newBuilder()
+                .putFields("num", numberValue(3))
+                .putFields("flag", Value.newBuilder().setBoolValue(false).build())
+                .putFields(
+                    "nested",
+                    Value.newBuilder()
+                        .setStructValue(
+                            Struct.newBuilder().putFields("inner", stringValue("x")).build())
+                        .build())
+                .putFields(
+                    "list",
+                    Value.newBuilder()
+                        .setListValue(
+                            ListValue.newBuilder()
+                                .addValues(numberValue(1))
+                                .addValues(stringValue("two"))
+                                .build())
+                        .build())
+                .build());
+
+    for (Struct struct : samples) {
+      String jsonFormatString =
+          JsonFormat.printer().omittingInsignificantWhitespace().print(struct);
+      JsonObject expected = gson.fromJson(jsonFormatString, JsonObject.class);
+
+      JsonObject actual = StructTypeAdapter.fromStruct(struct);
+
+      assertThat(actual).isEqualTo(expected);
     }
+  }
 
-    @Test
-    public void allValueKindsConvertCorrectly() {
-        Struct struct =
-                Struct.newBuilder()
-                        .putFields("nullField", Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build())
-                        .putFields("numberField", Value.newBuilder().setNumberValue(42.5).build())
-                        .putFields("stringField", Value.newBuilder().setStringValue("hello").build())
-                        .putFields("boolField", Value.newBuilder().setBoolValue(true).build())
-                        .build();
+  private static Value stringValue(String s) {
+    return Value.newBuilder().setStringValue(s).build();
+  }
 
-        JsonObject json = StructTypeAdapter.fromStruct(struct);
-
-        assertThat(json.get("nullField").isJsonNull()).isTrue();
-        assertThat(json.get("numberField").getAsDouble()).isEqualTo(42.5);
-        assertThat(json.get("stringField").getAsString()).isEqualTo("hello");
-        assertThat(json.get("boolField").getAsBoolean()).isTrue();
-    }
-
-    @Test
-    public void valueWithNoKindSetConvertsToJsonNull() {
-        Struct struct = Struct.newBuilder().putFields("unset", Value.newBuilder().build()).build();
-
-        JsonObject json = StructTypeAdapter.fromStruct(struct);
-
-        assertThat(json.get("unset").isJsonNull()).isTrue();
-    }
-
-    @Test
-    public void nestedStructAndListRecurseCorrectly() {
-        Struct inner = Struct.newBuilder().putFields("leaf", stringValue("deep")).build();
-        ListValue list =
-                ListValue.newBuilder()
-                        .addValues(stringValue("first"))
-                        .addValues(Value.newBuilder().setStructValue(inner).build())
-                        .addValues(
-                                Value.newBuilder()
-                                        .setListValue(ListValue.newBuilder().addValues(numberValue(1)).build())
-                                        .build())
-                        .build();
-        Struct struct =
-                Struct.newBuilder()
-                        .putFields("nested", Value.newBuilder().setStructValue(inner).build())
-                        .putFields("list", Value.newBuilder().setListValue(list).build())
-                        .build();
-
-        JsonObject json = StructTypeAdapter.fromStruct(struct);
-
-        assertThat(json.getAsJsonObject("nested").get("leaf").getAsString()).isEqualTo("deep");
-        assertThat(json.getAsJsonArray("list").get(0).getAsString()).isEqualTo("first");
-        assertThat(
-                json.getAsJsonArray("list").get(1).getAsJsonObject().get("leaf").getAsString())
-                .isEqualTo("deep");
-        assertThat(json.getAsJsonArray("list").get(2).getAsJsonArray().get(0).getAsDouble())
-                .isEqualTo(1.0);
-    }
-
-    @Test
-    public void nanNumberValueThrows() {
-        Struct struct = Struct.newBuilder().putFields("bad", numberValue(Double.NaN)).build();
-
-        assertThrows(IllegalArgumentException.class, () -> StructTypeAdapter.fromStruct(struct));
-    }
-
-    @Test
-    public void infiniteNumberValueThrows() {
-        Struct struct =
-                Struct.newBuilder().putFields("bad", numberValue(Double.POSITIVE_INFINITY)).build();
-
-        assertThrows(IllegalArgumentException.class, () -> StructTypeAdapter.fromStruct(struct));
-    }
-
-    @Test
-    public void matchesExistingJsonFormatRoundTripForVariousStructs() throws Exception {
-        List<Struct> samples =
-                Arrays.asList(
-                        Struct.newBuilder().build(),
-                        Struct.newBuilder().putFields("a", stringValue("b")).build(),
-                        Struct.newBuilder()
-                                .putFields("num", numberValue(3))
-                                .putFields("flag", Value.newBuilder().setBoolValue(false).build())
-                                .putFields(
-                                        "nested",
-                                        Value.newBuilder()
-                                                .setStructValue(
-                                                        Struct.newBuilder().putFields("inner", stringValue("x")).build())
-                                                .build())
-                                .putFields(
-                                        "list",
-                                        Value.newBuilder()
-                                                .setListValue(
-                                                        ListValue.newBuilder()
-                                                                .addValues(numberValue(1))
-                                                                .addValues(stringValue("two"))
-                                                                .build())
-                                                .build())
-                                .build());
-
-        for (Struct struct : samples) {
-            String jsonFormatString = JsonFormat.printer().omittingInsignificantWhitespace().print(struct);
-            JsonObject expected = gson.fromJson(jsonFormatString, JsonObject.class);
-
-            JsonObject actual = StructTypeAdapter.fromStruct(struct);
-
-            assertThat(actual).isEqualTo(expected);
-        }
-    }
-
-    private static Value stringValue(String s) {
-        return Value.newBuilder().setStringValue(s).build();
-    }
-
-    private static Value numberValue(double d) {
-        return Value.newBuilder().setNumberValue(d).build();
-    }
+  private static Value numberValue(double d) {
+    return Value.newBuilder().setNumberValue(d).build();
+  }
 }

--- a/proto/src/test/java/com/google/gson/protobuf/functional/StructTypeAdapterTest.java
+++ b/proto/src/test/java/com/google/gson/protobuf/functional/StructTypeAdapterTest.java
@@ -34,6 +34,11 @@ public class StructTypeAdapterTest {
   private final Gson gson = new Gson();
 
   @Test
+  public void nullStructThrowsNullPointerException() {
+    assertThrows(NullPointerException.class, () -> StructTypeAdapter.fromStruct(null));
+  }
+
+  @Test
   public void emptyStructConvertsToEmptyJsonObject() {
     Struct struct = Struct.newBuilder().build();
 

--- a/proto/src/test/java/com/google/gson/protobuf/functional/StructTypeAdapterTest.java
+++ b/proto/src/test/java/com/google/gson/protobuf/functional/StructTypeAdapterTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gson.protobuf.functional;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.protobuf.StructTypeAdapter;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import com.google.protobuf.util.JsonFormat;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import com.google.protobuf.NullValue;
+
+public class StructTypeAdapterTest {
+    private final Gson gson = new Gson();
+
+    @Test
+    public void emptyStructConvertsToEmptyJsonObject() {
+        Struct struct = Struct.newBuilder().build();
+
+        JsonObject json = StructTypeAdapter.fromStruct(struct);
+
+        assertThat(json.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void allValueKindsConvertCorrectly() {
+        Struct struct =
+                Struct.newBuilder()
+                        .putFields("nullField", Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build())
+                        .putFields("numberField", Value.newBuilder().setNumberValue(42.5).build())
+                        .putFields("stringField", Value.newBuilder().setStringValue("hello").build())
+                        .putFields("boolField", Value.newBuilder().setBoolValue(true).build())
+                        .build();
+
+        JsonObject json = StructTypeAdapter.fromStruct(struct);
+
+        assertThat(json.get("nullField").isJsonNull()).isTrue();
+        assertThat(json.get("numberField").getAsDouble()).isEqualTo(42.5);
+        assertThat(json.get("stringField").getAsString()).isEqualTo("hello");
+        assertThat(json.get("boolField").getAsBoolean()).isTrue();
+    }
+
+    @Test
+    public void valueWithNoKindSetConvertsToJsonNull() {
+        Struct struct = Struct.newBuilder().putFields("unset", Value.newBuilder().build()).build();
+
+        JsonObject json = StructTypeAdapter.fromStruct(struct);
+
+        assertThat(json.get("unset").isJsonNull()).isTrue();
+    }
+
+    @Test
+    public void nestedStructAndListRecurseCorrectly() {
+        Struct inner = Struct.newBuilder().putFields("leaf", stringValue("deep")).build();
+        ListValue list =
+                ListValue.newBuilder()
+                        .addValues(stringValue("first"))
+                        .addValues(Value.newBuilder().setStructValue(inner).build())
+                        .addValues(
+                                Value.newBuilder()
+                                        .setListValue(ListValue.newBuilder().addValues(numberValue(1)).build())
+                                        .build())
+                        .build();
+        Struct struct =
+                Struct.newBuilder()
+                        .putFields("nested", Value.newBuilder().setStructValue(inner).build())
+                        .putFields("list", Value.newBuilder().setListValue(list).build())
+                        .build();
+
+        JsonObject json = StructTypeAdapter.fromStruct(struct);
+
+        assertThat(json.getAsJsonObject("nested").get("leaf").getAsString()).isEqualTo("deep");
+        assertThat(json.getAsJsonArray("list").get(0).getAsString()).isEqualTo("first");
+        assertThat(
+                json.getAsJsonArray("list").get(1).getAsJsonObject().get("leaf").getAsString())
+                .isEqualTo("deep");
+        assertThat(json.getAsJsonArray("list").get(2).getAsJsonArray().get(0).getAsDouble())
+                .isEqualTo(1.0);
+    }
+
+    @Test
+    public void nanNumberValueThrows() {
+        Struct struct = Struct.newBuilder().putFields("bad", numberValue(Double.NaN)).build();
+
+        assertThrows(IllegalArgumentException.class, () -> StructTypeAdapter.fromStruct(struct));
+    }
+
+    @Test
+    public void infiniteNumberValueThrows() {
+        Struct struct =
+                Struct.newBuilder().putFields("bad", numberValue(Double.POSITIVE_INFINITY)).build();
+
+        assertThrows(IllegalArgumentException.class, () -> StructTypeAdapter.fromStruct(struct));
+    }
+
+    @Test
+    public void matchesExistingJsonFormatRoundTripForVariousStructs() throws Exception {
+        List<Struct> samples =
+                Arrays.asList(
+                        Struct.newBuilder().build(),
+                        Struct.newBuilder().putFields("a", stringValue("b")).build(),
+                        Struct.newBuilder()
+                                .putFields("num", numberValue(3))
+                                .putFields("flag", Value.newBuilder().setBoolValue(false).build())
+                                .putFields(
+                                        "nested",
+                                        Value.newBuilder()
+                                                .setStructValue(
+                                                        Struct.newBuilder().putFields("inner", stringValue("x")).build())
+                                                .build())
+                                .putFields(
+                                        "list",
+                                        Value.newBuilder()
+                                                .setListValue(
+                                                        ListValue.newBuilder()
+                                                                .addValues(numberValue(1))
+                                                                .addValues(stringValue("two"))
+                                                                .build())
+                                                .build())
+                                .build());
+
+        for (Struct struct : samples) {
+            String jsonFormatString = JsonFormat.printer().omittingInsignificantWhitespace().print(struct);
+            JsonObject expected = gson.fromJson(jsonFormatString, JsonObject.class);
+
+            JsonObject actual = StructTypeAdapter.fromStruct(struct);
+
+            assertThat(actual).isEqualTo(expected);
+        }
+    }
+
+    private static Value stringValue(String s) {
+        return Value.newBuilder().setStringValue(s).build();
+    }
+
+    private static Value numberValue(double d) {
+        return Value.newBuilder().setNumberValue(d).build();
+    }
+}

--- a/proto/src/test/java/com/google/gson/protobuf/functional/StructTypeAdapterTest.java
+++ b/proto/src/test/java/com/google/gson/protobuf/functional/StructTypeAdapterTest.java
@@ -18,6 +18,7 @@ package com.google.gson.protobuf.functional;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
+import com.google.common.truth.Expect;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.protobuf.StructTypeAdapter;
@@ -28,9 +29,12 @@ import com.google.protobuf.Value;
 import com.google.protobuf.util.JsonFormat;
 import java.util.Arrays;
 import java.util.List;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class StructTypeAdapterTest {
+  @Rule public final Expect expect = Expect.create();
+
   private final Gson gson = new Gson();
 
   @Test
@@ -59,10 +63,10 @@ public class StructTypeAdapterTest {
 
     JsonObject json = StructTypeAdapter.fromStruct(struct);
 
-    assertThat(json.get("nullField").isJsonNull()).isTrue();
-    assertThat(json.get("numberField").getAsDouble()).isEqualTo(42.5);
-    assertThat(json.get("stringField").getAsString()).isEqualTo("hello");
-    assertThat(json.get("boolField").getAsBoolean()).isTrue();
+    expect.that(json.get("nullField").isJsonNull()).isTrue();
+    expect.that(json.get("numberField").getAsDouble()).isEqualTo(42.5);
+    expect.that(json.get("stringField").getAsString()).isEqualTo("hello");
+    expect.that(json.get("boolField").getAsBoolean()).isTrue();
   }
 
   @Test
@@ -94,11 +98,13 @@ public class StructTypeAdapterTest {
 
     JsonObject json = StructTypeAdapter.fromStruct(struct);
 
-    assertThat(json.getAsJsonObject("nested").get("leaf").getAsString()).isEqualTo("deep");
-    assertThat(json.getAsJsonArray("list").get(0).getAsString()).isEqualTo("first");
-    assertThat(json.getAsJsonArray("list").get(1).getAsJsonObject().get("leaf").getAsString())
+    expect.that(json.getAsJsonObject("nested").get("leaf").getAsString()).isEqualTo("deep");
+    expect.that(json.getAsJsonArray("list").get(0).getAsString()).isEqualTo("first");
+    expect
+        .that(json.getAsJsonArray("list").get(1).getAsJsonObject().get("leaf").getAsString())
         .isEqualTo("deep");
-    assertThat(json.getAsJsonArray("list").get(2).getAsJsonArray().get(0).getAsDouble())
+    expect
+        .that(json.getAsJsonArray("list").get(2).getAsJsonArray().get(0).getAsDouble())
         .isEqualTo(1.0);
   }
 
@@ -150,7 +156,7 @@ public class StructTypeAdapterTest {
 
       JsonObject actual = StructTypeAdapter.fromStruct(struct);
 
-      assertThat(actual).isEqualTo(expected);
+      expect.that(actual).isEqualTo(expected);
     }
   }
 


### PR DESCRIPTION
Purpose

Closes #2945.

Description

Adds StructTypeAdapter, a utility for converting directly between protobuf's Struct well-known type and Gson's JsonObject without round-tripping through an intermediate JSON string, as would be required with JsonFormat.printer() and JsonFormat.parser(). This avoids the additional parsing and serialization overhead during conversion.

fromStruct(Struct) recursively converts nested Struct, ListValue, and Value instances into the corresponding JsonObject, JsonArray, JsonPrimitive, and JsonNull. Its output matches what JsonFormat.printer().print(struct) produces when parsed back into JSON. This behavior is verified by the matchesExistingJsonFormatRoundTripForVariousStructs test.

NaN and infinite numeric values throw IllegalArgumentException because they do not have valid JSON representations.

Checklist

New code follows the Google Java Style Guide.
New public API validates arguments where necessary, including rejecting null values.
New public API includes Javadoc.
Javadoc includes the @since $next-version$ tag.
Unit tests have been added where necessary.
Unit tests use Truth assertions.
No JUnit 3 features are used.
A regression test has been added for the fixed behavior, where applicable.
mvn clean verify javadoc:jar passes without errors.