### PR TITLE
Extend "map as array" deserialization tests

### DIFF
--- a/gson/src/test/java/com/google/gson/functional/MapAsArrayTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MapAsArrayTypeAdapterTest.java
@@ -24,7 +24,9 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.Ignore;
@@ -129,6 +131,74 @@ public class MapAsArrayTypeAdapterTest {
     assertThat(value).isEqualTo(new Point(4, 5));
   }
 
+  @Test
+  public void testDeserializationWithNullKey() {
+    Gson gson = new GsonBuilder().enableComplexMapKeySerialization().create();
+    Type typeOfMap = new TypeToken<Map<String, Integer>>() {}.getType();
+    Map<String, Integer> map = gson.fromJson("[[null,123]]", typeOfMap);
+    assertThat(map).hasSize(1);
+    assertThat(map.get(null)).isEqualTo(123);
+  }
+
+  /** Tests deserializing as raw {@code Map.class} with {@code null} key. */
+  @Test
+  public void testDeserializeRawMapNullKey() {
+    Gson gson = new GsonBuilder().enableComplexMapKeySerialization().create();
+    String json = "[[\"a\", 1.0], [null, 2.0], [\"b\", 3.0]]";
+
+    Map<Object, Double> expectedMap = new LinkedHashMap<>();
+    expectedMap.put("a", 1.0);
+    expectedMap.put(null, 2.0);
+    expectedMap.put("b", 3.0);
+
+    assertThat(gson.fromJson(json, Map.class)).isEqualTo(expectedMap);
+  }
+
+  /** Tests deserializing as raw {@code Map.class} with non-{@code Comparable} key. */
+  @Test
+  public void testDeserializeRawMapNonComparableKey() {
+    Gson gson = new GsonBuilder().enableComplexMapKeySerialization().create();
+    String json = "[[\"a\", 1.0], [{}, 2.0], [\"b\", 3.0]]";
+
+    Map<Object, Double> expectedMap = new LinkedHashMap<>();
+    expectedMap.put("a", 1.0);
+    expectedMap.put(Collections.emptyMap(), 2.0);
+    expectedMap.put("b", 3.0);
+
+    @SuppressWarnings("unchecked")
+    Map<Object, Double> map = gson.fromJson(json, Map.class);
+    assertThat(map).isEqualTo(expectedMap);
+
+    Iterator<Map.Entry<Object, Double>> mapIterator = map.entrySet().iterator();
+    mapIterator.next(); // skip first entry
+    Map.Entry<Object, Double> entry = mapIterator.next();
+    Object key = entry.getKey();
+    assertThat(key).isEqualTo(Collections.emptyMap());
+    assertThat(key).isNotInstanceOf(Comparable.class);
+    assertThat(entry.getValue()).isEqualTo(2.0);
+  }
+
+  /**
+   * Deserialization of array should work, even if {@link
+   * GsonBuilder#enableComplexMapKeySerialization()} is not used.
+   */
+  @Test
+  public void testDeserializationWithoutExplicitlyEnabled() {
+    Gson gson = new GsonBuilder().create();
+    Type type = new TypeToken<Map<Integer, Integer>>() {}.getType();
+    String json = "[[1, 11], [2, 22]]";
+    Map<Integer, Integer> map = gson.fromJson(json, type);
+    assertThat(map).containsExactly(1, 11, 2, 22).inOrder();
+
+    // But for "map as array" all entries have to be encoded as `[key, value]` pairs
+    var e = assertThrows(JsonSyntaxException.class, () -> gson.fromJson("[[1, 11], 2, 22]", type));
+    assertThat(e).hasCauseThat().isInstanceOf(IllegalStateException.class);
+    assertThat(e)
+        .hasCauseThat()
+        .hasMessageThat()
+        .startsWith("Expected BEGIN_ARRAY but was NUMBER at line 1 column 12 path $[1]");
+  }
+
   static class Point {
     int x;
     int y;
@@ -138,6 +208,7 @@ public class MapAsArrayTypeAdapterTest {
       this.y = y;
     }
 
+    @SuppressWarnings("unused")
     Point() {}
 
     @Override

--- a/gson/src/test/java/com/google/gson/functional/MapTest.java
+++ b/gson/src/test/java/com/google/gson/functional/MapTest.java
@@ -30,9 +30,13 @@ import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializer;
 import com.google.gson.JsonSyntaxException;
+import com.google.gson.TypeAdapter;
 import com.google.gson.common.TestTypes;
 import com.google.gson.internal.GsonTypes;
 import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.AbstractMap;
 import java.util.Collection;
@@ -163,12 +167,42 @@ public class MapTest {
     assertThat(map.get(null)).isNull();
   }
 
+  /**
+   * Tests deserializing as {@code Map<String, ...>} with a key being deserialized as {@code null}.
+   * This can only occur if a custom type adapter for {@code String} is used. (Unless "map as array"
+   * form is used, see {@link MapAsArrayTypeAdapterTest}.)
+   */
   @Test
-  public void testMapDeserializationWithNullKeyAndListOfEntries() {
-    Type typeOfMap = new TypeToken<Map<String, Integer>>() {}.getType();
-    Map<String, Integer> map = gson.fromJson("[[null,123]]", typeOfMap);
-    assertThat(map).hasSize(1);
-    assertThat(map.get(null)).isEqualTo(123);
+  public void testStringMapDeserializationWithCustomAdapterNullKey() {
+    Gson gson =
+        new GsonBuilder()
+            .enableComplexMapKeySerialization()
+            .registerTypeAdapter(
+                String.class,
+                new TypeAdapter<String>() {
+                  @Override
+                  public String read(JsonReader in) throws IOException {
+                    String value = in.nextString();
+                    return value.isEmpty() ? null : value;
+                  }
+
+                  @Override
+                  public void write(JsonWriter out, String value) {
+                    throw new AssertionError("not needed for this test");
+                  }
+                })
+            .create();
+
+    String json = "{\"a\":1,\"\":2,\"b\":3}";
+
+    Map<String, Integer> expectedMap = new LinkedHashMap<>();
+    expectedMap.put("a", 1);
+    expectedMap.put(null, 2);
+    expectedMap.put("b", 3);
+
+    Type type = new TypeToken<Map<String, Integer>>() {}.getType();
+    Map<String, Integer> map = gson.fromJson(json, type);
+    assertThat(map).containsExactlyEntriesIn(expectedMap).inOrder();
   }
 
   @Test


### PR DESCRIPTION
### Purpose
Follow-up for #3057

(taken from my old PR #2152)

### Description
Extends the tests to cover more deserialization of "map as array", especially with `null` and non-`Comparable` keys.