### PR TITLE
docs: remove outdated third-party content

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,6 @@ Please use the ['gson' tag on StackOverflow](https://stackoverflow.com/questions
 
 See the details in the related section in the [Troubleshooting guide](Troubleshooting.md#proguard-r8).
 
-### Related Content Created by Third Parties
-  * [Gson Tutorial](https://www.studytrails.com/java/json/java-google-json-introduction/) by `StudyTrails`
-  * [Gson Tutorial Series](https://futurestud.io/tutorials/gson-getting-started-with-java-json-serialization-deserialization) by `Future Studio`
-  * [Gson API Report](https://abi-laboratory.pro/java/tracker/timeline/gson/)
-
 ### Building
 
 Gson uses Maven to build the project:


### PR DESCRIPTION
### Purpose

Remove the obsolete "Related Content Created by Third Parties" section from the README.

Closes #2350

### Description

The section links to third-party resources which are broken or outdated. Per the maintainer's decision in #2350, this change removes the complete section instead of replacing links that may become stale again.

This matches the scope of the earlier unmerged PR #2355, whose author did not complete the required Google CLA.

### Checklist

- [x] New code follows the Google Java Style Guide (N/A: documentation-only deletion)
- [x] If necessary, new public API validates arguments (N/A: no API change)
- [x] New public API has Javadoc (N/A: no API change)
- [x] If necessary, new unit tests have been added (N/A: no behavior change)
- [ ] `mvn clean verify javadoc:jar` passes without errors (Maven is unavailable locally; normal CI will run the build matrix)

### Validation

- confirmed the heading and all three obsolete references are absent
- confirmed the surrounding README section structure
- `git diff --check`
- trailing-whitespace and final-newline checks

### AI disclosure

This focused documentation cleanup was prepared and independently reviewed with AI assistance.
