### PR TITLE
Only deserialize `InetAddress` from numeric IP addresses.

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -737,16 +737,16 @@ public final class TypeAdapters {
 
   public static final TypeAdapterFactory URI_FACTORY = newFactory(URI.class, URI);
 
-  /**
-   * A pattern that matches every IP address and no DNS address. It matches plenty of things that
-   * aren't either of those, which is fine. An IPv4 address is n.n.n.n where each n is a
-   * non-negative integer. An IPv6 address contains at least one colon. (There are further
-   * constraints in both cases, but they don't matter here.)
-   */
-  private static final Pattern IP_ADDRESS_PATTERN = Pattern.compile(".*:.*|[0-9]+(\\.[0-9]+){3}");
-
   public static final TypeAdapter<InetAddress> INET_ADDRESS =
       new TypeAdapter<InetAddress>() {
+
+        // A pattern that matches every IP address and no DNS address. It matches plenty of things
+        // that aren't either of those, which is fine. An IPv4 address is n.n.n.n where each n is a
+        // non-negative integer. An IPv6 address contains at least one colon. (There are further
+        // constraints in both cases, but they don't matter here.)
+        private static final Pattern IP_ADDRESS_PATTERN =
+            Pattern.compile(".*:.*|[0-9]+(\\.[0-9]+){3}");
+
         @Override
         public InetAddress read(JsonReader in) throws IOException {
           if (in.peek() == JsonToken.NULL) {
@@ -758,7 +758,7 @@ public final class TypeAdapters {
               && !Boolean.getBoolean("gson.allowDnsInetAddress")) {
             throw new JsonSyntaxException(
                 "Failed parsing '"
-                    + in.peek().toString()
+                    + s
                     + "' as InetAddress; at path "
                     + in.getPreviousPath()
                     + "; to allow DNS addresses, set system property gson.allowDnsInetAddress to"

--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -744,8 +744,7 @@ public final class TypeAdapters {
         // that aren't either of those, which is fine. An IPv4 address is n.n.n.n where each n is a
         // non-negative integer. An IPv6 address contains at least one colon. (There are further
         // constraints in both cases, but they don't matter here.)
-        private static final Pattern IP_ADDRESS_PATTERN =
-            Pattern.compile(".*:.*|[0-9]+(\\.[0-9]+){3}");
+        private final Pattern ip_address_pattern = Pattern.compile(".*:.*|[0-9]+(\\.[0-9]+){3}");
 
         @Override
         public InetAddress read(JsonReader in) throws IOException {
@@ -754,7 +753,7 @@ public final class TypeAdapters {
             return null;
           }
           String s = in.nextString();
-          if (!IP_ADDRESS_PATTERN.matcher(s).matches()
+          if (!ip_address_pattern.matcher(s).matches()
               && !Boolean.getBoolean("gson.allowDnsInetAddress")) {
             throw new JsonSyntaxException(
                 "Failed parsing '"

--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -52,6 +52,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongArray;
+import java.util.regex.Pattern;
 
 /**
  * Type adapters for basic types. More complex adapters exist as separate classes in the enclosing
@@ -736,6 +737,14 @@ public final class TypeAdapters {
 
   public static final TypeAdapterFactory URI_FACTORY = newFactory(URI.class, URI);
 
+  /**
+   * A pattern that matches every IP address and no DNS address. It matches plenty of things that
+   * aren't either of those, which is fine. An IPv4 address is n.n.n.n where each n is a
+   * non-negative integer. An IPv6 address contains at least one colon. (There are further
+   * constraints in both cases, but they don't matter here.)
+   */
+  private static final Pattern IP_ADDRESS_PATTERN = Pattern.compile(".*:.*|[0-9]+(\\.[0-9]+){3}");
+
   public static final TypeAdapter<InetAddress> INET_ADDRESS =
       new TypeAdapter<InetAddress>() {
         @Override
@@ -744,11 +753,19 @@ public final class TypeAdapters {
             in.nextNull();
             return null;
           }
-          // regrettably, this should have included both the host name and the host address
-          // For compatibility, we use InetAddress.getByName rather than the possibly-better
-          // .getAllByName
+          String s = in.nextString();
+          if (!IP_ADDRESS_PATTERN.matcher(s).matches()
+              && !Boolean.getBoolean("gson.allowDnsInetAddress")) {
+            throw new JsonSyntaxException(
+                "Failed parsing '"
+                    + in.peek().toString()
+                    + "' as InetAddress; at path "
+                    + in.getPreviousPath()
+                    + "; to allow DNS addresses, set system property gson.allowDnsInetAddress to"
+                    + " \"true\"");
+          }
           @SuppressWarnings("AddressSelection")
-          InetAddress addr = InetAddress.getByName(in.nextString());
+          InetAddress addr = InetAddress.getByName(s);
           return addr;
         }
 

--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -744,7 +744,7 @@ public final class TypeAdapters {
         // that aren't either of those, which is fine. An IPv4 address is n.n.n.n where each n is a
         // non-negative integer. An IPv6 address contains at least one colon. (There are further
         // constraints in both cases, but they don't matter here.)
-        private final Pattern ip_address_pattern = Pattern.compile(".*:.*|[0-9]+(\\.[0-9]+){3}");
+        private final Pattern ipAddressPattern = Pattern.compile(".*:.*|[0-9]+(\\.[0-9]+){3}");
 
         @Override
         public InetAddress read(JsonReader in) throws IOException {
@@ -753,7 +753,7 @@ public final class TypeAdapters {
             return null;
           }
           String s = in.nextString();
-          if (!ip_address_pattern.matcher(s).matches()
+          if (!ipAddressPattern.matcher(s).matches()
               && !Boolean.getBoolean("gson.allowDnsInetAddress")) {
             throw new JsonSyntaxException(
                 "Failed parsing '"

--- a/gson/src/test/java/com/google/gson/DefaultInetAddressTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/DefaultInetAddressTypeAdapterTest.java
@@ -59,7 +59,12 @@ public class DefaultInetAddressTypeAdapterTest {
   @Test
   public void testInetAddressDeserializeNonIpAddress() {
     String jsonAddress = "\"localhost\"";
-    assertThrows(JsonSyntaxException.class, () -> gson.fromJson(jsonAddress, InetAddress.class));
+    JsonSyntaxException e =
+        assertThrows(
+            JsonSyntaxException.class, () -> gson.fromJson(jsonAddress, InetAddress.class));
+    assertThat(e)
+        .hasMessageThat()
+        .startsWith("Failed parsing 'localhost' as InetAddress; at path $");
   }
 
   @Test

--- a/gson/src/test/java/com/google/gson/DefaultInetAddressTypeAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/DefaultInetAddressTypeAdapterTest.java
@@ -17,6 +17,7 @@
 package com.google.gson;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import java.net.InetAddress;
 import org.junit.Before;
@@ -44,5 +45,32 @@ public class DefaultInetAddressTypeAdapterTest {
 
     InetAddress value = gson.fromJson(jsonAddress, InetAddress.class);
     assertThat(address).isEqualTo(value);
+  }
+
+  @Test
+  public void testInetAddressSerializationAndDeserializationIpv6() throws Exception {
+    @SuppressWarnings("AddressSelection") // we really do want this method
+    InetAddress address = InetAddress.getByName("::1"); // IPv6 loopback address
+    String jsonAddress = gson.toJson(address);
+    InetAddress actual = gson.fromJson(jsonAddress, InetAddress.class);
+    assertThat(actual).isEqualTo(address);
+  }
+
+  @Test
+  public void testInetAddressDeserializeNonIpAddress() {
+    String jsonAddress = "\"localhost\"";
+    assertThrows(JsonSyntaxException.class, () -> gson.fromJson(jsonAddress, InetAddress.class));
+  }
+
+  @Test
+  public void testInetAddressDeserializeNonIpAddressAllowed() throws Exception {
+    String jsonAddress = "\"localhost\"";
+    InetAddress expected = InetAddress.getByName("localhost");
+    System.setProperty("gson.allowDnsInetAddress", "true");
+    try {
+      assertThat(gson.fromJson(jsonAddress, InetAddress.class)).isEqualTo(expected);
+    } finally {
+      System.clearProperty("gson.allowDnsInetAddress");
+    }
   }
 }


### PR DESCRIPTION
When *serializing* `InetAddress`, we serialize the numeric form, like `"127.0.0.1"` or `"0:0:0:0:0:0:0:1"`. Because of historic deficiencies in the Java API, Gson uses a method that deserializes these forms, but also host names
like `"localhost"`. Resolving names like that can be expensive, and given that the canonical serial form is numeric, Gson should not do it by default.

Google has many thousands of internal tests that rely directly or indirectly on Gson. We ran them all with a changed version of Gson that produced an exception on deserializing *any* non-null string to an `InetAddress`, even a numeric one. No tests failed. So apparently Google's giant source base has zero occurrences of deserializing an `InetAddress` with Gson. If, however, you do have code that does that, and if it does rely on being able to accept host names, you can set the new system property `gson.allowDnsInetAdress` to `true` to restore the previous behaviour.