### PR TITLE
Include location in NumberFormatException thrown by JsonTreeReader

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
@@ -434,8 +434,7 @@ public final class JsonTreeReader extends JsonReader {
   }
 
   /** Creates a {@link NumberFormatException} whose message includes the current path. */
-  private NumberFormatException numberFormatException(
-      String message, NumberFormatException cause) {
+  private NumberFormatException numberFormatException(String message, NumberFormatException cause) {
     NumberFormatException exception = new NumberFormatException(message + locationString());
     exception.initCause(cause);
     return exception;

--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
@@ -243,7 +243,13 @@ public final class JsonTreeReader extends JsonReader {
       throw new IllegalStateException(
           "Expected " + JsonToken.NUMBER + " but was " + token + locationString());
     }
-    double result = ((JsonPrimitive) peekStack()).getAsDouble();
+    JsonPrimitive primitive = (JsonPrimitive) peekStack();
+    double result;
+    try {
+      result = primitive.getAsDouble();
+    } catch (NumberFormatException e) {
+      throw numberFormatException("Expected a double but was " + primitive.getAsString(), e);
+    }
     if (!isLenient() && (Double.isNaN(result) || Double.isInfinite(result))) {
       throw new MalformedJsonException("JSON forbids NaN and infinities: " + result);
     }
@@ -265,7 +271,12 @@ public final class JsonTreeReader extends JsonReader {
     if (token == JsonToken.STRING) {
       validateAscii(primitive.getAsString());
     }
-    long result = primitive.getAsLong();
+    long result;
+    try {
+      result = primitive.getAsLong();
+    } catch (NumberFormatException e) {
+      throw numberFormatException("Expected a long but was " + primitive.getAsString(), e);
+    }
     popStack();
     if (stackSize > 0) {
       pathIndices[stackSize - 1]++;
@@ -284,7 +295,12 @@ public final class JsonTreeReader extends JsonReader {
     if (token == JsonToken.STRING) {
       validateAscii(primitive.getAsString());
     }
-    int result = primitive.getAsInt();
+    int result;
+    try {
+      result = primitive.getAsInt();
+    } catch (NumberFormatException e) {
+      throw numberFormatException("Expected an int but was " + primitive.getAsString(), e);
+    }
     popStack();
     if (stackSize > 0) {
       pathIndices[stackSize - 1]++;
@@ -415,5 +431,13 @@ public final class JsonTreeReader extends JsonReader {
       throw new MalformedJsonException(
           "String contains non-ASCII characters: " + s + locationString());
     }
+  }
+
+  /** Creates a {@link NumberFormatException} whose message includes the current path. */
+  private NumberFormatException numberFormatException(
+      String message, NumberFormatException cause) {
+    NumberFormatException exception = new NumberFormatException(message + locationString());
+    exception.initCause(cause);
+    return exception;
   }
 }

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeReaderTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeReaderTest.java
@@ -164,6 +164,47 @@ public class JsonTreeReaderTest {
     assertThat(reader.nextLong()).isEqualTo(456L);
   }
 
+  /**
+   * Regression test for the {@link JsonTreeReader} counterpart of the location reporting added for
+   * {@link JsonReader} in <a href="https://github.com/google/gson/issues/1564">#1564</a>. When a
+   * numeric value cannot be parsed, the thrown {@link NumberFormatException} must include the JSON
+   * path, consistent with the streaming {@code JsonReader} implementation.
+   */
+  @Test
+  public void testNextDoubleNumberFormatExceptionContainsLocation() throws IOException {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("x", "");
+    JsonTreeReader reader = new JsonTreeReader(jsonObject);
+    reader.beginObject();
+    var unused = reader.nextName();
+    NumberFormatException e = assertThrows(NumberFormatException.class, () -> reader.nextDouble());
+    assertThat(e).hasMessageThat().contains("path $.x");
+  }
+
+  /** See {@link #testNextDoubleNumberFormatExceptionContainsLocation}. */
+  @Test
+  public void testNextIntNumberFormatExceptionContainsLocation() throws IOException {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("x", "");
+    JsonTreeReader reader = new JsonTreeReader(jsonObject);
+    reader.beginObject();
+    var unused = reader.nextName();
+    NumberFormatException e = assertThrows(NumberFormatException.class, () -> reader.nextInt());
+    assertThat(e).hasMessageThat().contains("path $.x");
+  }
+
+  /** See {@link #testNextDoubleNumberFormatExceptionContainsLocation}. */
+  @Test
+  public void testNextLongNumberFormatExceptionContainsLocation() throws IOException {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("y", "");
+    JsonTreeReader reader = new JsonTreeReader(jsonObject);
+    reader.beginObject();
+    var unused = reader.nextName();
+    NumberFormatException e = assertThrows(NumberFormatException.class, () -> reader.nextLong());
+    assertThat(e).hasMessageThat().contains("path $.y");
+  }
+
   @Test
   public void testCustomJsonElementSubclass() throws IOException {
     @SuppressWarnings("deprecation") // superclass constructor


### PR DESCRIPTION
## Problem

`JsonReader.nextDouble()`, `nextLong()` and `nextInt()` already include the JSON path in the `NumberFormatException` thrown when a value cannot be parsed. This was added in #3000 as a fix for #1564.

However, the corresponding methods in `JsonTreeReader` were missing this handling. As a result, the two public deserialization entry points behave inconsistently:

```java
class Model { int x; }

// Streaming path — already includes location (since #3000)
new Gson().fromJson("{\"x\":\"\"}", Model.class);
// -> JsonSyntaxException: ... Expected an int but was  at line 1 column 8 path $.x

// Tree path — no location information
JsonObject obj = new JsonObject();
obj.add("x", new JsonPrimitive(""));
new Gson().fromJson(obj, Model.class);
// -> JsonSyntaxException: ... NumberFormatException: For input string: ""
```

Both paths consume untrusted JSON and report parse failures to the caller, so they should report the same location information.

## Fix

Mirror the existing `JsonReader` handling: wrap the `JsonPrimitive` conversion in `nextDouble()`, `nextLong()` and `nextInt()` with a try-catch, and rethrow a `NumberFormatException` containing the offending value and `locationString()`, preserving the original exception as the cause (via `initCause(e)`), exactly as the streaming `JsonReader` does.

## Tests

Added three regression tests in `JsonTreeReaderTest` (`testNextDouble/NextInt/NextLongNumberFormatExceptionContainsLocation`), asserting the message contains the JSON path (`path $.x` / `path $.y`), paralleling the existing tests added for `JsonReader` in `JsonReaderTest`.

Full test suite: `Tests run: 4607, Failures: 0, Errors: 0, Skipped: 20` — no regressions.

## Notes

- This is the tree-path counterpart of #3000; `JsonTreeReader` overrides the same `JsonReader` methods, so the omission is a direct symmetric gap.
- The outer `Gson.fromJson` only catches `EOFException`/`IllegalStateException`/`IOException`, so the bare `NumberFormatException` from the tree path reaches the caller unwrapped, making the missing location directly user-visible.