### PR TITLE
Improve `JsonObject` null handling documentation

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonObject.java
+++ b/gson/src/main/java/com/google/gson/JsonObject.java
@@ -23,10 +23,10 @@ import java.util.Set;
 
 /**
  * A class representing an object type in JSON. An object consists of name-value pairs where names
- * are strings, and values are any other type of {@link JsonElement}. This allows for a creating a
- * tree of JsonElements. The member elements of this object are maintained in order they were added.
- * This class does not support {@code null} values. If {@code null} is provided as value argument to
- * any of the methods, it is converted to a {@link JsonNull}.
+ * are strings, and values are any type of {@link JsonElement}. This allows for a creating a tree of
+ * JsonElements. The member elements of this object are maintained in the order they were added.
+ * Member names must be non-{@code null}. Member values cannot be {@code null} either; if {@code
+ * null} is provided as value argument to any of the methods, it is converted to a {@link JsonNull}.
  *
  * <p>{@code JsonObject} does not implement the {@link Map} interface, but a {@code Map} view of it
  * can be obtained with {@link #asMap()}.


### PR DESCRIPTION
### Purpose
Explicitly mention that member names must be non-null
