### PR TITLE
Support building with JDK 25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,19 +17,26 @@ env:
 
 jobs:
   build:
-    name: "Build on JDK ${{ matrix.java }}"
+    name: "Build on JDK ${{ matrix.java }} (${{ matrix.java-package }})"
     strategy:
       matrix:
-        java: [ 17, 21 ]
+        java: [ 17, 21, 25 ]
+        java-package: [ jdk ]
         include:
           # Custom JDK 11 configuration because some of the plugins and test dependencies don't support it anymore,
           # but it is important to still test with a JDK version without Record classes
           - java: 11
+            java-package: jdk
             # Disable Enforcer check which (intentionally) prevents using JDK 11 for building
             # Exclude 'test-graal-native-image' module because JUnit 6 requires >= Java 17
             # Exclude 'proto' module because protobuf-maven-plugin requires >= Java 17
             extra-mvn-args: -Denforcer.fail=false --projects '!test-graal-native-image,!proto'
+          # Additional build with JDK 25 and jmod files, to run ProGuard-related tests on JDK 25 as well
+          # Not needed for older JDK versions tested here, they include jmod files by default
+          # See also https://github.com/Guardsquare/proguard/issues/473
+          # TODO: Remove this and the `java-package` config once ProGuard does not require jmod files anymore
           - java: 25
+            java-package: jdk+jmods
     runs-on: ubuntu-latest
 
     steps:
@@ -37,10 +44,11 @@ jobs:
         with:
           persist-credentials: false
       - name: "Set up JDK ${{ matrix.java }}"
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95  # v5.6.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c  # v6.0.0
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          java-package: ${{ matrix.java-package }}
           cache: 'maven'
       - name: Build with Maven
         # This also runs javadoc:jar to detect any issues with the Javadoc generated during release
@@ -55,7 +63,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up JDK
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95  # v5.6.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c  # v6.0.0
         with:
           distribution: 'temurin'
           java-version: 21
@@ -96,7 +104,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up JDK
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95  # v5.6.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c  # v6.0.0
         with:
           distribution: 'temurin'
           java-version: 17

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,11 +30,6 @@ jobs:
             # Exclude 'proto' module because protobuf-maven-plugin requires >= Java 17
             extra-mvn-args: -Denforcer.fail=false --projects '!test-graal-native-image,!proto'
           - java: 25
-            # Disable Enforcer check which (intentionally) prevents using JDK 25 for building
-            # Exclude 'test-shrinker' because ProGuard does not support JDK 25 yet, see
-            # https://github.com/Guardsquare/proguard/issues/481 and https://github.com/Guardsquare/proguard/issues/473
-            # TODO: Once ProGuard supports JDK 25, also remove the corresponding 'JDK25' profile in `gson/pom.xml`
-            extra-mvn-args: -Denforcer.fail=false --projects '!test-shrinker'
     runs-on: ubuntu-latest
 
     steps:
@@ -72,12 +67,7 @@ jobs:
     name: "GraalVM Native Image test (JDK ${{ matrix.java }})"
     strategy:
       matrix:
-        java: [ 21 ]
-        include:
-          - java: 25
-            # Disable Enforcer check which (intentionally) prevents using JDK 25 for building
-            # TODO: Remove this once JDK 25 is fully supported for building Gson
-            extra-mvn-args: -Denforcer.fail=false
+        java: [ 21, 25 ]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-android-compatibility.yml
+++ b/.github/workflows/check-android-compatibility.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up JDK
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95  # v5.6.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c  # v6.0.0
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/check-api-compatibility.yml
+++ b/.github/workflows/check-api-compatibility.yml
@@ -32,7 +32,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up JDK
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95  # v5.6.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c  # v6.0.0
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Set up JDK
       if: ${{ matrix.language == 'java' }}
-      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95  # v5.6.0
+      uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c  # v6.0.0
       with:
         distribution: 'temurin'
         java-version: '17'

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Gson uses Maven to build the project:
 mvn clean verify
 ```
 
-JDK 17 or newer is required for building, JDK 21 is recommended. Newer JDKs are currently not supported for building (but are supported when _using_ Gson).
+JDK 17 or newer is required for building, JDK 21 is recommended. JDK 25 is supported, but only runs a subset of all tests if JDK `jmod` files are missing. Newer JDKs are currently not supported for building (but are supported when _using_ Gson).
 
 ### Contributing
 

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -353,8 +353,9 @@
   </build>
 
   <profiles>
+    <!-- Profile for building additional tests which require >= Java 17 -->
     <profile>
-      <id>JDK17</id>
+      <id>JDK17-test</id>
       <activation>
         <jdk>[17,)</jdk>
       </activation>
@@ -363,14 +364,19 @@
         <excludeTestCompilation />
       </properties>
     </profile>
-    <!-- For JDK 25+ skip tests which rely on ProGuard because it does not support JDK 25 yet -->
-    <!-- TODO: Remove this once ProGuard supports JDK 25, and there is a solution for https://github.com/Guardsquare/proguard/issues/473 -->
+
+    <!-- For JDK 25+ without jmod files, skip tests which rely on ProGuard because it requires jmod files -->
+    <!-- TODO: Remove this once https://github.com/Guardsquare/proguard/issues/473 is resolved -->
     <profile>
-      <id>JDK25</id>
+      <id>JDK25-proguard</id>
       <activation>
         <jdk>[25,)</jdk>
+        <file>
+          <missing>${java.home}/jmods/java.base.jmod</missing>
+        </file>
       </activation>
       <properties>
+        <!-- Exclude ProGuard-dependent test class -->
         <excludeTestCompilation>com/google/gson/functional/EnumWithObfuscatedTest.java</excludeTestCompilation>
       </properties>
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
                   <!-- Also disallow too new JDK versions; they might introduce new lints, drop support
                     for older compiler Java target versions or cause issues for some Maven plugins.
                     Failing fast for such versions is better than failing with a confusing error during build. -->
-                  <version>[17,22)</version>
+                  <version>[17,26)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>
@@ -561,6 +561,7 @@
         </plugins>
       </build>
     </profile>
+
     <!-- Disable Error Prone before Java 21 -->
     <profile>
       <id>disable-error-prone</id>

--- a/test-graal-native-image/pom.xml
+++ b/test-graal-native-image/pom.xml
@@ -116,8 +116,9 @@
   </build>
 
   <profiles>
+    <!-- Profile for building additional tests which require >= Java 17 -->
     <profile>
-      <id>JDK17</id>
+      <id>JDK17-test</id>
       <activation>
         <jdk>[17,)</jdk>
       </activation>

--- a/test-shrinker/pom.xml
+++ b/test-shrinker/pom.xml
@@ -210,4 +210,37 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <!-- For JDK 25+ without jmod files, skip tests which rely on ProGuard because it requires jmod files -->
+    <!-- TODO: Remove this once https://github.com/Guardsquare/proguard/issues/473 is resolved -->
+    <profile>
+      <id>JDK25-proguard</id>
+      <activation>
+        <jdk>[25,)</jdk>
+        <file>
+          <missing>${java.home}/jmods/java.base.jmod</missing>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.wvengen</groupId>
+            <artifactId>proguard-maven-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <!-- Skip tests because they cannot succeed if ProGuard did not run -->
+              <skipITs>true</skipITs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
### Purpose
Support building with JDK 25

Follow-up for #2847 and #2921


### Description
Previously building with JDK 25 was possible (and was done by CI), but was not officially supported.

The underlying issue is that recent JDK builds (at least those from Temurin) do not include `jmod` files anymore but ProGuard [still depends on them](https://redirect.github.com/Guardsquare/proguard/issues/473).

This PR here now adjusts the Maven build config so that it gracefully skips ProGuard and related tests when building with JDK 25 but `jmod` files are missing.
Additionally it uses `actions/setup-java`'s new [`jmod` file support](https://redirect.github.com/actions/setup-java/pull/1149) to actually test JDK 25 with `jmod` files being present.

This means it runs now intentionally two tests for JDK 25 on CI:
- without `jmod` files: this matches the behavior if a user would use Temurin JDK 25, and ensures that the build works
- with `jmod` files: this verifies that a full build including ProGuard-related tests works for JDK 25, and also matches the behavior if a user would use a JDK distribution which includes `jmod` files
