### PR TITLE
Fix URI type adapter to preserve identity for non-ASCII URIs

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -730,7 +730,7 @@ public final class TypeAdapters {
 
         @Override
         public void write(JsonWriter out, URI value) throws IOException {
-          out.value(value == null ? null : value.toASCIIString());
+          out.value(value == null ? null : value.toString());
         }
       };
 

--- a/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
@@ -188,6 +188,15 @@ public class DefaultTypeAdaptersTest {
   }
 
   @Test
+  public void testUriRoundTripWithNonAscii() throws Exception {
+    URI uri = new URI("s3://bucket/path/Kankyō.png");
+    String json = gson.toJson(uri);
+    URI roundTripUri = gson.fromJson(json, URI.class);
+    assertThat(roundTripUri).isEqualTo(uri);
+    assertThat(roundTripUri.toString()).isEqualTo(uri.toString());
+  }
+
+  @Test
   public void testNullSerialization() {
     testNullSerializationAndDeserialization(Boolean.class);
     testNullSerializationAndDeserialization(Byte.class);

--- a/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
@@ -184,7 +184,7 @@ public class DefaultTypeAdaptersTest {
     String uriValue = "http://google.com/";
     String json = '"' + uriValue + '"';
     URI target = gson.fromJson(json, URI.class);
-    assertThat(target.toASCIIString()).isEqualTo(uriValue);
+    assertThat(target.toString()).isEqualTo(uriValue);
   }
 
   @Test


### PR DESCRIPTION
The URI type adapter was calling `URI.toASCIIString()` in its `write()` method, which percent-encodes non-ASCII characters and applies Unicode normalization. The `read()` method does not reverse this percent-encoding, causing URIs with international characters to lose their original identity during round-trip serialization. For example, `s3://bucket/path/Kankyō.png` would fail an equality check after being serialized and deserialized.

The fix replaces `toASCIIString()` with `toString()` in line 733 of TypeAdapters.java. This preserves the original URI representation without normalization while remaining JSON-spec compliant, as JSON allows UTF-8 non-ASCII characters in strings. The change is backward compatible because pure-ASCII URIs produce identical output with both methods.

A regression test was added to verify that URIs with non-ASCII characters maintain equality after round-trip serialization.

Fixes #1587
