### PR TITLE
Make `LazilyParsedNumber` implement `Comparable`.

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/LazilyParsedNumber.java
+++ b/gson/src/main/java/com/google/gson/internal/LazilyParsedNumber.java
@@ -18,7 +18,6 @@ package com.google.gson.internal;
 import java.io.IOException;
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
-import java.io.ObjectStreamException;
 import java.math.BigDecimal;
 
 /**

--- a/gson/src/main/java/com/google/gson/internal/LazilyParsedNumber.java
+++ b/gson/src/main/java/com/google/gson/internal/LazilyParsedNumber.java
@@ -27,7 +27,7 @@ import java.math.BigDecimal;
  * @author Inderjeet Singh
  */
 @SuppressWarnings("serial") // ignore warning about missing serialVersionUID
-public final class LazilyParsedNumber extends Number {
+public final class LazilyParsedNumber extends Number implements Comparable<LazilyParsedNumber> {
   private final String value;
 
   /**
@@ -82,7 +82,7 @@ public final class LazilyParsedNumber extends Number {
    * If somebody is unlucky enough to have to serialize one of these, serialize it as a BigDecimal
    * so that they won't need Gson on the other side to deserialize it.
    */
-  private Object writeReplace() throws ObjectStreamException {
+  private Object writeReplace() {
     return asBigDecimal();
   }
 
@@ -90,6 +90,17 @@ public final class LazilyParsedNumber extends Number {
     // Don't permit directly deserializing this class; writeReplace() should have written a
     // replacement
     throw new InvalidObjectException("Deserialization is unsupported");
+  }
+
+  /**
+   * Compares this LazilyParsedNumber with the specified LazilyParsedNumber. The comparison is
+   * lexicographical, based on the string values of the two numbers, so it does not in general
+   * correspond to numeric comparison. For numeric comparison, call {@link #asBigDecimal()} on both
+   * numbers and compare the results.
+   */
+  @Override
+  public int compareTo(LazilyParsedNumber other) {
+    return value.compareTo(other.value);
   }
 
   @Override

--- a/gson/src/test/java/com/google/gson/internal/LazilyParsedNumberTest.java
+++ b/gson/src/test/java/com/google/gson/internal/LazilyParsedNumberTest.java
@@ -23,6 +23,9 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.junit.Test;
 
 public class LazilyParsedNumberTest {
@@ -38,6 +41,14 @@ public class LazilyParsedNumberTest {
     LazilyParsedNumber n1 = new LazilyParsedNumber("1");
     LazilyParsedNumber n1Another = new LazilyParsedNumber("1");
     assertThat(n1.equals(n1Another)).isTrue();
+  }
+
+  @Test
+  public void testCompareTo() {
+    List<String> inputs = Arrays.asList(new String[] {"1", "1.0", "2", "1e6"});
+    Collections.sort(inputs);
+    List<String> expected = Arrays.asList(new String[] {"1", "1.0", "1e6", "2"});
+    assertThat(inputs).isEqualTo(expected);
   }
 
   @Test


### PR DESCRIPTION
This means that it can be put in a `TreeSet` or used as a key in a `TreeMap`, though only if the other elements or keys are also instances of `LazilyParsedNumber`. Typically that will be the case if they all came from the same place, for example by parsing incoming JSON in the same way.
