### PR TITLE
Add missing @return javadoc to deepCopy methods

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonArray.java
+++ b/gson/src/main/java/com/google/gson/JsonArray.java
@@ -63,6 +63,7 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
   /**
    * Creates a deep copy of this element and all its children.
    *
+   * @return a deep copy of this array
    * @since 2.8.2
    */
   @Override

--- a/gson/src/main/java/com/google/gson/JsonElement.java
+++ b/gson/src/main/java/com/google/gson/JsonElement.java
@@ -106,6 +106,7 @@ public abstract class JsonElement {
    * Returns a deep copy of this element. Immutable elements like primitives and nulls are not
    * copied.
    *
+   * @return a deep copy of this element
    * @since 2.8.2
    */
   public abstract JsonElement deepCopy();

--- a/gson/src/main/java/com/google/gson/JsonNull.java
+++ b/gson/src/main/java/com/google/gson/JsonNull.java
@@ -44,6 +44,7 @@ public final class JsonNull extends JsonElement {
   /**
    * Returns the same instance since it is an immutable value.
    *
+   * @return the same instance since it is an immutable value
    * @since 2.8.2
    */
   @Override

--- a/gson/src/main/java/com/google/gson/JsonObject.java
+++ b/gson/src/main/java/com/google/gson/JsonObject.java
@@ -47,6 +47,7 @@ public final class JsonObject extends JsonElement {
   /**
    * Creates a deep copy of this element and all its children.
    *
+   * @return a deep copy of this object
    * @since 2.8.2
    */
   @Override

--- a/gson/src/main/java/com/google/gson/JsonPrimitive.java
+++ b/gson/src/main/java/com/google/gson/JsonPrimitive.java
@@ -88,6 +88,7 @@ public final class JsonPrimitive extends JsonElement {
   /**
    * Returns the same value as primitives are immutable.
    *
+   * @return the same value as primitives are immutable
    * @since 2.8.2
    */
   @Override


### PR DESCRIPTION
Fixes missing @return javadoc in deepCopy overrides.