### PR TITLE
Avoid quadratic removeIf in JsonArray list views

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/NonNullElementWrapperList.java
+++ b/gson/src/main/java/com/google/gson/internal/NonNullElementWrapperList.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.RandomAccess;
 import java.util.Spliterator;
+import java.util.function.Predicate;
 
 /**
  * {@link List} which wraps another {@code List} but prevents insertion of {@code null} elements.
@@ -92,6 +93,11 @@ public class NonNullElementWrapperList<E> extends AbstractList<E> implements Ran
   @Override
   public boolean retainAll(Collection<?> c) {
     return delegate.retainAll(c);
+  }
+
+  @Override
+  public boolean removeIf(Predicate<? super E> filter) {
+    return delegate.removeIf(filter);
   }
 
   @Override

--- a/gson/src/test/java/com/google/gson/JsonArrayAsListTest.java
+++ b/gson/src/test/java/com/google/gson/JsonArrayAsListTest.java
@@ -168,6 +168,38 @@ public class JsonArrayAsListTest {
   }
 
   @Test
+  public void testRemoveIf() {
+    JsonArray a = new JsonArray();
+    a.add(1);
+    a.add(2);
+    a.add(3);
+    a.add(2);
+    a.add(JsonNull.INSTANCE);
+
+    List<JsonElement> list = a.asList();
+    assertThat(list.removeIf(element -> element.equals(new JsonPrimitive(2)))).isTrue();
+    assertThat(a.toString()).isEqualTo("[1,3,null]");
+    assertThat(list.removeIf(JsonElement::isJsonNull)).isTrue();
+    assertThat(a.toString()).isEqualTo("[1,3]");
+    assertThat(list.removeIf(element -> false)).isFalse();
+    assertThat(a.toString()).isEqualTo("[1,3]");
+    assertThat(list.removeIf(element -> true)).isTrue();
+    assertThat(a).isEmpty();
+    assertThat(list.removeIf(element -> true)).isFalse();
+  }
+
+  @Test
+  public void testRemoveIfNullPredicate() {
+    JsonArray a = new JsonArray();
+    List<JsonElement> list = a.asList();
+    assertThrows(NullPointerException.class, () -> list.removeIf(null));
+
+    a.add(1);
+    assertThrows(NullPointerException.class, () -> list.removeIf(null));
+    assertThat(a.toString()).isEqualTo("[1]");
+  }
+
+  @Test
   public void testContains() {
     JsonArray a = new JsonArray();
     a.add(1);


### PR DESCRIPTION
### Purpose

Avoid quadratic time when removing many elements through `JsonArray.asList().removeIf(...)`.

### Description

`NonNullElementWrapperList` inherits `Collection.removeIf`, which removes matching elements through the iterator. Each removal shifts the tail of the backing `ArrayList`. Filtering out a large fraction of an array therefore repeatedly copies the remaining elements.

Delegate `removeIf` to the backing `ArrayList` so it uses bulk removal, consistent with the existing `removeAll` and `retainAll` overrides. No dependency or public API is added.

The tests cover duplicate matches, JSON nulls, remaining element order, all/no matches, empty arrays, null predicates, and updates to the original `JsonArray`.

This also follows `ArrayList` behavior if the predicate throws: the operation may leave the list unchanged instead of partially filtered. The `Collection` contract does not guarantee a particular partial result on exception.

### Validation

- Java 21: `mvn -B -ntp clean verify javadoc:jar` passed across all eight modules.
- Test reports: 4,868 tests, 21 skipped, zero failures or errors.
- Focused `JsonArrayAsListTest` and `JsonArrayAsListSuiteTest`: 422 tests passed.

A local microbenchmark compiled the wrapper source before and after the change, populated an `ArrayList<Integer>` with consecutive integers, and timed `new NonNullElementWrapperList<>(backing).removeIf(value -> (value & 1) == 0)`. Array construction was outside the timed interval. After ten 10,000-element warmups, medians of seven samples were:

| Elements | Before | After |
| --- | ---: | ---: |
| 50,000 | 74.449 ms | 0.604 ms |
| 100,000 | 335.909 ms | 0.479 ms |
| 200,000 | 1388.171 ms | 0.778 ms |

These are illustrative single-machine measurements, not a JMH benchmark or an end-to-end application speed guarantee. The added functional tests verify behavior; they do not use timing assertions.

### Checklist

- [x] Google Java Style checks pass.
- [x] Unit tests use Truth and JUnit 4, with no new JUnit 3 features.
- [x] `mvn clean verify javadoc:jar` passes.
- Public API validation/Javadoc/`@since`: not applicable; no new public API.

### AI assistance

Codex identified the performance issue, prepared the implementation and tests, ran local validation, and drafted this description.
