### PR TITLE
Create separate Dependabot PRs for JUnit 6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,13 @@ updates:
       # Name is used for branch name and pull request title
       maven:
         patterns:
-        # Create a single pull request for all dependencies and plugins
-        - "*"
+          # Create a single pull request for all dependencies and plugins
+          - "*"
+        exclude-patterns:
+          # Exclude JUnit 6 from the group (that is, create a separate PR for it)
+          # It is currently only used by `/test-graal-native-image` and frequently causes incompatibilities
+          # there with `org.graalvm.buildtools:native-maven-plugin`, causing the complete Dependabot PR to fail
+          - "org.junit:junit-bom"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -23,5 +28,5 @@ updates:
       # Name is used for branch name and pull request title
       github-actions:
         patterns:
-        # Create a single pull request for all actions
-        - "*"
+          # Create a single pull request for all actions
+          - "*"


### PR DESCRIPTION
### Purpose
Avoid incompatibilities with native-maven-plugin

### Description
native-maven-plugin maintains a hardcoded list of JUnit classes initialized at build time ([at least for GraalVM for JDK 21?](https://github.com/junit-team/junit-framework/issues/5134#issuecomment-3481992112)). In the past it has happened multiple times that Dependabot PRs failed because JUnit was updated but native-maven-plugin was not, and therefore was missing a newly introduced JUnit class (or that native-maven-plugin was updated, but the version did not include the JUnit class nonetheless). See for example #3078.

This PR here tries to prevent that by letting Dependabot creates separate PRs for JUnit 6. The regular grouped Dependabot Maven PR should then hopefully build without issues, and the separate JUnit PR can be delayed if necessary until `main` uses a matching native-maven-plugin version.

Supersedes #3087