### PR TITLE
Skip accessibility check in BoundField once it is known to have passed

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ReflectiveTypeAdapterFactory.java
@@ -218,15 +218,33 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
       writeTypeAdapter = typeAdapter;
     }
     return new BoundField(serializedName, field) {
+      /**
+       * Whether the accessibility check has already passed. The result depends only on the member
+       * and the {@code ReflectionAccessFilter}s of the {@code Gson} instance, not on the object
+       * being serialized or deserialized, so once the check passes it will pass for every later
+       * call and the reflective check can be skipped. A single field suffices because {@code
+       * accessor} is fixed for this instance, and it is non-null only for records, which are
+       * deserialized via {@link #readIntoArray} rather than {@link #readIntoField}.
+       *
+       * <p>Deliberately not {@code volatile}: under concurrent use a thread may observe a stale
+       * {@code false} and redo the check, but the check is idempotent and always produces the same
+       * result for a given member, so the race is benign. Do not cache a negative result here; that
+       * would make the race unsafe.
+       */
+      private boolean knownAccessible;
+
       @Override
       void write(JsonWriter writer, Object source) throws IOException, IllegalAccessException {
         if (blockInaccessible) {
-          if (accessor == null) {
-            checkAccessible(source, field);
-          } else {
-            // Note: This check might actually be redundant because access check for canonical
-            // constructor should have failed already
-            checkAccessible(source, accessor);
+          if (!knownAccessible) {
+            if (accessor == null) {
+              checkAccessible(source, field);
+            } else {
+              // Note: This check might actually be redundant because access check for canonical
+              // constructor should have failed already
+              checkAccessible(source, accessor);
+            }
+            knownAccessible = true;
           }
         }
 
@@ -274,7 +292,10 @@ public final class ReflectiveTypeAdapterFactory implements TypeAdapterFactory {
         Object fieldValue = typeAdapter.read(reader);
         if (fieldValue != null || !isPrimitive) {
           if (blockInaccessible) {
-            checkAccessible(target, field);
+            if (!knownAccessible) {
+              checkAccessible(target, field);
+              knownAccessible = true;
+            }
           } else if (isStaticFinalField) {
             // Reflection does not permit setting value of `static final` field, even after calling
             // `setAccessible`


### PR DESCRIPTION
Closes #2202

Follow-up to #3054, which I accidentally closed for good by deleting my fork while cleaning up old repos (sorry about that, GitHub won't let a PR reopen once the head repo is gone).

This is the simpler approach @eamonnmcmanus suggested there instead of my original AccessibleCache class: checkAccessible now takes an AtomicBoolean knownAccessible. If it's already true the reflective check is skipped, otherwise the check runs and sets it on success. The unusual inaccessible case just redoes the check and rebuilds the exception message every time, no caching of the failure.

The record constructor check in RecordAdapter passes a throwaway AtomicBoolean since it already only runs once per adapter.

Unlike last time I got a proper maven setup working locally, so this one is actually fully verified: mvn -pl gson verify passes end to end, 4619 tests, 0 failures, 0 errors (19 skipped), including spotless and error-prone.