### PR TITLE
Fix typos and grammar issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ Also many small improvements to javadoc.
 ## Version 2.8.8
 
 * Fixed issue with recursive types (https://github.com/google/gson/issues/1390).
-* Better behaviour with Java 9+ and `Unsafe` if there is a security manager (https://github.com/google/gson/pull/1712).
+* Better behavior with Java 9+ and `Unsafe` if there is a security manager (https://github.com/google/gson/pull/1712).
 * `EnumTypeAdapter` now works better when ProGuard has obfuscated enum fields (https://github.com/google/gson/pull/1495).
 
 ## Version 2.8.7
@@ -102,7 +102,7 @@ _2018-05-21_  [GitHub Diff](https://github.com/google/gson/compare/gson-parent-2
 
 ## Version 2.8.4
 _2018-05-01_  [GitHub Diff](https://github.com/google/gson/compare/gson-parent-2.8.3...gson-parent-2.8.4)
- * Added a new FieldNamingPolicy, `LOWER_CASE_WITH_DOTS` that mapps JSON name `someFieldName` to `some.field.name`
+ * Added a new FieldNamingPolicy, `LOWER_CASE_WITH_DOTS` that maps JSON name `someFieldName` to `some.field.name`
  * Fixed issue https://github.com/google/gson/issues/1305 by removing compile/runtime dependency on `sun.misc.Unsafe`
 
 ## Version 2.8.3

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Older Gson versions may also support lower API levels, however this has not been
   * [User guide](UserGuide.md): This guide contains examples on how to use Gson in your code
   * [Troubleshooting guide](Troubleshooting.md): Describes how to solve common issues when using Gson
   * [Releases and change log](https://github.com/google/gson/releases): Latest releases and changes in these versions; for older releases see [`CHANGELOG.md`](CHANGELOG.md)
-  * [Design document](GsonDesignDocument.md): This document discusses issues we faced while designing Gson. It also includes a comparison of Gson with other Java libraries that can be used for Json conversion
+  * [Design document](GsonDesignDocument.md): This document discusses issues we faced while designing Gson. It also includes a comparison of Gson with other Java libraries that can be used for JSON conversion
 
 Please use the ['gson' tag on StackOverflow](https://stackoverflow.com/questions/tagged/gson), [GitHub Discussions](https://github.com/google/gson/discussions) or the [google-gson Google group](https://groups.google.com/group/google-gson) to discuss Gson or to post questions.
 

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -528,7 +528,7 @@ String jsonOutput = gson.toJson(someObject);
 
 ### Null Object Support
 
-The default behaviour that is implemented in Gson is that `null` object fields are ignored. This allows for a more compact output format; however, the client must define a default value for these fields as the JSON format is converted back into its Java form.
+The default behavior that is implemented in Gson is that `null` object fields are ignored. This allows for a more compact output format; however, the client must define a default value for these fields as the JSON format is converted back into its Java form.
 
 Here's how you would configure a `Gson` instance to output null:
 

--- a/extras/src/main/java/com/google/gson/interceptors/Intercept.java
+++ b/extras/src/main/java/com/google/gson/interceptors/Intercept.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 /**
  * Use this annotation to indicate various interceptors for class instances after they have been
  * processed by Gson. For example, you can use it to validate an instance after it has been
- * deserialized from Json. Here is an example of how this annotation is used:
+ * deserialized from JSON. Here is an example of how this annotation is used:
  *
  * <p>Here is an example of how this annotation is used:
  *

--- a/extras/src/main/java/com/google/gson/interceptors/JsonPostDeserializer.java
+++ b/extras/src/main/java/com/google/gson/interceptors/JsonPostDeserializer.java
@@ -26,6 +26,6 @@ import com.google.gson.InstanceCreator;
  */
 public interface JsonPostDeserializer<T> {
 
-  /** This method is called by Gson after the object has been deserialized from Json. */
+  /** This method is called by Gson after the object has been deserialized from JSON. */
   public void postDeserialize(T object);
 }

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -232,7 +232,7 @@ public final class GsonBuilder {
   }
 
   /**
-   * Makes the output JSON non-executable in Javascript by prefixing the generated JSON with some
+   * Makes the output JSON non-executable in JavaScript by prefixing the generated JSON with some
    * special text. This prevents attacks from third-party sites through script sourcing. See <a
    * href="http://code.google.com/p/google-gson/issues/detail?id=42">Gson Issue 42</a> for details.
    *
@@ -652,7 +652,7 @@ public final class GsonBuilder {
   /**
    * Configures Gson to serialize {@code Date} objects according to the date style value provided.
    * You can call this method or {@link #setDateFormat(String)} multiple times, but only the last
-   * invocation will be used to decide the serialization format. This methods leaves the current
+   * invocation will be used to decide the serialization format. This method leaves the current
    * 'time style' unchanged.
    *
    * <p>Note that this style value should be one of the predefined constants in the {@link
@@ -843,8 +843,8 @@ public final class GsonBuilder {
   /**
    * Section 6 of <a href="https://www.ietf.org/rfc/rfc8259.txt">JSON specification</a> disallows
    * special double values (NaN, Infinity, -Infinity). However, <a
-   * href="http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf">Javascript
-   * specification</a> (see section 4.3.20, 4.3.22, 4.3.23) allows these values as valid Javascript
+   * href="http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf">JavaScript
+   * specification</a> (see section 4.3.20, 4.3.22, 4.3.23) allows these values as valid JavaScript
    * values. Moreover, most JavaScript engines will accept these special values in JSON without
    * problem. So, at a practical level, it makes sense to accept these values as valid JSON even
    * though JSON specification disallows them.

--- a/gson/src/main/java/com/google/gson/JsonDeserializer.java
+++ b/gson/src/main/java/com/google/gson/JsonDeserializer.java
@@ -86,7 +86,7 @@ public interface JsonDeserializer<T> {
    * passing {@code json} since that will cause an infinite loop (Gson will call your call-back
    * method again).
    *
-   * @param json The Json data being deserialized
+   * @param json The JSON data being deserialized
    * @param typeOfT The type of the Object to deserialize to
    * @return a deserialized object of the specified type typeOfT which is a subclass of {@code T}
    * @throws JsonParseException if json is not in the expected format of {@code typeOfT}

--- a/gson/src/main/java/com/google/gson/JsonObject.java
+++ b/gson/src/main/java/com/google/gson/JsonObject.java
@@ -23,7 +23,7 @@ import java.util.Set;
 
 /**
  * A class representing an object type in JSON. An object consists of name-value pairs where names
- * are strings, and values are any type of {@link JsonElement}. This allows for a creating a tree of
+ * are strings, and values are any type of {@link JsonElement}. This allows for creating a tree of
  * JsonElements. The member elements of this object are maintained in the order they were added.
  * Member names must be non-{@code null}. Member values cannot be {@code null} either; if {@code
  * null} is provided as value argument to any of the methods, it is converted to a {@link JsonNull}.

--- a/gson/src/main/java/com/google/gson/JsonParseException.java
+++ b/gson/src/main/java/com/google/gson/JsonParseException.java
@@ -17,14 +17,14 @@
 package com.google.gson;
 
 /**
- * This exception is raised if there is a serious issue that occurs during parsing of a Json string.
- * One of the main usages for this class is for the Gson infrastructure. If the incoming Json is
+ * This exception is raised if there is a serious issue that occurs during parsing of a JSON string.
+ * One of the main usages for this class is for the Gson infrastructure. If the incoming JSON is
  * bad/malicious, an instance of this exception is raised.
  *
  * <p>This exception is a {@link RuntimeException} because it is exposed to the client. Using a
  * {@link RuntimeException} avoids bad coding practices on the client side where they catch the
  * exception and do nothing. It is often the case that you want to blow up if there is a parsing
- * error (i.e. often clients do not know how to recover from a {@link JsonParseException}.
+ * error (i.e. often clients do not know how to recover from a {@link JsonParseException}).
  *
  * @author Inderjeet Singh
  * @author Joel Leitch

--- a/gson/src/main/java/com/google/gson/JsonSerializer.java
+++ b/gson/src/main/java/com/google/gson/JsonSerializer.java
@@ -84,7 +84,7 @@ public interface JsonSerializer<T> {
    * src} object itself since that will cause an infinite loop (Gson will call your call-back method
    * again).
    *
-   * @param src the object that needs to be converted to Json.
+   * @param src the object that needs to be converted to JSON.
    * @param typeOfSrc the actual type (fully genericized version) of the source object.
    * @return a JsonElement corresponding to the specified object.
    */

--- a/gson/src/main/java/com/google/gson/internal/LinkedTreeMap.java
+++ b/gson/src/main/java/com/google/gson/internal/LinkedTreeMap.java
@@ -663,7 +663,7 @@ public final class LinkedTreeMap<K, V> extends AbstractMap<K, V> implements Seri
   /**
    * If somebody is unlucky enough to have to serialize one of these, serialize it as a
    * LinkedHashMap so that they won't need Gson on the other side to deserialize it. Using
-   * serialization defeats our DoS defence, so most apps shouldn't use it.
+   * serialization defeats our DoS defense, so most apps shouldn't use it.
    */
   private Object writeReplace() throws ObjectStreamException {
     return new LinkedHashMap<>(this);

--- a/gson/src/main/java/com/google/gson/internal/bind/JavaTimeTypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JavaTimeTypeAdapters.java
@@ -287,7 +287,7 @@ final class JavaTimeTypeAdapters implements TypeAdapters.FactorySupplier {
   // A ZoneId is either a ZoneOffset or a ZoneRegion, where ZoneOffset is public and ZoneRegion is
   // not. For compatibility with reflection-based serialization, we need to write the "id" field of
   // ZoneRegion if we have a ZoneRegion, and we need to write the "totalSeconds" field of ZoneOffset
-  // if we have a ZoneOffset. When reading, we need to construct the the appropriate thing depending
+  // if we have a ZoneOffset. When reading, we need to construct the appropriate thing depending
   // on which of those two fields we see.
   private static final TypeAdapter<ZoneId> ZONE_ID =
       new TypeAdapter<ZoneId>() {

--- a/gson/src/main/java/com/google/gson/package-info.java
+++ b/gson/src/main/java/com/google/gson/package-info.java
@@ -15,7 +15,7 @@
  */
 
 /**
- * This package provides the {@link com.google.gson.Gson} class to convert Json to Java and
+ * This package provides the {@link com.google.gson.Gson} class to convert JSON to Java and
  * vice-versa.
  *
  * <p>The primary class to use is {@link com.google.gson.Gson} which can be constructed with {@code

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -376,7 +376,7 @@ public class JsonReader implements Closeable {
    *       to the following departures from RFC 8259:
    *       <ul>
    *         <li>Streams that start with the <a href="#nonexecuteprefix">non-execute prefix</a>,
-   *             {@code ")]}'\n"}
+   *             <code>")]}'\n"</code>
    *         <li>Streams that include multiple top-level values. With legacy strict or strict
    *             parsing, each stream must contain exactly one top-level value.
    *         <li>Numbers may be {@link Double#isNaN() NaNs} or {@link Double#isInfinite()
@@ -1613,7 +1613,7 @@ public class JsonReader implements Closeable {
         pos = p;
         /*
          * Skip a # hash end-of-line comment. The JSON RFC doesn't
-         * specify this behaviour, but it's required to parse
+         * specify this behavior, but it's required to parse
          * existing documents. See http://b/2571423.
          */
         checkLenient();

--- a/gson/src/test/java/com/google/gson/functional/CollectionTest.java
+++ b/gson/src/test/java/com/google/gson/functional/CollectionTest.java
@@ -353,7 +353,7 @@ public class CollectionTest {
   }
 
   @Test
-  public void testWildcardPrimitiveCollectionSerilaization() {
+  public void testWildcardPrimitiveCollectionSerialization() {
     Collection<? extends Integer> target = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9);
     Type collectionType = new TypeToken<Collection<? extends Integer>>() {}.getType();
     String json = gson.toJson(target, collectionType);
@@ -364,7 +364,7 @@ public class CollectionTest {
   }
 
   @Test
-  public void testWildcardPrimitiveCollectionDeserilaization() {
+  public void testWildcardPrimitiveCollectionDeserialization() {
     String json = "[1,2,3,4,5,6,7,8,9]";
     Type collectionType = new TypeToken<Collection<? extends Integer>>() {}.getType();
     Collection<? extends Integer> target = gson.fromJson(json, collectionType);

--- a/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
+++ b/gson/src/test/java/com/google/gson/functional/DefaultTypeAdaptersTest.java
@@ -633,7 +633,7 @@ public class DefaultTypeAdaptersTest {
   }
 
   @Test
-  public void testDateSerializationWithPatternNotOverridenByTypeAdapter() {
+  public void testDateSerializationWithPatternNotOverriddenByTypeAdapter() {
     String pattern = "yyyy-MM-dd";
     Gson gson =
         new GsonBuilder()

--- a/gson/src/test/java/com/google/gson/functional/NamingPolicyTest.java
+++ b/gson/src/test/java/com/google/gson/functional/NamingPolicyTest.java
@@ -57,7 +57,7 @@ public class NamingPolicyTest {
   }
 
   @Test
-  public void testGsonWithNonDefaultFieldNamingPolicyDeserialiation() {
+  public void testGsonWithNonDefaultFieldNamingPolicyDeserialization() {
     Gson gson = builder.setFieldNamingPolicy(FieldNamingPolicy.UPPER_CAMEL_CASE).create();
     String target = "{\"SomeConstantStringInstanceField\":\"someValue\"}";
     StringWrapper deserializedObject = gson.fromJson(target, StringWrapper.class);
@@ -87,7 +87,7 @@ public class NamingPolicyTest {
   }
 
   @Test
-  public void testGsonWithLowerCaseDotPolicyDeserialiation() {
+  public void testGsonWithLowerCaseDotPolicyDeserialization() {
     Gson gson = builder.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_DOTS).create();
     String target = "{\"some.constant.string.instance.field\":\"someValue\"}";
     StringWrapper deserializedObject = gson.fromJson(target, StringWrapper.class);
@@ -95,7 +95,7 @@ public class NamingPolicyTest {
   }
 
   @Test
-  public void testGsonWithLowerCaseDashPolicyDeserialiation() {
+  public void testGsonWithLowerCaseDashPolicyDeserialization() {
     Gson gson = builder.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_DASHES).create();
     String target = "{\"some-constant-string-instance-field\":\"someValue\"}";
     StringWrapper deserializedObject = gson.fromJson(target, StringWrapper.class);
@@ -115,7 +115,7 @@ public class NamingPolicyTest {
   }
 
   @Test
-  public void testGsonWithLowerCaseUnderscorePolicyDeserialiation() {
+  public void testGsonWithLowerCaseUnderscorePolicyDeserialization() {
     Gson gson =
         builder.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create();
     String target = "{\"some_constant_string_instance_field\":\"someValue\"}";
@@ -172,7 +172,7 @@ public class NamingPolicyTest {
   }
 
   @Test
-  public void testGsonWithUpperCamelCaseSpacesPolicySerialiation() {
+  public void testGsonWithUpperCamelCaseSpacesPolicySerialization() {
     Gson gson =
         builder.setFieldNamingPolicy(FieldNamingPolicy.UPPER_CAMEL_CASE_WITH_SPACES).create();
     StringWrapper target = new StringWrapper("blah");
@@ -184,7 +184,7 @@ public class NamingPolicyTest {
   }
 
   @Test
-  public void testGsonWithUpperCamelCaseSpacesPolicyDeserialiation() {
+  public void testGsonWithUpperCamelCaseSpacesPolicyDeserialization() {
     Gson gson =
         builder.setFieldNamingPolicy(FieldNamingPolicy.UPPER_CAMEL_CASE_WITH_SPACES).create();
     String target = "{\"Some Constant String Instance Field\":\"someValue\"}";
@@ -205,7 +205,7 @@ public class NamingPolicyTest {
   }
 
   @Test
-  public void testGsonWithUpperCaseUnderscorePolicyDeserialiation() {
+  public void testGsonWithUpperCaseUnderscorePolicyDeserialization() {
     Gson gson =
         builder.setFieldNamingPolicy(FieldNamingPolicy.UPPER_CASE_WITH_UNDERSCORES).create();
     String target = "{\"SOME_CONSTANT_STRING_INSTANCE_FIELD\":\"someValue\"}";
@@ -239,7 +239,7 @@ public class NamingPolicyTest {
   }
 
   @Test
-  public void testGsonWithNameDeserialiation() {
+  public void testGsonWithNameDeserialization() {
     Gson gson =
         builder
             .setFieldNamingStrategy(
@@ -262,7 +262,7 @@ public class NamingPolicyTest {
   }
 
   @Test
-  public void testGsonWithAlternateNamesDeserialiation() {
+  public void testGsonWithAlternateNamesDeserialization() {
     Gson gson =
         builder
             .setFieldNamingStrategy(

--- a/gson/src/test/java/com/google/gson/functional/ParameterizedTypesTest.java
+++ b/gson/src/test/java/com/google/gson/functional/ParameterizedTypesTest.java
@@ -287,7 +287,7 @@ public class ParameterizedTypesTest {
   }
 
   /**
-   * An test object that has fields that are type variables.
+   * A test object that has fields that are type variables.
    *
    * @param <T> Enforce T to be a string to make writing the "toExpectedJson" method easier.
    */

--- a/gson/src/test/java/com/google/gson/functional/PrimitiveTest.java
+++ b/gson/src/test/java/com/google/gson/functional/PrimitiveTest.java
@@ -731,7 +731,7 @@ public class PrimitiveTest {
     String result = gson.toJson(15L);
     assertThat(result).isEqualTo("\"15\"");
 
-    // Test with an integer and ensure its still a number
+    // Test with an integer and ensure it's still a number
     result = gson.toJson(2);
     assertThat(result).isEqualTo("2");
   }

--- a/gson/src/test/java/com/google/gson/functional/SecurityTest.java
+++ b/gson/src/test/java/com/google/gson/functional/SecurityTest.java
@@ -59,18 +59,18 @@ public class SecurityTest {
   }
 
   @Test
-  public void testJsonWithNonExectuableTokenSerialization() {
+  public void testJsonWithNonExecutableTokenSerialization() {
     Gson gson = gsonBuilder.generateNonExecutableJson().create();
     String json = gson.toJson(JSON_NON_EXECUTABLE_PREFIX);
     assertThat(json).isEqualTo(JSON_NON_EXECUTABLE_PREFIX + "\")]}\\u0027\\n\"");
   }
 
   /**
-   * Gson should be able to deserialize a stream with non-exectuable token even if it is created
+   * Gson should be able to deserialize a stream with non-executable token even if it is created
    * without {@link GsonBuilder#generateNonExecutableJson()}.
    */
   @Test
-  public void testJsonWithNonExectuableTokenWithRegularGsonDeserialization() {
+  public void testJsonWithNonExecutableTokenWithRegularGsonDeserialization() {
     Gson gson = gsonBuilder.create();
     // Note: Embedding non-executable prefix literally is only possible because Gson is lenient by
     // default
@@ -81,12 +81,11 @@ public class SecurityTest {
   }
 
   /**
-   * Gson should be able to deserialize a stream with non-exectuable token if it is created with
+   * Gson should be able to deserialize a stream with non-executable token if it is created with
    * {@link GsonBuilder#generateNonExecutableJson()}.
    */
   @Test
-  public void testJsonWithNonExectuableTokenWithConfiguredGsonDeserialization() {
-    // Gson should be able to deserialize a stream with non-exectuable token even if it is created
+  public void testJsonWithNonExecutableTokenWithConfiguredGsonDeserialization() {
     Gson gson = gsonBuilder.generateNonExecutableJson().create();
     // Note: Embedding non-executable prefix literally is only possible because Gson is lenient by
     // default

--- a/gson/src/test/java/com/google/gson/functional/TypeHierarchyAdapterTest.java
+++ b/gson/src/test/java/com/google/gson/functional/TypeHierarchyAdapterTest.java
@@ -135,7 +135,7 @@ public final class TypeHierarchyAdapterTest {
     assertThat(copied.userid).isEqualTo(manager.userid);
   }
 
-  /** This behaviour changed in Gson 2.1; it used to throw. */
+  /** This behavior changed in Gson 2.1; it used to throw. */
   @Test
   public void testRegisterSubTypeFirstAllowed() {
     Gson unused =
@@ -189,12 +189,12 @@ public final class TypeHierarchyAdapterTest {
       }
 
       // only managers have minions
-      JsonElement minons = object.get("minions");
-      if (minons != null) {
+      JsonElement minions = object.get("minions");
+      if (minions != null) {
         if (result == null) {
           result = new Manager();
         }
-        ((Manager) result).minions = context.deserialize(minons, Employee[].class);
+        ((Manager) result).minions = context.deserialize(minions, Employee[].class);
       }
 
       if (result == null) {

--- a/gson/src/test/java/com/google/gson/metrics/PerformanceTest.java
+++ b/gson/src/test/java/com/google/gson/metrics/PerformanceTest.java
@@ -54,7 +54,7 @@ public class PerformanceTest {
 
   @Test
   public void testDummy() {
-    // This is here to prevent Junit for complaining when we disable all tests.
+    // This is here to prevent JUnit from complaining when we disable all tests.
   }
 
   @Test

--- a/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonWriterTest.java
@@ -103,9 +103,9 @@ public final class JsonWriterTest {
     assertThat(string4.toString()).isEqualTo("123.4");
 
     StringWriter string5 = new StringWriter();
-    JsonWriter writert = new JsonWriter(string5);
-    writert.value("a");
-    writert.close();
+    JsonWriter writer5 = new JsonWriter(string5);
+    writer5.value("a");
+    writer5.close();
     assertThat(string5.toString()).isEqualTo("\"a\"");
   }
 

--- a/proto/src/main/java/com/google/gson/protobuf/ProtoTypeAdapter.java
+++ b/proto/src/main/java/com/google/gson/protobuf/ProtoTypeAdapter.java
@@ -142,7 +142,7 @@ public class ProtoTypeAdapter implements JsonSerializer<Message>, JsonDeserializ
      * string client_app_id = 1 [(serialized_name) = "appId"];
      * </pre>
      *
-     * ...the adapter will serialize the field using '{@code appId}' instead of the default ' {@code
+     * ...the adapter will serialize the field using '{@code appId}' instead of the default '{@code
      * clientAppId}'. This lets you customize the name serialization of any proto field.
      */
     @CanIgnoreReturnValue
@@ -154,7 +154,7 @@ public class ProtoTypeAdapter implements JsonSerializer<Message>, JsonDeserializ
 
     /**
      * Adds an enum value proto annotation that, when set, overrides the default <b>enum</b> value
-     * serialization/deserialization of this adapter. For example, if you add the ' {@code
+     * serialization/deserialization of this adapter. For example, if you add the '{@code
      * serialized_value}' annotation and you define an enum in your proto like the one below:
      *
      * <pre>

--- a/proto/src/test/java/com/google/gson/protobuf/functional/LegacyProtoTypeAdapterFactoryTest.java
+++ b/proto/src/test/java/com/google/gson/protobuf/functional/LegacyProtoTypeAdapterFactoryTest.java
@@ -189,7 +189,7 @@ public final class LegacyProtoTypeAdapterFactoryTest {
   }
 
   private static void rewriteJsonObject(JsonObject json) {
-    // The RTAF JSON includes a field `fooMemoizedSerializedSize` for every `foo` that is a a
+    // The RTAF JSON includes a field `fooMemoizedSerializedSize` for every `foo` that is a
     // repeated non-message field. Not including it means that it gets its default value of -1,
     // which implies that it will be computed on demand. We verify `getSerializedSize()` in
     // `legacyCompatToRtaf`, which would fail if the absence of `fooMemoizedSerializedSize` were a


### PR DESCRIPTION
Found by IntelliJ.

IntelliJ also reported other issues such as missing and unexpected hyphens between words and missing commas. However, they might not be so relevant and therefore I have not made those changes.