### PR TITLE
Fix LegacyProtoTypeAdapterFactoryTest bitfield regex pattern.

### DIFF
--- a/proto/src/test/java/com/google/gson/protobuf/functional/LegacyProtoTypeAdapterFactoryTest.java
+++ b/proto/src/test/java/com/google/gson/protobuf/functional/LegacyProtoTypeAdapterFactoryTest.java
@@ -199,6 +199,7 @@ public final class LegacyProtoTypeAdapterFactoryTest {
     Pattern pattern =
         Pattern.compile(
             "^(memoized.?(Hash.?Code|Is.?Initialized|Size))|unknown.?Fields"
+                + "|bit.?[fF]ield.*"
                 + "|.*Memoized.?Serialized.?Size$",
             Pattern.CASE_INSENSITIVE);
     var keysToRemove =


### PR DESCRIPTION
This will allow the test to pass even after some upcoming changes to the internal representation of Java protos.

This is internal cl/958647397.