### PR TITLE
fix: reject unpaired surrogates in strict JSON

### DIFF
--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -1228,10 +1228,10 @@ public class JsonReader implements Closeable {
           pos = p;
           int len = p - start - 1;
           if (builder == null) {
-            return new String(buffer, start, len);
+            return validateString(new String(buffer, start, len));
           } else {
             builder.append(buffer, start, len);
-            return builder.toString();
+            return validateString(builder.toString());
           }
         } else if (c == '\\') {
           pos = p;
@@ -1261,6 +1261,24 @@ public class JsonReader implements Closeable {
         throw syntaxError("Unterminated string");
       }
     }
+  }
+
+  /** Validates that a string does not contain unpaired UTF-16 surrogate characters. */
+  private String validateString(String value) throws IOException {
+    if (strictness != Strictness.STRICT) {
+      return value;
+    }
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (Character.isHighSurrogate(c)) {
+        if (i + 1 >= value.length() || !Character.isLowSurrogate(value.charAt(++i))) {
+          throw syntaxError("Unpaired surrogate characters are not allowed in strict mode");
+        }
+      } else if (Character.isLowSurrogate(c)) {
+        throw syntaxError("Unpaired surrogate characters are not allowed in strict mode");
+      }
+    }
+    return value;
   }
 
   /** Returns an unquoted value as a string. */

--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -1270,11 +1270,12 @@ public class JsonReader implements Closeable {
     }
     for (int i = 0; i < value.length(); i++) {
       char c = value.charAt(i);
-      if (Character.isHighSurrogate(c)) {
-        if (i + 1 >= value.length() || !Character.isLowSurrogate(value.charAt(++i))) {
-          throw syntaxError("Unpaired surrogate characters are not allowed in strict mode");
+      if (Character.isSurrogate(c)) {
+        if (Character.isHighSurrogate(c)
+            && i + 1 < value.length()
+            && Character.isLowSurrogate(value.charAt(++i))) {
+          continue;
         }
-      } else if (Character.isLowSurrogate(c)) {
         throw syntaxError("Unpaired surrogate characters are not allowed in strict mode");
       }
     }

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -138,6 +138,33 @@ public final class JsonReaderTest {
   }
 
   @Test
+  public void testStrictModeRejectsUnpairedSurrogates() throws IOException {
+    for (String json : new String[] {"\"\\uD800\"", "\"\\uDC00\"", "{\"\\uD800\":1}"}) {
+      JsonReader reader = new JsonReader(reader(json));
+      reader.setStrictness(Strictness.STRICT);
+      if (json.startsWith("{")) {
+        reader.beginObject();
+        IOException expected = assertThrows(IOException.class, reader::nextName);
+        assertThat(expected)
+            .hasMessageThat()
+            .startsWith("Unpaired surrogate characters are not allowed in strict mode");
+      } else {
+        IOException expected = assertThrows(IOException.class, reader::nextString);
+        assertThat(expected)
+            .hasMessageThat()
+            .startsWith("Unpaired surrogate characters are not allowed in strict mode");
+      }
+    }
+  }
+
+  @Test
+  public void testStrictModeAllowsPairedSurrogates() throws IOException {
+    JsonReader reader = new JsonReader(reader("\"\\uD834\\uDD1E\""));
+    reader.setStrictness(Strictness.STRICT);
+    assertThat(reader.nextString()).isEqualTo("\uD834\uDD1E");
+  }
+
+  @Test
   public void testNonStrictModeParsesUnescapedControlCharacter() throws IOException {
     String json = "\"\t\"";
     JsonReader reader = new JsonReader(reader(json));

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -139,7 +139,8 @@ public final class JsonReaderTest {
 
   @Test
   public void testStrictModeRejectsUnpairedSurrogates() throws IOException {
-    for (String json : new String[] {"\"\\uD800\"", "\"\\uDC00\"", "{\"\\uD800\":1}"}) {
+    for (String json :
+        new String[] {"\"\\uD800\"", "\"\\uDC00\"", "\"\uD800\"", "{\"\\uD800\":1}"}) {
       JsonReader reader = new JsonReader(reader(json));
       reader.setStrictness(Strictness.STRICT);
       if (json.startsWith("{")) {


### PR DESCRIPTION
Fixes #3113

`JsonReader` currently accepts `\uD800` / `\uDC00` escapes as lone UTF-16 surrogate code units even when `Strictness.STRICT` is selected. This can return malformed Java strings for both values and object member names. Validate the fully decoded quoted string at the boundary where it is returned, rejecting unpaired surrogates while allowing valid surrogate pairs and leaving legacy/lenient modes unchanged.

## Validation

- `mvn -pl gson -Denforcer.skip=true -Dtest=com.google.gson.stream.JsonReaderTest test` (164 tests, 3 skipped; JDK 26 requires the repository enforcer override)
- `git diff --check`

The regression test covers escaped lone high/low surrogates in values and names, plus a valid escaped pair.