### PR TITLE
Increase Dependabot cooldown for JUnit 6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,24 @@ updates:
         patterns:
         # Create a single pull request for all dependencies and plugins
         - "*"
+    ignore:
+      # Ignore JUnit 6, see dedicated configuration below
+      - dependency-name: "org.junit:junit-bom"
+
+  # Dedicated config for JUnit 6
+  # Currently JUnit 6 is only used for `/test-graal-native-image`, but it frequently causes incompatibilities
+  # there with `org.graalvm.buildtools:native-maven-plugin` because that maintains a hardcoded list of some JUnit
+  # classes (at least for JDK 21, see https://github.com/junit-team/junit-framework/issues/5134#issuecomment-3481992112)
+  # When JUnit introduces a new class but the native-maven-plugin has not included it yet, the Dependabot PR fails
+  # Therefore increase cooldown specifically for JUnit to reduce the risk of this happening
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 50
+    allow:
+      - dependency-name: "org.junit:junit-bom"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,7 +27,7 @@ updates:
     schedule:
       interval: "monthly"
     cooldown:
-      default-days: 50
+      default-days: 70
     allow:
       - dependency-name: "org.junit:junit-bom"
     # Hack: Work around Dependabot restriction "update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,9 @@ updates:
       default-days: 50
     allow:
       - dependency-name: "org.junit:junit-bom"
+    # Hack: Work around Dependabot restriction "update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'"
+    # see https://github.com/dependabot/dependabot-core/issues/1778#issuecomment-1988140219
+    target-branch: "main"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
### Purpose
Reduce risk of incompatibilities with native-maven-plugin.

### Description
native-maven-plugin maintains a hardcoded list of JUnit classes initialized at build time ([at least for GraalVM for JDK 21?](https://github.com/junit-team/junit-framework/issues/5134#issuecomment-3481992112)). In the past it has happened multiple times that Dependabot PRs failed because JUnit was updated but native-maven-plugin was not, and therefore was missing a newly introduced JUnit class (or that native-maven-plugin was updated, but the version did not include the JUnit class nonetheless). See for example #3078.

This PR here tries to reduce the risk of this by increasing the cooldown for JUnit 6, making it more likely that at the point when it is updated, native-maven-plugin's list already includes the new JUnit classes.

> [!WARNING]
> - I have made these changes based on the documentation and examples from other repositories; so I think they should be correct and it seems to work as desired in my fork.
> - This could maybe introduce other issues where in the opposite direction a JUnit fix is needed for native-maven-plugin / GraalVM, e.g. https://redirect.github.com/junit-team/junit-framework/pull/5901 (not sure).