### PR TITLE
Reject non-ASCII digits in JsonTreeReader.nextInt/nextLong

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
@@ -258,7 +258,11 @@ public final class JsonTreeReader extends JsonReader {
       throw new IllegalStateException(
           "Expected " + JsonToken.NUMBER + " but was " + token + locationString());
     }
-    long result = ((JsonPrimitive) peekStack()).getAsLong();
+    JsonPrimitive primitive = (JsonPrimitive) peekStack();
+    if (token == JsonToken.STRING) {
+      validateAscii(primitive.getAsString());
+    }
+    long result = primitive.getAsLong();
     popStack();
     if (stackSize > 0) {
       pathIndices[stackSize - 1]++;
@@ -273,7 +277,11 @@ public final class JsonTreeReader extends JsonReader {
       throw new IllegalStateException(
           "Expected " + JsonToken.NUMBER + " but was " + token + locationString());
     }
-    int result = ((JsonPrimitive) peekStack()).getAsInt();
+    JsonPrimitive primitive = (JsonPrimitive) peekStack();
+    if (token == JsonToken.STRING) {
+      validateAscii(primitive.getAsString());
+    }
+    int result = primitive.getAsInt();
     popStack();
     if (stackSize > 0) {
       pathIndices[stackSize - 1]++;
@@ -387,5 +395,19 @@ public final class JsonTreeReader extends JsonReader {
 
   private String locationString() {
     return " at path " + getPath();
+  }
+
+  // Mirror the ASCII validation added to the streaming JsonReader in #2995:
+  // a string token being parsed as an integer or long must not silently accept
+  // non-ASCII digit variants (e.g. full-width U+FF10-FF19), which Integer.parseInt
+  // and Long.parseLong would otherwise coerce. Without this the tree-based path
+  // diverges from the streaming path for the same input.
+  private void validateAscii(String s) throws MalformedJsonException {
+    for (int i = 0; i < s.length(); i++) {
+      if (s.charAt(i) > 127) {
+        throw new MalformedJsonException(
+            "String contains non-ASCII characters: " + s + locationString());
+      }
+    }
   }
 }

--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
@@ -400,17 +400,20 @@ public final class JsonTreeReader extends JsonReader {
     return " at path " + getPath();
   }
 
-  // Mirror the ASCII validation added to the streaming JsonReader in #2995:
-  // a string token being parsed as an integer or long must not silently accept
-  // non-ASCII digit variants (e.g. full-width U+FF10-FF19), which Integer.parseInt
-  // and Long.parseLong would otherwise coerce. Without this the tree-based path
-  // diverges from the streaming path for the same input.
-  private void validateAscii(String s) throws MalformedJsonException {
+  /** Returns whether every character of {@code s} is ASCII (code point at most 127). */
+  public static boolean isAllAscii(String s) {
     for (int i = 0; i < s.length(); i++) {
       if (s.charAt(i) > 127) {
-        throw new MalformedJsonException(
-            "String contains non-ASCII characters: " + s + locationString());
+        return false;
       }
+    }
+    return true;
+  }
+
+  private void validateAscii(String s) throws MalformedJsonException {
+    if (!isAllAscii(s)) {
+      throw new MalformedJsonException(
+          "String contains non-ASCII characters: " + s + locationString());
     }
   }
 }

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -1880,10 +1880,8 @@ public class JsonReader implements Closeable {
   }
 
   private void validateAscii(String s) throws MalformedJsonException {
-    for (int i = 0; i < s.length(); i++) {
-      if (s.charAt(i) > 127) {
-        throw syntaxError("String contains non-ASCII characters: " + s);
-      }
+    if (!JsonTreeReader.isAllAscii(s)) {
+      throw syntaxError("String contains non-ASCII characters: " + s);
     }
   }
 

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeReaderTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeReaderTest.java
@@ -113,6 +113,59 @@ public class JsonTreeReaderTest {
     assertThat(reader.hasNext()).isFalse();
   }
 
+  /**
+   * Regression test for the {@link JsonTreeReader} counterpart of the non-ASCII digit validation
+   * added for the streaming {@link JsonReader} in
+   * <a href="https://github.com/google/gson/issues/2994">#2994</a> /
+   * <a href="https://github.com/google/gson/pull/2995">#2995</a>. A string token parsed as an
+   * {@code int} or {@code long} must reject non-ASCII digit variants (e.g. full-width digits
+   * U+FF10-FF19), which {@link Integer#parseInt} and {@link Long#parseLong} would otherwise
+   * silently coerce. Without this the tree-based path diverges from the streaming path.
+   */
+  @Test
+  public void testNextIntRejectsNonAsciiDigits() throws IOException {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("x", "１２３"); // full-width digits
+    JsonTreeReader reader = new JsonTreeReader(jsonObject);
+    reader.beginObject();
+    var unused = reader.nextName();
+    MalformedJsonException e =
+        assertThrows(MalformedJsonException.class, () -> reader.nextInt());
+    assertThat(e).hasMessageThat().contains("non-ASCII");
+    assertThat(e).hasMessageThat().contains("path $.x");
+  }
+
+  /** See {@link #testNextIntRejectsNonAsciiDigits}. */
+  @Test
+  public void testNextLongRejectsNonAsciiDigits() throws IOException {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("y", "１２３");
+    JsonTreeReader reader = new JsonTreeReader(jsonObject);
+    reader.beginObject();
+    var unused = reader.nextName();
+    MalformedJsonException e =
+        assertThrows(MalformedJsonException.class, () -> reader.nextLong());
+    assertThat(e).hasMessageThat().contains("non-ASCII");
+    assertThat(e).hasMessageThat().contains("path $.y");
+  }
+
+  /**
+   * Confirms ASCII digits in a string token still parse normally after the non-ASCII validation was
+   * added, for both {@code int} and {@code long}.
+   */
+  @Test
+  public void testNextIntAndLongAcceptAsciiDigitsInString() throws IOException {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("i", "123");
+    jsonObject.addProperty("l", "456");
+    JsonTreeReader reader = new JsonTreeReader(jsonObject);
+    reader.beginObject();
+    assertThat(reader.nextName()).isEqualTo("i");
+    assertThat(reader.nextInt()).isEqualTo(123);
+    assertThat(reader.nextName()).isEqualTo("l");
+    assertThat(reader.nextLong()).isEqualTo(456L);
+  }
+
   @Test
   public void testCustomJsonElementSubclass() throws IOException {
     @SuppressWarnings("deprecation") // superclass constructor

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeReaderTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeReaderTest.java
@@ -115,12 +115,12 @@ public class JsonTreeReaderTest {
 
   /**
    * Regression test for the {@link JsonTreeReader} counterpart of the non-ASCII digit validation
-   * added for the streaming {@link JsonReader} in
-   * <a href="https://github.com/google/gson/issues/2994">#2994</a> /
-   * <a href="https://github.com/google/gson/pull/2995">#2995</a>. A string token parsed as an
-   * {@code int} or {@code long} must reject non-ASCII digit variants (e.g. full-width digits
-   * U+FF10-FF19), which {@link Integer#parseInt} and {@link Long#parseLong} would otherwise
-   * silently coerce. Without this the tree-based path diverges from the streaming path.
+   * added for the streaming {@link JsonReader} in <a
+   * href="https://github.com/google/gson/issues/2994">#2994</a> / <a
+   * href="https://github.com/google/gson/pull/2995">#2995</a>. A string token parsed as an {@code
+   * int} or {@code long} must reject non-ASCII digit variants (e.g. full-width digits U+FF10-FF19),
+   * which {@link Integer#parseInt} and {@link Long#parseLong} would otherwise silently coerce.
+   * Without this the tree-based path diverges from the streaming path.
    */
   @Test
   public void testNextIntRejectsNonAsciiDigits() throws IOException {
@@ -129,8 +129,7 @@ public class JsonTreeReaderTest {
     JsonTreeReader reader = new JsonTreeReader(jsonObject);
     reader.beginObject();
     var unused = reader.nextName();
-    MalformedJsonException e =
-        assertThrows(MalformedJsonException.class, () -> reader.nextInt());
+    MalformedJsonException e = assertThrows(MalformedJsonException.class, () -> reader.nextInt());
     assertThat(e).hasMessageThat().contains("non-ASCII");
     assertThat(e).hasMessageThat().contains("path $.x");
   }
@@ -143,8 +142,7 @@ public class JsonTreeReaderTest {
     JsonTreeReader reader = new JsonTreeReader(jsonObject);
     reader.beginObject();
     var unused = reader.nextName();
-    MalformedJsonException e =
-        assertThrows(MalformedJsonException.class, () -> reader.nextLong());
+    MalformedJsonException e = assertThrows(MalformedJsonException.class, () -> reader.nextLong());
     assertThat(e).hasMessageThat().contains("non-ASCII");
     assertThat(e).hasMessageThat().contains("path $.y");
   }


### PR DESCRIPTION
## Summary

`JsonTreeReader.nextInt()` and `nextLong()` silently accept non-ASCII digit variants (e.g. full-width digits U+FF10–FF19, Arabic-Indic, Bengali) when a JSON **string** token is parsed as an integer/long. This is the tree-based counterpart of the streaming-reader gap fixed in #2995 (issue #2994), and was missed when that fix landed.

## Problem

Since #2995, the streaming `JsonReader.nextInt()` / `nextLong()` reject non-ASCII characters via `validateAscii()` before calling `Integer.parseInt()` / `Long.parseLong()`. But the tree-based `JsonTreeReader` — used by `Gson.fromJson(JsonElement, Type)`, `fromJsonTree(...)`, and any path that deserializes from an already-parsed `JsonElement` — has no such check. It goes straight to `JsonPrimitive.getAsInt()` → `Integer.parseInt(getAsString())`, and `Integer.parseInt` uses `Character.digit(...)`, which recognizes *any* Unicode decimal digit, not just ASCII `0-9`.

The result is a behavioral divergence for identical input:

```java
// streaming path (fixed by #2995): throws MalformedJsonException
new Gson().fromJson("{\"x\":\"１２３\"}", Payload.class);   // JsonReader

// tree-based path (this PR's bug): silently returns 123
new Gson().fromJson(JsonParser.parseString("{\"x\":\"１２３\"}"), Payload.class);
```

This is also an incomplete fix for the security concern in #2994 (validation bypass via silent Unicode-digit coercion): any caller that deserializes from a `JsonElement` rather than a raw string still gets the old, vulnerable behavior.

Confirmed on `main` (JDK 21): `Integer.parseInt("１２３")` returns `123`; `JsonTreeReader.nextInt()` on `"１２３"` returns `123` without throwing. (`Double.parseDouble` rejects non-ASCII digits, so `nextDouble()` is unaffected and intentionally not touched here — matching the scope of #2995.)

## Fix

Mirror the approach taken by #2995 in the streaming reader: on the **string** token path of `JsonTreeReader.nextInt()` / `nextLong()`, call a new `validateAscii(primitive.getAsString())` that throws `MalformedJsonException` (including `locationString()`, consistent with the rest of `JsonTreeReader`) if any character exceeds U+007F. The `NUMBER` token path is left untouched — a `JsonPrimitive` that is a `Number` already holds a legitimate numeric value, exactly as the streaming reader only validates the string-to-number path.

```java
JsonPrimitive primitive = (JsonPrimitive) peekStack();
if (token == JsonToken.STRING) {
  validateAscii(primitive.getAsString());
}
int result = primitive.getAsInt();
```

This is a strictly-tightening change with no effect on ASCII input, and keeps the tree reader consistent with the streaming reader.

## Tests

Added to `JsonTreeReaderTest`:

- `testNextIntRejectsNonAsciiDigits` — `"１２３"` via `nextInt()` throws `MalformedJsonException` whose message contains `"non-ASCII"` and `"path $.x"`.
- `testNextLongRejectsNonAsciiDigits` — same for `nextLong()` with `"path $.y"`.
- `testNextIntAndLongAcceptAsciiDigitsInString` — confirms plain ASCII `"123"` / `"456"` in string tokens still parse normally.

All 4607 existing tests pass (3 new ones added), 0 failures, 20 skipped.

## Scope

- Touches only `JsonTreeReader.java` and its test.
- Same one-method `validateAscii` shape as the streaming reader, adapted to throw `MalformedJsonException` + `locationString()` (the streaming reader uses `syntaxError()`).
- No behavioral change for ASCII input; only the tree-based string-to-int/long path is tightened to match the streaming path.

This completes the tree-based counterpart of the #2994 / #2995 fix.