### PR TITLE
Don't suggest Moshi for Kotlin anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,8 @@ There are a few open-source projects that can convert Java objects to JSON. Howe
 
 > [!IMPORTANT]\
 > Gson is not a recommended library for interacting with JSON on Android. The open-ended reflection in the Gson runtime doesn't play nicely with shrinking/optimization/obfuscation passes that Android release apps should perform.\
-> If your app or library may be running on Android, consider using [Kotlin Serialization](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/basic-serialization.md#basics) or [Moshi's Codegen](https://github.com/square/moshi?tab=readme-ov-file#codegen),
-> which use code generation instead of reflection. This avoids Gson's runtime crashes when optimizations are applied (usually due to the fields missing or being obfuscated), and results in faster performance on Android devices.
-> The Moshi APIs may be more familiar to users who already know Gson.
+> If your app or library may be running on Android, consider using [Kotlin Serialization](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/basic-serialization.md#basics),
+> which uses code generation instead of reflection. This avoids Gson's runtime crashes when optimizations are applied (usually due to the fields missing or being obfuscated), and results in faster performance on Android devices.
 > If you still want to use Gson and attempt to avoid these crashes, you can see how to do so [here](Troubleshooting.md#proguard-r8).
 
 ### Goals


### PR DESCRIPTION
See https://redirect.github.com/square/moshi/issues/2079#issuecomment-4051193660
> I also don't recommend Moshi to others writing Kotlin. I recommend kotlinx.serialization because while it has many things I think are worse it has enough that's better to justify its use.

However that comment was written in March 2026 and might be outdated, and the maintainer says they are only speaking for themselves and not the other maintainers.
